### PR TITLE
Added optional SDL support for Wii builds

### DIFF
--- a/arch/wii/CONFIG.SDLWII
+++ b/arch/wii/CONFIG.SDLWII
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-./config.sh --platform wii --prefix $DEVKITPPC --optimize-speed --enable-release \
+./config.sh --platform wii --prefix $DEVKITPPC --enable-release \
             --disable-utils --disable-libpng --enable-meter

--- a/arch/wii/CONFIG.SDLWII
+++ b/arch/wii/CONFIG.SDLWII
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+./config.sh --platform wii --prefix $DEVKITPPC --optimize-speed --enable-release \
+            --disable-utils --disable-libpng --enable-meter

--- a/arch/wii/CONFIG.WII
+++ b/arch/wii/CONFIG.WII
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-./config.sh --platform wii --prefix $DEVKITPPC --optimize-size \
+./config.sh --platform wii --prefix $DEVKITPPC --disable-sdl --enable-release \
             --disable-utils --disable-libpng --enable-meter

--- a/arch/wii/Makefile.in
+++ b/arch/wii/Makefile.in
@@ -28,6 +28,14 @@ STRIP  = /bin/true
 # Override library paths
 #
 
+#
+# If building with SDLWii, these need to be set manually--no sdl-config.
+# libSDL has to be linked at a very specific place in the library list,
+# but SDL_LDFLAGS gets appended to the end, so set it to something useless.
+#
+SDL_CFLAGS     = -isystem $(DEVKITPRO)/libogc/include/SDL
+SDL_LDFLAGS    = $(SDL_CFLAGS)
+
 VORBIS_CFLAGS  = -Iarch/wii/libvorbis/include -Iarch/wii/libogg/include
 VORBIS_LDFLAGS = -Larch/wii/libvorbis/lib -Larch/wii/libogg/lib \
                  -lvorbisfile -lvorbis -logg
@@ -38,7 +46,9 @@ EXTRA_INCLUDES = -isystem $(DEVKITPRO)/libogc/include \
 EXTRA_LIBS     = -L$(DEVKITPRO)/libogc/lib/wii \
                  -L$(DEVKITPRO)/libfat-ogc/lib/wii \
                  -L$(DEVKITPRO)/portlibs/wii/lib \
-                 -lfat -lasnd -lwiikeyboard -lwiiuse -lbte -logc -lstdc++ -lm
+                 $(if $(BUILD_SDL), -lSDL,) \
+                 -lz -lfat -lasnd -lwiikeyboard -lwiiuse -lbte -logc -lstdc++ -lm
+
 
 MACHDEP = -DGEKKO -mrvl -mcpu=750 -meabi -mhard-float
 

--- a/arch/wii/Makefile.in
+++ b/arch/wii/Makefile.in
@@ -47,7 +47,7 @@ EXTRA_LIBS     = -L$(DEVKITPRO)/libogc/lib/wii \
                  -L$(DEVKITPRO)/libfat-ogc/lib/wii \
                  -L$(DEVKITPRO)/portlibs/wii/lib \
                  $(if $(BUILD_SDL), -lSDL,) \
-                 -lz -lfat -lasnd -lwiikeyboard -lwiiuse -lbte -logc -lstdc++ -lm
+                 -lfat -lasnd -lwiikeyboard -lwiiuse -lbte -logc -lstdc++ -lm
 
 
 MACHDEP = -DGEKKO -mrvl -mcpu=750 -meabi -mhard-float

--- a/arch/wii/Makefile.in
+++ b/arch/wii/Makefile.in
@@ -75,7 +75,12 @@ arch/wii/%.o: arch/wii/%.c
 #
 build := build/${SUBPLATFORM}/apps/megazeux
 build: package ${build}
-	${CP} arch/wii/pad.config arch/wii/icon.png ${build}
+ifeq ($(BUILD_SDL),)
+	${CP} arch/wii/pad.config ${build}
+else
+	${CP} arch/wii/pad.config.sdl ${build}/pad.config
+endif
+	${CP} arch/wii/icon.png ${build}
 	${CP} boot.dol megazeux.dol ${build}
 	@sed "s/%VERSION%/${VERSION}/g;s/%DATE%/`date -u +%Y%m%d%H%M`/g" \
 	    arch/wii/meta.xml > ${build}/meta.xml

