### PR TITLE
Editor undo

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -65,6 +65,7 @@ usage() {
 	echo "  --enable-egl          Enables EGL backend (if SDL disabled)."
 	echo "  --disable-check-alloc Disables memory allocator error handling."
 	echo "  --disable-uthash      Disables hash counter/string lookups."
+  echo "  --disable-undo        Disables undo/redo operations in the editor."
 	echo "  --enable-debytecode   Enable experimental 'debytecode' transform."
 	echo "  --disable-libsdl2     Disable SDL 2.0 support (falls back on 1.2)."
 	echo "  --enable-fps          Enable frames-per-second counter."
@@ -119,6 +120,7 @@ SDL="true"
 EGL="false"
 CHECK_ALLOC="true"
 UTHASH="true"
+UNDO="true"
 DEBYTECODE="false"
 LIBSDL2="true"
 FPSCOUNTER="false"
@@ -261,6 +263,9 @@ while [ "$1" != "" ]; do
 
 	[ "$1" = "--enable-uthash" ]  && UTHASH="true"
 	[ "$1" = "--disable-uthash" ] && UTHASH="false"
+
+	[ "$1" = "--enable-undo" ]  && UNDO="true"
+	[ "$1" = "--disable-undo" ] && UNDO="false"
 
 	[ "$1" = "--enable-debytecode" ]  && DEBYTECODE="true"
 	[ "$1" = "--disable-debytecode" ] && DEBYTECODE="false"
@@ -1013,6 +1018,18 @@ if [ "$UTHASH" = "true" ]; then
 	echo "#define CONFIG_UTHASH" >> src/config.h
 else
 	echo "uthash counter/string lookup disabled (using binary search)."
+fi
+
+#
+# Allow use of undo/redo in the editor
+#
+if [ "$EDITOR" = "true" ]; then
+	if [ "$UNDO" = "true" ]; then
+		echo "undo/redo enabled."
+		echo "#define CONFIG_UNDO" >> src/config.h
+	else
+		echo "undo/redo disabled."
+	fi
 fi
 
 #

--- a/config.sh
+++ b/config.sh
@@ -65,7 +65,6 @@ usage() {
 	echo "  --enable-egl          Enables EGL backend (if SDL disabled)."
 	echo "  --disable-check-alloc Disables memory allocator error handling."
 	echo "  --disable-uthash      Disables hash counter/string lookups."
-	echo "  --disable-undo        Disables undo/redo operations in the editor."
 	echo "  --enable-debytecode   Enable experimental 'debytecode' transform."
 	echo "  --disable-libsdl2     Disable SDL 2.0 support (falls back on 1.2)."
 	echo "  --enable-fps          Enable frames-per-second counter."
@@ -120,7 +119,6 @@ SDL="true"
 EGL="false"
 CHECK_ALLOC="true"
 UTHASH="true"
-UNDO="true"
 DEBYTECODE="false"
 LIBSDL2="true"
 FPSCOUNTER="false"
@@ -263,9 +261,6 @@ while [ "$1" != "" ]; do
 
 	[ "$1" = "--enable-uthash" ]  && UTHASH="true"
 	[ "$1" = "--disable-uthash" ] && UTHASH="false"
-
-	[ "$1" = "--enable-undo" ]  && UNDO="true"
-	[ "$1" = "--disable-undo" ] && UNDO="false"
 
 	[ "$1" = "--enable-debytecode" ]  && DEBYTECODE="true"
 	[ "$1" = "--disable-debytecode" ] && DEBYTECODE="false"
@@ -1018,18 +1013,6 @@ if [ "$UTHASH" = "true" ]; then
 	echo "#define CONFIG_UTHASH" >> src/config.h
 else
 	echo "uthash counter/string lookup disabled (using binary search)."
-fi
-
-#
-# Allow use of undo/redo in the editor
-#
-if [ "$EDITOR" = "true" ]; then
-	if [ "$UNDO" = "true" ]; then
-		echo "undo/redo enabled."
-		echo "#define CONFIG_UNDO" >> src/config.h
-	else
-		echo "undo/redo disabled."
-	fi
 fi
 
 #

--- a/config.sh
+++ b/config.sh
@@ -65,7 +65,7 @@ usage() {
 	echo "  --enable-egl          Enables EGL backend (if SDL disabled)."
 	echo "  --disable-check-alloc Disables memory allocator error handling."
 	echo "  --disable-uthash      Disables hash counter/string lookups."
-  echo "  --disable-undo        Disables undo/redo operations in the editor."
+	echo "  --disable-undo        Disables undo/redo operations in the editor."
 	echo "  --enable-debytecode   Enable experimental 'debytecode' transform."
 	echo "  --disable-libsdl2     Disable SDL 2.0 support (falls back on 1.2)."
 	echo "  --enable-fps          Enable frames-per-second counter."

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,6 +1,15 @@
 MZX GIT
 
 FIXME: size_pos_vlayer() needs a real help file context (edit_di.c, 747).
+FIXME: board undo notes:
+  * Board/overlay/vlayer histories reset on world load, clear
+    world (Alt+R), testing (Alt+T), and exiting the editor.
+  * Board/overlay histories reset on board change, clear board
+    (Alt+Z), board resize (Alt+P), and import board (Alt+I).
+  * Vlayer history resets on clear vlayer (Alt+Z) and resize
+    vlayer (Alt+P).
+  * Changes in world/board settings, status counters, etc. are
+    not included in the history.
 
 FEATURES
 
@@ -15,6 +24,9 @@ FEATURES
   invisible global overlay that can be used to store and
   retrieve graphical data through Robotic. See the editor help
   and the Robotic reference manual for more details.
++ Added undo/redo functionality to the world editor. Use Ctrl+Z
+  to undo changes to the board/overlay/vlayer and Ctrl+Y to
+  redo.
 + The default size of the char editor undo history has been
   extended to 100 levels. The undo/redo shortcuts are now Ctrl+Z
   for undo and Ctrl+Y for redo.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,13 @@ FEATURES
   renamed.
 + Saved positions now have confirmation dialogs. Saved positions
   are saved to/loaded from the editor.cnf file for each world.
++ Pressing Enter/Return on the overlay (and vlayer) now acts the
+  same as on the board, changing both the buffer and the current
+  layer being edited.
++ Pressing P on the overlay (and vlayer) now acts the same as on
+  the board, changing the character in the buffer but NOT on the
+  current layer. This is equivalent to the original overlay
+  behavior for Enter.
 + Block tiling movement (Ctrl+Arrows) now works with most block
   actions, and does not require an initial block placement to
   activate.

--- a/src/editor/block.h
+++ b/src/editor/block.h
@@ -49,6 +49,11 @@ void mirror_board_block(struct board *dest_board, int dest_offset,
 void paint_layer_block(char *dest_color, int dest_width, int dest_offset,
  int block_width, int block_height, int paint_color);
 
+void copy_layer_buffer_to_buffer(
+ char *src_char, char *src_color, int src_width, int src_offset,
+ char *dest_char, char *dest_color, int dest_width, int dest_offset,
+ int block_width, int block_height);
+
 void move_layer_block(
  char *src_char, char *src_color, int src_width, int src_offset,
  char *dest_char, char *dest_color, int dest_width, int dest_offset,

--- a/src/editor/board.c
+++ b/src/editor/board.c
@@ -294,6 +294,27 @@ struct board *create_blank_board(struct editor_config_info *conf)
   return cur_board;
 }
 
+struct board *create_buffer_board(int width, int height)
+{
+  // Create a dummy board to be used as a buffer for undo block actions
+  struct board *src_board = ccalloc(1, sizeof(struct board *));
+  int layer_size = width * height;
+
+  src_board->board_width = width;
+  src_board->board_height = height;
+
+  src_board->robot_list = ccalloc(1, sizeof(struct robot *));
+  src_board->scroll_list = ccalloc(1, sizeof(struct scroll *));
+  src_board->sensor_list = ccalloc(1, sizeof(struct sensor *));
+
+  src_board->level_id = cmalloc(layer_size);
+  src_board->level_color = cmalloc(layer_size);
+  src_board->level_param = cmalloc(layer_size);
+  src_board->level_under_id = cmalloc(layer_size);
+  src_board->level_under_color = cmalloc(layer_size);
+  src_board->level_under_param = cmalloc(layer_size);
+}
+
 void change_board_size(struct board *src_board, int new_width, int new_height)
 {
   int board_width = src_board->board_width;

--- a/src/editor/board.c
+++ b/src/editor/board.c
@@ -313,6 +313,8 @@ struct board *create_buffer_board(int width, int height)
   src_board->level_under_id = cmalloc(layer_size);
   src_board->level_under_color = cmalloc(layer_size);
   src_board->level_under_param = cmalloc(layer_size);
+
+  return src_board;
 }
 
 void change_board_size(struct board *src_board, int new_width, int new_height)

--- a/src/editor/board.c
+++ b/src/editor/board.c
@@ -297,7 +297,7 @@ struct board *create_blank_board(struct editor_config_info *conf)
 struct board *create_buffer_board(int width, int height)
 {
   // Create a dummy board to be used as a buffer for undo block actions
-  struct board *src_board = ccalloc(1, sizeof(struct board *));
+  struct board *src_board = ccalloc(1, sizeof(struct board));
   int layer_size = width * height;
 
   src_board->board_width = width;
@@ -307,12 +307,12 @@ struct board *create_buffer_board(int width, int height)
   src_board->scroll_list = ccalloc(1, sizeof(struct scroll *));
   src_board->sensor_list = ccalloc(1, sizeof(struct sensor *));
 
-  src_board->level_id = cmalloc(layer_size);
-  src_board->level_color = cmalloc(layer_size);
-  src_board->level_param = cmalloc(layer_size);
-  src_board->level_under_id = cmalloc(layer_size);
-  src_board->level_under_color = cmalloc(layer_size);
-  src_board->level_under_param = cmalloc(layer_size);
+  src_board->level_id = ccalloc(1, layer_size);
+  src_board->level_color = ccalloc(1, layer_size);
+  src_board->level_param = ccalloc(1, layer_size);
+  src_board->level_under_id = ccalloc(1, layer_size);
+  src_board->level_under_color = ccalloc(1, layer_size);
+  src_board->level_under_param = ccalloc(1, layer_size);
 
   return src_board;
 }

--- a/src/editor/board.h
+++ b/src/editor/board.h
@@ -31,6 +31,7 @@ __M_BEGIN_DECLS
 
 void replace_current_board(struct world *mzx_world, char *name);
 struct board *create_blank_board(struct editor_config_info *conf);
+struct board *create_buffer_board(int width, int height);
 void save_board_file(struct world *mzx_world, struct board *cur_board, char *name);
 void change_board_size(struct board *src_board, int new_width, int new_height);
 

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -3984,8 +3984,21 @@ static void __edit_world(struct world *mzx_world, int reload_curr_file)
       {
         if(get_alt_status(keycode_internal))
         {
+          // Test world
           int fade;
           int current_board_id = mzx_world->current_board_id;
+
+          // Clear undo histories and prepare to reset them
+          // We don't want the undo buffer wasting memory while testing
+          destruct_undo_history(board_history);
+          destruct_undo_history(overlay_history);
+          destruct_undo_history(vlayer_history);
+          board_history = NULL;
+          overlay_history = NULL;
+          vlayer_history = NULL;
+          clear_board_history = 1;
+          clear_overlay_history = 1;
+          clear_vlayer_history = 1;
 
           if(!save_world(mzx_world, "__test.mzx", 0, WORLD_VERSION))
           {
@@ -4061,10 +4074,6 @@ static void __edit_world(struct world *mzx_world, int reload_curr_file)
             // Do this in case a different world was loaded/created
             fix_scroll(&cursor_board_x, &cursor_board_y, &scroll_x, &scroll_y,
              &debug_x, board_width, board_height, edit_screen_height);
-
-            clear_board_history = 1;
-            clear_overlay_history = 1;
-            clear_vlayer_history = 1;
 
             insta_fadein();
 

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -1944,14 +1944,6 @@ static void __edit_world(struct world *mzx_world, int reload_curr_file)
         break;
       }
 
-      case IKEY_INSERT:
-      {
-        grab_at_xy(mzx_world, &current_id, &current_color, &current_param,
-         &copy_robot, &copy_scroll, &copy_sensor, cursor_board_x,
-         cursor_board_y, overlay_edit);
-        break;
-      }
-
       case IKEY_TAB:
       {
         if(!get_alt_status(keycode_internal))
@@ -1970,6 +1962,14 @@ static void __edit_world(struct world *mzx_world, int reload_curr_file)
           }
         }
 
+        break;
+      }
+
+      case IKEY_INSERT:
+      {
+        grab_at_xy(mzx_world, &current_id, &current_color, &current_param,
+         &copy_robot, &copy_scroll, &copy_sensor, cursor_board_x,
+         cursor_board_y, overlay_edit);
         break;
       }
 
@@ -1997,6 +1997,107 @@ static void __edit_world(struct world *mzx_world, int reload_curr_file)
           }
         }
         modified = 1;
+        break;
+      }
+
+      case IKEY_HOME:
+      {
+        cursor_board_x = 0;
+        cursor_board_y = 0;
+        scroll_x = 0;
+        scroll_y = 0;
+
+        if((cursor_board_x - scroll_x) < (debug_x + 25))
+        {
+          debug_x = 60;
+          clear_screen_no_update();
+        }
+
+        break;
+      }
+
+      case IKEY_END:
+      {
+        cursor_board_x = board_width - 1;
+        cursor_board_y = board_height - 1;
+        scroll_x = board_width - 80;
+        scroll_y = board_height - edit_screen_height;
+
+        if(scroll_x < 0)
+          scroll_x = 0;
+
+        if(scroll_y < 0)
+          scroll_y = 0;
+
+        if((cursor_board_x - scroll_x) > (debug_x - 5))
+        {
+          debug_x = 0;
+          clear_screen_no_update();
+        }
+
+        break;
+      }
+
+      case IKEY_PAGEDOWN:
+      {
+        current_menu++;
+
+        if(current_menu == 6)
+          current_menu = 0;
+
+        break;
+      }
+
+      case IKEY_PAGEUP:
+      {
+        current_menu--;
+
+        if(current_menu == -1)
+          current_menu = 5;
+
+        break;
+      }
+
+      case IKEY_ESCAPE:
+      {
+        if(draw_mode)
+        {
+          draw_mode = 0;
+          key = 0;
+        }
+        else
+
+        if(overlay_edit)
+        {
+          if(overlay_edit == EDIT_VLAYER)
+          {
+            // Disable vlayer mode and fix the display
+            set_vlayer_mode(EDIT_BOARD, &overlay_edit,
+             &cursor_board_x, &cursor_board_y, &scroll_x, &scroll_y,
+             &cursor_vlayer_x, &cursor_vlayer_y, &vscroll_x, &vscroll_y);
+
+            synchronize_board_values(mzx_world, &src_board, &board_width,
+             &board_height, &level_id, &level_param, &level_color,
+             &overlay, &overlay_color, &vlayer_chars, &vlayer_colors,
+             overlay_edit);
+
+            fix_scroll(&cursor_board_x, &cursor_board_y, &scroll_x,
+             &scroll_y, &debug_x, board_width, board_height,
+             edit_screen_height);
+          }
+
+          overlay_edit = EDIT_BOARD;
+          current_id = SPACE;
+          current_param = 0;
+          current_color = 7;
+          key = 0;
+        }
+
+        else
+        {
+          exit = 1;
+        }
+
         break;
       }
 
@@ -2197,192 +2298,26 @@ static void __edit_world(struct world *mzx_world, int reload_curr_file)
         break;
       }
 
