### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 -include platform.inc
 include version.inc
 
-all: mzx
+all: mzx assets/help.fil
 debuglink: all mzx.debug
 
 -include arch/${PLATFORM}/Makefile.in

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifeq ($(filter -r,$(MAKEFLAGS)),)
 MAKEFLAGS += -r
 endif
 
-.PHONY: clean help_check mzx mzx.debug build build_clean source
+.PHONY: all clean help_check mzx mzx.debug build build_clean source
 
 -include platform.inc
 include version.inc


### PR DESCRIPTION
'all' is not a file, therefore it's a phony target.

Ensure that help is regenerated when docs/WIPhelp.txt is modified.