### PR TITLE
Improved updater deletion failure handling

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -142,6 +142,12 @@ __libspec int main(int argc, char *argv[])
 
   set_mouse_mul(8, 14);
 
+  init_event();
+
+  if(!init_video(&mzx_world.conf, CAPTION))
+    goto err_free_config;
+  init_audio(&(mzx_world.conf));
+
   if(network_layer_init(&mzx_world.conf))
   {
     if(!updater_init(argc, argv))
@@ -149,12 +155,6 @@ __libspec int main(int argc, char *argv[])
   }
   else
     info("Network layer disabled.\n");
-
-  init_event();
-
-  if(!init_video(&mzx_world.conf, CAPTION))
-    goto err_network_layer_exit;
-  init_audio(&(mzx_world.conf));
 
   warp_mouse(39, 12);
   cursor_off();
@@ -189,11 +189,11 @@ __libspec int main(int argc, char *argv[])
   help_close(&mzx_world);
 #endif
 
+  network_layer_exit(&mzx_world.conf);
   quit_audio();
 
   err = 0;
-err_network_layer_exit:
-  network_layer_exit(&mzx_world.conf);
+err_free_config:
   if(mzx_world.update_done)
     free(mzx_world.update_done);
   free_config(&mzx_world.conf);

--- a/src/network/manifest.c
+++ b/src/network/manifest.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <time.h>
 
 #define BLOCK_SIZE    4096UL
 #define LINE_BUF_LEN  256
@@ -61,7 +62,7 @@ static bool manifest_parse_size(char *p, unsigned long *size)
   return true;
 }
 
