### PR TITLE
Fixed unbound smzx msgbox and setview

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -35,6 +35,8 @@ BUGFIXES
   the robot editor. (Lancer-X)
 + Fixed a bug where key presses in dialogs could be detected in
   games, and keypresses could still carry between other dialogs.
++ [ message boxes now use the same screen mode as everything
+  else. Same with scrolls. (Lancer-X)
 
 DEVELOPERS
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -37,6 +37,9 @@ BUGFIXES
   games, and keypresses could still carry between other dialogs.
 + [ message boxes now use the same screen mode as everything
   else. Same with scrolls. (Lancer-X)
++ spr#_setview now works with unbound sprites. It's pretty nasty
+  as the viewport can't scroll with pixel precision, but the new
+  behavior should still be better than the old. (Lancer-X)
 
 DEVELOPERS
 

--- a/src/counter.c
+++ b/src/counter.c
@@ -1020,12 +1020,19 @@ static void spr_setview_write(struct world *mzx_world,
   src_board->scroll_x = 0;
   src_board->scroll_y = 0;
   calculate_xytop(mzx_world, &n_scroll_x, &n_scroll_y);
-  src_board->scroll_x =
-   (cur_sprite->x + (cur_sprite->width >> 1)) -
-   (src_board->viewport_width >> 1) - n_scroll_x;
-  src_board->scroll_y =
-   (cur_sprite->y + (cur_sprite->height >> 1)) -
-   (src_board->viewport_height >> 1) - n_scroll_y;
+  if (cur_sprite->flags & SPRITE_UNBOUND) {
+    src_board->scroll_x = ((cur_sprite->x + cur_sprite->width * 4
+     - src_board->viewport_width * 4) - n_scroll_x * 8) / 8;
+    src_board->scroll_y = ((cur_sprite->y + cur_sprite->height * 7
+     - src_board->viewport_height * 7) - n_scroll_x * 14) / 14;
+  } else {
+    src_board->scroll_x =
+    (cur_sprite->x + (cur_sprite->width >> 1)) -
+    (src_board->viewport_width >> 1) - n_scroll_x;
+    src_board->scroll_y =
+    (cur_sprite->y + (cur_sprite->height >> 1)) -
+    (src_board->viewport_height >> 1) - n_scroll_y;
+  }
   return;
 }
 

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1124,7 +1124,20 @@ static void init_layers(void)
 
   select_layer(UI_LAYER);
 
+  graphics.video_layers[BOARD_LAYER].mode = graphics.screen_mode;
+  graphics.video_layers[OVERLAY_LAYER].mode = graphics.screen_mode;
+  graphics.video_layers[UI_LAYER].mode = 0;
+
   blank_layers();
+}
+
+void enable_gui_mode0(void)
+{
+  graphics.video_layers[UI_LAYER].mode = 0;
+}
+void disable_gui_mode0(void)
+{
+  graphics.video_layers[UI_LAYER].mode = graphics.screen_mode;
 }
 
 void select_layer(Uint32 layer)
@@ -1156,9 +1169,7 @@ void blank_layers(void)
    sizeof(struct char_element) * SCREEN_W * SCREEN_H);
   memset(graphics.video_layers[UI_LAYER].data, 0xFF,
    sizeof(struct char_element) * SCREEN_W * SCREEN_H);
-  graphics.video_layers[BOARD_LAYER].mode = graphics.screen_mode;
-  graphics.video_layers[OVERLAY_LAYER].mode = graphics.screen_mode;
-  graphics.video_layers[UI_LAYER].mode = 0;
+
   for (i = 3; i < graphics.layer_count; i++)
   {
     if (graphics.video_layers[i].data)

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -245,6 +245,8 @@ CORE_LIBSPEC void insta_fadeout(void);
 CORE_LIBSPEC void dialog_fadein(void);
 CORE_LIBSPEC void dialog_fadeout(void);
 CORE_LIBSPEC void default_palette(void);
+CORE_LIBSPEC void disable_gui_mode0(void);
+CORE_LIBSPEC void enable_gui_mode0(void);
 
 CORE_LIBSPEC void m_hide(void);
 CORE_LIBSPEC void m_show(void);

--- a/src/robot.c
+++ b/src/robot.c
@@ -2719,6 +2719,7 @@ void robot_box_display(struct world *mzx_world, char *program,
 
   // Draw screen
   save_screen();
+  disable_gui_mode0();
   m_show();
 
   dialog_fadein();
@@ -2920,6 +2921,7 @@ void robot_box_display(struct world *mzx_world, char *program,
   // Restore screen and exit
   m_hide();
   restore_screen();
+  enable_gui_mode0();
   update_event_status();
 }
 

--- a/src/scrdisp.c
+++ b/src/scrdisp.c
@@ -118,7 +118,7 @@ void scroll_edit(struct world *mzx_world, struct scroll *scroll, int type)
 
   // Draw screen
   save_screen();
-
+  disable_gui_mode0();
   dialog_fadein();
 
   if(editing)
@@ -383,7 +383,7 @@ void scroll_edit(struct world *mzx_world, struct scroll *scroll, int type)
   } while(key != IKEY_ESCAPE);
   // Restore screen and exit
   restore_screen();
-
+  enable_gui_mode0();
   dialog_fadeout();
 }
 


### PR DESCRIPTION
+ [ message boxes now use the same screen mode as everything
  else. Same with scrolls. (Lancer-X)
+ spr#_setview now works with unbound sprites. It's pretty nasty
  as the viewport can't scroll with pixel precision, but the new
  behavior should still be better than the old. (Lancer-X)