--- a/arch/wii/pad.config.sdl
+++ b/arch/wii/pad.config.sdl
@@ -1,0 +1,98 @@
+### Wiimotes (1 to 4) ###
+
+# The mappings for SDL Wii work different than the normal MZX Wii mappings.
+#
+# Button      None  Nunchuk  Classic  
+# ------------------------------------
+# A           1     -        -
+# B           2     -        -
+# 1           3     -        -
+# 2           4     -        -
+# Minus       5     -        -
+# Plus        6     -        -
+# Home        7     -        -
+#
+# Z           -     8        -
+# C           -     9        -
+#
+# a           -     -        10
+# b           -     -        11
+# x           -     -        12
+# y           -     -        13
+# L           -     -        14
+# R           -     -        15
+# ZL          -     -        16
+# ZR          -     -        17
+# Minus       -     -        18
+# Plus        -     -        19
+# Home        -     -        20
+#
+# Axes:
+# 1/2 Nunchuk
+# 1/2 Classic Left stick
+# 3/4 Classic Right stick
+# 5/6 Classic L/R (positive values only)
+#
+# When the Classic Controller is plugged in, the hat is the Classic Controller d-pad.
+# Otherwise, the hat is the Wii Remote d-pad.
+
+# General
+joy1hat = 273, 274, 276, 275
+joy1axis1 = 276, 275
+joy1axis2 = 273, 274
+
+# Wii Remote
+joy1button1 = 284    # A     -> F3 (load world/save game)
+joy1button2 = 285    # B     -> F4 (load saved game)
+joy1button3 = 13     # 1     -> Enter
+joy1button4 = 32     # 2     -> Space
+joy1button5 = 283    # Minus -> F2 (settings)
+joy1button6 = 286    # Plus  -> F5 (play/switch bomb type)
+joy1button7 = 27     # Home  -> Escape
+
+# Nunchuk
+joy1button8 = 32     # Z     -> Space
+joy1button9 = 127    # C     -> Delete
+
+# Classic Controller
+joy1axis3 = 276, 275
+joy1axis4 = 273, 274
+joy1button10 = 13    # a     -> Enter
+joy1button11 = 32    # b     -> Space
+joy1button12 = 115   # x     -> S
+joy1button13 = 127   # y     -> Delete
+joy1button14 = 284   # L     -> F3 (load world/save game)
+joy1button15 = 285   # R     -> F4 (load saved game)
+#joy1button16 =      # ZL    -> unmapped
+#joy1button17 =      # ZR    -> unmapped
+joy1button18 = 283   # Minus -> F2 (settings)
+joy1button19 = 286   # Plus  -> F5 (play/switch bomb type)
+joy1button20 = 27    # Home  -> Escape
+
+### GameCube controllers (5 to 8) ###
+
+#  1 A
+#  2 B
+#  3 X
+#  4 Y
+#  5 Z
+#  6 L
+#  7 R
+#  8 Start
+
+# 1/2 Analog stick
+# 3/4 C stick
+# 5/6 L/R (positive values only)
+
+joy5axis1 = 276, 275
+joy5axis2 = 273, 274
+joy5axis3 = 276, 275
+joy5axis4 = 273, 274
+joy5button1 = 32     # A     -> Space
+joy5button2 = 13     # B     -> Enter
+joy5button3 = 115    # X     -> S
+joy5button4 = 127    # Y     -> Delete
+joy5button5 = 27     # Z     -> Escape
+joy5button6 = 284    # L     -> F3 (load world/save)
+joy5button7 = 285    # R     -> F4 (load save)
+joy5button8 = 286    # Start -> F5 (play/switch bomb type)

--- a/config.sh
+++ b/config.sh
@@ -465,11 +465,7 @@ echo "SHAREDIR=$SHAREDIR"     >> platform.inc
 if [ "$PLATFORM" = "wii" ]; then
 	echo "#define CONFIG_WII" >> src/config.h
 	echo "BUILD_WII=1" >> platform.inc
-fi
-
-if [ "$PLATFORM" = "wii" ]; then
-	echo "Disabling SDL (Wii)."
-	SDL="false"
+	LIBSDL2="false"
 fi
 
 if [ "$PLATFORM" = "3ds" ]; then
@@ -864,7 +860,7 @@ fi
 #
 # GX renderer (Wii and GameCube)
 #
-if [ "$PLATFORM" = "wii" ]; then
+if [ "$PLATFORM" = "wii" -a "$SDL" = "false" ]; then
 	echo "Building custom GX renderer."
 	echo "#define CONFIG_RENDER_GX" >> src/config.h
 	echo "BUILD_RENDER_GX=1" >> platform.inc

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -122,9 +122,12 @@ LINK_CC := ${CXX}
 endif
 
 ifeq (${BUILD_WII},1)
+# SDL and platform_sdl.c takes care of all of this when enabled.
+ifeq (${BUILD_SDL},)
 core_cobjs += arch/wii/event.o arch/wii/platform.o
 ifeq (${BUILD_AUDIO},1)
 core_cobjs += arch/wii/audio.o