-      case IKEY_c:
+      case IKEY_8:
+      case IKEY_KP_MULTIPLY:
       {
-        if(draw_mode != 2)
-        {
-          cursor_off();
-          if(get_alt_status(keycode_internal))
-          {
-            char_editor(mzx_world);
-            modified = 1;
-          }
-          else
-          {
-            int new_color = color_selection(current_color, 0);
-            if(new_color >= 0)
-              current_color = new_color;
-          }
-        }
-        else
+        if(draw_mode == 2)
         {
           text_place = 1;
         }
-        break;
-      }
-
-      case IKEY_o:
-      {
-        if(draw_mode != 2)
-        {
-          if(get_alt_status(keycode_internal))
-          {
-            if(overlay_edit != EDIT_OVERLAY)
-            {
-              if(!src_board->overlay_mode)
-              {
-                error("Overlay mode is not on (see Board Info)",
-                 0, 8, 0x1103);
-              }
-              else
-              {
-                if(overlay_edit == EDIT_VLAYER)
-                {
-                  // Disable vlayer mode and fix the display
-                  set_vlayer_mode(EDIT_OVERLAY, &overlay_edit,
-                   &cursor_board_x, &cursor_board_y, &scroll_x, &scroll_y,
-                   &cursor_vlayer_x, &cursor_vlayer_y, &vscroll_x, &vscroll_y);
-
-                  synchronize_board_values(mzx_world, &src_board, &board_width,
-                   &board_height, &level_id, &level_param, &level_color,
-                   &overlay, &overlay_color, &vlayer_chars, &vlayer_colors,
-                   overlay_edit);
-
-                  fix_scroll(&cursor_board_x, &cursor_board_y, &scroll_x,
-                   &scroll_y, &debug_x, board_width, board_height,
-                   edit_screen_height);
-                }
-
-                draw_mode = 0;
-                overlay_edit = EDIT_OVERLAY;
-                current_param = 32;
-                current_color = 7;
-              }
-            }
-            else
-            {
-              draw_mode = 0;
-              overlay_edit = EDIT_BOARD;
-              current_id = SPACE;
-              current_param = 0;
-              current_color = 7;
-            }
-          }
-        }
         else
+
+        if(get_shift_status(keycode_internal) ||
+         (key == IKEY_KP_MULTIPLY))
         {
-          text_place = 1;
-        }
-        break;
-      }
+          src_board->mod_playing[0] = '*';
+          src_board->mod_playing[1] = 0;
+          fix_mod(mzx_world, src_board, listening_flag);
+          draw_mod_timer = DRAW_MOD_TIMER_MAX;
 
-      case IKEY_s:
-      {
-        if(draw_mode != 2)
-        {
-          if(get_alt_status(keycode_internal))
-          {
-            if(overlay_edit == EDIT_OVERLAY)
-            {
-              show_level ^= 1;
-            }
-            else
-            {
-              status_counter_info(mzx_world);
-              modified = 1;
-            }
-          }
-          else
-          {
-            char world_name[MAX_PATH];
-            char new_path[MAX_PATH];
-            strcpy(world_name, current_world);
-            if(!new_file(mzx_world, world_ext, ".mzx", world_name,
-             "Save world", 1))
-            {
-              debug("Save path: %s\n", world_name);
-              // Save entire game
-              strcpy(current_world, world_name);
-              strcpy(curr_file, current_world);
-              save_world(mzx_world, current_world, 0, WORLD_VERSION);
-
-              // It's now officially WORLD_VERSION
-              mzx_world->version = WORLD_VERSION;
-
-              get_path(world_name, new_path, MAX_PATH);
-              if(new_path[0])
-                chdir(new_path);
-
-              modified = 0;
-            }
-          }
-        }
-        else
-        {
-          text_place = 1;
+          modified = 1;
         }
 
-        break;
-      }
-
-      case IKEY_HOME:
-      {
-        cursor_board_x = 0;
-        cursor_board_y = 0;
-        scroll_x = 0;
-        scroll_y = 0;
-
-        if((cursor_board_x - scroll_x) < (debug_x + 25))
-        {
-          debug_x = 60;
-          clear_screen_no_update();
-        }
-
-        break;
-      }
-
-      case IKEY_END:
-      {
-        cursor_board_x = board_width - 1;
-        cursor_board_y = board_height - 1;
-        scroll_x = board_width - 80;
-        scroll_y = board_height - edit_screen_height;
-
-        if(scroll_x < 0)
-          scroll_x = 0;
-
-        if(scroll_y < 0)
-          scroll_y = 0;
-
-        if((cursor_board_x - scroll_x) > (debug_x - 5))
-        {
-          debug_x = 0;
-          clear_screen_no_update();
-        }
-
-        break;
-      }
-
-      case IKEY_b:
-      {
-        if(draw_mode != 2)
-        {
-          if(get_alt_status(keycode_internal))
-          {
-            block_x = cursor_board_x;
-            block_y = cursor_board_y;
-            draw_mode = 3;
-          }
-          else
-            new_board =
-             choose_board(mzx_world, mzx_world->current_board_id,
-             "Select current board:", 0);
-
-        }
-        else
-        {
-          text_place = 1;
-        }
         break;
       }
 
@@ -2416,537 +2351,6 @@ static void __edit_world(struct world *mzx_world, int reload_curr_file)
         else
           text_place = 1;
 
