### PR TITLE
Added standalone mode

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -234,6 +234,29 @@
 
 # startup_editor = 1
 
+# Enable standalone mode. This is a game mode meant to be used
+# for packaged standalone MegaZeux games. In standalone mode:
+# - ENTER_MENU, ESCAPE_MENU, HELP_MENU, F2_MENU and LOAD_MENU
+#   can be used on the title screen to disable these menus.
+# - HELP_MENU prevents the help menu from being opened even
+#   when other builtin dialogs are open
+# - EXIT_GAME can be used on the title screen to exit MegaZeux
+# - The default title screen message does not appear
+# - PLAY_GAME can be set to 1 to start a game 
+# - Using ALT-F4, closing the window or using other OS-specific
+#   ways of closing an application will exit MZX entirely,
+#   without asking for confirmation first
+# Standalone mode can only be used from MZXRun.
+
+# standalone_mode = 1
+
+# Enable no titlescreen mode. This mode only works if standalone
+# mode is enabled and causes the following:
+# - The title screen is skipped and the game begins on the first
+#   board.
+# - Exiting to the title screen exits MegaZeux
+
+# no_titlescreen = 1
 
 ### Board editor options ###
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -46,6 +46,11 @@ FEATURES
   the ? and the : will be evaluated. If the value to the left of
   ? is equal to zero, the expression to the right of : will be
   evaluated.
++ Added standalone mode. The config parameters standalone_mode
+  and no_titlescreen can now be used (from MZXRun only) to
+  create standalone versions of MZX with the ability to fully
+  customise the player's experience. See config.txt for details.
+  (Lancer-X)
 
 + Debytecode: the LOAD_SOURCE_FILE special counter can now be
   used to load and compile a robot program from source code.

--- a/src/configure.c
+++ b/src/configure.c
@@ -443,6 +443,18 @@ static void config_startup_editor(struct config_info *conf, char *name,
   conf->startup_editor = strtoul(value, NULL, 10);
 }
 
+static void config_standalone_mode(struct config_info *conf, char *name,
+ char *value, char *extended_data)
+{
+  conf->standalone_mode = strtoul(value, NULL, 10);
+}
+
+static void config_no_titlescreen(struct config_info *conf, char *name,
+ char *value, char *extended_data)
+{
+  conf->no_titlescreen = strtoul(value, NULL, 10);
+}
+
 static void config_set_video_ratio(struct config_info *conf, char *name,
  char *value, char *extended_data)
 {
@@ -490,6 +502,7 @@ static const struct config_entry config_options[] =
 #ifdef CONFIG_NETWORK
   { "network_enabled", config_set_network_enabled },
 #endif
+  { "no_titlescreen", config_no_titlescreen },
   { "num_buffered_events", config_set_num_buffered_events },
   { "pause_on_unfocus", pause_on_unfocus },
   { "pc_speaker_on", config_set_pc_speaker },
@@ -501,6 +514,7 @@ static const struct config_entry config_options[] =
   { "socks_host", config_set_socks_host },
   { "socks_port", config_set_socks_port },
 #endif
+  { "standalone_mode", config_standalone_mode },
   { "startup_editor", config_startup_editor },
   { "startup_file", config_startup_file },
   { "startup_path", config_startup_path },
@@ -576,6 +590,8 @@ static const struct config_info default_options =
   1,                            // disassemble_extras
   10,                           // disassemble_base
   0,                            // startup_editor
+  0,                            // standalone_mode
+  0,                            // no_titlescreen
 
   1,                            // mask_midchars
   false,                        // system_mouse

--- a/src/configure.h
+++ b/src/configure.h
@@ -68,6 +68,8 @@ struct config_info
   int disassemble_extras;
   int disassemble_base;
   int startup_editor;
+  int standalone_mode;
+  int no_titlescreen;
 
   // Misc options
   int mask_midchars;

--- a/src/counter.c
+++ b/src/counter.c
@@ -1571,6 +1571,17 @@ static void exit_game_write(struct world *mzx_world,
   }
 }
 