+endif
 endif
 endif
 

--- a/src/configure.c
+++ b/src/configure.c
@@ -33,22 +33,40 @@
 #include "util.h"
 #include "sys/stat.h"
 
-#if defined(CONFIG_NDS)
+// Arch-specific config.
+#ifdef CONFIG_NDS
 #define VIDEO_OUTPUT_DEFAULT "nds"
-#elif defined(CONFIG_GP2X)
+#endif
+
+#ifdef CONFIG_GP2X
 #define VIDEO_OUTPUT_DEFAULT "gp2x"
 #define AUDIO_BUFFER_SIZE 128
-#elif defined(CONFIG_PSP)
+#endif
+
+#ifdef CONFIG_PSP
 #define FULLSCREEN_WIDTH_DEFAULT 640
 #define FULLSCREEN_HEIGHT_DEFAULT 363
 #define FORCE_BPP_DEFAULT 8
 #define FULLSCREEN_DEFAULT 1
-#elif defined(CONFIG_WII)
+#endif
+
+#ifdef CONFIG_WII
 #define AUDIO_SAMPLE_RATE 48000
-#elif defined(ANDROID)
+#ifdef CONFIG_SDL
+#define VIDEO_OUTPUT_DEFAULT "software"
+#define FULLSCREEN_WIDTH_DEFAULT 640
+#define FULLSCREEN_HEIGHT_DEFAULT 480
 #define FORCE_BPP_DEFAULT 16
 #define FULLSCREEN_DEFAULT 1
 #endif
+#endif
+
+#ifdef ANDROID
+#define FORCE_BPP_DEFAULT 16
+#define FULLSCREEN_DEFAULT 1
+#endif
+
+// End arch-specific config.
 
 #ifndef FORCE_BPP_DEFAULT
 #define FORCE_BPP_DEFAULT 32

--- a/src/main.c
+++ b/src/main.c
@@ -87,6 +87,11 @@ __libspec int main(int argc, char *argv[])
   }
 #endif // __APPLE__
 
+#ifdef CONFIG_WII
+  // argc may be 0 if the loader doesn't set args
+  argv[0] = (char *)(SHAREDIR "megazeux");
+#endif
+
   if(mzx_res_init(argv[0], is_editor()))
     goto err_free_res;
 

--- a/src/main.c
+++ b/src/main.c
@@ -67,6 +67,7 @@
 
 __libspec int main(int argc, char *argv[])
 {
+  char *_backup_argv[] = { (char*) SHAREDIR "/megazeux" };
   int err = 1;
 
   // Keep this 7.2k structure off the stack..
@@ -87,10 +88,12 @@ __libspec int main(int argc, char *argv[])
   }
 #endif // __APPLE__
 
-#ifdef CONFIG_WII
-  // argc may be 0 if the loader doesn't set args
-  argv[0] = (char *)(SHAREDIR "megazeux");
-#endif
+  // argc may be 0 on e.g. some Wii homebrew loaders.
+  if(argc == 0)
+  {
+    argv = _backup_argv;
+    argc = 1;
+  }
 
   if(mzx_res_init(argv[0], is_editor()))
     goto err_free_res;

--- a/src/platform_sdl.c
+++ b/src/platform_sdl.c
@@ -33,6 +33,11 @@
 #include <unistd.h> //for chdir, execl
 #endif
 
+#ifdef CONFIG_WII
+#include <sys/iosupport.h>
+#include <fat.h>
+#endif
+
 void delay(Uint32 ms)
 {
   SDL_Delay(ms);
@@ -49,6 +54,11 @@ bool platform_init(void)
 
 #ifdef CONFIG_PSP
   scePowerSetClockFrequency(333, 333, 166);
+#endif
+
+#ifdef CONFIG_WII
+  if(!fatInitDefault())
+    return false;
 #endif
 
 #ifdef DEBUG
@@ -84,6 +94,16 @@ bool platform_init(void)
 void platform_quit(void)
 {
   SDL_Quit();
+
+#ifdef CONFIG_WII
+  {
+    int i;
+
+    for(i = 0; i < STD_MAX; i++)
+      if(devoptab_list[i] && devoptab_list[i]->chdir_r)
+        fatUnmount(devoptab_list[i]->name);
+  }
+#endif
 
 #ifdef CONFIG_GP2X
   chdir("/usr/gp2x");


### PR DESCRIPTION
Added SDL support for the Wii since our regular Wii port is currently more unstable than SDL Wii is (Mr_Alert is currently working on this, however). Right now, SDL has to be explicitly disabled using --disable-sdl to build without SDL.  The button mapping for SDL Wii is a bit different from our regular mapping, but the controls themselves should be close to normal.