### PR TITLE
Include SDL when linking on macOS.

### DIFF
--- a/src/editor/Makefile.in
+++ b/src/editor/Makefile.in
@@ -16,7 +16,7 @@ editor_spec := -DEDITOR_LIBSPEC="__declspec(dllexport)"
 endif
 
 ifeq (${PLATFORM},darwin)
-editor_ldflags += -framework Cocoa
+editor_ldflags += -framework Cocoa ${SDL_LDFLAGS}
 endif
 
 ifneq (${X11DIR},)


### PR DESCRIPTION
This change was required when I performed a stock build on macOS, otherwise there were undefined references to SDL clipboard functions.