-        break;
-      }
-
-      case IKEY_l:
-      {
-        if(get_alt_status(keycode_internal))
-        {
-          char test_wav[MAX_PATH] = { 0, };
-          const char *const sam_ext[] = { ".WAV", ".SAM", ".OGG", NULL };
-
-          if(!choose_file(mzx_world, sam_ext, test_wav,
-           "Choose a wav file", 1))
-          {
-            play_sample(0, test_wav, false);
-          }
-        }
-        else
-
-        if(draw_mode != 2)
-        {
-          if(!modified || !confirm(mzx_world,
-           "Load: World has not been saved, are you sure?"))
-          {
-            char last_world[MAX_PATH];
-            char load_world[MAX_PATH];
-            strcpy(last_world, current_world);
-            strcpy(load_world, current_world);
-
-            if(!choose_file_ch(mzx_world, world_ext, load_world,
-             "Load World", 1))
-            {
-              int fade;
-
-              //end_module();
-
-              // Load world curr_file
-              strcpy(current_world, load_world);
-              if(!editor_reload_world(mzx_world, current_world, &fade))
-              {
-                strcpy(current_world, last_world);
-
-                fix_mod(mzx_world, src_board, listening_flag);
-                break;
-                //create_blank_world(mzx_world);
-              }
-              strcpy(curr_file, current_world);
-
-              mzx_world->current_board_id = mzx_world->first_board;
-              mzx_world->current_board =
-               mzx_world->board_list[mzx_world->current_board_id];
-              src_board = mzx_world->current_board;
-
-              if(draw_mode > 3)
-                draw_mode = 0;
-
-              insta_fadein();
-
-              // Exit vlayer mode if necessary.
-              set_vlayer_mode(EDIT_BOARD, &overlay_edit,
-               &cursor_board_x, &cursor_board_y, &scroll_x, &scroll_y,
-               &cursor_vlayer_x, &cursor_vlayer_y, &vscroll_x, &vscroll_y);
-
-              synchronize_board_values(mzx_world, &src_board, &board_width,
-               &board_height, &level_id, &level_param, &level_color,
-               &overlay, &overlay_color, &vlayer_chars, &vlayer_colors,
-               overlay_edit);
-
-              fix_scroll(&cursor_board_x, &cursor_board_y, &scroll_x,
-               &scroll_y, &debug_x, board_width, board_height,
-               edit_screen_height);
-
-              fix_mod(mzx_world, src_board, listening_flag);
-
-              if(!src_board->overlay_mode && overlay_edit == EDIT_OVERLAY)
-                overlay_edit = EDIT_BOARD;
-
-              modified = 0;
-            }
-          }
-        }
-        else
-        {
-          text_place = 1;
-        }
-        break;
-      }
-
-      case IKEY_i:
-      {
-        if(get_alt_status(keycode_internal))
-        {
-          int import_number = import_type(mzx_world);
-          if(import_number >= 0)
-          {
-            char import_name[MAX_PATH];
-            import_name[0] = 0;
-
-            switch(import_number)
-            {
-              case 0:
-              {
-                if(!choose_file(mzx_world, mzb_ext, import_name,
-                 "Choose board to import", 1))
-                {
-                  replace_current_board(mzx_world, import_name);
-
-                  // Exit vlayer mode if necessary.
-                  set_vlayer_mode(EDIT_BOARD, &overlay_edit,
-                   &cursor_board_x, &cursor_board_y, &scroll_x, &scroll_y,
-                   &cursor_vlayer_x, &cursor_vlayer_y, &vscroll_x, &vscroll_y);
-
-                  synchronize_board_values(mzx_world, &src_board, &board_width,
-                   &board_height, &level_id, &level_param, &level_color,
-                   &overlay, &overlay_color, &vlayer_chars, &vlayer_colors,
-                   overlay_edit);
-
-                  fix_scroll(&cursor_board_x, &cursor_board_y, &scroll_x,
-                   &scroll_y, &debug_x, board_width, board_height,
-                   edit_screen_height);
-
-                  // fixme load_mod_check
-                  if(strcmp(src_board->mod_playing, "*") &&
-                   strcasecmp(src_board->mod_playing,
-                   mzx_world->real_mod_playing))
-                    fix_mod(mzx_world, src_board, listening_flag);
-
-                  if((draw_mode > 3) &&
-                   (block_board == (mzx_world->current_board)))
-                    draw_mode = 0;
-
-                  modified = 1;
-                }
-                break;
-              }
-
-              case 1:
-              {
-                // Character set
-                int char_offset = 0;
-                struct element *elements[] =
-                {
-                  construct_number_box(21, 20, "Offset:  ",
-                   0, 255, 0, &char_offset),
-                };
-
-                if(!file_manager(mzx_world, chr_ext, NULL, import_name,
-                 "Choose character set to import", 1, 0,
-                 elements, 1, 2))
-                {
-                  ec_load_set_var(import_name, char_offset, 0);
-                }
-                modified = 1;
-                break;
-              }
-
-              case 2:
-              {
-                // World file
-                if(!choose_file(mzx_world, world_ext, import_name,
-                 "Choose world to import", 1))
-                {
-                  // FIXME: Check retval?
-                  append_world(mzx_world, import_name);
-                }
-
-                if(draw_mode > 3)
-                  draw_mode = 0;
-
-                modified = 1;
-                break;
-              }
-
-              case 3:
-              {
-                // Palette
-                // Character set
-                const char *pal_ext[] = { ".PAL", NULL };
-                if(!choose_file(mzx_world, pal_ext, import_name,
-                 "Choose palette to import", 1))
-                {
-                  load_palette(import_name);
-                  update_palette();
-                  modified = 1;
-                }
-                break;
-              }
-
-              case 4:
-              {
-                // Sound effects
-                const char *sfx_ext[] = { ".SFX", NULL };
-                if(!choose_file(mzx_world, sfx_ext, import_name,
-                 "Choose SFX file to import", 1))
-                {
-                  FILE *sfx_file;
-
-                  sfx_file = fopen_unsafe(import_name, "rb");
-                  fread(mzx_world->custom_sfx, SFX_SIZE, NUM_SFX, sfx_file);
-                  mzx_world->custom_sfx_on = 1;
-                  fclose(sfx_file);
-                  modified = 1;
-                }
-                break;
-              }
-
-              case 5:
-              {
-                // MZM file
-                const char *mzm_ext[] = { ".MZM", NULL };
-                if(!choose_file(mzx_world, mzm_ext,
-                 mzm_name_buffer, "Choose image file to import", 1))
-                {
-                  draw_mode = 5;
-                  block_command = 10;
-                }
-
-                break;
-              }
-            }
-          }
-        }
-        else
-
-        if(draw_mode != 2)
-        {
-          if(overlay_edit != EDIT_VLAYER)
-          {
-            board_info(mzx_world);
-            // If this is the first board, patch the title into the world name
-            if(mzx_world->current_board_id == 0)
-              strcpy(mzx_world->name, src_board->board_name);
-
-            // Mostly doing this to update the caption
-            synchronize_board_values(mzx_world, &src_board, &board_width,
-             &board_height, &level_id, &level_param, &level_color,
-             &overlay, &overlay_color, &vlayer_chars, &vlayer_colors,
-             overlay_edit);
-
-            if(!src_board->overlay_mode && overlay_edit == EDIT_OVERLAY)
-              overlay_edit = EDIT_BOARD;
-
-            modified = 1;
-          }
-        }
-        else
-        {
-          text_place = 1;
-        }
-        break;
-      }
-
-      case IKEY_g:
-      {
-        if(draw_mode != 2)
-        {
-          if(get_ctrl_status(keycode_internal))
-          {
-            // Goto board position
-            if(!board_goto(mzx_world, overlay_edit,
-             &cursor_board_x, &cursor_board_y))
-            {
-              // This will get fixed if necessary.
-              scroll_x = cursor_board_x - 39;
-              scroll_y = cursor_board_y - edit_screen_height / 2;
-
-              fix_scroll(&cursor_board_x, &cursor_board_y, &scroll_x, &scroll_y,
-               &debug_x, board_width, board_height, edit_screen_height);
-            }
-          }
-          else
-
-          if(get_alt_status(keycode_internal))
-          {
-            global_robot(mzx_world);
-          }
-
-          else
-          {
-            global_info(mzx_world);
-          }
-
-          fix_caption(mzx_world, modified);
-          modified = 1;
-        }
-        else
-        {
-          text_place = 1;
-        }
-        break;
-      }
-
-      case IKEY_p:
-      {
-        if(draw_mode != 2)
-        {
-          if(get_alt_status(keycode_internal))
-          {
-            if(overlay_edit == EDIT_VLAYER)
-            {
-              size_pos_vlayer(mzx_world);
-            }
-            else
-            {
-              size_pos(mzx_world);
-              set_update_done_current(mzx_world);
-            }
-
-            synchronize_board_values(mzx_world, &src_board, &board_width,
-             &board_height, &level_id, &level_param, &level_color,
-             &overlay, &overlay_color, &vlayer_chars, &vlayer_colors,
-             overlay_edit);
-
-            fix_scroll(&cursor_board_x, &cursor_board_y, &scroll_x, &scroll_y,
-             &debug_x, board_width, board_height, edit_screen_height);
-
-            if(draw_mode > 3)
-              draw_mode = 0;
-
-            // Uh oh, we might need a new player
-            if((mzx_world->player_x >= board_width) ||
-             (mzx_world->player_y >= board_height))
-              replace_player(mzx_world);
-
-            modified = 1;
-          }
-          else
-
-          if(!overlay_edit)
-          {
-            if(current_id < SENSOR)
-            {
-              int new_param = change_param(mzx_world, current_id,
-               current_param, NULL, NULL, NULL);
-
-              if(new_param >= 0)
-                current_param = new_param;
-
-              modified = 1;
-            }
-          }
-        }
-        else
-        {
-          text_place = 1;
-        }
-        break;
-      }
-
-      case IKEY_x:
-      {
-        if(get_alt_status(keycode_internal))
-        {
-          int export_number = export_type(mzx_world);
-          if(export_number >= 0)
-          {
-            char export_name[MAX_PATH];
-            export_name[0] = 0;
-
-            switch(export_number)
-            {
-              case 0:
-              {
-                // Board file
-                if(!new_file(mzx_world, mzb_ext, ".mzb", export_name,
-                 "Export board file", 1))
-                {
-                  save_board_file(mzx_world, src_board, export_name);
-                }
-                break;
-              }
-
-              case 1:
-              {
-                // Character set
-                int char_offset = 0;
-                int char_size = 256;
-                struct element *elements[] =
-                {
-                  construct_number_box(9, 20, "Offset:  ",
-                   0, 255, 0, &char_offset),
-                  construct_number_box(35, 20, "Size: ",
-                   1, 256, 0, &char_size)
-                };
-
-                if(!file_manager(mzx_world, chr_ext, NULL, export_name,
-                 "Export character set", 1, 1, elements, 2, 2))
-                {
-                  add_ext(export_name, ".chr");
-                  ec_save_set_var(export_name, char_offset,
-                   char_size);
-                }
-
-                break;
-              }
-
-              case 2:
-              {
-                // Palette
-                if(!new_file(mzx_world, pal_ext, ".pal", export_name,
-                 "Export palette", 1))
-                {
-                  save_palette(export_name);
-                }
-
-                break;
-              }
-
-              case 3:
-              {
-                // Sound effects
-                if(!new_file(mzx_world, sfx_ext, ".sfx", export_name,
-                 "Export SFX file", 1))
-                {
-                  FILE *sfx_file;
-
-                  sfx_file = fopen_unsafe(export_name, "wb");
-
-                  if(sfx_file)
-                  {
-                    if(mzx_world->custom_sfx_on)
-                      fwrite(mzx_world->custom_sfx, SFX_SIZE, NUM_SFX, sfx_file);
-                    else
-                      fwrite(sfx_strs, SFX_SIZE, NUM_SFX, sfx_file);
-
-                    fclose(sfx_file);
-                  }
-                }
-                break;
-              }
-
-              case 4:
-              {
-                // Downver. world
-                char title[80];
-
-                sprintf(title, "Export world to previous version (%d.%d)",
-                 (WORLD_VERSION_PREV >> 8) & 0xFF, WORLD_VERSION_PREV & 0xFF);
-
-                if(!new_file(mzx_world, world_ext, ".mzx", export_name,
-                 title, 1))
-                {
-                  save_world(mzx_world, export_name, 0, WORLD_VERSION_PREV);
-                }
-              }
-            }
-          }
-        }
-        else
-
-        if(draw_mode != 2)
-        {
-          // Doesn't make sense on the vlayer
-          if(overlay_edit != EDIT_VLAYER)
-          {
-            board_exits(mzx_world);
-            modified = 1;
-          }
-        }
-        else
-        {
-          text_place = 1;
-        }
-        break;
-      }
-
-      case IKEY_n:
-      {
-        if(draw_mode != 2)
-        {
-          // Board mod
-          // Doesn't make sense on the vlayer
-          if(get_alt_status(keycode_internal) && overlay_edit != EDIT_VLAYER)
-          {
-            if(!src_board->mod_playing[0])
-            {
-              char new_mod[MAX_PATH] = { 0 };
-
-              if(!choose_file(mzx_world, mod_ext, new_mod,
-               "Choose a module file", 2)) // 2:subdirsonly
-              {
-                strcpy(src_board->mod_playing, new_mod);
-                strcpy(mzx_world->real_mod_playing, new_mod);
-                fix_mod(mzx_world, src_board, listening_flag);
-                draw_mod_timer = DRAW_MOD_TIMER_MAX;
-              }
-            }
-            else
-            {
-              src_board->mod_playing[0] = 0;
-              mzx_world->real_mod_playing[0] = 0;
-              fix_mod(mzx_world, src_board, listening_flag);
-              draw_mod_timer = DRAW_MOD_TIMER_MAX;
-            }
-            modified = 1;
-          }
-          else
-
-          if(get_ctrl_status(keycode_internal))
-          {
-            if(!listening_flag)
-            {
-              char current_dir[MAX_PATH];
-              char new_mod[MAX_PATH] = { 0 } ;
-
-              getcwd(current_dir, MAX_PATH);
-              chdir(current_listening_dir);
-
-              if(!choose_file(mzx_world, mod_gdm_ext, new_mod,
-               "Choose a module file (listening only)", 1))
-              {
-                load_module(new_mod, false, 255);
-                strcpy(current_listening_mod, new_mod);
-                get_path(new_mod, current_listening_dir, MAX_PATH);
-                listening_flag = 1;
-              }
-
-              chdir(current_dir);
-            }
-            else
-            {
-              end_module();
-              listening_flag = 0;
-              if(mzx_world->real_mod_playing[0])
-                load_module(mzx_world->real_mod_playing, true, 255);
-            }
-          }
-        }
-        else
-        {
-          text_place = 1;
-        }
         break;
       }
 
@@ -3650,6 +3054,160 @@ static void __edit_world(struct world *mzx_world, int reload_curr_file)
         break;
       }
 
