### PR TITLE
Numlock fix for win32

### DIFF
--- a/src/event_sdl.c
+++ b/src/event_sdl.c
@@ -343,7 +343,7 @@ static bool process_event(SDL_Event *event)
 
       if(ckey == IKEY_NUMLOCK)
       {
-#ifdef __WIN32__
+#if !SDL_VERSION_ATLEAST(2,0,0) && defined(__WIN32__)
         status->numlock_status = true;
 #endif
         break;
@@ -405,7 +405,7 @@ static bool process_event(SDL_Event *event)
 
       if(ckey == IKEY_NUMLOCK)
       {
-#ifdef __WIN32__
+#if !SDL_VERSION_ATLEAST(2,0,0) && defined(__WIN32__)
         status->numlock_status = false;
 #else
         status->numlock_status = !status->numlock_status;


### PR DESCRIPTION
This doesn't make numlock a key again, but it should enable the keypad logic to work like SDL 1.2 did on win32 previously.

Take this fix if you want the compatibility, otherwise let me know if you don't care about this any more and would prefer numlock to be treated like a regular key.