+static void play_game_write(struct world *mzx_world,
+ const struct function_counter *counter, const char *name, int value, int id)
+{
+  struct config_info *conf = &mzx_world->conf;
+  if(value && conf->standalone_mode)
+  {
+    // Signal the main loop that the game state should change.
+    mzx_world->change_game_state = CHANGE_STATE_PLAY_GAME_ROBOTIC;
+  }
+}
+
 static int load_game_read(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int id)
 {
@@ -2564,6 +2575,7 @@ static const struct function_counter builtin_counters[] =
   { "playerlastdir", 0, playerlastdir_read, playerlastdir_write },   // <=2.51
   { "playerx", 0x0208, playerx_read, NULL },                         // 2.51s1
   { "playery", 0x0208, playery_read, NULL },                         // 2.51s1
+  { "play_game", 0x0255, NULL, play_game_write },                    // 2.85
   { "r!.*", 0x0241, r_read, r_write },                               // 2.65
   { "red_value", 0x0209, red_value_read, red_value_write },          // 2.60
   { "rid*", 0x0246, rid_read, NULL },                                // 2.69b

--- a/src/game.c
+++ b/src/game.c
@@ -154,8 +154,11 @@ static void draw_intro_mesg(struct world *mzx_world)
 {
   static const char mesg1[] = "F1: Help   ";
   static const char mesg2[] = "Enter: Menu   Ctrl-Alt-Enter: Fullscreen";
+  struct config_info *conf = &mzx_world->conf;
 
   if(intro_mesg_timer == 0)
+    return;
+  if (conf->standalone_mode)
     return;
 
   if(mzx_world->help_file)
@@ -1734,6 +1737,10 @@ static int update(struct world *mzx_world, int game, int *fadein)
       // Exit game--skip input processing. The game state will exit.
       return 1;
 
+    case CHANGE_STATE_PLAY_GAME_ROBOTIC:
+      // we need to continue input processing
+      return 0;
+
     default:
       break;
   }
@@ -1984,11 +1991,13 @@ __editor_maybe_static void play_game(struct world *mzx_world)
   // We have the world loaded, on the proper scene.
   // We are faded out. Commence playing!
   int exit;
+  int confirm_exit = 0;
   int key = -1;
   int key_status = 0;
   char keylbl[5] = "KEY?";
   struct board *src_board;
   int fadein = 1;
+  struct config_info *conf = &mzx_world->conf;
 
   // Main game loop
   // Mouse remains hidden unless menu/etc. is invoked
@@ -2387,7 +2396,10 @@ __editor_maybe_static void play_game(struct world *mzx_world)
 
           if(mzx_world->version < 0x0255 || escape_menu_status)
             if(key_status == 1)
+            {
+              confirm_exit = 1;
               exit = 1;
+            }
 
           break;
         }
@@ -2397,15 +2409,26 @@ __editor_maybe_static void play_game(struct world *mzx_world)
     // Quit
     if(exit)
     {
-      m_show();
+      // Special behaviour in standalone- only escape exits
+      // ask for confirmation
+      if (conf->no_titlescreen ||
+       (conf->standalone_mode && !confirm_exit))
+      {
+        mzx_world->full_exit = true;
+      }
+      
+      if (confirm_exit || !conf->standalone_mode)
+      {
+        confirm_exit = 0;
+        m_show();
 
-      exit = !confirm(mzx_world, "Quit playing- Are you sure?");
+        exit = !confirm(mzx_world, "Quit playing- Are you sure?");
 
-      update_event_status();
+        update_event_status();
+      }
     }
 
   } while(!exit);
-
   pop_context();
   vquick_fadeout();
   clear_sfx_queue();
@@ -2414,6 +2437,7 @@ __editor_maybe_static void play_game(struct world *mzx_world)
 void title_screen(struct world *mzx_world)
 {
   int exit;
+  int confirm_exit = 0;
   int fadein = 1;
   int key = 0;
   int key_status = 0;
@@ -2421,6 +2445,7 @@ void title_screen(struct world *mzx_world)
   struct stat file_info;
   struct board *src_board;
   char *current_dir;
+  struct config_info *conf = &mzx_world->conf;
 
   debug_mode = false;
 
@@ -2435,8 +2460,18 @@ void title_screen(struct world *mzx_world)
   set_config_from_file(&(mzx_world->conf), "title.cnf");
   chdir(current_dir);
 
+  // First, disable standalone mode if this is a build of MZX
+  // with the editor enabled
+  if (edit_world)
+  {
+    conf->standalone_mode = 0;
+  }
+
   if(edit_world && mzx_world->conf.startup_editor)
   {
+    // Disable standalone mode
+    conf->standalone_mode = 0;
+
     set_intro_mesg_timer(0);
     edit_world(mzx_world, 0);
   }
@@ -2445,8 +2480,17 @@ void title_screen(struct world *mzx_world)
     if(!stat(curr_file, &file_info))
       load_world_file(mzx_world, curr_file);
     else
+    {
+      // Disable standalone mode
+      conf->standalone_mode = 0;
+
       load_world_selection(mzx_world);
+    }
   }
