### PR TITLE
Updated msys2 build scripts

### DIFF
--- a/scripts/msys2-buildscripts/mingw-build.sh
+++ b/scripts/msys2-buildscripts/mingw-build.sh
@@ -8,8 +8,8 @@
 MSYSTEM=$6
 . /etc/profile
 cd /mzx-build-workingdir/megazeux
-git checkout $5
-git pull origin $5
+git fetch
+git checkout origin/$5
 
 ./config.sh --platform $2 $3 --enable-release
 make clean

--- a/scripts/msys2-buildscripts/mingw-release-single.sh
+++ b/scripts/msys2-buildscripts/mingw-release-single.sh
@@ -1,0 +1,3 @@
+rm -f /mzx-build-workingdir/zips/$1-$2.zip
+zip -r /mzx-build-workingdir/zips/$1-$2.zip *
+/mzx-build-scripts/builddir-to-updatedir.sh

--- a/scripts/msys2-buildscripts/mingw-release.sh
+++ b/scripts/msys2-buildscripts/mingw-release.sh
@@ -25,14 +25,13 @@ do
   for A in $archs
   do
     pushd $A
-    rm -f /mzx-build-workingdir/zips/$T-$A.zip
-    zip -r /mzx-build-workingdir/zips/$T-$A.zip *
-    /mzx-build-scripts/builddir-to-updatedir.sh
+    /mingw-release-single.sh $T $A &
     popd
   done
   popd
   echo "Current-$1: $T" >> updates-uncompressed.txt
   shift
 done
+wait
 /mzx-build-scripts/releasedir-to-tar.sh
 popd


### PR DESCRIPTION
The build script now checks out the remote branch and builds that rather
than relying on local branches which can cause problems. The release
script is now multithreaded and should run much faster.