### PR TITLE
Made opengl2 and glsl endian-correct

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -262,6 +262,7 @@ BUGFIXES
   slashes in their names would fail to be recognized as the same
   mod.
 + Fixed a bug where SMZX palette intensities were not saved.
++ Made the opengl2 and glsl renderers endian-correct. (Lancer-X)
 + Fixed a bug where keystrokes were getting lost during event
   processing. (Lancer-X)
 + The UI now uses the regular MZX mode and the protected palette

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -2077,7 +2077,11 @@ void dump_screen(void)
     palette_size = make_palette(palette);
     for (i = 0; i < palette_size; i++)
     {
+      #if PLATFORM_BYTE_ORDER == PLATFORM_BIG_ENDIAN
+      graphics.flat_intensity_palette[i] = (palette[i].r << 8) | (palette[i].g << 16) | (palette[i].b << 24);
+      #else
       graphics.flat_intensity_palette[i] = (palette[i].r << 16) | (palette[i].g << 8) | (palette[i].b << 0);
+      #endif /* PLATFORM_BYTE_ORDER == PLATFORM_BIG_ENDIAN */
     }
     
     for (layer = 0; layer < graphics.layer_count; layer++)

--- a/src/render_gl2.c
+++ b/src/render_gl2.c
@@ -350,13 +350,8 @@ static void gl2_update_colors(struct graphics_data *graphics,
   Uint32 i;
   for(i = 0; i < count; i++)
   {
-#if PLATFORM_BYTE_ORDER == PLATFORM_BIG_ENDIAN
-    graphics->flat_intensity_palette[i] = (palette[i].r << 24) |
-     (palette[i].g << 16) | (palette[i].b << 8) | (0xFF);
-#else
     graphics->flat_intensity_palette[i] = (0xFF << 24) | (palette[i].b << 16) |
      (palette[i].g << 8) | palette[i].r;
-#endif
     render_data->palette[i*3  ] = (GLubyte)palette[i].r;
     render_data->palette[i*3+1] = (GLubyte)palette[i].g;
     render_data->palette[i*3+2] = (GLubyte)palette[i].b;

--- a/src/render_glsl.c
+++ b/src/render_glsl.c
@@ -625,13 +625,8 @@ static void glsl_update_colors(struct graphics_data *graphics,
   Uint32 i;
   for(i = 0; i < count; i++)
   {
-#if PLATFORM_BYTE_ORDER == PLATFORM_BIG_ENDIAN
-    graphics->flat_intensity_palette[i] = (palette[i].r << 24) |
-     (palette[i].g << 16) | (palette[i].b << 8) | (0xFF);
-#else
     graphics->flat_intensity_palette[i] = (0xFF << 24) | (palette[i].b << 16) |
      (palette[i].g << 8) | palette[i].r;
-#endif
     render_data->palette[i*3  ] = (GLubyte)palette[i].r;
     render_data->palette[i*3+1] = (GLubyte)palette[i].g;
     render_data->palette[i*3+2] = (GLubyte)palette[i].b;


### PR DESCRIPTION
Ironically, this mainly involved removing existing endian checks.

The screenshot fix was not included in the changelog as the regression is also new to 2.90.