### PR TITLE
Fixed GLSL on Intel HD cards

### DIFF
--- a/assets/shaders/tilemap.frag
+++ b/assets/shaders/tilemap.frag
@@ -2,44 +2,32 @@ uniform sampler2D baseMap;
 
 varying vec2 vTexcoord;
 
+float fract_(float v)
+{
+  return clamp(fract(v + 0.001) - 0.001, 0.000, 0.999);
+}
+
+float floor_(float v)
+{
+  return floor(v + 0.001);
+}
+
 void main( void )
 {
-    int x = int(vTexcoord.x * 256.0 * 8.0);
-    int y = int(vTexcoord.y * 14.0);
+    vec4 tileinfo = texture2D( baseMap, vec2(vTexcoord.x / 2.0, (vTexcoord.y+901.0)/1024.0));
 
-    int cx = x / 8;
-    int cy = y / 14;
-
-    vec4 tileinfo = texture2D( baseMap, vec2(float(cx) / 512.0, (float(cy) + 901.0)/1024.0));
-    int ti_byte1 = int(tileinfo.x * 255.0);
-    int ti_byte2 = int(tileinfo.y * 255.0);
-    int ti_byte3 = int(tileinfo.z * 255.0);
-    int ti_byte4 = int(tileinfo.w * 255.0);
-
-    // 00000000 00000000 00000000 00000000
-    // CCCCCCCC CCCCCCBB BBBBBBBF FFFFFFFF
-
-    int fg_color = ti_byte1 + int(mod(float(ti_byte2), 2.0)) * 256;
-    int bg_color = ti_byte2 / 2 + int(mod(float(ti_byte3), 4.0)) * 128;
-    int char_num = ti_byte3 / 4 + ti_byte4 * 64;
-    if (fg_color == 272 || bg_color == 272) {
-      gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
-      return;
-    }
-    
-    int px = int(mod(float(x), 8.0));
-    int py = int(mod(float(y), 14.0));
-    int char_x = int(mod(float(char_num), 64.0)) * 8 + px;
-    int char_y = char_num / 64 * 14 + py;
-    
-    bool pixset = texture2D(baseMap, vec2(1.0 / 512.0 * float(char_x), 1.0 / 1024.0 * float(char_y))).x > 0.5;
-    
-    if(pixset)
+    if(
+      texture2D(baseMap, vec2(
+        fract_((floor_(tileinfo.z * 63.75) + tileinfo.w * 255.0 * 64.0) / 64.0) + fract_(vTexcoord.x * 256.0) / 64.0
+        ,
+        floor_((floor_(tileinfo.z * 63.75) + tileinfo.w * 255.0 * 64.0) / 64.0) * 14.0 / 1024.0 + fract_(vTexcoord.y) * 14.0 / 1024.0
+       )
+      ).x > 0.5)
     {
-      gl_FragColor = texture2D( baseMap, vec2(1.0 / 512.0 * float(fg_color), 896.0/1024.0));
+      gl_FragColor = texture2D( baseMap, vec2(tileinfo.x * 0.5 + fract_(tileinfo.y * 127.501), 896.0/1024.0));
     }
     else
     {
-      gl_FragColor = texture2D( baseMap, vec2(1.0 / 512.0 * float(bg_color), 896.0/1024.0));
+      gl_FragColor = texture2D( baseMap, vec2(floor_(tileinfo.y * 127.5) / 512.0 + fract_(tileinfo.z * 63.751), 896.0/1024.0));
     }
 }

--- a/assets/shaders/tilemap.smzx.frag
+++ b/assets/shaders/tilemap.smzx.frag
@@ -2,41 +2,51 @@ uniform sampler2D baseMap;
 
 varying vec2 vTexcoord;
 