+
+  // if standalone mode is disabled, also disable no_titlescreen
+  if (!conf->standalone_mode)
+    conf->no_titlescreen = 0;
 
   src_board = mzx_world->current_board;
   draw_intro_mesg(mzx_world);
@@ -2455,39 +2499,60 @@ void title_screen(struct world *mzx_world)
 
   do
   {
-    // Focus on center
-    if(fadein)
-    {
-      int x, y;
-      set_screen_coords(640/2, 350/2, &x, &y);
-      focus_pixel(x, y);
-    }
-
-    // Update
-    if(mzx_world->active)
-    {
-      if(update(mzx_world, 0, &fadein))
+    if (!conf->no_titlescreen) {
+      // Focus on center
+      if(fadein)
       {
-        update_event_status();
-        continue;
+        int x, y;
+        set_screen_coords(640/2, 350/2, &x, &y);
+        focus_pixel(x, y);
+      }
+
+      // Update
+      if(mzx_world->active)
+      {
+        if(update(mzx_world, 0, &fadein))
+        {
+          update_event_status();
+          continue;
+        }
+      }
+      else
+      {
+        // Give some delay time if nothing's loaded
+        update_event_status_delay();
+        update_screen();
+      }
+
+      src_board = mzx_world->current_board;
+
+      update_event_status();
+
+      // Keycheck
+      key = get_key(keycode_internal);
+      key_status = get_key_status(keycode_internal, key);
+
+      exit = get_exit_status();
+      if (conf->standalone_mode)
+      {
+        switch (mzx_world->change_game_state)
+        {
+          case CHANGE_STATE_EXIT_GAME_ROBOTIC:
+            exit = 1;
+            break;
+          case CHANGE_STATE_PLAY_GAME_ROBOTIC:
+            key = IKEY_p;
+            break;
+          default:
+            break;
+        }
       }
     }
     else
     {
-      // Give some delay time if nothing's loaded
-      update_event_status_delay();
-      update_screen();
+      // No titlescreen mode, so jump straight to the game
+      key = IKEY_p;
     }
-
-    src_board = mzx_world->current_board;
-
-    update_event_status();
-
-    // Keycheck
-    key = get_key(keycode_internal);
-    key_status = get_key_status(keycode_internal, key);
-
-    exit = get_exit_status();
 
     if(key && !exit)
     {
@@ -2506,6 +2571,10 @@ void title_screen(struct world *mzx_world)
         case IKEY_F1:
         case IKEY_h:
         {
+          int help_menu_status =
+           get_counter(mzx_world, "HELP_MENU", 0);
+          if(conf->standalone_mode || !help_menu_status)
+            break;
           m_show();
           help_system(mzx_world);
           update_screen();
@@ -2515,6 +2584,10 @@ void title_screen(struct world *mzx_world)
         case IKEY_F2:
         case IKEY_s:
         {
+          int f2_menu_status =
+           get_counter(mzx_world, "F2_MENU", 0);
+          if(conf->standalone_mode || !f2_menu_status)
+            break;
           // Settings
           m_show();
 
@@ -2528,6 +2601,7 @@ void title_screen(struct world *mzx_world)
         case IKEY_F3:
         case IKEY_l:
         {
+          if (conf->standalone_mode) break;
           load_world_selection(mzx_world);
           fadein = 1;
           src_board = mzx_world->current_board;
@@ -2547,6 +2621,10 @@ void title_screen(struct world *mzx_world)
         case IKEY_r:
         {
           char save_file_name[MAX_PATH] = { 0 };
+          int load_menu_status =
+           get_counter(mzx_world, "LOAD_MENU", 0);
+          if(conf->standalone_mode && !load_menu_status)
+            break;
 
           // Restore
           m_show();
@@ -2590,7 +2668,7 @@ void title_screen(struct world *mzx_world)
 
               update_event_status();
               play_game(mzx_world);
-
+              if (mzx_world->full_exit) break;
               // Done playing- load world again
               // Already faded out from play_game()
               end_module();
@@ -2690,6 +2768,7 @@ void title_screen(struct world *mzx_world)
               vquick_fadeout();
 
               play_game(mzx_world);
+              if (mzx_world->full_exit) break;
               // Done playing- load world again
               // Already faded out from play_game()
               end_module();
@@ -2769,6 +2848,11 @@ void title_screen(struct world *mzx_world)
         // Quickload
         case IKEY_F10:
         {
+          int load_menu_status =
+           get_counter(mzx_world, "LOAD_MENU", 0);
+          if(conf->standalone_mode && !load_menu_status)
+            break;
+          
           // Restore
           m_show();
 
@@ -2809,7 +2893,7 @@ void title_screen(struct world *mzx_world)
             vquick_fadeout();
 
             play_game(mzx_world);
-
+            if (mzx_world->full_exit) break;
             // Done playing- load world again
             // Already faded out from play_game()
             end_module();
@@ -2846,9 +2930,13 @@ void title_screen(struct world *mzx_world)
         case IKEY_RETURN: // Enter
         {
           int key, status;
+          int enter_menu_status =
+           get_counter(mzx_world, "ENTER_MENU", 0);
 
           // Ignore if this isn't a fresh press
           if(key_status != 1)
+            break;
+          if (conf->standalone_mode && !enter_menu_status)
             break;
 
           save_screen();
@@ -2886,8 +2974,19 @@ void title_screen(struct world *mzx_world)
 
         case IKEY_ESCAPE:
         {
-          if(key_status==1)
-            exit = 1;
+          // ESCAPE_MENU (2.85+)
+          int escape_menu_status =
+           get_counter(mzx_world, "ESCAPE_MENU", 0);
+          
+          // Escape menu only works on the title screen if the
+          // standalone_mode config option is set
+          if(!conf->standalone_mode || escape_menu_status)
+            if(key_status == 1)
+            {
+              confirm_exit = 1;
+              exit = 1;
+            }
+
           break;
         }
       }
@@ -2897,13 +2996,21 @@ void title_screen(struct world *mzx_world)
     // Quit
     if(exit)
     {
-      m_show();
+      // Special behaviour in standalone- only escape exits
+      // ask for confirmation
+      if (confirm_exit || !conf->standalone_mode)
+      {
+        confirm_exit = 0;
+        m_show();
 
-      exit = !confirm(mzx_world, "Exit MegaZeux - Are you sure?");
+        exit = !confirm(mzx_world, "Exit MegaZeux - Are you sure?");
 
-      update_screen();
-      update_event_status();
+        update_screen();
+        update_event_status();
+      }
     }
+
+    if (mzx_world->full_exit) break;
 
   } while(!exit);
 

--- a/src/window.c
+++ b/src/window.c
@@ -674,6 +674,7 @@ int run_dialog(struct world *mzx_world, struct dialog *di)
   signed char vid_usage[2000];
   int current_key, new_key;
   int i;
+  struct config_info *conf = &mzx_world->conf;
 
   if(context == 72)
     set_context(98);
@@ -896,7 +897,11 @@ int run_dialog(struct world *mzx_world, struct dialog *di)
 #ifdef CONFIG_HELPSYS
       case IKEY_F1: // F1
       {
-        help_system(mzx_world);
+        if (conf->standalone_mode &&
+         get_counter(mzx_world, "HELP_MENU", 0))
+        {
+          help_system(mzx_world);
+        }
         break;
       }
 #endif

--- a/src/world_struct.h
+++ b/src/world_struct.h
@@ -40,6 +40,7 @@ __M_BEGIN_DECLS
 #define CHANGE_STATE_SWAP_WORLD 1
 #define CHANGE_STATE_LOAD_GAME_ROBOTIC 2
 #define CHANGE_STATE_EXIT_GAME_ROBOTIC 3
+#define CHANGE_STATE_PLAY_GAME_ROBOTIC 4
 
 struct world
 {
@@ -206,6 +207,8 @@ struct world
   // An array for game2.cpp
   char *update_done;
   int update_done_size;
+  // Are we exiting all the way out of MZX?
+  bool full_exit;
 };
 
 __M_END_DECLS


### PR DESCRIPTION
The config parameters standalone_mode and no_titlescreen can now be used
(from MZXRun only) to create standalone versions of MZX with the ability
to fully customise the player's experience. See config.txt for details.