### PR TITLE
Assorted bugfixes from port work

### DIFF
--- a/src/audio_sdl.c
+++ b/src/audio_sdl.c
@@ -18,11 +18,15 @@
  */
 
 #include "audio.h"
+#include "util.h"
 #include "SDL.h"
 
 #include <stdlib.h>
 
 static SDL_AudioSpec audio_settings;
+#if SDL_VERSION_ATLEAST(2,0,0)
+static SDL_AudioDeviceID audio_device;
+#endif
 
 static void sdl_audio_callback(void *userdata, Uint8 *stream, int len)
 {
@@ -46,16 +50,28 @@ void init_audio_platform(struct config_info *conf)
 
   desired_spec.freq = audio.output_frequency;
 
+#if SDL_VERSION_ATLEAST(2,0,0)
+  audio_device = SDL_OpenAudioDevice(NULL, 0, &desired_spec, &audio_settings, 0);
+#else
   SDL_OpenAudio(&desired_spec, &audio_settings);
+#endif
   audio.mix_buffer = cmalloc(audio_settings.size * 2);
   audio.buffer_samples = audio_settings.samples;
 
   // now set the audio going
+#if SDL_VERSION_ATLEAST(2,0,0)
+  SDL_PauseAudioDevice(audio_device, 0);
+#else
   SDL_PauseAudio(0);
+#endif
 }
 
 void quit_audio_platform(void)
 {
+#if SDL_VERSION_ATLEAST(2,0,0)
+  SDL_PauseAudioDevice(audio_device, 1);
+#else
   SDL_PauseAudio(1);
+#endif
   free(audio.mix_buffer);
 }