+float mod_(float v, float r)
+{
+  return clamp(mod(v + 0.01, r) - 0.01, 0.0, r);
+}
+
+int int_(float v)
+{
+  return int(v + 0.01);
+}
+
 void main( void )
 {
-    int x = int(vTexcoord.x * 256.0 * 8.0);
-    int y = int(vTexcoord.y * 14.0);
+    int x = int_(vTexcoord.x * 256.0 * 8.0);
+    int y = int_(vTexcoord.y * 14.0);
 
     int cx = x / 8;
     int cy = y / 14;
 
     vec4 tileinfo = texture2D( baseMap, vec2(float(cx) / 512.0, (float(cy) + 901.0)/1024.0));
-    int ti_byte1 = int(tileinfo.x * 255.0);
-    int ti_byte2 = int(tileinfo.y * 255.0);
-    int ti_byte3 = int(tileinfo.z * 255.0);
-    int ti_byte4 = int(tileinfo.w * 255.0);
+    int ti_byte1 = int_(tileinfo.x * 255.0);
+    int ti_byte2 = int_(tileinfo.y * 255.0);
+    int ti_byte3 = int_(tileinfo.z * 255.0);
+    int ti_byte4 = int_(tileinfo.w * 255.0);
 
     // 00000000 00000000 00000000 00000000
     // CCCCCCCC CCCCCCBB BBBBBBBF FFFFFFFF
 
-    int fg_color = ti_byte1 + int(mod(float(ti_byte2), 2.0)) * 256;
-    int bg_color = ti_byte2 / 2 + int(mod(float(ti_byte3), 4.0)) * 128;
+    int fg_color = ti_byte1 + int_(mod_(float(ti_byte2), 2.0)) * 256;
+    int bg_color = ti_byte2 / 2 + int_(mod_(float(ti_byte3), 4.0)) * 128;
     int char_num = ti_byte3 / 4 + ti_byte4 * 64;
     if (fg_color == 272 || bg_color == 272) {
       gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
       return;
     }
-    //char_num = mod(char_num, 256);
+    //char_num = mod_(char_num, 256);
     
-    int px = int(mod(float(x), 8.0));
-    int py = int(mod(float(y), 14.0));
+    int px = int_(mod_(float(x), 8.0));
+    int py = int_(mod_(float(y), 14.0));
     /*
     if (px == 0 && py == 13)
       gl_FragColor = texture2D( baseMap, vec2(1.0 / 512.0 * fg_color, 896.0/1024.0));
     else
       gl_FragColor = texture2D( baseMap, vec2(1.0 / 512.0 * bg_color, 896.0/1024.0));
     */
-    int char_x = int(mod(float(char_num), 64.0)) * 8 + (px / 2 * 2);
+    int char_x = int_(mod_(float(char_num), 64.0)) * 8 + (px / 2 * 2);
     int char_y = char_num / 64 * 14 + py;
     
     int smzx_col;
@@ -54,7 +64,7 @@ void main( void )
       }
     }
 
-    int mzx_col = int(mod(float(bg_color), 16.0)) * 16 + int(mod(float(fg_color), 16.0));
-    int real_col = int(texture2D( baseMap, vec2(1.0 / 512.0 * float(mzx_col), (897.0 + float(smzx_col))/1024.0)).r * 255.0);
+    int mzx_col = int_(mod_(float(bg_color), 16.0)) * 16 + int_(mod_(float(fg_color), 16.0));
+    int real_col = int_(texture2D( baseMap, vec2(1.0 / 512.0 * float(mzx_col), (897.0 + float(smzx_col))/1024.0)).r * 255.0);
     gl_FragColor = texture2D( baseMap, vec2(1.0 / 512.0 * float(real_col), 896.0/1024.0));
 }

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -42,6 +42,9 @@ BUGFIXES
 + spr#_setview now works with unbound sprites. It's pretty nasty
   as the viewport can't scroll with pixel precision, but the new
   behavior should still be better than the old. (Lancer-X)
++ fixed a bug affecting certain Intel HD Graphics cards and the
+  GLSL renderer that appears to have been around since that
+  renderer was first introduced. (Lancer-X)
 
 DEVELOPERS
 


### PR DESCRIPTION
Intel HD cards have some peculiar inaccuracies when it comes to GLSL, and this causes problems with MZX's GLSL renderer.