### PR TITLE
Make a CR-insensitive comparison in help_check.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ assets/help.fil: ${txt2hlp} docs/WIPHelp.txt
 
 help_check: ${hlp2txt} assets/help.fil
 	@src/utils/hlp2txt assets/help.fil help.txt
-	@diff -q docs/WIPHelp.txt help.txt
+	@diff --strip-trailing-cr -q docs/WIPHelp.txt help.txt
 	@rm -f help.txt
 
 endif


### PR DESCRIPTION
`make help_check` failed in my Linux system. This fixes it. The problem is that `hlp2txt` outputs lines in the native line ending format, while `.gitattributes` forces CR/LF.

[Edit: It will probably have to be applied by hand if PR #10 is accepted, as it will probably conflict.]

A better approach IMO would be to fix `.gitattributes` and renormalize the repository. Still, this PR would help in the case of non-git source downloads.

I can submit a PR for the .gitattributes change if requested.
