### PR TITLE
Fixed smzx editor regression

### DIFF
--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1169,6 +1169,14 @@ void blank_layers(void)
    sizeof(struct char_element) * SCREEN_W * SCREEN_H);
   memset(graphics.video_layers[UI_LAYER].data, 0xFF,
    sizeof(struct char_element) * SCREEN_W * SCREEN_H);
+  
+  // Fix the layer modes
+  if (graphics.video_layers[BOARD_LAYER].mode != graphics.screen_mode)
+  {
+    graphics.video_layers[BOARD_LAYER].mode = graphics.screen_mode;
+    graphics.video_layers[OVERLAY_LAYER].mode = graphics.screen_mode;
+    graphics.video_layers[UI_LAYER].mode = 0;
+  }
 
   for (i = 3; i < graphics.layer_count; i++)
   {


### PR DESCRIPTION
Fixed regression added by 711709cc8e0b7271c594cf10f585750dfb572ace causing SMZX mode to not work in the editor (and possibly causing other problems with changes to SMZX modes).