### PR TITLE
Added config option to disable all editor undo functionality

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -65,6 +65,7 @@ usage() {
 	echo "  --enable-egl          Enables EGL backend (if SDL disabled)."
 	echo "  --disable-check-alloc Disables memory allocator error handling."
 	echo "  --disable-uthash      Disables hash counter/string lookups."
+	echo "  --disable-undo        Disables undo/redo operations in the editor."
 	echo "  --enable-debytecode   Enable experimental 'debytecode' transform."
 	echo "  --disable-libsdl2     Disable SDL 2.0 support (falls back on 1.2)."
 	echo "  --enable-fps          Enable frames-per-second counter."
@@ -119,6 +120,7 @@ SDL="true"
 EGL="false"
 CHECK_ALLOC="true"
 UTHASH="true"
+UNDO="true"
 DEBYTECODE="false"
 LIBSDL2="true"
 FPSCOUNTER="false"
@@ -261,6 +263,9 @@ while [ "$1" != "" ]; do
 
 	[ "$1" = "--enable-uthash" ]  && UTHASH="true"
 	[ "$1" = "--disable-uthash" ] && UTHASH="false"
+
+	[ "$1" = "--enable-undo" ]  && UNDO="true"
+	[ "$1" = "--disable-undo" ] && UNDO="false"
 
 	[ "$1" = "--enable-debytecode" ]  && DEBYTECODE="true"
 	[ "$1" = "--disable-debytecode" ] && DEBYTECODE="false"
@@ -1013,6 +1018,18 @@ if [ "$UTHASH" = "true" ]; then
 	echo "#define CONFIG_UTHASH" >> src/config.h
 else
 	echo "uthash counter/string lookup disabled (using binary search)."
+fi
+
+#
+# Allow use of undo/redo in the editor
+#
+if [ "$EDITOR" = "true" ]; then
+	if [ "$UNDO" = "true" ]; then
+		echo "undo/redo enabled."
+		echo "#define CONFIG_UNDO" >> src/config.h
+	else
+		echo "undo/redo disabled."
+	fi
 fi
 
 #

--- a/src/editor/undo.c
+++ b/src/editor/undo.c
@@ -31,6 +31,8 @@
 #include "../world.h"
 #include "../world_struct.h"
 
+#ifdef CONFIG_UNDO
+
 /* Operations for handling undo histories:
  *   Construct a history buffer of some size
  *   Add a new frame to the history, clearing old frames as-needed
@@ -878,3 +880,5 @@ void add_layer_undo_frame(struct undo_history *h, char *layer_chars,
    width, height
   );
 }
+
+#endif // CONFIG_UNDO

--- a/src/editor/undo.h
+++ b/src/editor/undo.h
@@ -46,6 +46,8 @@ struct undo_history
   void (*clear_function)(struct undo_frame *);
 };
 
+#ifdef CONFIG_UNDO
+
 int apply_undo(struct undo_history *h);
 int apply_redo(struct undo_history *h);
 void update_undo_frame(struct undo_history *h);
@@ -69,6 +71,32 @@ void add_block_undo_frame(struct world *mzx_world, struct undo_history *h,
 
 void add_layer_undo_frame(struct undo_history *h, char *layer_chars,
  char *layer_colors, int layer_width, int layer_offset, int width, int height);
+
+#else
+
+static inline int apply_undo(void *h) { return 0; }
+static inline int apply_redo(void *h) { return 0; }
+static inline void update_undo_frame(void *h) { }
+static inline void destruct_undo_history(void *h) { }
+
+static inline void *construct_charset_undo_history(int m) { return NULL; }
+static inline void *construct_board_undo_history(int m) { return NULL; }
+static inline void *construct_layer_undo_history(int m) { return NULL; }
+
+static inline void add_charset_undo_frame(void *h, int o, int wi, int hi) { }
+
+static inline void add_board_undo_frame(void *m, void *h, int i, int c, int p,
+ int x, int y, void *r, void *sc, void *se) { }
+
+static inline void add_board_undo_position(void *h, int x, int y) { }
+
+static inline void add_block_undo_frame(void *m, void *h, void *b, int o,
+ int wi, int hi) { }
+
+static inline void add_layer_undo_frame(void *h, void *ch, void *co, int lw,
+ int o, int wi, int hi) { }
+
+#endif
 
 __M_END_DECLS
 


### PR DESCRIPTION
This should only be merged if it's needed.  This branch adds an option to the config script to disable all editor undo functionality.  This was intended for low memory systems, but most low memory systems can either disable the editor altogether or have the undo history size lowered in the config file.