-static void manifest_entry_free(struct manifest_entry *e)
+void manifest_entry_free(struct manifest_entry *e)
 {
   free(e->name);
   free(e);
@@ -418,7 +419,7 @@ bool manifest_entry_download_replace(struct host *h, const char *basedir,
   f = fopen_unsafe(e->name, "w+b");
   if(!f)
   {
-    snprintf(buf, LINE_BUF_LEN, "%s~", e->name);
+    snprintf(buf, LINE_BUF_LEN, "%s-%u~", e->name, (unsigned int)time(NULL));
     if(rename(e->name, buf))
     {
       warn("Failed to rename in-use file '%s' to '%s'\n", e->name, buf);
@@ -460,4 +461,3 @@ err_close:
 err_out:
   return valid;
 }
-

--- a/src/network/manifest.h
+++ b/src/network/manifest.h
@@ -44,6 +44,7 @@ UPDATER_LIBSPEC bool manifest_entry_check_validity(struct manifest_entry *e,
  FILE *f);
 UPDATER_LIBSPEC struct manifest_entry *manifest_list_create(FILE *f);
 
+UPDATER_LIBSPEC void manifest_entry_free(struct manifest_entry *e);
 UPDATER_LIBSPEC void manifest_list_free(struct manifest_entry **head);
 UPDATER_LIBSPEC bool manifest_get_updates(struct host *h, const char *basedir,
  struct manifest_entry **removed, struct manifest_entry **replaced,

--- a/src/updater.c
+++ b/src/updater.c
@@ -460,6 +460,10 @@ err_delete_failed:
       buf[71] = 0;
 
       error(buf, 1, 8, 0);
+
+      if(e_next)
+        e->next = e_next->next;
+
       continue;
     }
   }

--- a/src/updater.c
+++ b/src/updater.c
@@ -383,6 +383,88 @@ static bool restore_original_manifest(bool ret)
   return true;
 }
 
+static bool write_delete_list(void)
+{
+  struct manifest_entry *e;
+  FILE *f;
+
+  if(delete_list)
+  {
+    f = fopen_unsafe(DELETE_TXT, "ab");
+    if(!f)
+    {
+      error("Failed to create \"" DELETE_TXT "\". Check permissions.", 1, 8, 0);
+      return false;
+    }
+
+    for(e = delete_list; e; e = e->next)
+    {
+      fprintf(f, "%08x%08x%08x%08x%08x%08x%08x%08x %lu %s\n",
+       e->sha256[0], e->sha256[1], e->sha256[2], e->sha256[3],
+       e->sha256[4], e->sha256[5], e->sha256[6], e->sha256[7],
+       e->size, e->name);
+    }
+
+    fclose(f);
+  }
+  return true;
+}
+
+static void apply_delete_list(void)
+{
+  struct manifest_entry *e_next = delete_list;
+  struct manifest_entry *e;
+  struct stat s;
+  bool ret;
+  FILE *f;
+
+  while(e_next)
+  {
+    e = e_next;
+    e_next = e->next;
+
+    if(!stat(e->name, &s))
+    {
+      f = fopen_unsafe(e->name, "rb");
+      if(!f)
+        goto err_delete_failed;
+
+      ret = manifest_entry_check_validity(e, f);
+      fclose(f);
+
+      if(ret)
+      {
+        if(unlink(e->name))
+          goto err_delete_failed;
+
+        /* Obtain the path for this file. If the file isn't at the top
+         * level, and the directory is empty (rmdir ensures this)
+         * the directory will be pruned.
+         */
+        check_prune_basedir(e->name);
+      }
+    }
+
+    // File was removed, doesn't exist, or is non-applicable; remove from list
+    if(delete_list == e)
+      delete_list = e_next;
+
+    manifest_entry_free(e);
+    continue;
+
+err_delete_failed:
+    {
+      char buf[72];
+      snprintf(buf, 72, "Failed to delete \"%.30s\". Check permissions.",
+       e->name);
+      buf[71] = 0;
+
+      error(buf, 1, 8, 0);
+      continue;
+    }
+  }
+}
+
 static bool reissue_connection(struct config_info *conf, struct host **h, char *host_name)
 {
   bool ret = false;
@@ -783,25 +865,8 @@ static void __check_for_updates(struct world *mzx_world, struct config_info *con
       }
     }
 
-    if(delete_list)
-    {
-      f = fopen_unsafe(DELETE_TXT, "wb");
-      if(!f)
-      {
-        error("Failed to create \"" DELETE_TXT "\". Check permissions.", 1, 8, 0);
-        goto err_free_delete_list;
-      }
-
-      for(e = delete_list; e; e = e->next)
-      {
-        fprintf(f, "%08x%08x%08x%08x%08x%08x%08x%08x %lu %s\n",
-         e->sha256[0], e->sha256[1], e->sha256[2], e->sha256[3],
-         e->sha256[4], e->sha256[5], e->sha256[6], e->sha256[7],
-         e->size, e->name);
-      }
-
-      fclose(f);
-    }
+    if(!write_delete_list())
+      goto err_free_delete_list;
 
     try_next_host = false;
     ret = true;
@@ -853,8 +918,6 @@ err_out:
 
 bool updater_init(int argc, char *argv[])
 {
-  struct manifest_entry *e;
-  bool ret;
   FILE *f;
 
   process_argc = argc;
@@ -872,30 +935,16 @@ bool updater_init(int argc, char *argv[])
   delete_list = manifest_list_create(f);
   fclose(f);
 
-  for(e = delete_list; e; e = e->next)
-  {
-    f = fopen_unsafe(e->name, "rb");
-    if(!f)
-      continue;
-
-    ret = manifest_entry_check_validity(e, f);
-    fclose(f);
-
-    if(!ret)
-      continue;
-
-    if(unlink(e->name))
-      continue;
-
-    /* Obtain the path for this file. If the file isn't at the top
-     * level, and the directory is empty (rmdir ensures this)
-     * the directory will be pruned.
-     */
-    check_prune_basedir(e->name);
-  }
-
-  manifest_list_free(&delete_list);
+  apply_delete_list();
   unlink(DELETE_TXT);
+
+  if(delete_list)
+  {
+    write_delete_list();
+    manifest_list_free(&delete_list);
+    error("Failed to delete files; check permissions and restart MegaZeux",
+     1, 8, 0);
+  }
 
 err_swivel_back:
   swivel_current_dir_back(false);


### PR DESCRIPTION
Failed deletions in the updater now trigger error messages and rewrite `delete.txt` so MegaZeux can try to delete them again the next time it starts.  Additionally, files that couldn't be overwritten (e.g. `core.dll`) are renamed to more unique temporary locations to prevent collisions during future updates.