+      case IKEY_a:
+      {
+        if(get_alt_status(keycode_internal))
+        {
+          int charset_load = choose_char_set(mzx_world);
+
+          switch(charset_load)
+          {
+            case 0:
+            {
+              ec_load_mzx();
+              break;
+            }
+
+            case 1:
+            {
+              ec_load_ascii();
+              break;
+            }
+
+            case 2:
+            {
+              ec_load_smzx();
+              break;
+            }
+
+            case 3:
+            {
+              ec_load_blank();
+              break;
+            }
+          }
+
+          modified = 1;
+        }
+        else
+
+        if(draw_mode != 2)
+        {
+          // Add board, find first free
+          for(i = 0; i < mzx_world->num_boards; i++)
+          {
+            if(mzx_world->board_list[i] == NULL)
+              break;
+          }
+
+          if(i < MAX_BOARDS)
+          {
+            if(add_board(mzx_world, i) >= 0)
+              new_board = i;
+          }
+        }
+        else
+        {
+          text_place = 1;
+        }
+        break;
+      }
+
+      case IKEY_b:
+      {
+        if(draw_mode != 2)
+        {
+          if(get_alt_status(keycode_internal))
+          {
+            block_x = cursor_board_x;
+            block_y = cursor_board_y;
+            draw_mode = 3;
+          }
+          else
+            new_board =
+             choose_board(mzx_world, mzx_world->current_board_id,
+             "Select current board:", 0);
+
+        }
+        else
+        {
+          text_place = 1;
+        }
+        break;
+      }
+
+      case IKEY_c:
+      {
+        if(draw_mode != 2)
+        {
+          cursor_off();
+          if(get_alt_status(keycode_internal))
+          {
+            char_editor(mzx_world);
+            modified = 1;
+          }
+          else
+          {
+            int new_color = color_selection(current_color, 0);
+            if(new_color >= 0)
+              current_color = new_color;
+          }
+        }
+        else
+        {
+          text_place = 1;
+        }
+        break;
+      }
+
+      case IKEY_d:
+      {
+        if(draw_mode != 2)
+        {
+          if(get_alt_status(keycode_internal))
+          {
+            // Toggle default built-in colors
+            use_default_color ^= 1;
+          }
+          else
+          {
+            int del_board =
+             choose_board(mzx_world, mzx_world->current_board_id,
+             "Delete board:", 0);
+
+            if((del_board > 0) &&
+             !confirm(mzx_world, "DELETE BOARD - Are you sure?"))
+            {
+              int current_board_id = mzx_world->current_board_id;
+              clear_board(mzx_world->board_list[del_board]);
+              mzx_world->board_list[del_board] = NULL;
+
+              // Remove null board from list
+              optimize_null_boards(mzx_world);
+
+              if(del_board == current_board_id)
+              {
+                new_board = 0;
+              }
+              else
+              {
+                synchronize_board_values(mzx_world, &src_board, &board_width,
+                 &board_height, &level_id, &level_param, &level_color,
+                 &overlay, &overlay_color, &vlayer_chars, &vlayer_colors,
+                 overlay_edit);
+              }
+            }
+          }
+
+          modified = 1;
+        }
+        else
+        {
+          text_place = 1;
+        }
+        break;
+      }
+
       case IKEY_e:
       {
         if(draw_mode != 2)
@@ -3693,149 +3251,692 @@ static void __edit_world(struct world *mzx_world, int reload_curr_file)
         break;
       }
 
-      case IKEY_ESCAPE:
+      case IKEY_g:
       {
-        if(draw_mode)
+        if(draw_mode != 2)
         {
-          draw_mode = 0;
-          key = 0;
-        }
-        else
-
-        if(overlay_edit)
-        {
-          if(overlay_edit == EDIT_VLAYER)
+          if(get_ctrl_status(keycode_internal))
           {
-            // Disable vlayer mode and fix the display
-            set_vlayer_mode(EDIT_BOARD, &overlay_edit,
-             &cursor_board_x, &cursor_board_y, &scroll_x, &scroll_y,
-             &cursor_vlayer_x, &cursor_vlayer_y, &vscroll_x, &vscroll_y);
+            // Goto board position
+            if(!board_goto(mzx_world, overlay_edit,
+             &cursor_board_x, &cursor_board_y))
+            {
+              // This will get fixed if necessary.
+              scroll_x = cursor_board_x - 39;
+              scroll_y = cursor_board_y - edit_screen_height / 2;
 
-            synchronize_board_values(mzx_world, &src_board, &board_width,
-             &board_height, &level_id, &level_param, &level_color,
-             &overlay, &overlay_color, &vlayer_chars, &vlayer_colors,
-             overlay_edit);
+              fix_scroll(&cursor_board_x, &cursor_board_y, &scroll_x, &scroll_y,
+               &debug_x, board_width, board_height, edit_screen_height);
+            }
+          }
+          else
 
-            fix_scroll(&cursor_board_x, &cursor_board_y, &scroll_x,
-             &scroll_y, &debug_x, board_width, board_height,
-             edit_screen_height);
+          if(get_alt_status(keycode_internal))
+          {
+            global_robot(mzx_world);
           }
 
-          overlay_edit = EDIT_BOARD;
-          current_id = SPACE;
-          current_param = 0;
-          current_color = 7;
-          key = 0;
-        }
+          else
+          {
+            global_info(mzx_world);
+          }
 
+          fix_caption(mzx_world, modified);
+          modified = 1;
+        }
         else
         {
-          exit = 1;
+          text_place = 1;
+        }
+        break;
+      }
+
+      case IKEY_h:
+      {
+        if(get_alt_status(keycode_internal))
+        {
+          if(edit_screen_height == EDIT_SCREEN_NORMAL)
+          {
+            edit_screen_height = EDIT_SCREEN_EXTENDED;
+            clear_screen_no_update();
+
+            if((scroll_y + 25) > board_height)
+              scroll_y = board_height - 25;
+
+            if(scroll_y < 0)
+              scroll_y = 0;
+          }
+          else
+          {
+            edit_screen_height = EDIT_SCREEN_NORMAL;
+            if((cursor_board_y - scroll_y) > 18)
+              scroll_y += cursor_board_y - scroll_y - 18;
+          }
+        }
+        else
+
+        if(draw_mode == 2)
+        {
+          text_place = 1;
         }
 
         break;
       }
 