--- a/src/audio_xmp.c
+++ b/src/audio_xmp.c
@@ -100,14 +100,7 @@ static void audio_xmp_set_frequency(struct sampled_stream *s_src, Uint32 frequen
 {
   if(frequency == 0)
   {
-    ((struct xmp_stream *)s_src)->effective_frequency = 44100;
     frequency = audio.output_frequency;
-  }
-  else
-  {
-    ((struct xmp_stream *)s_src)->effective_frequency = frequency;
-    frequency = (Uint32)((float)frequency *
-     audio.output_frequency / 44100);
   }
 
   s_src->frequency = frequency;

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -738,7 +738,7 @@ void update_screen(void)
     graphics.cursor_timestamp = ticks;
   }
 
-  if (graphics.requires_extended && graphics.renderer.render_layer) {
+  if ((graphics.requires_extended || !graphics.renderer.render_graph) && graphics.renderer.render_layer) {
     for (layer = 0; layer < graphics.layer_count; layer++)
     {
       graphics.sorted_video_layers[layer] = &graphics.video_layers[layer];

--- a/src/platform_dummy.c
+++ b/src/platform_dummy.c
@@ -68,7 +68,7 @@ void initialize_joysticks(void)
   // stub
 }
 
-Uint32 __update_event_status(void)
+bool __update_event_status(void)
 {
   // stub
   return 0;

--- a/src/util.h
+++ b/src/util.h
@@ -106,6 +106,10 @@ CORE_LIBSPEC int create_path_if_not_exists(const char *filename);
 
 CORE_LIBSPEC int change_dir_name(char *path_name, const char *dest);
 
+CORE_LIBSPEC void join_path_names(char* target, int max_len, const char* path1, const char* path2);
+
+CORE_LIBSPEC void clean_path_slashes(const char *source, char *dest, size_t buf_size);
+
 typedef void (*fn_ptr)(void);
 
 struct dso_syms_map

--- a/src/window.c
+++ b/src/window.c
@@ -2720,9 +2720,7 @@ skip_dir:
           change_dir_name(current_dir_name, ret_path);
 
         if(ret_file[0])
-          snprintf(ret, MAX_PATH, "%s%s%s",
-           current_dir_name, DIR_SEPARATOR, ret_file);
-
+          join_path_names(ret, MAX_PATH, current_dir_name, ret_file);
       }
     }
 
@@ -2758,8 +2756,7 @@ skip_dir:
         // the complete name
         if(di.current_element == FILESEL_FILE_LIST &&
          strcmp(ret_file, file_list[chosen_file] + 56))
-          snprintf(ret, MAX_PATH, "%s%s%s",
-           current_dir_name, DIR_SEPARATOR, file_list[chosen_file] + 56);
+          join_path_names(ret, MAX_PATH, current_dir_name, file_list[chosen_file] + 56);
 
         if(default_ext)
           add_ext(ret, default_ext);
@@ -2823,8 +2820,7 @@ skip_dir:
         if(!confirm_input(mzx_world, "Create New Directory",
          "New directory name:", new_name))
         {
-          snprintf(full_name, MAX_PATH, "%s%s%s",
-            current_dir_name, DIR_SEPARATOR, new_name);
+          join_path_names(full_name, MAX_PATH, current_dir_name, new_name);
 
           if(stat(full_name, &file_info) < 0)
           {
@@ -2873,10 +2869,8 @@ skip_dir:
 
         if(!confirm_input(mzx_world, "Rename File", "New file name:", new_name))
         {
-          snprintf(old_path, MAX_PATH, "%s%s%s", current_dir_name,
-           DIR_SEPARATOR, file_list[chosen_file] + 56);
-          snprintf(new_path, MAX_PATH, "%s%s%s", current_dir_name,
-           DIR_SEPARATOR, new_name);
+          join_path_names(old_path, MAX_PATH, current_dir_name, file_list[chosen_file] + 56);
+          join_path_names(new_path, MAX_PATH, current_dir_name, new_name);
 
           if(strcmp(old_path, new_path))
             if(rename(old_path, new_path))
@@ -2904,8 +2898,7 @@ skip_dir:
           if(!confirm(mzx_world, confirm_string))
           {
             char file_name_ch[MAX_PATH];
-            snprintf(file_name_ch, MAX_PATH, "%s%s%s",
-             current_dir_name, DIR_SEPARATOR, dir_list[chosen_dir]);
+            join_path_names(file_name_ch, MAX_PATH, current_dir_name, dir_list[chosen_dir]);
 
             if(!ask_yes_no(mzx_world,
              (char *)"Delete subdirectories recursively?"))
@@ -2937,10 +2930,8 @@ skip_dir:
 
           if(!confirm_input(mzx_world, "Rename Directory", "New directory name:", new_name))
           {
-            snprintf(old_path, MAX_PATH, "%s%s%s", current_dir_name,
-             DIR_SEPARATOR, dir_list[chosen_dir]);
-            snprintf(new_path, MAX_PATH, "%s%s%s", current_dir_name,
-             DIR_SEPARATOR, new_name);
+            join_path_names(old_path, MAX_PATH, current_dir_name, dir_list[chosen_dir]);
+            join_path_names(new_path, MAX_PATH, current_dir_name, new_name);
 
             if(strcmp(old_path, new_path))
               if(rename(old_path, new_path))

--- a/src/world.c
+++ b/src/world.c
@@ -2862,8 +2862,7 @@ bool reload_world(struct world *mzx_world, const char *file, int *faded)
     getcwd(current_dir, MAX_PATH);
 
     split_path_filename(curr_sav, NULL, 0, save_name, MAX_PATH);
-    snprintf(curr_sav, MAX_PATH, "%s%s%s",
-     current_dir, DIR_SEPARATOR, save_name);
+    join_path_names(curr_sav, MAX_PATH, current_dir, save_name);
   }
 
   return true;
@@ -2923,8 +2922,7 @@ bool reload_swap(struct world *mzx_world, const char *file, int *faded)
   // Give curr_file a full path
   getcwd(full_path, MAX_PATH);
   split_path_filename(file, NULL, 0, file_name, MAX_PATH);
-  snprintf(curr_file, MAX_PATH, "%s%s%s",
-   full_path, DIR_SEPARATOR, file_name);
+  join_path_names(curr_file, MAX_PATH, full_path, file_name);
 
   return true;
 }


### PR DESCRIPTION
- make audio_sdl.c use SDL 2.0's OpenAudioDevice. This enables SDL2's transparent audio conversion in case a given SDL_AudioSpec is not supported.
- fix audio_xmp.c's frequency logic further
- allow new renderers to only implement render_layer and not render_graph
- mark platform_dummy.c's __update_event_status as bool for consistency
- implement join_path_names to join two paths together without duplicated separators