### PR TITLE
Added per-user configuration file support

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -22,7 +22,7 @@ usage() {
 	echo "  unix           Unix-like / Linux / Solaris / BSD / Embedded"
 	echo "  unix-devel     As above, but for running from current dir"
 	echo "  darwin         Macintosh OS X (not Classic)"
-	echo "  psp            Expegzrimental PSP port"
+	echo "  psp            Experimental PSP port"
 	echo "  gp2x           Experimental GP2X port"
 	echo "  nds            Experimental NDS port"
 	echo "  wii            Experimental Wii port"

--- a/config.sh
+++ b/config.sh
@@ -22,7 +22,7 @@ usage() {
 	echo "  unix           Unix-like / Linux / Solaris / BSD / Embedded"
 	echo "  unix-devel     As above, but for running from current dir"
 	echo "  darwin         Macintosh OS X (not Classic)"
-	echo "  psp            Experimental PSP port"
+	echo "  psp            Expegzrimental PSP port"
 	echo "  gp2x           Experimental GP2X port"
 	echo "  nds            Experimental NDS port"
 	echo "  wii            Experimental Wii port"
@@ -407,8 +407,9 @@ echo "#define CONFDIR \"$SYSCONFDIR/\"" >> src/config.h
 # FIXME: SHAREDIR should be hardcoded in fewer cases
 #
 if [ "$PLATFORM" = "unix" ]; then
-	echo "#define CONFFILE \"megazeux-config\""    >> src/config.h
-	echo "#define SHAREDIR \"$SHAREDIR/megazeux/\"" >> src/config.h
+	echo "#define CONFFILE \"megazeux-config\""        >> src/config.h
+	echo "#define SHAREDIR \"$SHAREDIR/megazeux/\""    >> src/config.h
+	echo "#define USERCONFFILE \"~/.megazeux-config\"" >> src/config.h
 elif [ "$PLATFORM" = "nds" ]; then
 	SHAREDIR=/games/megazeux
 	GAMESDIR=$SHAREDIR
@@ -425,8 +426,9 @@ elif [ "$PLATFORM" = "darwin" ]; then
 	SHAREDIR=../Resources
 	GAMESDIR=$SHAREDIR
 	BINDIR=$SHAREDIR
-	echo "#define CONFFILE \"config.txt\"" >> src/config.h
-	echo "#define SHAREDIR \"$SHAREDIR\""  >> src/config.h
+	echo "#define CONFFILE \"config.txt\""             >> src/config.h
+	echo "#define SHAREDIR \"$SHAREDIR\""              >> src/config.h
+	echo "#define USERCONFFILE \"~/.megazeux-config\"" >> src/config.h
 elif [ "$PLATFORM" = "android" ]; then
 	SHAREDIR=/data/megazeux
 	GAMESDIR=/data/megazeux

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -51,6 +51,10 @@ FEATURES
   create standalone versions of MZX with the ability to fully
   customise the player's experience. See config.txt for details.
   (Lancer-X)
++ On Linux and Mac OS X the configuration file will be copied
+  into the user's home directory and given the name
+  .megazeux-config if it is not already present. This config
+  file will then be used instead of the global one. (Lancer-X)
 
 + Debytecode: the LOAD_SOURCE_FILE special counter can now be
   used to load and compile a robot program from source code.


### PR DESCRIPTION
We may want to implement this in a better fashion, especially for
standalone releases. On Windows there is no problem, but on other
operating systems if each standalone game writes over the same
configuration file we will have some problems, particularly if their
include their own settings. The best approach may be to put this setting
in the global config file- read it first, then decide whether or not to
create a per-user config file.