-      case IKEY_v:
+      case IKEY_i:
       {
+        if(get_alt_status(keycode_internal))
+        {
+          int import_number = import_type(mzx_world);
+          if(import_number >= 0)
+          {
+            char import_name[MAX_PATH];
+            import_name[0] = 0;
+
+            switch(import_number)
+            {
+              case 0:
+              {
+                if(!choose_file(mzx_world, mzb_ext, import_name,
+                 "Choose board to import", 1))
+                {
+                  replace_current_board(mzx_world, import_name);
+
+                  // Exit vlayer mode if necessary.
+                  set_vlayer_mode(EDIT_BOARD, &overlay_edit,
+                   &cursor_board_x, &cursor_board_y, &scroll_x, &scroll_y,
+                   &cursor_vlayer_x, &cursor_vlayer_y, &vscroll_x, &vscroll_y);
+
+                  synchronize_board_values(mzx_world, &src_board, &board_width,
+                   &board_height, &level_id, &level_param, &level_color,
+                   &overlay, &overlay_color, &vlayer_chars, &vlayer_colors,
+                   overlay_edit);
+
+                  fix_scroll(&cursor_board_x, &cursor_board_y, &scroll_x,
+                   &scroll_y, &debug_x, board_width, board_height,
+                   edit_screen_height);
+
+                  // fixme load_mod_check
+                  if(strcmp(src_board->mod_playing, "*") &&
+                   strcasecmp(src_board->mod_playing,
+                   mzx_world->real_mod_playing))
+                    fix_mod(mzx_world, src_board, listening_flag);
+
+                  if((draw_mode > 3) &&
+                   (block_board == (mzx_world->current_board)))
+                    draw_mode = 0;
+
+                  modified = 1;
+                }
+                break;
+              }
+
+              case 1:
+              {
+                // Character set
+                int char_offset = 0;
+                struct element *elements[] =
+                {
+                  construct_number_box(21, 20, "Offset:  ",
+                   0, 255, 0, &char_offset),
+                };
+
+                if(!file_manager(mzx_world, chr_ext, NULL, import_name,
+                 "Choose character set to import", 1, 0,
+                 elements, 1, 2))
+                {
+                  ec_load_set_var(import_name, char_offset, 0);
+                }
+                modified = 1;
+                break;
+              }
+
+              case 2:
+              {
+                // World file
+                if(!choose_file(mzx_world, world_ext, import_name,
+                 "Choose world to import", 1))
+                {
+                  // FIXME: Check retval?
+                  append_world(mzx_world, import_name);
+                }
+
+                if(draw_mode > 3)
+                  draw_mode = 0;
+
+                modified = 1;
+                break;
+              }
+
+              case 3:
+              {
+                // Palette
+                // Character set
+                const char *pal_ext[] = { ".PAL", NULL };
+                if(!choose_file(mzx_world, pal_ext, import_name,
+                 "Choose palette to import", 1))
+                {
+                  load_palette(import_name);
+                  update_palette();
+                  modified = 1;
+                }
+                break;
+              }
+
+              case 4:
+              {
+                // Sound effects
+                const char *sfx_ext[] = { ".SFX", NULL };
+                if(!choose_file(mzx_world, sfx_ext, import_name,
+                 "Choose SFX file to import", 1))
+                {
+                  FILE *sfx_file;
+
+                  sfx_file = fopen_unsafe(import_name, "rb");
+                  fread(mzx_world->custom_sfx, SFX_SIZE, NUM_SFX, sfx_file);
+                  mzx_world->custom_sfx_on = 1;
+                  fclose(sfx_file);
+                  modified = 1;
+                }
+                break;
+              }
+
+              case 5:
+              {
+                // MZM file
+                const char *mzm_ext[] = { ".MZM", NULL };
+                if(!choose_file(mzx_world, mzm_ext,
+                 mzm_name_buffer, "Choose image file to import", 1))
+                {
+                  draw_mode = 5;
+                  block_command = 10;
+                }
+
+                break;
+              }
+            }
+          }
+        }
+        else
+
         if(draw_mode != 2)
         {
-          if(get_alt_status(keycode_internal))
+          if(overlay_edit != EDIT_VLAYER)
           {
-            // Toggle vlayer editing
-            int target_mode = EDIT_VLAYER;
+            board_info(mzx_world);
+            // If this is the first board, patch the title into the world name
+            if(mzx_world->current_board_id == 0)
+              strcpy(mzx_world->name, src_board->board_name);
 
-            if(overlay_edit == EDIT_VLAYER)
-            {
-              target_mode = EDIT_BOARD;
-            }
-
-            set_vlayer_mode(target_mode, &overlay_edit,
-             &cursor_board_x, &cursor_board_y, &scroll_x, &scroll_y,
-             &cursor_vlayer_x, &cursor_vlayer_y, &vscroll_x, &vscroll_y);
-
+            // Mostly doing this to update the caption
             synchronize_board_values(mzx_world, &src_board, &board_width,
              &board_height, &level_id, &level_param, &level_color,
              &overlay, &overlay_color, &vlayer_chars, &vlayer_colors,
              overlay_edit);
 
-            fix_scroll(&cursor_board_x, &cursor_board_y, &scroll_x,
-             &scroll_y, &debug_x, board_width, board_height,
-             edit_screen_height);
+            if(!src_board->overlay_mode && overlay_edit == EDIT_OVERLAY)
+              overlay_edit = EDIT_BOARD;
 
-            draw_mode = 0;
-            current_id = SPACE;
-            current_param = 32;
-            current_color = 7;
-            break;
-          }
-          else
-
-          if(overlay_edit != EDIT_VLAYER)
-          {
-            // View mode
-            int viewport_width = src_board->viewport_width;
-            int viewport_height = src_board->viewport_height;
-            int v_scroll_x = scroll_x;
-            int v_scroll_y = CLAMP(scroll_y, 0,
-             src_board->board_height - src_board->viewport_height);
-            int v_key;
-
-            cursor_off();
-            m_hide();
-
-            do
-            {
-              draw_viewport(mzx_world);
-              draw_game_window(src_board, v_scroll_x, v_scroll_y);
-              update_screen();
-
-              update_event_status_delay();
-              v_key = get_key(keycode_internal_wrt_numlock);
-
-              if(get_exit_status())
-                v_key = IKEY_ESCAPE;
-
-              switch(v_key)
-              {
-                case IKEY_LEFT:
-                {
-                  if(v_scroll_x)
-                    v_scroll_x--;
-                  break;
-                }
-
-                case IKEY_RIGHT:
-                {
-                  if(v_scroll_x < (board_width - viewport_width))
-                    v_scroll_x++;
-                  break;
-                }
-
-                case IKEY_UP:
-                {
-                  if(v_scroll_y)
-                    v_scroll_y--;
-                  break;
-                }
-
-                case IKEY_DOWN:
-                {
-                  if(v_scroll_y < (board_height - viewport_height))
-                    v_scroll_y++;
-                  break;
-                }
-              }
-            } while(v_key != IKEY_ESCAPE);
-
-            m_show();
-            clear_screen_no_update();
+            modified = 1;
           }
         }
         else
         {
           text_place = 1;
         }
+        break;
+      }
+
+      case IKEY_l:
+      {
+        if(get_alt_status(keycode_internal))
+        {
+          char test_wav[MAX_PATH] = { 0, };
+          const char *const sam_ext[] = { ".WAV", ".SAM", ".OGG", NULL };
+
+          if(!choose_file(mzx_world, sam_ext, test_wav,
+           "Choose a wav file", 1))
+          {
+            play_sample(0, test_wav, false);
+          }
+        }
+        else
+
+        if(draw_mode != 2)
+        {
+          if(!modified || !confirm(mzx_world,
+           "Load: World has not been saved, are you sure?"))
+          {
+            char last_world[MAX_PATH];
+            char load_world[MAX_PATH];
+            strcpy(last_world, current_world);
+            strcpy(load_world, current_world);
+
+            if(!choose_file_ch(mzx_world, world_ext, load_world,
+             "Load World", 1))
+            {
+              int fade;
+
+              //end_module();
+
+              // Load world curr_file
+              strcpy(current_world, load_world);
+              if(!editor_reload_world(mzx_world, current_world, &fade))
+              {
+                strcpy(current_world, last_world);
+
+                fix_mod(mzx_world, src_board, listening_flag);
+                break;
+                //create_blank_world(mzx_world);
+              }
+              strcpy(curr_file, current_world);
+
+              mzx_world->current_board_id = mzx_world->first_board;
+              mzx_world->current_board =
+               mzx_world->board_list[mzx_world->current_board_id];
+              src_board = mzx_world->current_board;
+
+              if(draw_mode > 3)
+                draw_mode = 0;
+
+              insta_fadein();
+
+              // Exit vlayer mode if necessary.
+              set_vlayer_mode(EDIT_BOARD, &overlay_edit,
+               &cursor_board_x, &cursor_board_y, &scroll_x, &scroll_y,
+               &cursor_vlayer_x, &cursor_vlayer_y, &vscroll_x, &vscroll_y);
+
+              synchronize_board_values(mzx_world, &src_board, &board_width,
+               &board_height, &level_id, &level_param, &level_color,
+               &overlay, &overlay_color, &vlayer_chars, &vlayer_colors,
+               overlay_edit);
+
+              fix_scroll(&cursor_board_x, &cursor_board_y, &scroll_x,
+               &scroll_y, &debug_x, board_width, board_height,
+               edit_screen_height);
+
+              fix_mod(mzx_world, src_board, listening_flag);
+
+              if(!src_board->overlay_mode && overlay_edit == EDIT_OVERLAY)
+                overlay_edit = EDIT_BOARD;
+
+              modified = 0;
+            }
+          }
+        }
+        else
+        {
+          text_place = 1;
+        }
+        break;
+      }
+
+      case IKEY_m:
+      {
+        if(draw_mode != 2)
+        {
+          // Modify
+          if(get_alt_status(keycode_internal))
+          {
+            int offset = cursor_board_x + (cursor_board_y * board_width);
+
+            if(overlay_edit == EDIT_BOARD)
+            {
+              enum thing d_id = (enum thing)level_id[offset];
+              int d_param = level_param[offset];
+              int new_param;
+
+              if(d_id == SENSOR)
+              {
+                edit_sensor(mzx_world, src_board->sensor_list[d_param]);
+                modified = 1;
+              }
+              else
+
+              if(is_robot(d_id))
+              {
+                draw_memory_timer = DRAW_MEMORY_TIMER_MAX;
+                edit_robot(mzx_world, src_board->robot_list[d_param]);
+                fix_caption(mzx_world, modified);
+                modified = 1;
+              }
+              else
+
+              if(is_signscroll(d_id))
+              {
+                edit_scroll(mzx_world, src_board->scroll_list[d_param]);
+                modified = 1;
+              }
+              else
+
+              if(is_storageless(d_id) &&
+               (0 <= (new_param = change_param(mzx_world, d_id, d_param, NULL, NULL, NULL))))
+              {
+                src_board->level_param[offset] = new_param;
+                modified = 1;
+              }
+            }
+            else
+
+            if(overlay_edit == EDIT_OVERLAY)
+            {
+              int o_ch = src_board->overlay[offset];
+              int new_ch;
+
+              if((new_ch = char_selection(o_ch)) >= 0)
+              {
+                src_board->overlay[offset] = new_ch;
+                modified = 1;
+              }
+            }
+
+            else // EDIT_VLAYER
+            {
+              int new_ch = char_selection(vlayer_chars[offset]);
+
+              if(new_ch >= 0)
+              {
+                vlayer_chars[offset] = new_ch;
+                modified = 1;
+              }
+            }
+          }
+          else
+
+          // Move current board
+          // Doesn't make sense on the vlayer
+          if(overlay_edit != EDIT_VLAYER)
+          {
+            int new_position;
+
+            if(mzx_world->current_board_id == 0)
+              break;
+
+            new_position =
+             choose_board(mzx_world, mzx_world->current_board_id,
+             "Move board to position:", 0);
+
+            if((new_position > 0) && (new_position < mzx_world->num_boards) &&
+             (new_position != mzx_world->current_board_id))
+            {
+              move_current_board(mzx_world, new_position);
+              new_board = new_position;
+              modified = 1;
+            }
+          }
+        }
+        else
+          text_place = 1;
+
+        break;
+      }
+
+      case IKEY_n:
+      {
+        if(draw_mode != 2)
+        {
+          // Board mod
+          // Doesn't make sense on the vlayer
+          if(get_alt_status(keycode_internal) && overlay_edit != EDIT_VLAYER)
+          {
+            if(!src_board->mod_playing[0])
+            {
+              char new_mod[MAX_PATH] = { 0 };
+
+              if(!choose_file(mzx_world, mod_ext, new_mod,
+               "Choose a module file", 2)) // 2:subdirsonly
+              {
+                strcpy(src_board->mod_playing, new_mod);
+                strcpy(mzx_world->real_mod_playing, new_mod);
+                fix_mod(mzx_world, src_board, listening_flag);
+                draw_mod_timer = DRAW_MOD_TIMER_MAX;
+              }
+            }
+            else
+            {
+              src_board->mod_playing[0] = 0;
+              mzx_world->real_mod_playing[0] = 0;
+              fix_mod(mzx_world, src_board, listening_flag);
+              draw_mod_timer = DRAW_MOD_TIMER_MAX;
+            }
+            modified = 1;
+          }
+          else
+
+          if(get_ctrl_status(keycode_internal))
+          {
+            if(!listening_flag)
+            {
+              char current_dir[MAX_PATH];
+              char new_mod[MAX_PATH] = { 0 } ;
+
+              getcwd(current_dir, MAX_PATH);
+              chdir(current_listening_dir);
+
+              if(!choose_file(mzx_world, mod_gdm_ext, new_mod,
+               "Choose a module file (listening only)", 1))
+              {
+                load_module(new_mod, false, 255);
+                strcpy(current_listening_mod, new_mod);
+                get_path(new_mod, current_listening_dir, MAX_PATH);
+                listening_flag = 1;
+              }
+
+              chdir(current_dir);
+            }
+            else
+            {
+              end_module();
+              listening_flag = 0;
+              if(mzx_world->real_mod_playing[0])
+                load_module(mzx_world->real_mod_playing, true, 255);
+            }
+          }
+        }
+        else
+        {
+          text_place = 1;
+        }
+        break;
+      }
+
+      case IKEY_o:
+      {
+        if(draw_mode != 2)
+        {
+          if(get_alt_status(keycode_internal))
+          {
+            if(overlay_edit != EDIT_OVERLAY)
+            {
+              if(!src_board->overlay_mode)
+              {
+                error("Overlay mode is not on (see Board Info)",
+                 0, 8, 0x1103);
+              }
+              else
+              {
+                if(overlay_edit == EDIT_VLAYER)
+                {
+                  // Disable vlayer mode and fix the display
+                  set_vlayer_mode(EDIT_OVERLAY, &overlay_edit,
+                   &cursor_board_x, &cursor_board_y, &scroll_x, &scroll_y,
+                   &cursor_vlayer_x, &cursor_vlayer_y, &vscroll_x, &vscroll_y);
+
+                  synchronize_board_values(mzx_world, &src_board, &board_width,
+                   &board_height, &level_id, &level_param, &level_color,
+                   &overlay, &overlay_color, &vlayer_chars, &vlayer_colors,
+                   overlay_edit);
+
+                  fix_scroll(&cursor_board_x, &cursor_board_y, &scroll_x,
+                   &scroll_y, &debug_x, board_width, board_height,
+                   edit_screen_height);
+                }
+
+                draw_mode = 0;
+                overlay_edit = EDIT_OVERLAY;
+                current_param = 32;
+                current_color = 7;
+              }
+            }
+            else
+            {
+              draw_mode = 0;
+              overlay_edit = EDIT_BOARD;
+              current_id = SPACE;
+              current_param = 0;
+              current_color = 7;
+            }
+          }
+        }
+        else
+        {
+          text_place = 1;
+        }
+        break;
+      }
+
+      case IKEY_p:
+      {
+        if(draw_mode != 2)
+        {
+          if(get_alt_status(keycode_internal))
+          {
+            if(overlay_edit == EDIT_VLAYER)
+            {
+              size_pos_vlayer(mzx_world);
+            }
+            else
+            {
+              size_pos(mzx_world);
+              set_update_done_current(mzx_world);
+            }
+
+            synchronize_board_values(mzx_world, &src_board, &board_width,
+             &board_height, &level_id, &level_param, &level_color,
+             &overlay, &overlay_color, &vlayer_chars, &vlayer_colors,
+             overlay_edit);
+
+            fix_scroll(&cursor_board_x, &cursor_board_y, &scroll_x, &scroll_y,
+             &debug_x, board_width, board_height, edit_screen_height);
+
+            if(draw_mode > 3)
+              draw_mode = 0;
+
+            // Uh oh, we might need a new player
+            if((mzx_world->player_x >= board_width) ||
+             (mzx_world->player_y >= board_height))
+              replace_player(mzx_world);
+
+            modified = 1;
+          }
+          else
+
+          if(!overlay_edit)
+          {
+            if(current_id < SENSOR)
+            {
+              int new_param = change_param(mzx_world, current_id,
+               current_param, NULL, NULL, NULL);
+
+              if(new_param >= 0)
+                current_param = new_param;
+
+              modified = 1;
+            }
+          }
+        }
+        else
+        {
+          text_place = 1;
+        }
+        break;
+      }
+
+      case IKEY_r:
+      {
+        if(get_alt_status(keycode_internal))
+        {
+          // Clear world
+          if(!confirm(mzx_world, "Clear ALL - Are you sure?"))
+          {
+            clear_world(mzx_world);
+            create_blank_world(mzx_world);
+
+            if(draw_mode > 3)
+              draw_mode = 0;
+
+            // Disable vlayer editing if we're in it
+            set_vlayer_mode(EDIT_BOARD, &overlay_edit,
+             &cursor_board_x, &cursor_board_y, &scroll_x, &scroll_y,
+             &cursor_vlayer_x, &cursor_vlayer_y, &vscroll_x, &vscroll_y);
+
+            synchronize_board_values(mzx_world, &src_board, &board_width,
+             &board_height, &level_id, &level_param, &level_color, &overlay,
+             &overlay_color, &vlayer_chars, &vlayer_colors, overlay_edit);
+
+            fix_scroll(&cursor_board_x, &cursor_board_y, &scroll_x, &scroll_y,
+             &debug_x, board_width, board_height, edit_screen_height);
+
+            end_module();
+
+            modified = 1;
+          }
+        }
+        else
+
+        if(draw_mode == 2)
+        {
+          text_place = 1;
+        }
+        break;
+      }
+
+      case IKEY_s:
+      {
+        if(draw_mode != 2)
+        {
+          if(get_alt_status(keycode_internal))
+          {
+            if(overlay_edit == EDIT_OVERLAY)
+            {
+              show_level ^= 1;
+            }
+            else
+            {
+              status_counter_info(mzx_world);
+              modified = 1;
+            }
+          }
+          else
+          {
+            char world_name[MAX_PATH];
+            char new_path[MAX_PATH];
+            strcpy(world_name, current_world);
+            if(!new_file(mzx_world, world_ext, ".mzx", world_name,
+             "Save world", 1))
+            {
+              debug("Save path: %s\n", world_name);
+              // Save entire game
+              strcpy(current_world, world_name);
+              strcpy(curr_file, current_world);
+              save_world(mzx_world, current_world, 0, WORLD_VERSION);
+
+              // It's now officially WORLD_VERSION
+              mzx_world->version = WORLD_VERSION;
+
+              get_path(world_name, new_path, MAX_PATH);
+              if(new_path[0])
+                chdir(new_path);
+
+              modified = 0;
+            }
+          }
+        }
+        else
+        {
+          text_place = 1;
+        }
+
         break;
       }
 
