### PR TITLE
Script fixes

### DIFF
--- a/scripts/build-rev.sh
+++ b/scripts/build-rev.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "$1" = "" -o "$2" = "" ]; then
 	echo "usage: $0 <datestr> <revision> <outdir> [branch]"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "$1" = "" ]; then
 	echo "usage: $0 <platform> [<sourcedir>]"


### PR DESCRIPTION
I reinstalled my server and some builds failed. This is because debian/ubuntu now use dash instead of bash as the default shell. dash is POSIX compatible but doesn't support bashisms like pushd/popd, so fix the offending scripts to require bash explicitly.