@@ -3947,56 +4048,100 @@ static void __edit_world(struct world *mzx_world, int reload_curr_file)
         break;
       }
 
-      case IKEY_a:
+      case IKEY_v:
       {
-        if(get_alt_status(keycode_internal))
-        {
-          int charset_load = choose_char_set(mzx_world);
-
-          switch(charset_load)
-          {
-            case 0:
-            {
-              ec_load_mzx();
-              break;
-            }
-
-            case 1:
-            {
-              ec_load_ascii();
-              break;
-            }
-
-            case 2:
-            {
-              ec_load_smzx();
-              break;
-            }
-
-            case 3:
-            {
-              ec_load_blank();
-              break;
-            }
-          }
-
-          modified = 1;
-        }
-        else
-
         if(draw_mode != 2)
         {
-          // Add board, find first free
-          for(i = 0; i < mzx_world->num_boards; i++)
+          if(get_alt_status(keycode_internal))
           {
-            if(mzx_world->board_list[i] == NULL)
-              break;
-          }
+            // Toggle vlayer editing
+            int target_mode = EDIT_VLAYER;
 
-          if(i < MAX_BOARDS)
+            if(overlay_edit == EDIT_VLAYER)
+            {
+              target_mode = EDIT_BOARD;
+            }
+
+            set_vlayer_mode(target_mode, &overlay_edit,
+             &cursor_board_x, &cursor_board_y, &scroll_x, &scroll_y,
+             &cursor_vlayer_x, &cursor_vlayer_y, &vscroll_x, &vscroll_y);
+
+            synchronize_board_values(mzx_world, &src_board, &board_width,
+             &board_height, &level_id, &level_param, &level_color,
+             &overlay, &overlay_color, &vlayer_chars, &vlayer_colors,
+             overlay_edit);
+
+            fix_scroll(&cursor_board_x, &cursor_board_y, &scroll_x,
+             &scroll_y, &debug_x, board_width, board_height,
+             edit_screen_height);
+
+            draw_mode = 0;
+            current_id = SPACE;
+            current_param = 32;
+            current_color = 7;
+            break;
+          }
+          else
+
+          if(overlay_edit != EDIT_VLAYER)
           {
-            if(add_board(mzx_world, i) >= 0)
-              new_board = i;
+            // View mode
+            int viewport_width = src_board->viewport_width;
+            int viewport_height = src_board->viewport_height;
+            int v_scroll_x = scroll_x;
+            int v_scroll_y = CLAMP(scroll_y, 0,
+             src_board->board_height - src_board->viewport_height);
+            int v_key;
+
+            cursor_off();
+            m_hide();
+
+            do
+            {
+              draw_viewport(mzx_world);
+              draw_game_window(src_board, v_scroll_x, v_scroll_y);
+              update_screen();
+
+              update_event_status_delay();
+              v_key = get_key(keycode_internal_wrt_numlock);
+
+              if(get_exit_status())
+                v_key = IKEY_ESCAPE;
+
+              switch(v_key)
+              {
+                case IKEY_LEFT:
+                {
+                  if(v_scroll_x)
+                    v_scroll_x--;
+                  break;
+                }
+
+                case IKEY_RIGHT:
+                {
+                  if(v_scroll_x < (board_width - viewport_width))
+                    v_scroll_x++;
+                  break;
+                }
+
+                case IKEY_UP:
+                {
+                  if(v_scroll_y)
+                    v_scroll_y--;
+                  break;
+                }
+
+                case IKEY_DOWN:
+                {
+                  if(v_scroll_y < (board_height - viewport_height))
+                    v_scroll_y++;
+                  break;
+                }
+              }
+            } while(v_key != IKEY_ESCAPE);
+
+            m_show();
+            clear_screen_no_update();
           }
         }
         else
@@ -4006,51 +4151,136 @@ static void __edit_world(struct world *mzx_world, int reload_curr_file)
         break;
       }
 
-      case IKEY_d:
+      case IKEY_x:
       {
-        if(draw_mode != 2)
+        if(get_alt_status(keycode_internal))
         {
-          if(get_alt_status(keycode_internal))
+          int export_number = export_type(mzx_world);
+          if(export_number >= 0)
           {
-            // Toggle default built-in colors
-            use_default_color ^= 1;
-          }
-          else
-          {
-            int del_board =
-             choose_board(mzx_world, mzx_world->current_board_id,
-             "Delete board:", 0);
+            char export_name[MAX_PATH];
+            export_name[0] = 0;
 
-            if((del_board > 0) &&
-             !confirm(mzx_world, "DELETE BOARD - Are you sure?"))
+            switch(export_number)
             {
-              int current_board_id = mzx_world->current_board_id;
-              clear_board(mzx_world->board_list[del_board]);
-              mzx_world->board_list[del_board] = NULL;
-
-              // Remove null board from list
-              optimize_null_boards(mzx_world);
-
-              if(del_board == current_board_id)
+              case 0:
               {
-                new_board = 0;
+                // Board file
+                if(!new_file(mzx_world, mzb_ext, ".mzb", export_name,
+                 "Export board file", 1))
+                {
+                  save_board_file(mzx_world, src_board, export_name);
+                }
+                break;
               }
-              else
+
+              case 1:
               {
-                synchronize_board_values(mzx_world, &src_board, &board_width,
-                 &board_height, &level_id, &level_param, &level_color,
-                 &overlay, &overlay_color, &vlayer_chars, &vlayer_colors,
-                 overlay_edit);
+                // Character set
+                int char_offset = 0;
+                int char_size = 256;
+                struct element *elements[] =
+                {
+                  construct_number_box(9, 20, "Offset:  ",
+                   0, 255, 0, &char_offset),
+                  construct_number_box(35, 20, "Size: ",
+                   1, 256, 0, &char_size)
+                };
+
+                if(!file_manager(mzx_world, chr_ext, NULL, export_name,
+                 "Export character set", 1, 1, elements, 2, 2))
+                {
+                  add_ext(export_name, ".chr");
+                  ec_save_set_var(export_name, char_offset,
+                   char_size);
+                }
+
+                break;
+              }
+
+              case 2:
+              {
+                // Palette
+                if(!new_file(mzx_world, pal_ext, ".pal", export_name,
+                 "Export palette", 1))
+                {
+                  save_palette(export_name);
+                }
+
+                break;
+              }
+
+              case 3:
+              {
+                // Sound effects
+                if(!new_file(mzx_world, sfx_ext, ".sfx", export_name,
+                 "Export SFX file", 1))
+                {
+                  FILE *sfx_file;
+
+                  sfx_file = fopen_unsafe(export_name, "wb");
+
+                  if(sfx_file)
+                  {
+                    if(mzx_world->custom_sfx_on)
+                      fwrite(mzx_world->custom_sfx, SFX_SIZE, NUM_SFX, sfx_file);
+                    else
+                      fwrite(sfx_strs, SFX_SIZE, NUM_SFX, sfx_file);
+
+                    fclose(sfx_file);
+                  }
+                }
+                break;
+              }
+
+              case 4:
+              {
+                // Downver. world
+                char title[80];
+
+                sprintf(title, "Export world to previous version (%d.%d)",
+                 (WORLD_VERSION_PREV >> 8) & 0xFF, WORLD_VERSION_PREV & 0xFF);
+
+                if(!new_file(mzx_world, world_ext, ".mzx", export_name,
+                 title, 1))
+                {
+                  save_world(mzx_world, export_name, 0, WORLD_VERSION_PREV);
+                }
               }
             }
           }
+        }
+        else
 
-          modified = 1;
+        if(draw_mode != 2)
+        {
+          // Doesn't make sense on the vlayer
+          if(overlay_edit != EDIT_VLAYER)
+          {
+            board_exits(mzx_world);
+            modified = 1;
+          }
         }
         else
         {
           text_place = 1;
         }
+        break;
+      }
+
+      case IKEY_y:
+      {
+        if(get_alt_status(keycode_internal))
+        {
+          debug_mode = !debug_mode;
+        }
+        else
+
+        if(draw_mode == 2)
+        {
+          text_place = 1;
+        }
+
         break;
       }
 
@@ -4109,237 +4339,6 @@ static void __edit_world(struct world *mzx_world, int reload_curr_file)
         }
         break;
       }
-
-      case IKEY_r:
-      {
-        if(get_alt_status(keycode_internal))
-        {
-          // Clear world
-          if(!confirm(mzx_world, "Clear ALL - Are you sure?"))
-          {
-            clear_world(mzx_world);
-            create_blank_world(mzx_world);
-
-            if(draw_mode > 3)
-              draw_mode = 0;
-
-            // Disable vlayer editing if we're in it
-            set_vlayer_mode(EDIT_BOARD, &overlay_edit,
-             &cursor_board_x, &cursor_board_y, &scroll_x, &scroll_y,
-             &cursor_vlayer_x, &cursor_vlayer_y, &vscroll_x, &vscroll_y);
-
-            synchronize_board_values(mzx_world, &src_board, &board_width,
-             &board_height, &level_id, &level_param, &level_color, &overlay,
-             &overlay_color, &vlayer_chars, &vlayer_colors, overlay_edit);
-
-            fix_scroll(&cursor_board_x, &cursor_board_y, &scroll_x, &scroll_y,
-             &debug_x, board_width, board_height, edit_screen_height);
-
-            end_module();
-
-            modified = 1;
-          }
-        }
-        else
-
-        if(draw_mode == 2)
-        {
-          text_place = 1;
-        }
-        break;
-      }
-
-      case IKEY_PAGEDOWN:
-      {
-        current_menu++;
-
-        if(current_menu == 6)
-          current_menu = 0;
-
-        break;
-      }
-
-      case IKEY_PAGEUP:
-      {
-        current_menu--;
-
-        if(current_menu == -1)
-          current_menu = 5;
-
-        break;
-      }
-
-      case IKEY_8:
-      case IKEY_KP_MULTIPLY:
-      {
-        if(draw_mode == 2)
-        {
-          text_place = 1;
-        }
-        else
-
-        if(get_shift_status(keycode_internal) ||
-         (key == IKEY_KP_MULTIPLY))
-        {
-          src_board->mod_playing[0] = '*';
-          src_board->mod_playing[1] = 0;
-          fix_mod(mzx_world, src_board, listening_flag);
-          draw_mod_timer = DRAW_MOD_TIMER_MAX;
-
-          modified = 1;
-        }
-
-        break;
-      }
-
-      case IKEY_m:
-      {
-        if(draw_mode != 2)
-        {
-          // Modify
-          if(get_alt_status(keycode_internal))
-          {
-            int offset = cursor_board_x + (cursor_board_y * board_width);
-
-            if(overlay_edit == EDIT_BOARD)
-            {
-              enum thing d_id = (enum thing)level_id[offset];
-              int d_param = level_param[offset];
-              int new_param;
-
-              if(d_id == SENSOR)
-              {
-                edit_sensor(mzx_world, src_board->sensor_list[d_param]);
-                modified = 1;
-              }
-              else
-
-              if(is_robot(d_id))
-              {
-                draw_memory_timer = DRAW_MEMORY_TIMER_MAX;
-                edit_robot(mzx_world, src_board->robot_list[d_param]);
-                fix_caption(mzx_world, modified);
-                modified = 1;
-              }
-              else
-
-              if(is_signscroll(d_id))
-              {
-                edit_scroll(mzx_world, src_board->scroll_list[d_param]);
-                modified = 1;
-              }
-              else
-
-              if(is_storageless(d_id) &&
-               (0 <= (new_param = change_param(mzx_world, d_id, d_param, NULL, NULL, NULL))))
-              {
-                src_board->level_param[offset] = new_param;
-                modified = 1;
-              }
-            }
-            else
-
-            if(overlay_edit == EDIT_OVERLAY)
-            {
-              int o_ch = src_board->overlay[offset];
-              int new_ch;
-
-              if((new_ch = char_selection(o_ch)) >= 0)
-              {
-                src_board->overlay[offset] = new_ch;
-                modified = 1;
-              }
-            }
-
-            else // EDIT_VLAYER
-            {
-              int new_ch = char_selection(vlayer_chars[offset]);
-
-              if(new_ch >= 0)
-              {
-                vlayer_chars[offset] = new_ch;
-                modified = 1;
-              }
-            }
-          }
-          else
-
-          // Move current board
-          // Doesn't make sense on the vlayer
-          if(overlay_edit != EDIT_VLAYER)
-          {
-            int new_position;
-
-            if(mzx_world->current_board_id == 0)
-              break;
-
-            new_position =
-             choose_board(mzx_world, mzx_world->current_board_id,
-             "Move board to position:", 0);
-
-            if((new_position > 0) && (new_position < mzx_world->num_boards) &&
-             (new_position != mzx_world->current_board_id))
-            {
-              move_current_board(mzx_world, new_position);
-              new_board = new_position;
-              modified = 1;
-            }
-          }
-        }
-        else
-          text_place = 1;
-
-        break;
-      }
-
-      case IKEY_y:
-      {
-        if(get_alt_status(keycode_internal))
-        {
-          debug_mode = !debug_mode;
-        }
-        else
-
-        if(draw_mode == 2)
-        {
-          text_place = 1;
-        }
-
-        break;
-      }
-
-      case IKEY_h:
-      {
-        if(get_alt_status(keycode_internal))
-        {
-          if(edit_screen_height == EDIT_SCREEN_NORMAL)
-          {
-            edit_screen_height = EDIT_SCREEN_EXTENDED;
-            clear_screen_no_update();
-
-            if((scroll_y + 25) > board_height)
-              scroll_y = board_height - 25;
-
-            if(scroll_y < 0)
-              scroll_y = 0;
-          }
-          else
-          {
-            edit_screen_height = EDIT_SCREEN_NORMAL;
-            if((cursor_board_y - scroll_y) > 18)
-              scroll_y += cursor_board_y - scroll_y - 18;
-          }
-        }
-        else
-
-        if(draw_mode == 2)
-        {
-          text_place = 1;
-        }
-
-        break;
-      }
-
 
       case 0:
       {

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -3013,15 +3013,10 @@ static void __edit_world(struct world *mzx_world, int reload_curr_file)
            change_param(mzx_world, current_id, current_param,
            &copy_robot, &copy_scroll, &copy_sensor);
 
-          // Kinda a hack, but should get the job done.
-          if(is_storageless(current_id) && (new_param >= 0))
-          {
-            int offset = cursor_board_x + (cursor_board_y * board_width);
-
-            level_param[offset] = new_param;
-            current_param = new_param;
-          }
-          else
+          // Place the buffer back on the board
+          // Ignore non-storage objects with no change.
+          if(!is_storageless(current_id) ||
+           (new_param >= 0 && new_param != current_param))
           {
             current_param = place_current_at_xy(mzx_world, current_id,
              current_color, new_param, cursor_board_x, cursor_board_y,

--- a/src/editor/edit.h
+++ b/src/editor/edit.h
@@ -43,6 +43,11 @@ int place_current_at_xy(struct world *mzx_world, enum thing id, int color,
  int param, int x, int y, struct robot *copy_robot, struct scroll *copy_scroll,
  struct sensor *copy_sensor, int overlay_edit, int save_history);
 
+void grab_at_xy(struct world *mzx_world, enum thing *new_id,
+ int *new_color, int *new_param, struct robot *copy_robot,
+ struct scroll *copy_scroll, struct sensor *copy_sensor,
+ int x, int y, int overlay_edit);
+
 #define EDIT_BOARD            0
 #define EDIT_OVERLAY          1
 #define EDIT_VLAYER           2

--- a/src/editor/edit.h
+++ b/src/editor/edit.h
@@ -40,8 +40,8 @@ EDITOR_LIBSPEC void refactor_saved_positions(struct world *mzx_world,
 */
 
 int place_current_at_xy(struct world *mzx_world, enum thing id, int color,
- int param, int x, int y, struct robot *copy_robot,
- struct scroll *copy_scroll, struct sensor *copy_sensor, int overlay_edit);
+ int param, int x, int y, struct robot *copy_robot, struct scroll *copy_scroll,
+ struct sensor *copy_sensor, int overlay_edit, int save_history);
 
 #define EDIT_BOARD            0
 #define EDIT_OVERLAY          1

--- a/src/editor/edit_di.c
+++ b/src/editor/edit_di.c
@@ -616,12 +616,14 @@ static void bound_board_size(int *width, int *height)
 }
 
 // Size/pos of board/viewport
-void size_pos(struct world *mzx_world)
+// Returns 1 if the board was resized
+int size_pos(struct world *mzx_world)
 {
   struct board *src_board = mzx_world->current_board;
   int dialog_result;
   struct element *elements[9];
   struct dialog di;
+  int resized = 0;
 
   int redo = 1;
 
@@ -705,6 +707,14 @@ void size_pos(struct world *mzx_world)
 
         bound_board_size(results + 4, results + 5);
 
+        if(results[4] == src_board->board_width &&
+         results[5] == src_board->board_height)
+        {
+          resized = 0;
+          redo = 0;
+        }
+        else
+
         if(((results[4] >= src_board->board_width) &&
           (results[5] >= src_board->board_height)) ||
           !confirm(mzx_world, "Reduce board size- Are you sure?"))
@@ -715,6 +725,7 @@ void size_pos(struct world *mzx_world)
           src_board->viewport_y = results[1];
           src_board->viewport_width = results[2];
           src_board->viewport_height = results[3];
+          resized = 1;
         }
         break;
       }
@@ -735,14 +746,18 @@ void size_pos(struct world *mzx_world)
   } while(redo);
 
   pop_context();
+
+  return resized;
 }
 
 // Size of vlayer
-void size_pos_vlayer(struct world *mzx_world)
+// Returns 1 if the vlayer was resized
+int size_pos_vlayer(struct world *mzx_world)
 {
   int dialog_result;
   struct element *elements[4];
   struct dialog di;
+  int resized = 0;
 
   int results[2] = {
     mzx_world->vlayer_width,
@@ -791,6 +806,14 @@ void size_pos_vlayer(struct world *mzx_world)
         // The vlayer has the same size restrictions as boards.
         bound_board_size(results + 0, results + 1);
 
+        if(results[0] == mzx_world->vlayer_width &&
+         results[1] == mzx_world->vlayer_height)
+        {
+          resized = 0;
+          redo = 0;
+        }
+        else
+
         if(((results[0] >= mzx_world->vlayer_width) &&
           (results[1] >= mzx_world->vlayer_height)) ||
           !confirm(mzx_world, "Reduce vlayer size- Are you sure?"))
@@ -811,6 +834,8 @@ void size_pos_vlayer(struct world *mzx_world)
           // Increasing size-- remap after
           if(size >= old_size)
             remap_vlayer(mzx_world, results[0], results[1]);
+
+          resized = 1;
         }
         break;
       }
@@ -819,6 +844,8 @@ void size_pos_vlayer(struct world *mzx_world)
   while(redo);
 
   pop_context();
+
+  return resized;
 }
 
 //Dialog- (board info)

--- a/src/editor/edit_di.h
+++ b/src/editor/edit_di.h
@@ -35,8 +35,8 @@ void board_info(struct world *mzx_world);
 void board_exits(struct world *mzx_world);
 void global_info(struct world *mzx_world);
 void global_robot(struct world *mzx_world);
-void size_pos(struct world *mzx_world);
-void size_pos_vlayer(struct world *mzx_world);
+int size_pos(struct world *mzx_world);
+int size_pos_vlayer(struct world *mzx_world);
 void set_confirm_buttons(struct element **elements);
 void status_counter_info(struct world *mzx_world);
 

--- a/src/editor/fill.c
+++ b/src/editor/fill.c
@@ -53,8 +53,8 @@ struct queue_elem
 }
 
 void fill_area(struct world *mzx_world, enum thing id, int color, int param,
- int x, int y, struct robot *copy_robot, struct scroll *copy_scroll, struct sensor *copy_sensor,
- int overlay_edit)
+ int x, int y, struct robot *copy_robot, struct scroll *copy_scroll,
+ struct sensor *copy_sensor, int overlay_edit)
 {
   struct board *cur_board = mzx_world->current_board;
 
@@ -149,7 +149,7 @@ void fill_area(struct world *mzx_world, enum thing id, int color, int param,
     do
     {
       if(place_current_at_xy(mzx_world, id, color, param, x, y, copy_robot,
-       copy_scroll, copy_sensor, overlay_edit) == -1)
+       copy_scroll, copy_sensor, overlay_edit, 0) == -1)
         goto err_free;
 
       if(y > 0 && MATCHING(offset - board_width))

--- a/src/editor/fill.c
+++ b/src/editor/fill.c
@@ -75,6 +75,10 @@ void fill_area(struct world *mzx_world, enum thing id, int color, int param,
   int fill_color = 0;
   int fill_param = 0;
 
+  // Do nothing if the player is in the buffer
+  if(id == PLAYER)
+    return;
+
   switch(overlay_edit)
   {
     default:

--- a/src/editor/fill.c
+++ b/src/editor/fill.c
@@ -20,10 +20,11 @@
 
 /* Fill function. */
 
+#include "edit.h"
 #include "fill.h"
+#include "undo.h"
 
 #include "../util.h"
-#include "edit.h"
 
 struct queue_elem
 {
@@ -52,13 +53,13 @@ struct queue_elem
   queue_next = (queue_next + 1) % QUEUE_SIZE;       \
 }
 
-void fill_area(struct world *mzx_world, enum thing id, int color, int param,
- int x, int y, struct robot *copy_robot, struct scroll *copy_scroll,
- struct sensor *copy_sensor, int overlay_edit)
+void fill_area(struct world *mzx_world, struct undo_history *h,
+ enum thing id, int color, int param, int x, int y, struct robot *copy_robot,
+ struct scroll *copy_scroll, struct sensor *copy_sensor, int overlay_edit)
 {
   struct board *cur_board = mzx_world->current_board;
 
-  struct queue_elem *queue = cmalloc(QUEUE_SIZE * sizeof(struct queue_elem));
+  struct queue_elem *queue;
   int queue_first = 0;
   int queue_next = 1;
   int matched_down;
@@ -81,7 +82,6 @@ void fill_area(struct world *mzx_world, enum thing id, int color, int param,
 
   switch(overlay_edit)
   {
-    default:
     case EDIT_BOARD:
       level_id = cur_board->level_id;
       level_color = cur_board->level_color;
@@ -97,8 +97,10 @@ void fill_area(struct world *mzx_world, enum thing id, int color, int param,
       level_param = cur_board->overlay;
       board_width = cur_board->board_width;
       board_height = cur_board->board_height;
+      id = param;
       break;
 
+    default:
     case EDIT_VLAYER:
       // Use chars for id so we don't have to check for NULL
       level_id = mzx_world->vlayer_chars;
@@ -106,6 +108,7 @@ void fill_area(struct world *mzx_world, enum thing id, int color, int param,
       level_param = mzx_world->vlayer_chars;
       board_width = mzx_world->vlayer_width;
       board_height = mzx_world->vlayer_height;
+      id = param;
       break;
   }
 
@@ -118,8 +121,20 @@ void fill_area(struct world *mzx_world, enum thing id, int color, int param,
   if((fill_id == id) &&
    (fill_color == color) &&
    (fill_param == param))
-    goto err_free;
+    return;
 
+  // Start the undo frame for this fill
+  if(overlay_edit == EDIT_BOARD)
+    add_board_undo_frame(mzx_world, h, id, color, param, x, y,
+     copy_robot, copy_scroll, copy_sensor);
+
+  // Layers don't have variable size undo frames because they're
+  // much lighter than the board; just save the whole thing
+  else
+    add_layer_undo_frame(h, level_id, level_color, board_width, 0,
+     board_width, board_height);
+
+  queue = cmalloc(QUEUE_SIZE * sizeof(struct queue_elem));
   queue[0].x = x;
   queue[0].y = y;
 
@@ -148,9 +163,13 @@ void fill_area(struct world *mzx_world, enum thing id, int color, int param,
     // Scan right
     do
     {
+      // Update the undo frame for the new position, then fill
+      if(overlay_edit == EDIT_BOARD)
+        add_board_undo_position(h, x, y);
+
       if(place_current_at_xy(mzx_world, id, color, param, x, y, copy_robot,
        copy_scroll, copy_sensor, overlay_edit, 0) == -1)
-        goto err_free;
+        goto out_free;
 
       if(y > 0 && MATCHING(offset - board_width))
       {
@@ -185,6 +204,9 @@ void fill_area(struct world *mzx_world, enum thing id, int color, int param,
   }
   while(queue_first != queue_next);
 
-err_free:
+out_free:
+  // Finalize the undo frame
+  update_undo_frame(h);
+
   free(queue);
 }

--- a/src/editor/fill.h
+++ b/src/editor/fill.h
@@ -26,11 +26,13 @@
 
 __M_BEGIN_DECLS
 
+#include "undo.h"
+
 #include "../world_struct.h"
 
-void fill_area(struct world *mzx_world, enum thing id, int color, int param,
- int x, int y, struct robot *copy_robot, struct scroll *copy_scroll,
- struct sensor *copy_sensor, int overlay_edit);
+void fill_area(struct world *mzx_world, struct undo_history *h,
+ enum thing id, int color, int param, int x, int y, struct robot *copy_robot,
+ struct scroll *copy_scroll, struct sensor *copy_sensor, int overlay_edit);
 
 __M_END_DECLS
 

--- a/src/editor/select.c
+++ b/src/editor/select.c
@@ -50,7 +50,7 @@
 //    _OK_      _Cancel_
 //
 //--------------------------
-int block_cmd(struct world *mzx_world, int overlay_edit)
+int select_block_command(struct world *mzx_world, int overlay_edit)
 {
   int dialog_result;
   struct element *elements[3];

--- a/src/editor/select.h
+++ b/src/editor/select.h
@@ -28,7 +28,7 @@ __M_BEGIN_DECLS
 
 #include "../world_struct.h"
 
-int block_cmd(struct world *mzx_world, int overlay_edit);
+int select_block_command(struct world *mzx_world, int overlay_edit);
 int layer_to_board_object_type(struct world *mzx_world);
 int select_screen_mode(struct world *mzx_world);
 int choose_char_set(struct world *mzx_world);

--- a/src/editor/undo.c
+++ b/src/editor/undo.c
@@ -28,6 +28,23 @@
 #include "../world.h"
 #include "../world_struct.h"
 
+/* Operations for handling undo histories:
+ *   Construct a history buffer of some size
+ *   Add a new frame to the history, clearing old frames as-needed
+ *   Update the current frame of the history (primarily for mouse input)
+ *   Perform an undo operation: apply previous version, then step back
+ *   Perform a redo operation: step forward, then apply current version
+ *   Destruct a history buffer
+ *
+ * Most of these options are generalizable and use the same functions,
+ * but the creation of a history buffer and adding a new frame require
+ * implementation-specific functions.
+ *
+ * All necessary data regarding the scope of the frame must be given when
+ * a new frame is created; this information can't change easily due to the
+ * way e.g. boards are stored.
+ */
+
 static struct undo_history *construct_undo_history(int max_size)
 {
   struct undo_history *h = cmalloc(sizeof(struct undo_history));

--- a/src/editor/undo.c
+++ b/src/editor/undo.c
@@ -24,7 +24,6 @@
 #include "../board.h"
 #include "../graphics.h"
 #include "../platform.h"
-#include "../robot.h"
 #include "../world.h"
 #include "../world_struct.h"
 

--- a/src/editor/undo.c
+++ b/src/editor/undo.c
@@ -31,8 +31,6 @@
 #include "../world.h"
 #include "../world_struct.h"
 
-#ifdef CONFIG_UNDO
-
 /* Operations for handling undo histories:
  *   Construct a history buffer of some size
  *   Add a new frame to the history, clearing old frames as-needed
@@ -880,5 +878,3 @@ void add_layer_undo_frame(struct undo_history *h, char *layer_chars,
    width, height
   );
 }
-
-#endif // CONFIG_UNDO

--- a/src/editor/undo.c
+++ b/src/editor/undo.c
@@ -667,6 +667,10 @@ void add_board_undo_position(struct undo_history *h, int x, int y)
   int grab_color;
   int grab_param;
 
+  // Can't place over player
+  if(src_board->level_id[offset] == PLAYER)
+    return;
+
   if(prev_size == prev_alloc)
   {
     if(!prev_alloc)

--- a/src/editor/undo.c
+++ b/src/editor/undo.c
@@ -182,14 +182,17 @@ void destruct_undo_history(struct undo_history *h)
   struct undo_frame *f;
   int i;
 
-  for(i = 0; i < h->size; i++)
+  if(h)
   {
-    f = h->frames[i];
-    if(f)
-      h->clear_function(f);
-  }
+    for(i = 0; i < h->size; i++)
+    {
+      f = h->frames[i];
+      if(f)
+        h->clear_function(f);
+    }
 
-  free(h);
+    free(h);
+  }
 }
 
 

--- a/src/editor/undo.c
+++ b/src/editor/undo.c
@@ -31,6 +31,8 @@
 #include "../world.h"
 #include "../world_struct.h"
 
+#ifdef CONFIG_UNDO
+
 /* Operations for handling undo histories:
  *   Construct a history buffer of some size
  *   Add a new frame to the history, clearing old frames as-needed
@@ -874,3 +876,5 @@ void add_layer_undo_frame(struct undo_history *h, char *layer_chars,
    width, height
   );
 }
+
+#endif // CONFIG_UNDO

--- a/src/editor/undo.h
+++ b/src/editor/undo.h
@@ -24,6 +24,7 @@
 
 __M_BEGIN_DECLS
 
+#include "data.h"
 #include "world_struct.h"
 
 struct undo_frame
@@ -45,8 +46,8 @@ struct undo_history
   void (*clear_function)(struct undo_frame *);
 };
 
-void apply_undo(struct undo_history *h);
-void apply_redo(struct undo_history *h);
+int apply_undo(struct undo_history *h);
+int apply_redo(struct undo_history *h);
 void update_undo_frame(struct undo_history *h);
 void destruct_undo_history(struct undo_history *h);
 
@@ -58,6 +59,12 @@ void add_charset_undo_frame(struct undo_history *h, int offset,
  int width, int height);
 
 void add_board_undo_frame(struct world *mzx_world, struct undo_history *h,
+ enum thing id, int color, int param, int x, int y, struct robot *copy_robot,
+ struct scroll *copy_scroll, struct sensor *copy_sensor);
+
+void add_board_undo_position(struct undo_history *h, int x, int y);
+
+void add_block_undo_frame(struct world *mzx_world, struct undo_history *h,
  struct board *src_board, int src_offset, int width, int height);
 
 void add_layer_undo_frame(struct undo_history *h, char *layer_chars,

--- a/src/editor/undo.h
+++ b/src/editor/undo.h
@@ -46,6 +46,8 @@ struct undo_history
   void (*clear_function)(struct undo_frame *);
 };
 
+#ifdef CONFIG_UNDO
+
 int apply_undo(struct undo_history *h);
 int apply_redo(struct undo_history *h);
 void update_undo_frame(struct undo_history *h);
@@ -69,6 +71,32 @@ void add_block_undo_frame(struct world *mzx_world, struct undo_history *h,
 
 void add_layer_undo_frame(struct undo_history *h, char *layer_chars,
  char *layer_colors, int layer_width, int layer_offset, int width, int height);
+
+#else
+
+static inline int apply_undo(void *h) { return 0; }
+static inline int apply_redo(void *h) { return 0; }
+static inline void update_undo_frame(void *h) { }
+static inline void destruct_undo_history(void *h) { }
+
+static inline void *construct_charset_undo_history(int m) { return NULL; }
+static inline void *construct_board_undo_history(int m) { return NULL; }
+static inline void *construct_layer_undo_history(int m) { return NULL; }
+
+static inline void add_charset_undo_frame(void *h, int o, int wi, int hi) { }
+
+static inline void add_board_undo_frame(void *m, void *h, int i, int c, int p,
+ int x, int y, void *r, void *sc, void *se) { }
+
+static inline void add_board_undo_position(void *h, int x, int y) { }
+
+static inline void add_block_undo_frame(void *m, void *h, void *b, int o,
+ int wi, int hi) { }
+
+static inline void add_layer_undo_frame(void *h, void *ch, void *co, int lw,
+ int o, int wi, int hi) { }
+
+#endif
 
 __M_END_DECLS
 

--- a/src/editor/undo.h
+++ b/src/editor/undo.h
@@ -24,6 +24,8 @@
 
 __M_BEGIN_DECLS
 
+#include "world_struct.h"
+
 struct undo_frame
 {
   int type;
@@ -49,9 +51,17 @@ void update_undo_frame(struct undo_history *h);
 void destruct_undo_history(struct undo_history *h);
 
 struct undo_history *construct_charset_undo_history(int max_size);
+struct undo_history *construct_board_undo_history(int max_size);
+struct undo_history *construct_layer_undo_history(int max_size);
 
 void add_charset_undo_frame(struct undo_history *h, int offset,
  int width, int height);
+
+void add_board_undo_frame(struct undo_history *h, struct board *src_board,
+ int board_offset, int width, int height);
+
+void add_layer_undo_frame(struct undo_history *h, char *layer_chars,
+ char *layer_colors, int layer_width, int layer_offset, int width, int height);
 
 __M_END_DECLS
 

--- a/src/editor/undo.h
+++ b/src/editor/undo.h
@@ -57,8 +57,8 @@ struct undo_history *construct_layer_undo_history(int max_size);
 void add_charset_undo_frame(struct undo_history *h, int offset,
  int width, int height);
 
-void add_board_undo_frame(struct undo_history *h, struct board *src_board,
- int board_offset, int width, int height);
+void add_board_undo_frame(struct world *mzx_world, struct undo_history *h,
+ struct board *src_board, int src_offset, int width, int height);
 
 void add_layer_undo_frame(struct undo_history *h, char *layer_chars,
  char *layer_colors, int layer_width, int layer_offset, int width, int height);

--- a/src/editor/undo.h
+++ b/src/editor/undo.h
@@ -46,8 +46,6 @@ struct undo_history
   void (*clear_function)(struct undo_frame *);
 };
 
-#ifdef CONFIG_UNDO
-
 int apply_undo(struct undo_history *h);
 int apply_redo(struct undo_history *h);
 void update_undo_frame(struct undo_history *h);
@@ -71,32 +69,6 @@ void add_block_undo_frame(struct world *mzx_world, struct undo_history *h,
 
 void add_layer_undo_frame(struct undo_history *h, char *layer_chars,
  char *layer_colors, int layer_width, int layer_offset, int width, int height);
-
-#else
-
-static inline int apply_undo(void *h) { return 0; }
-static inline int apply_redo(void *h) { return 0; }
-static inline void update_undo_frame(void *h) { }
-static inline void destruct_undo_history(void *h) { }
-
-static inline void *construct_charset_undo_history(int m) { return NULL; }
-static inline void *construct_board_undo_history(int m) { return NULL; }
-static inline void *construct_layer_undo_history(int m) { return NULL; }
-
-static inline void add_charset_undo_frame(void *h, int o, int wi, int hi) { }
-
-static inline void add_board_undo_frame(void *m, void *h, int i, int c, int p,
- int x, int y, void *r, void *sc, void *se) { }
-
-static inline void add_board_undo_position(void *h, int x, int y) { }
-
-static inline void add_block_undo_frame(void *m, void *h, void *b, int o,
- int wi, int hi) { }
-
-static inline void add_layer_undo_frame(void *h, void *ch, void *co, int lw,
- int o, int wi, int hi) { }
-
-#endif
 
 __M_END_DECLS
 

--- a/src/util.h
+++ b/src/util.h
@@ -40,6 +40,8 @@ __M_BEGIN_DECLS
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
 
+#define SGN(x) ((x > 0) - (x < 0))
+
 #ifndef DIR_SEPARATOR
 #ifdef __WIN32__
 #define DIR_SEPARATOR "\\"


### PR DESCRIPTION
Board/overlay/vlayer undo functionality. Use Ctrl+Z to undo, and Ctrl+Y to redo. Note that quite a few things will clear the entire undo stack (a temporary list is located in the changelog; this should be moved elsewhere).