### PR TITLE
Refactor version checking

### DIFF
--- a/src/counter.c
+++ b/src/counter.c
@@ -3242,7 +3242,7 @@ static int score_gateway(struct world *mzx_world, struct counter *counter,
  const char *name, int value, int id)
 {
   // Protection for score < 0, as per the behavior in DOS MZX.
-  if((value < 0) && (mzx_world->version <= 0x249))
+  if((value < 0) && (mzx_world->version < VPORT))
     return 0;
 
   return value;

--- a/src/counter.c
+++ b/src/counter.c
@@ -1095,7 +1095,7 @@ static int key_read(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int id)
 {
   // In DOS versions key was a board counter
-  if(mzx_world->version < VPORT)
+  if(mzx_world->version < VERSION_PORT)
   {
     return mzx_world->current_board->last_key;
   }
@@ -1106,7 +1106,7 @@ static void key_write(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int value, int id)
 {
   // In DOS versions key was a board counter
-  if(mzx_world->version < VPORT)
+  if(mzx_world->version < VERSION_PORT)
   {
     mzx_world->current_board->last_key = CLAMP(value, 0, 255);
   }
@@ -2367,6 +2367,8 @@ static void max_samples_write(struct world *mzx_world,
  *       in these versions. This is unfortunately not fixable.
  */
 
+#define ALL VERSION_ALL
+
 static const struct function_counter builtin_counters[] =
 {
   { "$*",               V262,   string_counter_read,  string_counter_write },
@@ -2387,7 +2389,7 @@ static const struct function_counter builtin_counters[] =
   { "board_param",      V265,   board_param_read,     board_param_write },
   { "board_w",          V265,   board_w_read,         NULL },
   { "bpr!,!",           V284,   bpr_read,             bpr_write },
-  { "bullettype",       Vall,   bullettype_read,      bullettype_write },
+  { "bullettype",       ALL,    bullettype_read,      bullettype_write },
   { "buttons",          V251s1, buttons_read,         NULL },
   { "char_byte",        V260,   char_byte_read,       char_byte_write },
   { "commands",         V260,   commands_read,        commands_write },
@@ -2413,11 +2415,11 @@ static const struct function_counter builtin_counters[] =
   { "fwrite_pos",       V260,   fwrite_pos_read,      fwrite_pos_write },
   { "goop_walk",        V290,   goop_walk_read,       goop_walk_write },
   { "green_value",      V260,   green_value_read,     green_value_write },
-  { "horizpld",         Vall,   horizpld_read,        NULL },
-  { "input",            Vall,   input_read,           input_write },
-  { "inputsize",        Vall,   inputsize_read,       inputsize_write },
+  { "horizpld",         ALL,    horizpld_read,        NULL },
+  { "input",            ALL,    input_read,           input_write },
+  { "inputsize",        ALL,    inputsize_read,       inputsize_write },
   { "int2bin",          V260,   int2bin_read,         int2bin_write },
-  { "key",              Vall,   key_read,             key_write },
+  { "key",              ALL,    key_read,             key_write },
   { "key?",             V269,   keyn_read,            NULL },
   { "key_code",         V269,   key_code_read,        NULL },
   { "key_pressed",      V260,   key_pressed_read,     NULL },
@@ -2428,10 +2430,10 @@ static const struct function_counter builtin_counters[] =
   { "load_game",        V268,   load_game_read,       NULL },
   { "load_robot?",      V270,   load_robot_read,      NULL },
 #ifdef CONFIG_DEBYTECODE
-  { "load_source_file?", VSOURCE, load_source_file_read, NULL },
+  { "load_source_file?", VERSION_SOURCE, load_source_file_read, NULL },
 #endif
   { "local?",           V251s1, local_read,           local_write },
-  { "loopcount",        Vall,   loopcount_read,       loopcount_write },
+  { "loopcount",        ALL,    loopcount_read,       loopcount_write },
   { "max!,!",           V284,   maxval_read,          NULL },
   { "max_samples",      V291,   max_samples_read,     max_samples_write },
   { "mboardx",          V251s1, mboardx_read,         NULL },
@@ -2453,9 +2455,9 @@ static const struct function_counter builtin_counters[] =
   { "overlay_color",    V260,   overlay_color_read,   NULL },
   { "overlay_mode",     V260,   overlay_mode_read,    NULL },
   { "pixel",            V260,   pixel_read,           pixel_write },
-  { "playerdist",       Vall,   playerdist_read,      NULL },
-  { "playerfacedir",    Vall,   playerfacedir_read,   playerfacedir_write },
-  { "playerlastdir",    Vall,   playerlastdir_read,   playerlastdir_write },
+  { "playerdist",       ALL,    playerdist_read,      NULL },
+  { "playerfacedir",    ALL,    playerfacedir_read,   playerfacedir_write },
+  { "playerlastdir",    ALL,    playerlastdir_read,   playerlastdir_write },
   { "playerx",          V251s1, playerx_read,         NULL },
   { "playery",          V251s1, playery_read,         NULL },
   { "play_game",        V290,   NULL,                 play_game_write },
@@ -2509,11 +2511,11 @@ static const struct function_counter builtin_counters[] =
   { "spr_yorder",       V265,   NULL,                 spr_yorder_write },
   { "sqrt!",            V268,   sqrt_read,            NULL },
   { "tan!",             V268,   tan_read,             NULL },
-  { "thisx",            Vall,   thisx_read,           NULL },
-  { "thisy",            Vall,   thisy_read,           NULL },
+  { "thisx",            ALL,    thisx_read,           NULL },
+  { "thisy",            ALL,    thisy_read,           NULL },
   { "this_char",        V260,   this_char_read,       NULL },
   { "this_color",       V260,   this_color_read,      NULL },
-  { "timereset",        Vall,   timereset_read,       timereset_write },
+  { "timereset",        ALL,    timereset_read,       timereset_write },
   { "time_hours",       V260,   time_hours_read,      NULL },
   { "time_minutes",     V260,   time_minutes_read,    NULL },
   { "time_seconds",     V260,   time_seconds_read,    NULL },
@@ -2523,7 +2525,7 @@ static const struct function_counter builtin_counters[] =
   { "upr!,!",           V284,   upr_read,             upr_write },
   { "vch!,!",           V269c,  vch_read,             vch_write },
   { "vco!,!",           V269c,  vco_read,             vco_write },
-  { "vertpld",          Vall,   vertpld_read,         NULL },
+  { "vertpld",          ALL,    vertpld_read,         NULL },
   { "vlayer_height",    V269c,  vlayer_height_read,   vlayer_height_write },
   { "vlayer_size",      V251,   vlayer_size_read,     vlayer_size_write },
   { "vlayer_width",     V269c,  vlayer_width_read,    vlayer_width_write },
@@ -3171,7 +3173,7 @@ static int health_dec_gateway(struct world *mzx_world, struct counter *counter,
   // Trying to decrease health? (legacy support)
   // Only handle here in pre-port MZX world versions
   // Otherwise, it will be handled in health_gateway()
-  if((value > 0) && (mzx_world->version < VPORT))
+  if((value > 0) && (mzx_world->version < VERSION_PORT))
   {
     value = hurt_player(mzx_world, value);
   }
@@ -3194,7 +3196,7 @@ static int health_gateway(struct world *mzx_world, struct counter *counter,
   // Trying to decrease health?
   // Only handle here in port MZX world versions
   // Otherwise, it will be handled in health_dec_gateway()
-  if((value < counter->value) && (mzx_world->version >= VPORT))
+  if((value < counter->value) && (mzx_world->version >= VERSION_PORT))
   {
     value = counter->value - hurt_player(mzx_world, counter->value - value);
   }
@@ -3242,7 +3244,7 @@ static int score_gateway(struct world *mzx_world, struct counter *counter,
  const char *name, int value, int id)
 {
   // Protection for score < 0, as per the behavior in DOS MZX.
-  if((value < 0) && (mzx_world->version < VPORT))
+  if((value < 0) && (mzx_world->version < VERSION_PORT))
     return 0;
 
   return value;

--- a/src/counter.c
+++ b/src/counter.c
@@ -3169,9 +3169,9 @@ static int health_dec_gateway(struct world *mzx_world, struct counter *counter,
  const char *name, int value, int id)
 {
   // Trying to decrease health? (legacy support)
-  // Only handle here if MZX world version <= 2.70
+  // Only handle here in pre-port MZX world versions
   // Otherwise, it will be handled in health_gateway()
-  if((value > 0) && (mzx_world->version <= V270))
+  if((value > 0) && (mzx_world->version < VPORT))
   {
     value = hurt_player(mzx_world, value);
   }
@@ -3192,9 +3192,9 @@ static int health_gateway(struct world *mzx_world, struct counter *counter,
   }
 
   // Trying to decrease health?
-  // Only handle here if MZX world version > 2.70
+  // Only handle here in port MZX world versions
   // Otherwise, it will be handled in health_dec_gateway()
-  if((value < counter->value) && (mzx_world->version > V270))
+  if((value < counter->value) && (mzx_world->version >= VPORT))
   {
     value = counter->value - hurt_player(mzx_world, counter->value - value);
   }

--- a/src/counter.c
+++ b/src/counter.c
@@ -2439,10 +2439,10 @@ static const struct function_counter builtin_counters[] =
   { "mboardx",          V251s1, mboardx_read,         NULL },
   { "mboardy",          V251s1, mboardy_read,         NULL },
   { "min!,!",           V284,   minval_read,          NULL },
-  { "mod_frequency",    V251,   mod_freq_read,        mod_freq_write },
+  { "mod_frequency",    V281,   mod_freq_read,        mod_freq_write },
   { "mod_length",       V291,   mod_length_read,      NULL },
   { "mod_order",        V262,   mod_order_read,       mod_order_write },
-  { "mod_position",     V251,   mod_position_read,    mod_position_write },
+  { "mod_position",     V281,   mod_position_read,    mod_position_write },
   { "mousepx",          V282,   mousepx_read,         mousepx_write },
   { "mousepy",          V282,   mousepy_read,         mousepy_write },
   { "mousex",           V251s1, mousex_read,          mousex_write },
@@ -2527,7 +2527,7 @@ static const struct function_counter builtin_counters[] =
   { "vco!,!",           V269c,  vco_read,             vco_write },
   { "vertpld",          ALL,    vertpld_read,         NULL },
   { "vlayer_height",    V269c,  vlayer_height_read,   vlayer_height_write },
-  { "vlayer_size",      V251,   vlayer_size_read,     vlayer_size_write },
+  { "vlayer_size",      V281,   vlayer_size_read,     vlayer_size_write },
   { "vlayer_width",     V269c,  vlayer_width_read,    vlayer_width_write },
 };
 

--- a/src/counter.c
+++ b/src/counter.c
@@ -439,7 +439,7 @@ static int board_color_read(struct world *mzx_world,
   unsigned int offset = get_board_x_board_y_offset(mzx_world, id);
   int ignore_under = 1;
 
-  if((mzx_world->version >= 0x0250) && (mzx_world->version <= 0x0253))
+  if((mzx_world->version >= V280) && (mzx_world->version <= V283))
     ignore_under = 0;
 
   return get_id_board_color(mzx_world->current_board, offset, ignore_under);
@@ -810,7 +810,7 @@ static void spr_ccheck_write(struct world *mzx_world,
   int spr_num = strtol(name + 3, NULL, 10) & (MAX_SPRITES - 1);
   struct sprite *cur_sprite = mzx_world->sprite_list[spr_num];
 
-  if (mzx_world->version < 0x025A)
+  if(mzx_world->version < V290)
   {  // Old (somewhat dodgy) behaviour tied to <2.90
     value %= 3;
     switch(value)
@@ -861,7 +861,7 @@ static void spr_cx_write(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int value, int id)
 {
   int spr_num = strtol(name + 3, NULL, 10) & (MAX_SPRITES - 1);
-  if (mzx_world->version < 0x025A) // Before 2.90 these fields were chars.
+  if(mzx_world->version < V290) // Before 2.90 these fields were chars.
     value = (signed char) value;
   (mzx_world->sprite_list[spr_num])->col_x = value;
 }
@@ -870,7 +870,7 @@ static void spr_cy_write(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int value, int id)
 {
   int spr_num = strtol(name + 3, NULL, 10) & (MAX_SPRITES - 1);
-  if (mzx_world->version < 0x025A) // Before 2.90 these fields were chars.
+  if(mzx_world->version < V290) // Before 2.90 these fields were chars.
     value = (signed char) value;
   (mzx_world->sprite_list[spr_num])->col_y = value;
 }
@@ -886,7 +886,7 @@ static void spr_offset_write(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int value, int id)
 {
   int spr_num = strtol(name + 3, NULL, 10) & (MAX_SPRITES - 1);
-  if (layer_renderer_check(true))
+  if(layer_renderer_check(true))
     (mzx_world->sprite_list[spr_num])->offset = value;
 }
 
@@ -894,7 +894,8 @@ static void spr_unbound_write(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int value, int id)
 {
   int spr_num = strtol(name + 3, NULL, 10) & (MAX_SPRITES - 1);
-  if (layer_renderer_check(true)) {
+  if(layer_renderer_check(true))
+  {
     (mzx_world->sprite_list[spr_num])->flags &= ~SPRITE_UNBOUND;
     (mzx_world->sprite_list[spr_num])->flags |= value ? SPRITE_UNBOUND : 0;
   }
@@ -904,7 +905,7 @@ static void spr_height_write(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int value, int id)
 {
   int spr_num = strtol(name + 3, NULL, 10) & (MAX_SPRITES - 1);
-  if (mzx_world->version < 0x025A) // Before 2.90 these fields were chars.
+  if(mzx_world->version < V290) // Before 2.90 these fields were chars.
     value = (char) value;
   (mzx_world->sprite_list[spr_num])->height = value;
 }
@@ -913,7 +914,7 @@ static void spr_width_write(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int value, int id)
 {
   int spr_num = strtol(name + 3, NULL, 10) & (MAX_SPRITES - 1);
-  if (mzx_world->version < 0x025A) // Before 2.90 these fields were chars.
+  if(mzx_world->version < V290) // Before 2.90 these fields were chars.
     value = (char) value;
   (mzx_world->sprite_list[spr_num])->width = value;
 }
@@ -1010,7 +1011,7 @@ static void spr_cwidth_write(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int value, int id)
 {
   int spr_num = strtol(name + 3, NULL, 10) & (MAX_SPRITES - 1);
-  if (mzx_world->version < 0x025A) // Before 2.90 these fields were chars.
+  if(mzx_world->version < V290) // Before 2.90 these fields were chars.
     value = (char) value;
   (mzx_world->sprite_list[spr_num])->col_width = value;
 }
@@ -1019,7 +1020,7 @@ static void spr_cheight_write(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int value, int id)
 {
   int spr_num = strtol(name + 3, NULL, 10) & (MAX_SPRITES - 1);
-  if (mzx_world->version < 0x025A) // Before 2.90 these fields were chars.
+  if(mzx_world->version < V290) // Before 2.90 these fields were chars.
     value = (char) value;
   (mzx_world->sprite_list[spr_num])->col_height = value;
 }
@@ -1034,12 +1035,15 @@ static void spr_setview_write(struct world *mzx_world,
   src_board->scroll_x = 0;
   src_board->scroll_y = 0;
   calculate_xytop(mzx_world, &n_scroll_x, &n_scroll_y);
-  if (cur_sprite->flags & SPRITE_UNBOUND) {
+  if(cur_sprite->flags & SPRITE_UNBOUND)
+  {
     src_board->scroll_x = ((cur_sprite->x + (signed)cur_sprite->width * 4
      - src_board->viewport_width * 4) - n_scroll_x * 8) / 8;
     src_board->scroll_y = ((cur_sprite->y + (signed)cur_sprite->height * 7
      - src_board->viewport_height * 7) - n_scroll_x * 14) / 14;
-  } else {
+  }
+  else
+  {
     src_board->scroll_x =
     (cur_sprite->x + (cur_sprite->width >> 1)) -
     (src_board->viewport_width >> 1) - n_scroll_x;
@@ -1090,8 +1094,8 @@ static void input_write(struct world *mzx_world,
 static int key_read(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int id)
 {
-  // In versions <=2.70 key was a board counter
-  if (mzx_world->version <= 0x0249)
+  // In DOS versions key was a board counter
+  if(mzx_world->version < VPORT)
   {
     return mzx_world->current_board->last_key;
   }
@@ -1101,8 +1105,8 @@ static int key_read(struct world *mzx_world,
 static void key_write(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int value, int id)
 {
-  // In versions <=2.70 key was a board counter
-  if (mzx_world->version <= 0x0249)
+  // In DOS versions key was a board counter
+  if(mzx_world->version < VPORT)
   {
     mzx_world->current_board->last_key = CLAMP(value, 0, 255);
   }
@@ -1127,7 +1131,7 @@ static int key_pressed_read(struct world *mzx_world,
 {
   // In 2.82X through 2.84X, this erroneously applied
   // numlock translations to the keycode.
-  if(mzx_world->version >= 0x0252 && mzx_world->version <= 0x0254)
+  if(mzx_world->version >= V282 && mzx_world->version <= V284)
     return get_key(keycode_internal_wrt_numlock);
 
   return get_key(keycode_internal);
@@ -1553,7 +1557,7 @@ static int char_byte_read(struct world *mzx_world,
   Uint16 char_num = get_counter(mzx_world, "CHAR", id);
 
   // Prior to 2.90 char params are clipped
-  if (mzx_world->version < 0x025A) char_num &= 0xFF;
+  if(mzx_world->version < V290) char_num &= 0xFF;
   
   return ec_read_byte(char_num,
    get_counter(mzx_world, "BYTE", id));
@@ -1565,8 +1569,8 @@ static void char_byte_write(struct world *mzx_world,
   Uint16 char_num = get_counter(mzx_world, "CHAR", id);
 
   // Prior to 2.90 char params are clipped
-  if (mzx_world->version < 0x025A) char_num &= 0xFF;
-  if (char_num > 0xFF && !layer_renderer_check(true)) return;
+  if(mzx_world->version < V290) char_num &= 0xFF;
+  if(char_num > 0xFF && !layer_renderer_check(true)) return;
 
   ec_change_byte(char_num,
    get_counter(mzx_world, "BYTE", id), value);
@@ -1852,7 +1856,7 @@ static int fread_counter_read(struct world *mzx_world,
 {
   if(!mzx_world->input_is_dir && mzx_world->input_file)
   {
-    if(mzx_world->version < 0x0252)
+    if(mzx_world->version < V282)
       return fgetw(mzx_world->input_file);
     else
       return fgetd(mzx_world->input_file);
@@ -1933,7 +1937,7 @@ static void fwrite_counter_write(struct world *mzx_world,
 {
   if(mzx_world->output_file)
   {
-    if(mzx_world->version < 0x0252)
+    if(mzx_world->version < V282)
       fputw(value, mzx_world->output_file);
     else
       fputd(value, mzx_world->output_file);
@@ -2059,7 +2063,7 @@ static void vlayer_size_write(struct world *mzx_world,
     }
     else
 
-    if(old_size < value && mzx_world->version >= 0x025B)
+    if(old_size < value && mzx_world->version >= V291)
     {
       // Clear new vlayer area (2.91+)
       memset(mzx_world->vlayer_chars + old_size, 32, value - old_size);
@@ -2082,7 +2086,7 @@ static void vlayer_height_write(struct world *mzx_world,
   new_width = mzx_world->vlayer_size / value;
   new_height = value;
 
-  if(mzx_world->version >= 0x025B)
+  if(mzx_world->version >= V291)
   {
     // Manipulate vlayer data so its contents change little as possible (2.91+)
     remap_vlayer(mzx_world, new_width, new_height);
@@ -2108,7 +2112,7 @@ static void vlayer_width_write(struct world *mzx_world,
   new_width = value;
   new_height = mzx_world->vlayer_size / value;
 
-  if(mzx_world->version >= 0x025B)
+  if(mzx_world->version >= V291)
   {
     // Manipulate vlayer data so its contents change little as possible (2.91+)
     remap_vlayer(mzx_world, new_width, new_height);
@@ -2136,34 +2140,34 @@ static int buttons_read(struct world *mzx_world,
    * second bit and middle the third, we'll map every button.
    */
 
-  if (raw_status & MOUSE_BUTTON(MOUSE_BUTTON_LEFT))
+  if(raw_status & MOUSE_BUTTON(MOUSE_BUTTON_LEFT))
     buttons_formatted |= MOUSE_BUTTON(1);
 
-  if (raw_status & MOUSE_BUTTON(MOUSE_BUTTON_RIGHT))
+  if(raw_status & MOUSE_BUTTON(MOUSE_BUTTON_RIGHT))
     buttons_formatted |= MOUSE_BUTTON(2);
 
-  if (raw_status & MOUSE_BUTTON(MOUSE_BUTTON_MIDDLE))
+  if(raw_status & MOUSE_BUTTON(MOUSE_BUTTON_MIDDLE))
     buttons_formatted |= MOUSE_BUTTON(3);
 
   // For 2.90+, also map the wheel and side buttons
-  if( mzx_world->version >= 0x025A )
+  if(mzx_world->version >= V290)
   {
-    if (raw_status_ext == MOUSE_BUTTON_WHEELUP)
+    if(raw_status_ext == MOUSE_BUTTON_WHEELUP)
       buttons_formatted |= MOUSE_BUTTON(4);
 
-    if (raw_status_ext == MOUSE_BUTTON_WHEELDOWN)
+    if(raw_status_ext == MOUSE_BUTTON_WHEELDOWN)
       buttons_formatted |= MOUSE_BUTTON(5);
 
-    if (raw_status_ext == MOUSE_BUTTON_WHEELLEFT)
+    if(raw_status_ext == MOUSE_BUTTON_WHEELLEFT)
       buttons_formatted |= MOUSE_BUTTON(6);
 
-    if (raw_status_ext == MOUSE_BUTTON_WHEELRIGHT)
+    if(raw_status_ext == MOUSE_BUTTON_WHEELRIGHT)
       buttons_formatted |= MOUSE_BUTTON(7);
 
-    if (raw_status & MOUSE_BUTTON(MOUSE_BUTTON_X1))
+    if(raw_status & MOUSE_BUTTON(MOUSE_BUTTON_X1))
       buttons_formatted |= MOUSE_BUTTON(8);
 
-    if (raw_status & MOUSE_BUTTON(MOUSE_BUTTON_X2))
+    if(raw_status & MOUSE_BUTTON(MOUSE_BUTTON_X2))
       buttons_formatted |= MOUSE_BUTTON(9);
   }
 
@@ -2365,164 +2369,164 @@ static void max_samples_write(struct world *mzx_world,
 
 static const struct function_counter builtin_counters[] =
 {
-  { "$*", 0x023E, string_counter_read, string_counter_write },       // 2.62
-  { "abs!", 0x0244, abs_read, NULL },                                // 2.68
-  { "acos!", 0x0244, acos_read, NULL },                              // 2.68
-  { "arctan!,!", 0x0254, atan2_read, NULL },                         // 2.84
-  { "asin!", 0x0244, asin_read, NULL },                              // 2.68
-  { "atan!", 0x0244, atan_read, NULL },                              // 2.68
-  { "bch!,!", 0x0254, bch_read, NULL },                              // 2.84
-  { "bco!,!", 0x0254, bco_read, NULL },                              // 2.84
-  { "bid!,!", 0x0254, bid_read, bid_write },                         // 2.84
-  { "bimesg", 0x0209, NULL, bimesg_write },                          // 2.51s3.2
-  { "blue_value", 0x0209, blue_value_read, blue_value_write },       // 2.60
-  { "board_char", 0x0209, board_char_read, NULL },                   // 2.60
-  { "board_color", 0x0209, board_color_read, NULL },                 // 2.60
-  { "board_h", 0x0241, board_h_read, NULL },                         // 2.65
-  { "board_id", 0x0241, board_id_read, board_id_write },             // 2.65
-  { "board_param", 0x0241, board_param_read, board_param_write },    // 2.65
-  { "board_w", 0x0241, board_w_read, NULL },                         // 2.65
-  { "bpr!,!", 0x0254, bpr_read, bpr_write },                         // 2.84
-  { "bullettype", 0, bullettype_read, bullettype_write },            // <=2.51
-  { "buttons", 0x0208, buttons_read, NULL },                         // 2.51s1
-  { "char_byte", 0x0209, char_byte_read, char_byte_write },          // 2.60
-  { "commands", 0x0209, commands_read, commands_write },             // 2.60
-  { "commands_stop", 0x025A, commands_stop_read, commands_stop_write },// 2.90
-  { "cos!", 0x0244, cos_read, NULL },                                // 2.68
-  { "c_divisions", 0x0244, c_divisions_read, c_divisions_write },    // 2.68
-  { "date_day", 0x0209, date_day_read, NULL },                       // 2.60
-  { "date_month", 0x0209, date_month_read, NULL },                   // 2.60
-  { "date_year", 0x0209, date_year_read, NULL },                     // 2.60
-  { "divider", 0x0244, divider_read, divider_write },                // 2.68
-  { "exit_game", 0x025A, NULL, exit_game_write },                    // 2.90
-  { "fread", 0x0209, fread_read, NULL },                             // 2.60
-  { "fread_counter", 0x0241, fread_counter_read, NULL },             // 2.65
-  { "fread_delimiter", 0x0254, NULL, fread_delim_write },            // 2.84
-  { "fread_open", 0x0209, fread_open_read, NULL },                   // 2.60
-  { "fread_pos", 0x0209, fread_pos_read, fread_pos_write },          // 2.60
-  { "fwrite", 0x0209, NULL, fwrite_write },                          // 2.60
-  { "fwrite_append", 0x0209, fwrite_append_read, NULL },             // 2.60
-  { "fwrite_counter", 0x0241, NULL, fwrite_counter_write },          // 2.65
-  { "fwrite_delimiter", 0x0254, NULL, fwrite_delim_write },          // 2.84
-  { "fwrite_modify", 0x0248, fwrite_modify_read, NULL },             // 2.69c
-  { "fwrite_open", 0x0209, fwrite_open_read, NULL },                 // 2.60
-  { "fwrite_pos", 0x0209, fwrite_pos_read, fwrite_pos_write },       // 2.60
-  { "goop_walk", 0x025A, goop_walk_read, goop_walk_write },          // 2.90
-  { "green_value", 0x0209, green_value_read, green_value_write },    // 2.60
-  { "horizpld", 0, horizpld_read, NULL },                            // <=2.51
-  { "input", 0, input_read, input_write },                           // <=2.51
-  { "inputsize", 0, inputsize_read, inputsize_write },               // <=2.51
-  { "int2bin", 0x0209, int2bin_read, int2bin_write },                // 2.60
-  { "key", 0, key_read, key_write },                                 // <=2.51
-  { "key?", 0x0245, keyn_read, NULL },                               // 2.69
-  { "key_code", 0x0245, key_code_read, NULL },                       // 2.69
-  { "key_pressed", 0x0209, key_pressed_read, NULL },                 // 2.60
-  { "key_release", 0x0245, key_release_read, NULL },                 // 2.69
-  { "lava_walk", 0x0209, lava_walk_read, lava_walk_write },          // 2.60
-  { "load_bc?", 0x0249, load_bc_read, NULL },                        // 2.70
-  { "load_counters", 0x025A, load_counters_read, NULL },             // 2.90
-  { "load_game", 0x0244, load_game_read, NULL },                     // 2.68
-  { "load_robot?", 0x0249, load_robot_read, NULL },                  // 2.70
+  { "$*",               V262,   string_counter_read,  string_counter_write },
+  { "abs!",             V268,   abs_read,             NULL },
+  { "acos!",            V268,   acos_read,            NULL },
+  { "arctan!,!",        V284,   atan2_read,           NULL },
+  { "asin!",            V268,   asin_read,            NULL },
+  { "atan!",            V268,   atan_read,            NULL },
+  { "bch!,!",           V284,   bch_read,             NULL },
+  { "bco!,!",           V284,   bco_read,             NULL },
+  { "bid!,!",           V284,   bid_read,             bid_write },
+  { "bimesg",           V251s3, NULL,                 bimesg_write }, // s3.2
+  { "blue_value",       V260,   blue_value_read,      blue_value_write },
+  { "board_char",       V260,   board_char_read,      NULL },
+  { "board_color",      V260,   board_color_read,     NULL },
+  { "board_h",          V265,   board_h_read,         NULL },
+  { "board_id",         V265,   board_id_read,        board_id_write },
+  { "board_param",      V265,   board_param_read,     board_param_write },
+  { "board_w",          V265,   board_w_read,         NULL },
+  { "bpr!,!",           V284,   bpr_read,             bpr_write },
+  { "bullettype",       Vall,   bullettype_read,      bullettype_write },
+  { "buttons",          V251s1, buttons_read,         NULL },
+  { "char_byte",        V260,   char_byte_read,       char_byte_write },
+  { "commands",         V260,   commands_read,        commands_write },
+  { "commands_stop",    V290,   commands_stop_read,   commands_stop_write },
+  { "cos!",             V268,   cos_read,             NULL },
+  { "c_divisions",      V268,   c_divisions_read,     c_divisions_write },
+  { "date_day",         V260,   date_day_read,        NULL },
+  { "date_month",       V260,   date_month_read,      NULL },
+  { "date_year",        V260,   date_year_read,       NULL },
+  { "divider",          V268,   divider_read,         divider_write },
+  { "exit_game",        V290,   NULL,                 exit_game_write },
+  { "fread",            V260,   fread_read,           NULL },
+  { "fread_counter",    V265,   fread_counter_read,   NULL },
+  { "fread_delimiter",  V284,   NULL,                 fread_delim_write },
+  { "fread_open",       V260,   fread_open_read,      NULL },
+  { "fread_pos",        V260,   fread_pos_read,       fread_pos_write },
+  { "fwrite",           V260,   NULL,                 fwrite_write },
+  { "fwrite_append",    V260,   fwrite_append_read,   NULL },
+  { "fwrite_counter",   V265,   NULL,                 fwrite_counter_write },
+  { "fwrite_delimiter", V284,   NULL,                 fwrite_delim_write },
+  { "fwrite_modify",    V269c,  fwrite_modify_read,   NULL },
+  { "fwrite_open",      V260,   fwrite_open_read,     NULL },
+  { "fwrite_pos",       V260,   fwrite_pos_read,      fwrite_pos_write },
+  { "goop_walk",        V290,   goop_walk_read,       goop_walk_write },
+  { "green_value",      V260,   green_value_read,     green_value_write },
+  { "horizpld",         Vall,   horizpld_read,        NULL },
+  { "input",            Vall,   input_read,           input_write },
+  { "inputsize",        Vall,   inputsize_read,       inputsize_write },
+  { "int2bin",          V260,   int2bin_read,         int2bin_write },
+  { "key",              Vall,   key_read,             key_write },
+  { "key?",             V269,   keyn_read,            NULL },
+  { "key_code",         V269,   key_code_read,        NULL },
+  { "key_pressed",      V260,   key_pressed_read,     NULL },
+  { "key_release",      V269,   key_release_read,     NULL },
+  { "lava_walk",        V260,   lava_walk_read,       lava_walk_write },
+  { "load_bc?",         V270,   load_bc_read,         NULL },
+  { "load_counters",    V290,   load_counters_read,   NULL },
+  { "load_game",        V268,   load_game_read,       NULL },
+  { "load_robot?",      V270,   load_robot_read,      NULL },
 #ifdef CONFIG_DEBYTECODE
-  { "load_source_file?", 0x0300, load_source_file_read, NULL },      // Debytecode
+  { "load_source_file?", VSOURCE, load_source_file_read, NULL },
 #endif
-  { "local?", 0x0208, local_read, local_write },                     // 2.51s1
-  { "loopcount", 0, loopcount_read, loopcount_write },               // <=2.51
-  { "max!,!", 0x0254, maxval_read, NULL },                           // 2.84
-  { "max_samples", 0x025B, max_samples_read, max_samples_write },    // 2.91
-  { "mboardx", 0x0208, mboardx_read, NULL },                         // 2.51s1
-  { "mboardy", 0x0208, mboardy_read, NULL },                         // 2.51s1
-  { "min!,!", 0x0254, minval_read, NULL },                           // 2.84
-  { "mod_frequency", 0x0251, mod_freq_read, mod_freq_write },        // 2.81
-  { "mod_length", 0x025B, mod_length_read, NULL },                   // 2.91
-  { "mod_order", 0x023E, mod_order_read, mod_order_write },          // 2.62
-  { "mod_position", 0x0251, mod_position_read, mod_position_write }, // 2.81
-  { "mousepx", 0x0252, mousepx_read, mousepx_write },                // 2.82
-  { "mousepy", 0x0252, mousepy_read, mousepy_write },                // 2.82
-  { "mousex", 0x0208, mousex_read, mousex_write },                   // 2.51s1
-  { "mousey", 0x0208, mousey_read, mousey_write },                   // 2.51s1
-  { "multiplier", 0x0244, multiplier_read, multiplier_write },       // 2.68
-  { "mzx_speed", 0x0209, mzx_speed_read, mzx_speed_write },          // 2.60
-  { "och!,!", 0x0254, och_read, NULL },                              // 2.84
-  { "oco!,!", 0x0254, oco_read, NULL },                              // 2.84
-  { "overlay_char", 0x0209, overlay_char_read, NULL },               // 2.60
-  { "overlay_color", 0x0209, overlay_color_read, NULL },             // 2.60
-  { "overlay_mode", 0x0209, overlay_mode_read, NULL },               // 2.60
-  { "pixel", 0x0209, pixel_read, pixel_write },                      // 2.60
-  { "playerdist", 0, playerdist_read, NULL },                        // <=2.51
-  { "playerfacedir", 0, playerfacedir_read, playerfacedir_write },   // <=2.51
-  { "playerlastdir", 0, playerlastdir_read, playerlastdir_write },   // <=2.51
-  { "playerx", 0x0208, playerx_read, NULL },                         // 2.51s1
-  { "playery", 0x0208, playery_read, NULL },                         // 2.51s1
-  { "play_game", 0x025A, NULL, play_game_write },                    // 2.90
-  { "r!.*", 0x0241, r_read, r_write },                               // 2.65
-  { "random_seed!", 0x025B, random_seed_read, random_seed_write },   // 2.91
-  { "red_value", 0x0209, red_value_read, red_value_write },          // 2.60
-  { "rid*", 0x0246, rid_read, NULL },                                // 2.69b
-  { "robot_id", 0x0209, robot_id_read, NULL },                       // 2.60
-  { "robot_id_*", 0x0241, robot_id_n_read, NULL },                   // 2.65
-  { "save_bc?", 0x0249, save_bc_read, NULL },                        // 2.70
-  { "save_counters", 0x025A, save_counters_read, NULL},              // 2.90
-  { "save_game", 0x0244, save_game_read, NULL },                     // 2.68
-  { "save_robot?", 0x0249, save_robot_read, NULL },                  // 2.70
-  { "scrolledx", 0x0208, scrolledx_read, NULL },                     // 2.51s1
-  { "scrolledy", 0x0208, scrolledy_read, NULL },                     // 2.51s1
-  { "sin!", 0x0244, sin_read, NULL },                                // 2.68
-  { "smzx_b!", 0x0245, smzx_b_read, smzx_b_write },                  // 2.69
-  { "smzx_g!", 0x0245, smzx_g_read, smzx_g_write },                  // 2.69
-  { "smzx_idx!,!", 0x025A, smzx_idx_read, smzx_idx_write },          // 2.90
-  { "smzx_indices", 0x025B, smzx_indices_read, NULL },               // 2.91
-  { "smzx_message", 0x025B, smzx_message_read, smzx_message_write }, // 2.91
-  { "smzx_mode", 0x0245, smzx_mode_read, smzx_mode_write },          // 2.69
-  { "smzx_palette", 0x0245, smzx_palette_read, NULL },               // 2.69
-  { "smzx_r!", 0x0245, smzx_r_read, smzx_r_write },                  // 2.69
-  { "spacelock", 0x0254, NULL, spacelock_write },                    // 2.84
-  { "spr!_ccheck", 0x0241, NULL, spr_ccheck_write },                 // 2.65
-  { "spr!_cheight", 0x0241, spr_cheight_read, spr_cheight_write },   // 2.65
-  { "spr!_clist", 0x0241, NULL, spr_clist_write },                   // 2.65
-  { "spr!_cwidth", 0x0241, spr_cwidth_read, spr_cwidth_write },      // 2.65
-  { "spr!_cx", 0x0241, spr_cx_read, spr_cx_write },                  // 2.65
-  { "spr!_cy", 0x0241, spr_cy_read, spr_cy_write },                  // 2.65
-  { "spr!_height", 0x0241, spr_height_read, spr_height_write },      // 2.65
-  { "spr!_off", 0x0241, NULL, spr_off_write },                       // 2.65
-  { "spr!_offset", 0x025A, spr_offset_read, spr_offset_write },      // 2.90
-  { "spr!_overlaid", 0x0241, NULL, spr_overlaid_write },             // 2.65
-  { "spr!_overlay", 0x0248, NULL, spr_overlaid_write },              // 2.69c
-  { "spr!_refx", 0x0241, spr_refx_read, spr_refx_write },            // 2.65
-  { "spr!_refy", 0x0241, spr_refy_read, spr_refy_write },            // 2.65
-  { "spr!_setview", 0x0241, NULL, spr_setview_write },               // 2.65
-  { "spr!_static", 0x0241, NULL, spr_static_write },                 // 2.65
-  { "spr!_swap", 0x0241, NULL, spr_swap_write },                     // 2.65
-  { "spr!_tcol", 0x025A, spr_tcol_read, spr_tcol_write },            // 2.90
-  { "spr!_unbound", 0x025A, spr_unbound_read, spr_unbound_write },   // 2.90
-  { "spr!_vlayer", 0x0248, NULL, spr_vlayer_write },                 // 2.69c
-  { "spr!_width", 0x0241, spr_width_read, spr_width_write },         // 2.65
-  { "spr!_x", 0x0241, spr_x_read, spr_x_write },                     // 2.65
-  { "spr!_y", 0x0241, spr_y_read, spr_y_write },                     // 2.65
-  { "spr_clist!", 0x0241, spr_clist_read, NULL },                    // 2.65
-  { "spr_collisions", 0x0241, spr_collisions_read, NULL },           // 2.65
-  { "spr_num", 0x0241, spr_num_read, spr_num_write },                // 2.65
-  { "spr_yorder", 0x0241, NULL, spr_yorder_write },                  // 2.65
-  { "sqrt!", 0x0244, sqrt_read, NULL },                              // 2.68
-  { "tan!", 0x0244, tan_read, NULL },                                // 2.68
-  { "thisx", 0, thisx_read, NULL },                                  // <=2.51
-  { "thisy", 0, thisy_read, NULL },                                  // <=2.51
-  { "this_char", 0x0209, this_char_read, NULL },                     // 2.60
-  { "this_color", 0x0209, this_color_read, NULL },                   // 2.60
-  { "timereset", 0, timereset_read, timereset_write },               // <=2.51
-  { "time_hours", 0x0209, time_hours_read, NULL },                   // 2.60
-  { "time_minutes", 0x0209, time_minutes_read, NULL },               // 2.60
-  { "time_seconds", 0x0209, time_seconds_read, NULL },               // 2.60
-  { "uch!,!", 0x0254, uch_read, NULL },                              // 2.84
-  { "uco!,!", 0x0254, uco_read, NULL },                              // 2.84
-  { "uid!,!", 0x0254, uid_read, uid_write },                         // 2.84
-  { "upr!,!", 0x0254, upr_read, upr_write },                         // 2.84
-  { "vch!,!", 0x0248, vch_read, vch_write },                         // 2.69c
-  { "vco!,!", 0x0248, vco_read, vco_write },                         // 2.69c
-  { "vertpld", 0, vertpld_read, NULL },                              // <=2.51
-  { "vlayer_height", 0x0248, vlayer_height_read, vlayer_height_write },// 2.69c
-  { "vlayer_size", 0x0251, vlayer_size_read, vlayer_size_write },    // 2.81
-  { "vlayer_width", 0x0248, vlayer_width_read, vlayer_width_write }, // 2.69c
+  { "local?",           V251s1, local_read,           local_write },
+  { "loopcount",        Vall,   loopcount_read,       loopcount_write },
+  { "max!,!",           V284,   maxval_read,          NULL },
+  { "max_samples",      V291,   max_samples_read,     max_samples_write },
+  { "mboardx",          V251s1, mboardx_read,         NULL },
+  { "mboardy",          V251s1, mboardy_read,         NULL },
+  { "min!,!",           V284,   minval_read,          NULL },
+  { "mod_frequency",    V251,   mod_freq_read,        mod_freq_write },
+  { "mod_length",       V291,   mod_length_read,      NULL },
+  { "mod_order",        V262,   mod_order_read,       mod_order_write },
+  { "mod_position",     V251,   mod_position_read,    mod_position_write },
+  { "mousepx",          V282,   mousepx_read,         mousepx_write },
+  { "mousepy",          V282,   mousepy_read,         mousepy_write },
+  { "mousex",           V251s1, mousex_read,          mousex_write },
+  { "mousey",           V251s1, mousey_read,          mousey_write },
+  { "multiplier",       V268,   multiplier_read,      multiplier_write },
+  { "mzx_speed",        V260,   mzx_speed_read,       mzx_speed_write },
+  { "och!,!",           V284,   och_read,             NULL },
+  { "oco!,!",           V284,   oco_read,             NULL },
+  { "overlay_char",     V260,   overlay_char_read,    NULL },
+  { "overlay_color",    V260,   overlay_color_read,   NULL },
+  { "overlay_mode",     V260,   overlay_mode_read,    NULL },
+  { "pixel",            V260,   pixel_read,           pixel_write },
+  { "playerdist",       Vall,   playerdist_read,      NULL },
+  { "playerfacedir",    Vall,   playerfacedir_read,   playerfacedir_write },
+  { "playerlastdir",    Vall,   playerlastdir_read,   playerlastdir_write },
+  { "playerx",          V251s1, playerx_read,         NULL },
+  { "playery",          V251s1, playery_read,         NULL },
+  { "play_game",        V290,   NULL,                 play_game_write },
+  { "r!.*",             V265,   r_read,               r_write },
+  { "random_seed!",     V291,   random_seed_read,     random_seed_write },
+  { "red_value",        V260,   red_value_read,       red_value_write },
+  { "rid*",             V269b,  rid_read,             NULL },
+  { "robot_id",         V260,   robot_id_read,        NULL },
+  { "robot_id_*",       V265,   robot_id_n_read,      NULL },
+  { "save_bc?",         V270,   save_bc_read,         NULL },
+  { "save_counters",    V290,   save_counters_read,   NULL },
+  { "save_game",        V268,   save_game_read,       NULL },
+  { "save_robot?",      V270,   save_robot_read,      NULL },
+  { "scrolledx",        V251s1, scrolledx_read,       NULL },
+  { "scrolledy",        V251s1, scrolledy_read,       NULL },
+  { "sin!",             V268,   sin_read,             NULL },
+  { "smzx_b!",          V269,   smzx_b_read,          smzx_b_write },
+  { "smzx_g!",          V269,   smzx_g_read,          smzx_g_write },
+  { "smzx_idx!,!",      V290,   smzx_idx_read,        smzx_idx_write },
+  { "smzx_indices",     V291,   smzx_indices_read,    NULL },
+  { "smzx_message",     V291,   smzx_message_read,    smzx_message_write },
+  { "smzx_mode",        V269,   smzx_mode_read,       smzx_mode_write },
+  { "smzx_palette",     V269,   smzx_palette_read,    NULL },
+  { "smzx_r!",          V269,   smzx_r_read,          smzx_r_write },
+  { "spacelock",        V284,   NULL,                 spacelock_write },
+  { "spr!_ccheck",      V265,   NULL,                 spr_ccheck_write },
+  { "spr!_cheight",     V265,   spr_cheight_read,     spr_cheight_write },
+  { "spr!_clist",       V265,   NULL,                 spr_clist_write },
+  { "spr!_cwidth",      V265,   spr_cwidth_read,      spr_cwidth_write },
+  { "spr!_cx",          V265,   spr_cx_read,          spr_cx_write },
+  { "spr!_cy",          V265,   spr_cy_read,          spr_cy_write },
+  { "spr!_height",      V265,   spr_height_read,      spr_height_write },
+  { "spr!_off",         V265,   NULL,                 spr_off_write },
+  { "spr!_offset",      V290,   spr_offset_read,      spr_offset_write },
+  { "spr!_overlaid",    V265,   NULL,                 spr_overlaid_write },
+  { "spr!_overlay",     V269c,  NULL,                 spr_overlaid_write },
+  { "spr!_refx",        V265,   spr_refx_read,        spr_refx_write },
+  { "spr!_refy",        V265,   spr_refy_read,        spr_refy_write },
+  { "spr!_setview",     V265,   NULL,                 spr_setview_write },
+  { "spr!_static",      V265,   NULL,                 spr_static_write },
+  { "spr!_swap",        V265,   NULL,                 spr_swap_write },
+  { "spr!_tcol",        V290,   spr_tcol_read,        spr_tcol_write },
+  { "spr!_unbound",     V290,   spr_unbound_read,     spr_unbound_write },
+  { "spr!_vlayer",      V269c,  NULL,                 spr_vlayer_write },
+  { "spr!_width",       V265,   spr_width_read,       spr_width_write },
+  { "spr!_x",           V265,   spr_x_read,           spr_x_write },
+  { "spr!_y",           V265,   spr_y_read,           spr_y_write },
+  { "spr_clist!",       V265,   spr_clist_read,       NULL },
+  { "spr_collisions",   V265,   spr_collisions_read,  NULL },
+  { "spr_num",          V265,   spr_num_read,         spr_num_write },
+  { "spr_yorder",       V265,   NULL,                 spr_yorder_write },
+  { "sqrt!",            V268,   sqrt_read,            NULL },
+  { "tan!",             V268,   tan_read,             NULL },
+  { "thisx",            Vall,   thisx_read,           NULL },
+  { "thisy",            Vall,   thisy_read,           NULL },
+  { "this_char",        V260,   this_char_read,       NULL },
+  { "this_color",       V260,   this_color_read,      NULL },
+  { "timereset",        Vall,   timereset_read,       timereset_write },
+  { "time_hours",       V260,   time_hours_read,      NULL },
+  { "time_minutes",     V260,   time_minutes_read,    NULL },
+  { "time_seconds",     V260,   time_seconds_read,    NULL },
+  { "uch!,!",           V284,   uch_read,             NULL },
+  { "uco!,!",           V284,   uco_read,             NULL },
+  { "uid!,!",           V284,   uid_read,             uid_write },
+  { "upr!,!",           V284,   upr_read,             upr_write },
+  { "vch!,!",           V269c,  vch_read,             vch_write },
+  { "vco!,!",           V269c,  vco_read,             vco_write },
+  { "vertpld",          Vall,   vertpld_read,         NULL },
+  { "vlayer_height",    V269c,  vlayer_height_read,   vlayer_height_write },
+  { "vlayer_size",      V251,   vlayer_size_read,     vlayer_size_write },
+  { "vlayer_width",     V269c,  vlayer_width_read,    vlayer_width_write },
 };
 
 static int counter_first_letter[512];
@@ -2737,7 +2741,7 @@ int set_counter_special(struct world *mzx_world, char *char_value,
       char *translated_path;
       int err;
 
-      if (mzx_world->version < 0x025A)
+      if(mzx_world->version < V290)
       {
         // Prior to 2.90, save_game took place immediately
         translated_path = cmalloc(MAX_PATH);
@@ -2750,7 +2754,7 @@ int set_counter_special(struct world *mzx_world, char *char_value,
 
         err = fsafetranslate(char_value, translated_path);
         if(err == -FSAFE_SUCCESS || err == -FSAFE_MATCH_FAILED)
-          save_world(mzx_world, translated_path, 1, WORLD_VERSION);
+          save_world(mzx_world, translated_path, 1, MZX_VERSION);
 
         free(translated_path);
       }
@@ -3167,7 +3171,7 @@ static int health_dec_gateway(struct world *mzx_world, struct counter *counter,
   // Trying to decrease health? (legacy support)
   // Only handle here if MZX world version <= 2.70
   // Otherwise, it will be handled in health_gateway()
-  if((value > 0) && (mzx_world->version <= 0x0249))
+  if((value > 0) && (mzx_world->version <= V270))
   {
     value = hurt_player(mzx_world, value);
   }
@@ -3190,7 +3194,7 @@ static int health_gateway(struct world *mzx_world, struct counter *counter,
   // Trying to decrease health?
   // Only handle here if MZX world version > 2.70
   // Otherwise, it will be handled in health_dec_gateway()
-  if((value < counter->value) && (mzx_world->version > 0x0249))
+  if((value < counter->value) && (mzx_world->version > V270))
   {
     value = counter->value - hurt_player(mzx_world, counter->value - value);
   }

--- a/src/editor/board.c
+++ b/src/editor/board.c
@@ -42,7 +42,7 @@ static int board_magic(const char magic_string[4])
     {
       // MZX versions >= 2.00 && <= 2.51S1
       if(magic_string[2] == 'B' && magic_string[3] == '2')
-        return 0x0200;
+        return V251;
 
       // MZX versions >= 2.51S2 && <= 9.xx
       if((magic_string[2] > 1) && (magic_string[2] < 10))
@@ -64,10 +64,10 @@ void save_board_file(struct world *mzx_world, struct board *cur_board,
     zputc(0xFF, zp);
 
     zputc('M', zp);
-    zputc((WORLD_VERSION >> 8) & 0xFF, zp);
-    zputc(WORLD_VERSION & 0xFF, zp);
+    zputc((MZX_VERSION >> 8) & 0xFF, zp);
+    zputc(MZX_VERSION & 0xFF, zp);
 
-    save_board(mzx_world, cur_board, zp, 0, WORLD_VERSION, 0);
+    save_board(mzx_world, cur_board, zp, 0, MZX_VERSION, 0);
 
     zip_close(zp, NULL);
   }
@@ -129,7 +129,7 @@ void replace_current_board(struct world *mzx_world, char *name)
     fread(version_string, 4, 1, fp);
     file_version = board_magic(version_string);
 
-    if(file_version > 0 && file_version <= WORLD_LEGACY_FORMAT_VERSION)
+    if(file_version > 0 && file_version <= MZX_LEGACY_FORMAT_VERSION)
     {
       // Legacy board.
       clear_board(src_board);
@@ -142,7 +142,7 @@ void replace_current_board(struct world *mzx_world, char *name)
     }
     else
 
-    if(file_version <= WORLD_VERSION)
+    if(file_version <= MZX_VERSION)
     {
       int board_id;
 

--- a/src/editor/debug.c
+++ b/src/editor/debug.c
@@ -2244,7 +2244,7 @@ void __draw_debug_box(struct world *mzx_world, int x, int y, int d_x, int d_y,
 
     // In 2.82X through 2.84X, this erroneously applied
     // numlock translations to the keycode.
-    if(mzx_world->version >= 0x0252 && mzx_world->version <= 0x0254)
+    if(mzx_world->version >= V282 && mzx_world->version <= V284)
       key = get_last_key(keycode_internal_wrt_numlock);
 
     else

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -1845,7 +1845,7 @@ static void __edit_world(struct world *mzx_world, int reload_curr_file)
   copy_sensor.used = 0;
   copy_scroll.used = 0;
 
-  mzx_world->version = WORLD_VERSION;
+  mzx_world->version = MZX_VERSION;
 
   set_palette_intensity(100);
 
@@ -1929,7 +1929,7 @@ static void __edit_world(struct world *mzx_world, int reload_curr_file)
 
       create_path_if_not_exists(backup_name);
 
-      save_world(mzx_world, backup_name_formatted, 0, WORLD_VERSION);
+      save_world(mzx_world, backup_name_formatted, 0, MZX_VERSION);
       backup_num = (backup_num + 1) % backup_count;
       backup_timestamp = get_ticks();
     }
@@ -4062,13 +4062,13 @@ static void __edit_world(struct world *mzx_world, int reload_curr_file)
             {
               debug("Save path: %s\n", world_name);
 
-              // It's now officially WORLD_VERSION
-              mzx_world->version = WORLD_VERSION;
+              // It's now officially the current MZX version
+              mzx_world->version = MZX_VERSION;
 
               // Save entire game
               strcpy(current_world, world_name);
               strcpy(curr_file, current_world);
-              save_world(mzx_world, current_world, 0, WORLD_VERSION);
+              save_world(mzx_world, current_world, 0, MZX_VERSION);
 
               get_path(world_name, new_path, MAX_PATH);
               if(new_path[0])
@@ -4106,7 +4106,7 @@ static void __edit_world(struct world *mzx_world, int reload_curr_file)
           clear_overlay_history = 1;
           clear_vlayer_history = 1;
 
-          if(!save_world(mzx_world, "__test.mzx", 0, WORLD_VERSION))
+          if(!save_world(mzx_world, "__test.mzx", 0, MZX_VERSION))
           {
             int world_version = mzx_world->version;
             char *return_dir = cmalloc(MAX_PATH);
@@ -4404,12 +4404,12 @@ static void __edit_world(struct world *mzx_world, int reload_curr_file)
                 char title[80];
 
                 sprintf(title, "Export world to previous version (%d.%d)",
-                 (WORLD_VERSION_PREV >> 8) & 0xFF, WORLD_VERSION_PREV & 0xFF);
+                 (MZX_VERSION_PREV >> 8) & 0xFF, MZX_VERSION_PREV & 0xFF);
 
                 if(!new_file(mzx_world, world_ext, ".mzx", export_name,
                  title, 1))
                 {
-                  save_world(mzx_world, export_name, 0, WORLD_VERSION_PREV);
+                  save_world(mzx_world, export_name, 0, MZX_VERSION_PREV);
                 }
               }
             }

--- a/src/expr.c
+++ b/src/expr.c
@@ -28,6 +28,7 @@
 #include "rasm.h"
 #include "robot.h"
 #include "str.h"
+#include "world.h"
 #include "world_struct.h"
 
 enum op
@@ -602,7 +603,7 @@ int parse_expression(struct world *mzx_world, char **_expression, int *error,
       // Ternary operator left (2.90+)
       case '?':
       {
-        if(mzx_world->version < 0x025A)
+        if(mzx_world->version < V290)
           goto err_out;
 
         // True
@@ -679,7 +680,7 @@ int parse_expression(struct world *mzx_world, char **_expression, int *error,
         int ternary_level = 0;
         int paren_level = 0;
 
-        if(mzx_world->version < 0x025A)
+        if(mzx_world->version < V290)
           goto err_out;
 
         if(!(state & EXPR_STATE_TERNARY_MIDDLE))
@@ -1219,7 +1220,7 @@ static int parse_argument(struct world *mzx_world, char **_argument,
     // Ternary operator left (2.90+)
     case '?':
     {
-      if(mzx_world->version < 0x025A)
+      if(mzx_world->version < V290)
       {
         *type = -1;
         *_argument = argument;
@@ -1299,7 +1300,7 @@ static int parse_argument(struct world *mzx_world, char **_argument,
       // We're only here because we finished execution of the inner argument.
       int paren_level = 0;
 
-      if(mzx_world->version < 0x025A)
+      if(mzx_world->version < V290)
       {
         *type = -1;
         *_argument = argument;

--- a/src/game.c
+++ b/src/game.c
@@ -2309,7 +2309,7 @@ __editor_maybe_static void play_game(struct world *mzx_world)
         keylbl[3] = key_char;
         send_robot_all_def(mzx_world, keylbl);
         // In pre-port MZX versions key was a board counter
-        if(mzx_world->version < VPORT)
+        if(mzx_world->version < VERSION_PORT)
         {
           char keych = toupper(key_char);
           // <2.60 it only supported 1-9 and A-Z

--- a/src/game.c
+++ b/src/game.c
@@ -1346,7 +1346,7 @@ static int update(struct world *mzx_world, int game, int *fadein)
 
   pal_update = false;
 
-  if(game && mzx_world->version >= 0x0208 &&
+  if(game && mzx_world->version >= V251s1 &&
    get_counter(mzx_world, "CURSORSTATE", 0))
   {
     // Turn on mouse
@@ -1685,7 +1685,7 @@ static int update(struct world *mzx_world, int game, int *fadein)
       /* I can't imagine anything actually relied on this obtuse misbehavior
        * but it's good to version lock anyhow.
        */
-      if((mzx_world->version <= 0x0253) || mzx_world->bi_mesg_status)
+      if((mzx_world->version <= V283) || mzx_world->bi_mesg_status)
       {
         src_board->b_mesg_row = 24;
         src_board->b_mesg_col = -1;
@@ -2277,7 +2277,7 @@ __editor_maybe_static void play_game(struct world *mzx_world)
     // Has the game/world been saved from robotic?
     if(mzx_world->robotic_save_type == SAVE_GAME)
     {
-      save_world(mzx_world, mzx_world->robotic_save_path, 1, WORLD_VERSION);
+      save_world(mzx_world, mzx_world->robotic_save_path, 1, MZX_VERSION);
       mzx_world->robotic_save_type = SAVE_NONE;
     }
 
@@ -2308,13 +2308,13 @@ __editor_maybe_static void play_game(struct world *mzx_world)
       {
         keylbl[3] = key_char;
         send_robot_all_def(mzx_world, keylbl);
-        // In MZX versions <=2.70 key was a board counter
-        if(mzx_world->version <= 0x0249)
+        // In pre-port MZX versions key was a board counter
+        if(mzx_world->version < VPORT)
         {
           char keych = toupper(key_char);
           // <2.60 it only supported 1-9 and A-Z
-          if(mzx_world->version >= 0x0232 ||
-           (keych >= 'A' && keych <= 'Z') |
+          if(mzx_world->version >= V260 ||
+           (keych >= 'A' && keych <= 'Z') ||
            (keych >= '1' && keych <= '9'))
           {
             src_board->last_key = keych;
@@ -2327,7 +2327,7 @@ __editor_maybe_static void play_game(struct world *mzx_world)
 #ifdef CONFIG_HELPSYS
         case IKEY_F1:
         {
-          if(mzx_world->version < 0x0209 ||
+          if(mzx_world->version < V260 ||
            get_counter(mzx_world, "HELP_MENU", 0))
           {
             m_show();
@@ -2341,7 +2341,7 @@ __editor_maybe_static void play_game(struct world *mzx_world)
         case IKEY_F2:
         {
           // Settings
-          if(mzx_world->version < 0x0209 ||
+          if(mzx_world->version < V260 ||
            get_counter(mzx_world, "F2_MENU", 0) ||
            !mzx_world->active)
           {
@@ -2376,7 +2376,7 @@ __editor_maybe_static void play_game(struct world *mzx_world)
               {
                 strcpy(curr_sav, save_game);
                 // Save entire game
-                save_world(mzx_world, curr_sav, 1, WORLD_VERSION);
+                save_world(mzx_world, curr_sav, 1, MZX_VERSION);
               }
 
               update_event_status();
@@ -2391,7 +2391,7 @@ __editor_maybe_static void play_game(struct world *mzx_world)
           if(get_alt_status(keycode_internal))
             break;
 
-          if(mzx_world->version < 0x0252 ||
+          if(mzx_world->version < V282 ||
            get_counter(mzx_world, "LOAD_MENU", 0))
           {
             // Restore
@@ -2564,7 +2564,7 @@ __editor_maybe_static void play_game(struct world *mzx_world)
              SENSOR)))
             {
               // Save entire game
-              save_world(mzx_world, curr_sav, 1, WORLD_VERSION);
+              save_world(mzx_world, curr_sav, 1, MZX_VERSION);
             }
           }
           break;
@@ -2573,7 +2573,7 @@ __editor_maybe_static void play_game(struct world *mzx_world)
         // Quick load
         case IKEY_F10:
         {
-          if(mzx_world->version < 0x0252 ||
+          if(mzx_world->version < V282 ||
            get_counter(mzx_world, "LOAD_MENU", 0))
           {
             struct stat file_info;
@@ -2634,7 +2634,7 @@ __editor_maybe_static void play_game(struct world *mzx_world)
           if(key_status != 1)
             break;
 
-          if(mzx_world->version < 0x0209 || enter_menu_status)
+          if(mzx_world->version < V260 || enter_menu_status)
           {
             int key, status;
             save_screen();
@@ -2681,7 +2681,7 @@ __editor_maybe_static void play_game(struct world *mzx_world)
           int escape_menu_status =
            get_counter(mzx_world, "ESCAPE_MENU", 0);
 
-          if(mzx_world->version < 0x025A || escape_menu_status)
+          if(mzx_world->version < V290 || escape_menu_status)
           {
             if(key_status == 1)
             {
@@ -3287,7 +3287,7 @@ void title_screen(struct world *mzx_world)
           
           // Escape menu only works on the title screen if the
           // standalone_mode config option is set
-          if(mzx_world->version < 0x025A || escape_menu_status ||
+          if(mzx_world->version < V290 || escape_menu_status ||
            !conf->standalone_mode)
           {
             if(key_status == 1)

--- a/src/game.c
+++ b/src/game.c
@@ -2313,7 +2313,8 @@ __editor_maybe_static void play_game(struct world *mzx_world)
         {
           char keych = toupper(key_char);
           // <2.60 it only supported 1-9 and A-Z
-          if(mzx_world->version >= V260 ||
+          // This is difficult to version check, so apply it to <2.62
+          if(mzx_world->version >= V262 ||
            (keych >= 'A' && keych <= 'Z') ||
            (keych >= '1' && keych <= '9'))
           {

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -194,13 +194,13 @@ Sint32 ec_load_set_var(char *name, Uint16 pos, int version)
   Uint32 size = CHARSET_SIZE;
   FILE *fp = fopen_unsafe(name, "rb");
   Uint32 maxChars = PROTECTED_CHARSET_POSITION;
-  if (version < 0x025A) maxChars = 256; // Prior to 2.90
+  if(version < V290) maxChars = 256; // Prior to 2.90
 
   if(!fp)
     return -1;
   
   size = ftell_and_rewind(fp) / CHAR_SIZE;
-  if (size + pos >= 256 && maxChars > 256 && !layer_renderer_check(true))
+  if(size + pos >= 256 && maxChars > 256 && !layer_renderer_check(true))
     maxChars = 256;
   
   if(size + pos > maxChars)
@@ -241,7 +241,7 @@ void ec_mem_load_set_var(char *chars, size_t len, Uint16 pos, int version)
   Uint32 offset = pos * CHAR_SIZE;
   Uint32 size;
   Uint32 maxChars = PROTECTED_CHARSET_POSITION;
-  if(version < 0x025A) maxChars = 256; // Prior to 2.90
+  if(version < V290) maxChars = 256; // Prior to 2.90
   if(len + offset > 256 * CHAR_SIZE && !layer_renderer_check(true))
     maxChars = 256;
 

--- a/src/legacy_board.c
+++ b/src/legacy_board.c
@@ -222,7 +222,7 @@ int legacy_load_board_direct(struct world *mzx_world, struct board *cur_board,
 
   // Load board parameters
 
-  if(file_version < 0x0253)
+  if(file_version < V283)
   {
     fread(cur_board->mod_playing, LEGACY_MOD_FILENAME_MAX, 1, fp);
     cur_board->mod_playing[LEGACY_MOD_FILENAME_MAX] = 0;
@@ -273,7 +273,7 @@ int legacy_load_board_direct(struct world *mzx_world, struct board *cur_board,
   cur_board->restart_if_zapped = fgetc(fp);
   cur_board->time_limit = fgetw(fp);
 
-  if(file_version < 0x0253)
+  if(file_version < V283)
   {
     cur_board->last_key = fgetc(fp);
     cur_board->num_input = fgetw(fp);
@@ -334,7 +334,7 @@ int legacy_load_board_direct(struct world *mzx_world, struct board *cur_board,
   cur_board->player_ew_locked = fgetc(fp);
   cur_board->player_attack_locked = fgetc(fp);
 
-  if(file_version < 0x0253 || savegame)
+  if(file_version < V283 || savegame)
   {
     cur_board->volume = fgetc(fp);
     cur_board->volume_inc = fgetc(fp);

--- a/src/legacy_robot.c
+++ b/src/legacy_robot.c
@@ -69,7 +69,7 @@ void legacy_load_robot_from_memory(struct world *mzx_world,
   cur_robot->num_labels = 0;
 
 #ifdef CONFIG_DEBYTECODE
-  if(version >= VERSION_PROGRAM_SOURCE)
+  if(version >= VERSION_SOURCE)
   {
     program_length = mem_getd(&bufferPtr);
   }
@@ -146,7 +146,7 @@ void legacy_load_robot_from_memory(struct world *mzx_world,
     // a bad person and relies on savegame type MZMs (even though he claims
     // to have made them in the editor)
 
-    if(version < VERSION_PROGRAM_SOURCE)
+    if(version < VERSION_SOURCE)
     {
       // The program is bytecode and we have to convert it to sourcecode.
       char *program_legacy_bytecode = cmalloc(program_length);
@@ -223,7 +223,7 @@ void legacy_load_robot_from_memory(struct world *mzx_world,
 
 #ifdef CONFIG_DEBYTECODE
     // World file loads source code.
-    if(version < VERSION_PROGRAM_SOURCE)
+    if(version < VERSION_SOURCE)
     {
       if((cur_robot->used) || (program_length >= 2))
       {
@@ -357,9 +357,9 @@ size_t legacy_load_robot_calculate_size(const void *buffer, int savegame,
   bufferPtr = (unsigned char *)buffer + 0;
   program_length = mem_getd(&bufferPtr);
 
-  // Prior to DBC / VERSION_PROGRAM_SOURCE the last two bytes are junk
+  // Prior to DBC / VERSION_SOURCE the last two bytes are junk
   #ifdef CONFIG_DEBYTECODE
-  if(version < VERSION_PROGRAM_SOURCE)
+  if(version < VERSION_SOURCE)
   #endif
     program_length &= 0xFFFF;
   

--- a/src/legacy_robot.c
+++ b/src/legacy_robot.c
@@ -29,8 +29,9 @@
 #include "legacy_rasm.h"
 #include "rasm.h"
 #include "robot.h"
-#include "world_struct.h"
 #include "util.h"
+#include "world.h"
+#include "world_struct.h"
 
 
 struct robot *legacy_load_robot_allocate(struct world *mzx_world, FILE *fp,
@@ -107,7 +108,7 @@ void legacy_load_robot_from_memory(struct world *mzx_world,
   // Skip local - these are in the save files now
   bufferPtr += 2;
   cur_robot->used = mem_getc(&bufferPtr);
-  if(version <= 0x0253)
+  if(version <= V283)
     cur_robot->loop_count = mem_getw(&bufferPtr);
   else
     bufferPtr += 2;
@@ -121,7 +122,7 @@ void legacy_load_robot_from_memory(struct world *mzx_world,
   {
     int stack_size;
 
-    if(version >= 0x0254)
+    if(version >= V284)
       cur_robot->loop_count = mem_getd(&bufferPtr);
 
     for(i = 0; i < 32; i++)
@@ -332,7 +333,7 @@ size_t legacy_calculate_partial_robot_size(int savegame, int version)
 
   if(savegame)
   {
-    if(version >= 0x0254)
+    if(version >= V284)
       partial_robot_size += 4; // loopcount
     partial_robot_size += 32 * 4; // 32 local counters
     partial_robot_size += 2 * 4; // stack size and position
@@ -366,7 +367,7 @@ size_t legacy_load_robot_calculate_size(const void *buffer, int savegame,
   if(savegame)
   {
     bufferPtr = (unsigned char *)buffer + 41;
-    if(version >= 0x0254) bufferPtr += 4; // Skip over loopcount
+    if(version >= V284) bufferPtr += 4; // Skip over loopcount
     bufferPtr += 32 * 4; // Skip over 32 local counters
     stack_size = mem_getd(&bufferPtr);
   }
@@ -375,7 +376,7 @@ size_t legacy_load_robot_calculate_size(const void *buffer, int savegame,
   robot_size = 41;
   if(savegame)
   {
-    if(version >= 0x0254) robot_size += 4;
+    if(version >= V284) robot_size += 4;
     robot_size += 32 * 4 + 2 * 4 + stack_size * 4;
   }
   robot_size += program_length;

--- a/src/legacy_world.c
+++ b/src/legacy_world.c
@@ -364,7 +364,7 @@ enum val_result validate_legacy_world_file(const char *file,
     if(!v)
       goto err_invalid;
 
-    else if (v > WORLD_LEGACY_FORMAT_VERSION)
+    else if(v > MZX_LEGACY_FORMAT_VERSION)
     {
       error_message(E_SAVE_VERSION_TOO_RECENT, v, NULL);
       result = VAL_VERSION;
@@ -373,8 +373,8 @@ enum val_result validate_legacy_world_file(const char *file,
 
     // This enables 2.84 save loading.
     // If we ever want to remove this, change this check.
-    //else if (v < WORLD_VERSION)
-    else if (v < WORLD_LEGACY_FORMAT_VERSION)
+    //else if (v < MZX_VERSION)
+    else if(v < MZX_LEGACY_FORMAT_VERSION)
     {
       error_message(E_SAVE_VERSION_OLD, v, NULL);
       result = VAL_VERSION;
@@ -520,13 +520,14 @@ enum val_result validate_legacy_world_file(const char *file,
     if(v == 0)
       goto err_invalid;
 
-    else if (v < 0x0205)
+    else if(v < V251)
     {
       error_message(E_WORLD_FILE_VERSION_OLD, v, NULL);
       result = VAL_VERSION;
       goto err_close;
     }
-    else if (v > WORLD_LEGACY_FORMAT_VERSION)
+
+    else if(v > MZX_LEGACY_FORMAT_VERSION)
     {
       error_message(E_WORLD_FILE_VERSION_TOO_RECENT, v, NULL);
       result = VAL_VERSION;
@@ -559,7 +560,7 @@ enum val_result validate_legacy_world_file(const char *file,
     int sfx_size = fgetw(f);
     int sfx_off = ftell(f);
 
-    for (i = 0; i < NUM_SFX; i++)
+    for(i = 0; i < NUM_SFX; i++)
     {
       if(fseek(f, fgetc(f), SEEK_CUR))
         break;

--- a/src/mzm.c
+++ b/src/mzm.c
@@ -406,7 +406,7 @@ static int load_mzm_header(const unsigned char **_bufferptr, int file_length,
       return -1;
 
     // MZM3 is like MZM2, except the robots are stored as source code if
-    // savegame_mode is 0 and version >= VERSION_PROGRAM_SOURCE.
+    // savegame_mode is 0 and version >= VERSION_SOURCE.
     *width = mem_getw(&bufferptr);
     *height = mem_getw(&bufferptr);
     *robots_location = mem_getd(&bufferptr);

--- a/src/mzm.c
+++ b/src/mzm.c
@@ -88,7 +88,7 @@ static void save_mzm_common(struct world *mzx_world, int start_x, int start_y,
            cur_robot->ypos < start_y + height)
           {
             mzm_size += save_robot_calculate_size(mzx_world, cur_robot,
-             savegame, WORLD_VERSION);
+             savegame, MZX_VERSION);
             num_robots_alloc++;
           }
         }
@@ -112,7 +112,7 @@ static void save_mzm_common(struct world *mzx_world, int start_x, int start_y,
     mem_putc(storage_mode, &bufferPtr);
     mem_putc(0, &bufferPtr);
 
-    mem_putw(WORLD_VERSION, &bufferPtr);
+    mem_putw(MZX_VERSION, &bufferPtr);
     bufferPtr += 3;
 
     switch(mode)
@@ -217,7 +217,7 @@ static void save_mzm_common(struct world *mzx_world, int start_x, int start_y,
 
             // Save each robot
             save_robot(mzx_world, robot_list[robot_numbers[i]], zp,
-             savegame, WORLD_VERSION, name);
+             savegame, MZX_VERSION, name);
           }
         }
 
@@ -369,7 +369,7 @@ static int load_mzm_header(const unsigned char **_bufferptr, int file_length,
 
   // MegaZeux 2.83 is the last version that won't save the ver,
   // so if we don't have a ver, just act like it's 2.83
-  *mzm_world_version = 0x0253;
+  *mzm_world_version = V283;
 
   memcpy(magic_string, bufferptr, 4);
   magic_string[4] = 0;
@@ -460,7 +460,7 @@ static int load_mzm_common(struct world *mzx_world, const void *buffer,
     goto err_invalid;
 
   // If the mzm version is newer than the MZX version, notify
-  if(mzm_world_version > WORLD_VERSION)
+  if(mzm_world_version > MZX_VERSION)
   {
     error_message(E_MZM_FILE_VERSION_TOO_RECENT, mzm_world_version, name);
   }
@@ -624,7 +624,7 @@ static int load_mzm_common(struct world *mzx_world, const void *buffer,
             // Reset the error count.
             get_and_reset_error_count();
 
-            if(mzm_world_version <= WORLD_LEGACY_FORMAT_VERSION)
+            if(mzm_world_version <= MZX_LEGACY_FORMAT_VERSION)
             {
               robot_partial_size =
                legacy_calculate_partial_robot_size(savegame_mode,
@@ -649,7 +649,7 @@ static int load_mzm_common(struct world *mzx_world, const void *buffer,
             // dummy out the robots.
 
             if((savegame_mode > savegame) ||
-              (WORLD_VERSION < mzm_world_version))
+              (MZX_VERSION < mzm_world_version))
             {
               dummy = 1;
             }
@@ -665,7 +665,7 @@ static int load_mzm_common(struct world *mzx_world, const void *buffer,
               // chars for dummy robots on clipped MZMs might be off. This
               // shouldn't matter too often though.
 
-              if(mzm_world_version <= WORLD_LEGACY_FORMAT_VERSION)
+              if(mzm_world_version <= MZX_LEGACY_FORMAT_VERSION)
               {
                 create_blank_robot(cur_robot);
 
@@ -804,7 +804,7 @@ static int load_mzm_common(struct world *mzx_world, const void *buffer,
               }
             }
 
-            if(mzm_world_version > WORLD_LEGACY_FORMAT_VERSION)
+            if(mzm_world_version > MZX_LEGACY_FORMAT_VERSION)
             {
               zip_close(zp, NULL);
             }

--- a/src/old/legacy_save.c
+++ b/src/old/legacy_save.c
@@ -82,7 +82,7 @@ size_t legacy_save_robot_calculate_size(struct world *mzx_world,
 
   if(savegame)
   {
-    if(version >= 0x0254)
+    if(version >= V284)
       robot_size += 4; // 4 bytes added for loopcount
     robot_size += 4 * 32; // 32 local counters
     robot_size += 4; // stack size
@@ -166,7 +166,7 @@ void legacy_save_robot_to_memory(struct robot *cur_robot, void *buffer, int save
   mem_putw(0, &bufferPtr);
   mem_putc(cur_robot->used, &bufferPtr);
   // loop_count
-  if(version <= 0x0253)
+  if(version <= V283)
     mem_putw(cur_robot->loop_count, &bufferPtr);
   else // junk
     mem_putw(0, &bufferPtr);
@@ -177,7 +177,7 @@ void legacy_save_robot_to_memory(struct robot *cur_robot, void *buffer, int save
     int stack_size = cur_robot->stack_size;
 
     // Write the local counters
-    if(version >= 0x0254)
+    if(version >= V284)
       mem_putd(cur_robot->loop_count, &bufferPtr);
 
     for(i = 0; i < 32; i++)
@@ -479,7 +479,7 @@ static inline void legacy_save_string(FILE *fp, struct string *src_string)
 
 int legacy_save_world(struct world *mzx_world, const char *file, int savegame)
 {
-  int file_version = WORLD_LEGACY_FORMAT_VERSION;
+  int file_version = MZX_LEGACY_FORMAT_VERSION;
 
   int i, num_boards;
   int gl_rob_position, gl_rob_save_position;

--- a/src/robot.c
+++ b/src/robot.c
@@ -2308,7 +2308,7 @@ int parse_param(struct world *mzx_world, char *program, int id)
   }
 
   // Expressions - Exo
-  if((program[1] == '(') && mzx_world->version >= 0x244)
+  if((program[1] == '(') && mzx_world->version >= V268)
   {
     char *e_ptr = program + 2;
     int val, error;
@@ -2977,7 +2977,7 @@ char *tr_msg_ext(struct world *mzx_world, char *mesg, int id, char *buffer,
   {
     current_char = *src_ptr;
 
-    if((current_char == '(') && (mzx_world->version >= 0x244))
+    if((current_char == '(') && (mzx_world->version >= V268))
     {
       src_ptr++;
       old_ptr = src_ptr;
@@ -3018,7 +3018,7 @@ char *tr_msg_ext(struct world *mzx_world, char *mesg, int id, char *buffer,
 
         while(current_char)
         {
-          if(current_char == '(' && (mzx_world->version >= 0x244))
+          if(current_char == '(' && (mzx_world->version >= V268))
           {
             src_ptr++;
             val = parse_expression(mzx_world, &src_ptr, &error, id);

--- a/src/robot.c
+++ b/src/robot.c
@@ -861,7 +861,7 @@ struct label **cache_robot_labels(struct robot *robot, int *num_labels)
       else
       {
         //compatibility fix for 2.80 to 2.83
-        if (robot->world_version >= 0x0250 && robot->world_version <= 0x0253)
+        if(robot->world_version >= V280 && robot->world_version <= V283)
           current_label->position = next + 1;
         else
           current_label->position = i;
@@ -1313,7 +1313,7 @@ int send_robot_id_def(struct world *mzx_world, int robot_id, const char *mesg,
   int result = send_robot_id(mzx_world, robot_id, mesg, ignore_lock), subresult;
 
   //now, attempt to send the subroutine version of it
-  if(mzx_world->version >= 0x0254)
+  if(mzx_world->version >= V284)
   {
     strcpy(submesg, "#");
     strncat(submesg, mesg, ROBOT_MAX_TR - 2);
@@ -1330,7 +1330,7 @@ void send_robot_all_def(struct world *mzx_world, const char *mesg)
   send_robot_all(mzx_world, mesg, 0);
 
   //now, attempt to send the subroutine version of it
-  if(mzx_world->version >= 0x0254)
+  if(mzx_world->version >= V284)
   {
     strcpy(submesg, "#");
     strncat(submesg, mesg, ROBOT_MAX_TR - 2);
@@ -1801,7 +1801,7 @@ static int send_robot_direct(struct world *mzx_world, struct robot *cur_robot,
           return_position = robot_position;
 
           // 2.90+: we want the pos_within_line too.
-          if(cur_robot->world_version >= 0x025A)
+          if(cur_robot->world_version >= V290)
             return_position_in_line = cur_robot->pos_within_line;
 
           if(send_self)
@@ -3376,13 +3376,16 @@ void duplicate_robot_direct(struct world *mzx_world, struct robot *cur_robot,
 #endif
   }
 
-  if (preserve_state && mzx_world->version < 0x0250) {
-    // Prior to 2.80, copy and copy block preserved the current robot state
+  if(preserve_state && mzx_world->version < VPORT)
+  {
+    // In DOS versions, copy and copy block preserved the current robot state
     // Therefore leave all robot vars alone and copy the stack over
     size_t stack_capacity = copy_robot->stack_size * sizeof(int);
     copy_robot->stack = cmalloc(stack_capacity);
     memcpy(copy_robot->stack, cur_robot->stack, stack_capacity);
-  } else {
+  }
+  else
+  {
     // Give the robot an empty stack.
     copy_robot->stack = NULL;
     copy_robot->stack_size = 0;

--- a/src/robot.c
+++ b/src/robot.c
@@ -157,7 +157,7 @@ static int load_robot_from_memory(struct world *mzx_world, struct robot *cur_rob
       case RPROP_CUR_PROG_LINE:
 #ifdef CONFIG_DEBYTECODE
         // Legacy bytecode and DBC bytecode don't necessarily correspond.
-        if(file_version < VERSION_PROGRAM_SOURCE) break;
+        if(file_version < VERSION_SOURCE) break;
 #endif
         cur_robot->cur_prog_line = load_prop_int(size, &prop);
         break;
@@ -165,7 +165,7 @@ static int load_robot_from_memory(struct world *mzx_world, struct robot *cur_rob
       case RPROP_POS_WITHIN_LINE:
 #ifdef CONFIG_DEBYTECODE
         // Legacy bytecode and DBC bytecode don't necessarily correspond.
-        if(file_version < VERSION_PROGRAM_SOURCE) break;
+        if(file_version < VERSION_SOURCE) break;
 #endif
         cur_robot->pos_within_line = load_prop_int(size, &prop);
         break;
@@ -294,7 +294,7 @@ static int load_robot_from_memory(struct world *mzx_world, struct robot *cur_rob
           break;
 
         // Load legacy bytecode, and compile it, if necessary.
-        if(file_version < VERSION_PROGRAM_SOURCE)
+        if(file_version < VERSION_SOURCE)
         {
           char *program_legacy_bytecode = (char *)prop.start;
           int v_size;
@@ -3376,7 +3376,7 @@ void duplicate_robot_direct(struct world *mzx_world, struct robot *cur_robot,
 #endif
   }
 
-  if(preserve_state && mzx_world->version < VPORT)
+  if(preserve_state && mzx_world->version < VERSION_PORT)
   {
     // In DOS versions, copy and copy block preserved the current robot state
     // Therefore leave all robot vars alone and copy the stack over

--- a/src/robot.h
+++ b/src/robot.h
@@ -57,10 +57,6 @@ __M_BEGIN_DECLS
 
 #ifdef CONFIG_DEBYTECODE
 
-// This is the version where programs became source code instead of
-// bytecode.
-#define VERSION_PROGRAM_SOURCE   0x0300
-
 CORE_LIBSPEC void change_robot_name(struct board *src_board,
  struct robot *cur_robot, char *new_name);
 CORE_LIBSPEC void add_robot_name_entry(struct board *src_board,

--- a/src/robot.h
+++ b/src/robot.h
@@ -61,9 +61,6 @@ __M_BEGIN_DECLS
 // bytecode.
 #define VERSION_PROGRAM_SOURCE   0x0300
 
-// And the last one where bytecode was used.
-#define VERSION_PROGRAM_BYTECODE 0x025A
-
 CORE_LIBSPEC void change_robot_name(struct board *src_board,
  struct robot *cur_robot, char *new_name);
 CORE_LIBSPEC void add_robot_name_entry(struct board *src_board,

--- a/src/run_robot.c
+++ b/src/run_robot.c
@@ -1903,8 +1903,8 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
             char *p4 = next_param_pos(p3);
             gotoed = send_self_label_tr(mzx_world,  p4 + 1, id);
 
-            // 2.80 through 2.84 allowed this to iterate the entire board.
-            if(mzx_world->version < 0x250 || mzx_world->version > 0x254)
+            // The port up through 2.84 allowed this to iterate the entire board.
+            if(mzx_world->version < VPORT || mzx_world->version > V284)
               break;
           }
         }

--- a/src/run_robot.c
+++ b/src/run_robot.c
@@ -693,7 +693,7 @@ static void copy_block(struct world *mzx_world, int id, int x, int y,
         src_type = 3;
 
       // Save MZM to string (2.90+)
-      if(mzx_world->version >= 0x025A && is_string(name_buffer))
+      if(mzx_world->version >= V290 && is_string(name_buffer))
       {
         save_mzm_string(mzx_world, name_buffer, src_x, src_y,
          width, height, src_type, 1, id);
@@ -1369,8 +1369,8 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
             // no longer necessary.
             if(mzx_world->special_counter_return == FOPEN_SAVE_GAME)
             {
-              if (mzx_world->version < 0x025A)
-              { // Prior to 2.90
+              if(mzx_world->version < V290)
+              {
                 if(!program[cur_robot->cur_prog_line])
                   cur_robot->cur_prog_line = 0;
 
@@ -1500,7 +1500,7 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
           }
 
           // String equality extensions (2.91+)
-          if(mzx_world->version >= 0x025B)
+          if(mzx_world->version >= V291)
           {
             if(comparison == EXACTLY_EQUAL || comparison == WILD_EXACTLY_EQUAL)
               exact_case = 1;
@@ -1519,7 +1519,8 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
           src_value = parse_param(mzx_world, src_string, id);
         }
 
-        if (mzx_world->version < 0x025a) {
+        if(mzx_world->version < V290)
+        {
           // In port releases prior to 2.90b there was a horrible
           // bug stopping comparisons between numbers with a
           // difference greater than 2^31-1.
@@ -2721,7 +2722,7 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
           }
         }
         // MZX 2.83 erroneously ended the cycle here, some games depend on it...
-        if(mzx_world->version == 0x0253)
+        if(mzx_world->version == V283)
         {
           // Continue to the next line.
           cur_robot->cur_prog_line += program[cur_robot->cur_prog_line] + 2;
@@ -2768,7 +2769,7 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
           }
         }
         // MZX 2.83 erroneously ended the cycle here, some games depend on it...
-        if(mzx_world->version == 0x0253)
+        if(mzx_world->version == V283)
         {
           // Continue to the next line.
           cur_robot->cur_prog_line += program[cur_robot->cur_prog_line] + 2;
@@ -2790,7 +2791,7 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
           }
         }
         // MZX 2.83 erroneously ended the cycle here, some games depend on it...
-        if(mzx_world->version == 0x0253)
+        if(mzx_world->version == V283)
         {
           // Continue to the next line.
           cur_robot->cur_prog_line += program[cur_robot->cur_prog_line] + 2;
@@ -2812,7 +2813,7 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
           }
         }
         // MZX 2.83 erroneously ended the cycle here, some games depend on it...
-        if(mzx_world->version == 0x0253)
+        if(mzx_world->version == V283)
         {
           // Continue to the next line.
           cur_robot->cur_prog_line += program[cur_robot->cur_prog_line] + 2;
@@ -2883,15 +2884,16 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
 
           tr_msg(mzx_world, cmd_ptr + 3, id, mzm_name_buffer);
 
-          if(mzx_world->version >= 0x025A && is_string(mzm_name_buffer))
+          if(mzx_world->version >= V290 && is_string(mzm_name_buffer))
           {
             struct string src;
             
             if(get_string(mzx_world, mzm_name_buffer, &src, id))
-              load_mzm_memory(mzx_world, mzm_name_buffer, put_x, put_y, put_param, 1, src.value, src.length);
+              load_mzm_memory(mzx_world, mzm_name_buffer, put_x, put_y,
+               put_param, 1, src.value, src.length);
           }
           else
-            {
+          {
             if(!fsafetranslate(mzm_name_buffer, translated_name))
             {
               load_mzm(mzx_world, translated_name, put_x, put_y,
@@ -3818,8 +3820,8 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
           next_param = next_param_pos(next_param);
         }
         // Prior to 2.90 char params are clipped
-        if (mzx_world->version < 0x025A) char_num &= 0xFF;
-        if (char_num <= 0xFF || layer_renderer_check(true))
+        if(mzx_world->version < V290) char_num &= 0xFF;
+        if(char_num <= 0xFF || layer_renderer_check(true))
           ec_change_char(char_num, char_buffer);
         break;
       }
@@ -4780,7 +4782,7 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
           int i;
 
           // Prior to 2.90 char params are clipped
-          if (mzx_world->version < 0x025A) char_num &= 0xFF;
+          if(mzx_world->version < V290) char_num &= 0xFF;
 
           ec_read_char(char_num, char_buffer);
 
@@ -4862,7 +4864,7 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
         if(is_cardinal_dir(flip_dir))
         {
           // Prior to 2.90 char params are clipped
-          if (mzx_world->version < 0x025A) char_num &= 0xFF;
+          if(mzx_world->version < V290) char_num &= 0xFF;
           
           ec_read_char(char_num, char_buffer);
 
@@ -4914,7 +4916,7 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
         int dest_char = parse_param(mzx_world, p2, id);
 
         // Prior to 2.90 char params are clipped
-        if (mzx_world->version < 0x025A)
+        if(mzx_world->version < V290)
         {
           src_char &= 0xFF;
           dest_char &= 0xFF;
@@ -5020,7 +5022,7 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
           int maxlen;
           // The offset string length was increased in 2.90 to
           // allow for accessing extended char sets.
-          if (mzx_world->version < 0x025A)
+          if(mzx_world->version < V290)
             maxlen = 3;
           else
             maxlen = 4;
@@ -5036,7 +5038,7 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
         }
 
         // Load from string (2.90+)
-        if(mzx_world->version >= 0x025A && is_string(src_name))
+        if(mzx_world->version >= V290 && is_string(src_name))
         {
           struct string src;
 
@@ -5118,7 +5120,7 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
         tr_msg(mzx_world, cmd_ptr + 2, id, name_buffer);
 
         // Load palette from string (2.90+)
-        if(mzx_world->version >= 0x025A && is_string(name_buffer))
+        if(mzx_world->version >= V290 && is_string(name_buffer))
         {
           struct string src;
 
@@ -5571,7 +5573,7 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
         // compatibility has been broken forever, so only do this for
         // old worlds.
 
-        if(mzx_world->version <= 0x0249)
+        if(mzx_world->version < VPORT)
         {
           if(last_label == cur_robot->cur_prog_line)
             goto breaker;

--- a/src/run_robot.c
+++ b/src/run_robot.c
@@ -1905,7 +1905,7 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
             gotoed = send_self_label_tr(mzx_world,  p4 + 1, id);
 
             // The port up through 2.84 allowed this to iterate the entire board.
-            if(mzx_world->version < VPORT || mzx_world->version > V284)
+            if(mzx_world->version < VERSION_PORT || mzx_world->version > V284)
               break;
           }
         }
@@ -5576,7 +5576,7 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
         // compatibility has been broken forever, so only do this for
         // old worlds.
 
-        if(mzx_world->version < VPORT)
+        if(mzx_world->version < VERSION_PORT)
         {
           if(last_label == cur_robot->cur_prog_line)
             goto breaker;

--- a/src/run_robot.c
+++ b/src/run_robot.c
@@ -1871,8 +1871,9 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
           }
         }
 
-        if(cmd == 19)
-          success ^= 1;     // Reverse truth if NOT is present
+        // Reverse truth if NOT is present
+        if(cmd == ROBOTIC_CMD_IF_NOT_CONDITION)
+          success ^= 1;
 
         if(success)
         {
@@ -2561,9 +2562,11 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
 
           // Move player
           move_player(mzx_world, dir_to_int(direction));
-          if((mzx_world->player_x == old_x) &&
+
+          if((cmd == ROBOTIC_CMD_MOVE_PLAYER_DIR_OR) &&
+           (mzx_world->player_x == old_x) &&
            (mzx_world->player_y == old_y) &&
-           (mzx_world->current_board_id == old_board) && (cmd == 62) &&
+           (mzx_world->current_board_id == old_board) &&
            (mzx_world->target_where == old_target))
           {
             char *p2 = next_param_pos(cmd_ptr + 1);
@@ -3376,7 +3379,7 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
              CAN_PUSH | CAN_TRANSPORT | CAN_FIREWALK | CAN_WATERWALK |
              CAN_LAVAWALK * cur_robot->can_lavawalk |
              (cur_robot->can_goopwalk ? CAN_GOOPWALK : 0))) &&
-             (cmd == 232))
+             (cmd == ROBOTIC_CMD_PERSISTENT_GO))
             {
               cur_robot->pos_within_line--; // persistent...
             }
@@ -4673,11 +4676,11 @@ void run_robot(struct world *mzx_world, int id, int x, int y)
         if((type[2] == type[3]) || ((type[2] > 2) && (type[3] == 0)))
           dest_type = type[2];
 
-        //something is wrong with the params, abort
+        // something is wrong with the params, abort
         if((src_type < 0) || (dest_type < 0))
           break;
 
-        if (cmd == ROBOTIC_CMD_COPY_OVERLAY_BLOCK)
+        if(cmd == ROBOTIC_CMD_COPY_OVERLAY_BLOCK)
         {
           if(src_type < 2)
             src_type ^= 1;

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -1043,7 +1043,7 @@ int sprite_colliding_xy(struct world *mzx_world, struct sprite *spr,
   struct mask spr_mask = null_mask(), target_mask = null_mask();
   bool spr_mask_allocated = false, target_mask_allocated;
 
-  if (mzx_world->version < 0x025A)
+  if(mzx_world->version < V290)
     return sprite_colliding_xy_old(mzx_world, spr, x, y);
 
   collision_sprite.x = x;

--- a/src/str.c
+++ b/src/str.c
@@ -983,7 +983,7 @@ int set_string(struct world *mzx_world, const char *name, struct string *src,
   else
 
   if(special_name_partial("load_source_file") &&
-   mzx_world->version >= VERSION_PROGRAM_SOURCE)
+   mzx_world->version >= VERSION_SOURCE)
   {
     // Source code (DBC+)
 

--- a/src/str.c
+++ b/src/str.c
@@ -32,6 +32,7 @@
 #include "rasm.h"
 #include "robot.h"
 #include "util.h"
+#include "world.h"
 
 #ifdef CONFIG_UTHASH
 #include <utcasehash.h>
@@ -395,7 +396,7 @@ int string_read_as_counter(struct world *mzx_world,
       if(index_specified)
       {
         // Negative indices and multiple indexing (2.91+)
-        if(mzx_world->version >= 0x025B)
+        if(mzx_world->version >= V291)
         {
           if(get_string_real_index(src, index, &real_index))
             return 0;
@@ -494,14 +495,14 @@ void string_write_as_counter(struct world *mzx_world,
       src = find_string(mzx_world, name, &next);
 
       // Negative indices (2.91+)
-      if(index < 0 && mzx_world->version < 0x025B)
+      if(index < 0 && mzx_world->version < V291)
         return;
 
       if(get_string_real_index(src, index, &write_index))
         return;
 
       // Multiple size (2.91+)
-      if(mzx_world->version < 0x025B)
+      if(mzx_world->version < V291)
         write_size = 1;
 
       // Tentatively increase the string's length to cater for this write
@@ -553,7 +554,7 @@ void string_write_as_counter(struct world *mzx_world,
       src->length = new_length;
 
       // Before 2.84, the length would be set to the alloc_length
-      if(mzx_world->version < 0x0254)
+      if(mzx_world->version < V284)
         src->length = alloc_length;
     }
   }
@@ -670,7 +671,7 @@ void load_string_board(struct world *mzx_world, const char *name,
     return;
 
   // Size/offset support (2.91+)
-  if(mzx_world->version < 0x025B && (offset_specified || size_specified))
+  if(mzx_world->version < V291 && (offset_specified || size_specified))
     return;
 
   dest = find_string(mzx_world, name, &next);
@@ -712,7 +713,7 @@ int set_string(struct world *mzx_world, const char *name, struct string *src,
   dest = find_string(mzx_world, name, &next);
 
   // Negative offsets (2.91+)
-  if(input_offset < 0 && mzx_world->version < 0x025B)
+  if(input_offset < 0 && mzx_world->version < V291)
     return 0;
 
   if(get_string_real_index(dest, input_offset, &offset))
@@ -931,7 +932,7 @@ int set_string(struct world *mzx_world, const char *name, struct string *src,
   // Load source code from a string
 
 #ifdef CONFIG_DEBYTECODE
-  if(special_name_partial("load_robot") && mzx_world->version >= 0x025A)
+  if(special_name_partial("load_robot") && mzx_world->version >= V290)
   {
     // Load legacy source code (2.90+)
 
@@ -1034,7 +1035,7 @@ int set_string(struct world *mzx_world, const char *name, struct string *src,
   }
 
 #else //!CONFIG_DEBYTECODE
-  if(special_name_partial("load_robot") && mzx_world->version >= 0x025A)
+  if(special_name_partial("load_robot") && mzx_world->version >= V290)
   {
     // Load robot from string (2.90+)
 
@@ -1135,7 +1136,7 @@ int get_string(struct world *mzx_world, const char *name, struct string *dest,
   if(src)
   {
     // Negative offsets (2.91+)
-    if(input_offset < 0 && mzx_world->version < 0x025B)
+    if(input_offset < 0 && mzx_world->version < V291)
       return 0;
 
     if(get_string_real_index(src, input_offset, &offset))

--- a/src/utils/downver.c
+++ b/src/utils/downver.c
@@ -50,19 +50,14 @@
 #include "../world_prop.h"
 #include "../zip.h"
 
-#define DOWNVER_WORLD_VERSION 0x025B
-
-#if WORLD_VERSION != DOWNVER_WORLD_VERSION
-  #error "Update downver for the new world version."
-#else
-
-#define WORLD_VERSION_HI ((WORLD_VERSION >> 8) & 0xff)
-#define WORLD_VERSION_LO (WORLD_VERSION & 0xff)
-
-#define WORLD_VERSION_PREV_HI ((WORLD_VERSION_PREV >> 8) & 0xff)
-#define WORLD_VERSION_PREV_LO (WORLD_VERSION_PREV & 0xff)
-
+#define DOWNVER_VERSION "2.91"
 #define DOWNVER_EXT ".290"
+
+#define MZX_VERSION_HI ((MZX_VERSION >> 8) & 0xff)
+#define MZX_VERSION_LO (MZX_VERSION & 0xff)
+
+#define MZX_VERSION_PREV_HI ((MZX_VERSION_PREV >> 8) & 0xff)
+#define MZX_VERSION_PREV_LO (MZX_VERSION_PREV & 0xff)
 
 enum status
 {
@@ -165,7 +160,7 @@ static void convert_291_to_290_world_info(struct memfile *dest,
       case WPROP_WORLD_VERSION:
       case WPROP_FILE_VERSION:
         // Replace the version number
-        save_prop_w(ident, WORLD_VERSION_PREV, dest);
+        save_prop_w(ident, MZX_VERSION_PREV, dest);
         break;
 
       default:
@@ -191,7 +186,7 @@ static void convert_291_to_290_board_info(struct memfile *dest,
     {
       case BPROP_FILE_VERSION:
         // Replace the version number
-        save_prop_w(ident, WORLD_VERSION_PREV, dest);
+        save_prop_w(ident, MZX_VERSION_PREV, dest);
         break;
 
       default:
@@ -262,6 +257,12 @@ int main(int argc, char *argv[])
   int byte;
   FILE *in;
   FILE *out;
+
+  if(strcmp(VERSION, DOWNVER_VERSION) < 0)
+  {
+    error("[ERROR] Update downver for " VERSION "!\n");
+    return 1;
+  }
 
   if(argc <= 1)
   {
@@ -379,10 +380,10 @@ int main(int argc, char *argv[])
     goto err_read;
   }
   else
-  if(byte != WORLD_VERSION_HI)
+  if(byte != MZX_VERSION_HI)
   {
     error("This tool only supports worlds or boards from %d.%d.\n",
-     WORLD_VERSION_HI, WORLD_VERSION_LO);
+     MZX_VERSION_HI, MZX_VERSION_LO);
     goto exit_close;
   }
 
@@ -392,10 +393,10 @@ int main(int argc, char *argv[])
     goto err_read;
   }
   else
-  if(byte != WORLD_VERSION_LO)
+  if(byte != MZX_VERSION_LO)
   {
     error("This tool only supports worlds or boards from %d.%d.\n",
-     WORLD_VERSION_HI, WORLD_VERSION_LO);
+     MZX_VERSION_HI, MZX_VERSION_LO);
     goto exit_close;
   }
 
@@ -403,11 +404,11 @@ int main(int argc, char *argv[])
 
   fputc('M', out);
 
-  byte = fputc(WORLD_VERSION_PREV_HI, out);
+  byte = fputc(MZX_VERSION_PREV_HI, out);
   if(byte == EOF)
     goto err_write;
 
-  byte = fputc(WORLD_VERSION_PREV_LO, out);
+  byte = fputc(MZX_VERSION_PREV_LO, out);
   if(byte == EOF)
     goto err_write;
 
@@ -429,8 +430,8 @@ int main(int argc, char *argv[])
   fprintf(stdout,
    "File '%s' successfully downgraded from %d.%d to %d.%d.\n"
    "Saved to '%s'.\n",
-   argv[1], WORLD_VERSION_HI, WORLD_VERSION_LO,
-   WORLD_VERSION_PREV_HI, WORLD_VERSION_PREV_LO, fname);
+   argv[1], MZX_VERSION_HI, MZX_VERSION_LO,
+   MZX_VERSION_PREV_HI, MZX_VERSION_PREV_LO, fname);
 
 exit_close:
   if(out)
@@ -453,5 +454,3 @@ err_write:
   error("Write error, aborting.\n");
   goto exit_close;
 }
-
-#endif // WORLD_VERSION == DOWNVER_WORLD_VERSION

--- a/src/world.c
+++ b/src/world.c
@@ -172,7 +172,7 @@ int get_version_string(char buffer[16], enum mzx_version version)
       sprintf(buffer, "2.51s2/2.61");
       break;
 
-    case VDECRYPTED:
+    case VERSION_DECRYPT:
       sprintf(buffer, "<decrypted>");
       break;
 
@@ -210,7 +210,7 @@ int get_version_string(char buffer[16], enum mzx_version version)
 
     default:
     {
-      if(version < VPORT)
+      if(version < VERSION_PORT)
       {
         sprintf(buffer, "<unknown %4.4Xh>", version);
       }
@@ -2166,7 +2166,7 @@ int save_world(struct world *mzx_world, const char *file, int savegame,
           int old_version = world_magic(tmp);
 
           // If it's non-debytecode, abort
-          if(old_version < VERSION_PROGRAM_SOURCE)
+          if(old_version < VERSION_SOURCE)
           {
             error_message(E_DBC_WORLD_OVERWRITE_OLD, old_version, NULL);
             fclose(fp);
@@ -2507,7 +2507,7 @@ static void load_world(struct world *mzx_world, struct zip_archive *zp,
 
 #ifdef CONFIG_DEBYTECODE
   // Convert SFX strings if needed
-  if(file_version < VERSION_PROGRAM_SOURCE)
+  if(file_version < VERSION_SOURCE)
   {
     char *sfx_offset = mzx_world->custom_sfx;
     int i;
@@ -2565,7 +2565,7 @@ static void load_world(struct world *mzx_world, struct zip_archive *zp,
 
   // If this is a pre-port world, limit the number of samples
   // playing to 4 (the maximum number in pre-port MZX)
-  if(mzx_world->version < VPORT)
+  if(mzx_world->version < VERSION_PORT)
     mzx_world->max_samples = 4;
 
   // This will be -1 (no limit) or whatever was loaded from a save
@@ -2669,6 +2669,7 @@ err_close:
     }
     else
 
+    // Allow the last pre-ZIP version, but none before it
     if(v > 0 && v < MZX_LEGACY_FORMAT_VERSION)
     {
       error_message(E_SAVE_VERSION_OLD, v, NULL);
@@ -2693,7 +2694,6 @@ err_close:
     {
       error_message(E_WORLD_FILE_VERSION_OLD, v, NULL);
     }
-
     else
 
     if(v == 0 || v > MZX_LEGACY_FORMAT_VERSION)

--- a/src/world.c
+++ b/src/world.c
@@ -96,11 +96,11 @@ int world_magic(const char magic_string[3])
       switch(magic_string[2])
       {
         case 'X':
-          return 0x0100;
+          return V100;
         case '2':
-          return 0x0205;
+          return V251;
         case 'A':
-          return 0x0208;
+          return V251s1;
       }
     }
     else
@@ -123,7 +123,7 @@ int save_magic(const char magic_string[5])
       case 'S':
         if((magic_string[3] == 'V') && (magic_string[4] == '2'))
         {
-          return 0x0205;
+          return V251;
         }
         else if((magic_string[3] >= 2) && (magic_string[3] <= 10))
         {
@@ -136,7 +136,7 @@ int save_magic(const char magic_string[5])
       case 'X':
         if((magic_string[3] == 'S') && (magic_string[4] == 'A'))
         {
-          return 0x0208;
+          return V251s1;
         }
         else
         {
@@ -152,83 +152,74 @@ int save_magic(const char magic_string[5])
   }
 }
 
-int get_version_string(char buffer[16], int world_version)
+int get_version_string(char buffer[16], enum mzx_version version)
 {
-  switch(world_version)
+  switch(version)
   {
-    // 1.xx
-    case 0x0100:
+    case V100:
       sprintf(buffer, "1.xx");
       break;
 
-    // <=2.51
-    case 0x0205:
+    case V251:
       sprintf(buffer, "2.xx/2.51");
       break;
 
-    // 2.51s1
-    case 0x0208:
+    case V251s1:
       sprintf(buffer, "2.51s1");
       break;
 
-    // 2.51s2 / 2.60 / 2.61
-    case 0x0209:
+    case V251s2: // through V261
       sprintf(buffer, "2.51s2/2.61");
       break;
 
-    // Decrypted worlds
-    case 0x0211:
+    case VDECRYPTED:
       sprintf(buffer, "<decrypted>");
       break;
 
-    // 2.62
-    case 0x0232:
+    case V262:
       sprintf(buffer, "2.62");
       break;
 
-    // 2.62b
-    case 0x023E:
+    case V262b:
       sprintf(buffer, "2.62b");
       break;
 
-    // 2.65
-    case 0x0241:
+    case V265:
       sprintf(buffer, "2.65");
       break;
 
-    // 2.68
-    case 0x0244:
+    case V268:
       sprintf(buffer, "2.68");
       break;
 
-    case 0x0245:
+    case V269:
       sprintf(buffer, "2.69");
       break;
 
-    case 0x0246:
+    case V269b:
       sprintf(buffer, "2.69b");
       break;
 
-    case 0x0248:
+    case V269c:
       sprintf(buffer, "2.69c");
       break;
 
-    case 0x0249:
+    case V270:
       sprintf(buffer, "2.70");
       break;
 
     default:
     {
-      if(world_version < 0x0250)
+      if(version < VPORT)
       {
-        sprintf(buffer, "<unknown %4.4Xh>", world_version);
+        sprintf(buffer, "<unknown %4.4Xh>", version);
       }
 
       else
       {
         buffer[11] = 0;
         snprintf(buffer, 11, "%d.%2.2d",
-         (world_version >> 8) & 0xFF, world_version & 0xFF);
+         (version >> 8) & 0xFF, version & 0xFF);
       }
 
       break;
@@ -244,7 +235,7 @@ static inline int save_world_info(struct world *mzx_world,
  struct zip_archive *zp, int savegame, int file_version,
  const char *name)
 {
-  int world_version = mzx_world->version;
+  enum mzx_version world_version = mzx_world->version;
 
   char *buffer;
   size_t buf_size = WORLD_PROP_SIZE;
@@ -317,7 +308,7 @@ static inline int save_world_info(struct world *mzx_world,
   save_prop_c(WPROP_ONLY_FROM_SWAP,     mzx_world->only_from_swap, mf);
 
   // SMZX and vlayer are global properties 2.91+
-  if(savegame || world_version >= 0x025B)
+  if(savegame || world_version >= V291)
   {
     save_prop_c(WPROP_SMZX_MODE,        get_screen_mode(), mf);
     save_prop_w(WPROP_VLAYER_WIDTH,     mzx_world->vlayer_width, mf);
@@ -464,7 +455,7 @@ static inline enum val_result validate_world_info(struct world *mzx_world,
   check(WPROP_CLEAR_ON_EXIT);
   check(WPROP_ONLY_FROM_SWAP);
 
-  if(!savegame && world_version < 0x025B)
+  if(!savegame && world_version < V291)
   {
     return VAL_SUCCESS;
   }
@@ -514,7 +505,7 @@ static inline enum val_result validate_world_info(struct world *mzx_world,
   check(WPROP_DIVIDER);
   check(WPROP_C_DIVISIONS);
 
-  if(world_version >= 0x025B)
+  if(world_version >= V291)
   {
     // Added in 2.91
     check(WPROP_MAX_SAMPLES);
@@ -536,7 +527,7 @@ err_free:
 }
 
 #define if_savegame         if(!savegame) { break; }
-#define if_savegame_or_291  if(!savegame && *file_version < 0x025B) { break; }
+#define if_savegame_or_291  if(!savegame && *file_version < V291) { break; }
 
 static inline void load_world_info(struct world *mzx_world,
  struct zip_archive *zp, int savegame, int *file_version, int *faded)
@@ -934,13 +925,13 @@ static inline void load_world_info(struct world *mzx_world,
       // Added in 2.91
       case WPROP_MAX_SAMPLES:
         if_savegame
-        if(mzx_world->version >= 0x025B)
+        if(mzx_world->version >= V291)
         mzx_world->max_samples = load_prop_int(size, prop);
         break;
 
       case WPROP_SMZX_MESSAGE:
         if_savegame
-        if(mzx_world->version >= 0x025B)
+        if(mzx_world->version >= V291)
         mzx_world->smzx_message = load_prop_int(size, prop);
         break;
 
@@ -1035,8 +1026,8 @@ static inline int load_world_chars(struct world *mzx_world,
   if(result == ZIP_SUCCESS)
   {
     // Load every charset (2.90 saves, 2.91+ worlds)
-    if((mzx_world->version >= 0x025B) ||
-     (savegame && mzx_world->version == 0x025A))
+    if((mzx_world->version >= V291) ||
+     (savegame && mzx_world->version == V290))
       actual_size = MIN(actual_size, PROTECTED_CHARSET_POSITION * CHAR_SIZE);
 
     // Load only the first charset
@@ -1044,7 +1035,7 @@ static inline int load_world_chars(struct world *mzx_world,
       actual_size = MIN(actual_size, CHARSET_SIZE * CHAR_SIZE);
 
     ec_clear_set();
-    ec_mem_load_set_var(buffer, actual_size, 0, WORLD_VERSION);
+    ec_mem_load_set_var(buffer, actual_size, 0, MZX_VERSION);
   }
 
   free(buffer);
@@ -1125,7 +1116,7 @@ static inline int load_world_pal_index(struct world *mzx_world,
 
   if(result == ZIP_SUCCESS)
   {
-    if(file_version >= 0x025B)
+    if(file_version >= V291)
       load_indices(buffer, actual_size);
 
     // 2.90 stored the internal indices instead of user-friendly indices
@@ -1970,7 +1961,7 @@ err:
 #undef if_savegame_or_291
 
 #define if_savegame         if(!savegame) { zip_skip_file(zp); break; }
-#define if_savegame_or_291  if(!savegame && mzx_world->version < 0x025B) \
+#define if_savegame_or_291  if(!savegame && mzx_world->version < V291) \
                              { zip_skip_file(zp); break; }
 
 static int load_world_zip(struct world *mzx_world, struct zip_archive *zp,
@@ -2156,7 +2147,7 @@ int save_world(struct world *mzx_world, const char *file, int savegame,
   // TODO we'll cross this bridge when we need to. That shouldn't be
   // until debytecode gets an actual release, though.
 
-  if(world_version == WORLD_VERSION_PREV)
+  if(world_version == MZX_VERSION_PREV)
   {
     error("Downver. not currently supported by debytecode.", 1, 8, 0);
     return -1;
@@ -2213,14 +2204,14 @@ int save_world(struct world *mzx_world, const char *file, int savegame,
   }
 
 #ifdef CONFIG_EDITOR
-  if(world_version == WORLD_VERSION_PREV)
+  if(world_version == MZX_VERSION_PREV)
   {
     // Temporarily replace the world version with the previous version
     int actual_world_version = mzx_world->version;
     int ret_val;
-    mzx_world->version = WORLD_VERSION_PREV;
+    mzx_world->version = MZX_VERSION_PREV;
 
-    ret_val = save_world_zip(mzx_world, file, savegame, WORLD_VERSION_PREV);
+    ret_val = save_world_zip(mzx_world, file, savegame, MZX_VERSION_PREV);
 
     mzx_world->version = actual_world_version;
     return ret_val;
@@ -2228,9 +2219,9 @@ int save_world(struct world *mzx_world, const char *file, int savegame,
   else
 #endif
 
-  if(world_version == WORLD_VERSION)
+  if(world_version == MZX_VERSION)
   {
-    return save_world_zip(mzx_world, file, savegame, WORLD_VERSION);
+    return save_world_zip(mzx_world, file, savegame, MZX_VERSION);
   }
 
   else
@@ -2574,7 +2565,7 @@ static void load_world(struct world *mzx_world, struct zip_archive *zp,
 
   // If this is a pre-port world, limit the number of samples
   // playing to 4 (the maximum number in pre-port MZX)
-  if(mzx_world->version < 0x0250)
+  if(mzx_world->version < VPORT)
     mzx_world->max_samples = 4;
 
   // This will be -1 (no limit) or whatever was loaded from a save
@@ -2637,7 +2628,7 @@ static struct zip_archive *try_load_zip_world(struct world *mzx_world,
   if(pr > 0 && pr <= 3 && strncmp(name, "PK", 2))
     goto err_protected;
 
-  if(v > 0 && v <= WORLD_LEGACY_FORMAT_VERSION)
+  if(v > 0 && v <= MZX_LEGACY_FORMAT_VERSION)
     goto err_close;
 
   // Get the actual file version out of the world metadata
@@ -2655,11 +2646,11 @@ static struct zip_archive *try_load_zip_world(struct world *mzx_world,
     goto err_close;
 
   // Should never happen, but if it did, it's totally invalid.
-  if(*file_version <= WORLD_LEGACY_FORMAT_VERSION)
+  if(*file_version <= MZX_LEGACY_FORMAT_VERSION)
     goto err_close;
 
   v = *file_version;
-  if(v > WORLD_VERSION)
+  if(v > MZX_VERSION)
     goto err_close;
 
   zip_rewind(zp);
@@ -2672,19 +2663,19 @@ err_close:
   // Display an appropriate error.
   if(savegame)
   {
-    if(v > WORLD_VERSION)
+    if(v > MZX_VERSION)
     {
       error_message(E_SAVE_VERSION_TOO_RECENT, v, NULL);
     }
     else
 
-    if(v > 0 && v < WORLD_LEGACY_FORMAT_VERSION)
+    if(v > 0 && v < MZX_LEGACY_FORMAT_VERSION)
     {
       error_message(E_SAVE_VERSION_OLD, v, NULL);
     }
     else
 
-    if(v != WORLD_LEGACY_FORMAT_VERSION)
+    if(v != MZX_LEGACY_FORMAT_VERSION)
     {
       error_message(E_SAVE_FILE_INVALID, 0, NULL);
     }
@@ -2692,20 +2683,20 @@ err_close:
 
   else
   {
-    if (v > WORLD_VERSION)
+    if (v > MZX_VERSION)
     {
       error_message(E_WORLD_FILE_VERSION_TOO_RECENT, v, NULL);
     }
     else
 
-    if(v > 0 && v < 0x0205)
+    if(v > 0 && v < V251)
     {
       error_message(E_WORLD_FILE_VERSION_OLD, v, NULL);
     }
 
     else
 
-    if(v == 0 || v > WORLD_LEGACY_FORMAT_VERSION)
+    if(v == 0 || v > MZX_LEGACY_FORMAT_VERSION)
     {
       error_message(E_WORLD_FILE_INVALID, 0, NULL);
     }
@@ -2768,7 +2759,7 @@ void try_load_world(struct world *mzx_world, struct zip_archive **zp,
   _zp = try_load_zip_world(mzx_world, file, savegame, &v, &protected, name);
 
   if(!_zp)
-    if(protected || (v >= 0x0205 && v <= WORLD_LEGACY_FORMAT_VERSION))
+    if(protected || (v >= V251 && v <= MZX_LEGACY_FORMAT_VERSION))
       _fp = try_load_legacy_world(file, savegame, &v, name);
 
   *zp = _zp;
@@ -2799,7 +2790,7 @@ void change_board(struct world *mzx_world, int board_id)
   cur_board = mzx_world->current_board;
 
   // Does this board need a duplicate? (2.90+)
-  if(mzx_world->version >= 0x025A && cur_board->reset_on_entry)
+  if(mzx_world->version >= V290 && cur_board->reset_on_entry)
   {
     struct board *dup_board = duplicate_board(mzx_world, cur_board);
     store_board_to_extram(cur_board);
@@ -2816,12 +2807,12 @@ void change_board_load_assets(struct world *mzx_world)
   char translated_name[MAX_PATH];
 
   // Does this board need a char set loaded? (2.90+)
-  if(mzx_world->version >= 0x025A && cur_board->charset_path[0])
+  if(mzx_world->version >= V290 && cur_board->charset_path[0])
     if(fsafetranslate(cur_board->charset_path, translated_name) == FSAFE_SUCCESS)
       ec_load_set(translated_name);
 
   // Does this board need a palette loaded? (2.90+)
-  if(mzx_world->version >= 0x025A && cur_board->palette_path[0])
+  if(mzx_world->version >= V290 && cur_board->palette_path[0])
   {
     if(fsafetranslate(cur_board->palette_path, translated_name) == FSAFE_SUCCESS)
     {

--- a/src/world.h
+++ b/src/world.h
@@ -99,33 +99,33 @@ __M_BEGIN_DECLS
 
 enum mzx_version
 {
-  Vall        = 0, // Used in versioned lists
-  V100        = 0x0100, // Magic: MZX
-  V251        = 0x0205, // Magic: MZ2
-  V251s1      = 0x0208, // Magic: MZA
-  V251s2      = 0x0209,
-  V251s3      = 0x0209,
-  V260        = 0x0209,
-  V261        = 0x0209,
-  VDECRYPTED  = 0x0211, // Special version used for decrypted worlds only.
-  V262        = 0x0232,
-  V262b       = 0x023E,
-  V265        = 0x0241,
-  V268        = 0x0244,
-  V269        = 0x0245,
-  V269b       = 0x0246,
-  V269c       = 0x0248,
-  V270        = 0x0249,
-  VPORT       = 0x0250, // For checks explicitly differentiating DOS and port
-  V280        = 0x0250,
-  V281        = 0x0251,
-  V282        = 0x0252,
-  V283        = 0x0253,
-  V284        = 0x0254,
-  V290        = 0x025A,
-  V291        = 0x025B,
+  VERSION_ALL     = 0,      // Used in versioned lists
+  V100            = 0x0100, // Magic: MZX
+  V251            = 0x0205, // Magic: MZ2
+  V251s1          = 0x0208, // Magic: MZA
+  V251s2          = 0x0209,
+  V251s3          = 0x0209,
+  V260            = 0x0209,
+  V261            = 0x0209,
+  VERSION_DECRYPT = 0x0211, // Special version used for decrypted worlds only.
+  V262            = 0x0232,
+  V262b           = 0x023E,
+  V265            = 0x0241,
+  V268            = 0x0244,
+  V269            = 0x0245,
+  V269b           = 0x0246,
+  V269c           = 0x0248,
+  V270            = 0x0249,
+  VERSION_PORT    = 0x0250, // For checks explicitly differentiating DOS and port
+  V280            = 0x0250,
+  V281            = 0x0251,
+  V282            = 0x0252,
+  V283            = 0x0253,
+  V284            = 0x0254,
+  V290            = 0x025A,
+  V291            = 0x025B,
 #ifdef CONFIG_DEBYTECODE
-  VSOURCE     = 0x0300, // For checks dependent on Robotic source changes
+  VERSION_SOURCE  = 0x0300, // For checks dependent on Robotic source changes
 #endif
 };
 

--- a/src/world.h
+++ b/src/world.h
@@ -97,33 +97,65 @@ __M_BEGIN_DECLS
  * necessitated, a numerical change must be enacted.
  */
 
+enum mzx_version
+{
+  Vall        = 0, // Used in versioned lists
+  V100        = 0x0100, // Magic: MZX
+  V251        = 0x0205, // Magic: MZ2
+  V251s1      = 0x0208, // Magic: MZA
+  V251s2      = 0x0209,
+  V251s3      = 0x0209,
+  V260        = 0x0209,
+  V261        = 0x0209,
+  VDECRYPTED  = 0x0211, // Special version used for decrypted worlds only.
+  V262        = 0x0232,
+  V262b       = 0x023E,
+  V265        = 0x0241,
+  V268        = 0x0244,
+  V269        = 0x0245,
+  V269b       = 0x0246,
+  V269c       = 0x0248,
+  V270        = 0x0249,
+  VPORT       = 0x0250, // For checks explicitly differentiating DOS and port
+  V280        = 0x0250,
+  V281        = 0x0251,
+  V282        = 0x0252,
+  V283        = 0x0253,
+  V284        = 0x0254,
+  V290        = 0x025A,
+  V291        = 0x025B,
+#ifdef CONFIG_DEBYTECODE
+  VSOURCE     = 0x0300, // For checks dependent on Robotic source changes
+#endif
+};
+
 /* The magic stamp for worlds, boards or SAV files created with this version
  * of MegaZeux. If you introduce a counter or any other incompatible change,
  * such as altering semantics or actually changing the binary format, this
  * value MUST be bumped.
  */
-#define WORLD_VERSION      0x025B
+#define MZX_VERSION      (V291)
 
 /* The world version that worlds will be saved as when Export Downver. World
  * is used from the editor. This function was previously fulfilled by downver,
  * but the increase in complexity of the world file made maintaining downver
  * infeasible.
  *
- * If you increase WORLD_VERSION, always make sure this is updated with its
+ * If you increase MZX_VERSION, always make sure this is updated with its
  * previous value. Therefore, users can always downgrade their work to an
  * older version (if it at all makes sense to do so).
  */
-#define WORLD_VERSION_PREV 0x025A
+#define MZX_VERSION_PREV (V290)
 
 // This is the last version of MegaZeux to use the legacy world format.
-#define WORLD_LEGACY_FORMAT_VERSION 0x0254
+#define MZX_LEGACY_FORMAT_VERSION (V284)
 
 // FIXME: hack
 #ifdef CONFIG_DEBYTECODE
-#undef  WORLD_VERSION
-#define WORLD_VERSION      0x0300
-#undef  WORLD_VERSION_PREV
-#define WORLD_VERSION_PREV 0x025B
+#undef  MZX_VERSION_PREV
+#define MZX_VERSION_PREV MZX_VERSION
+#undef  MZX_VERSION
+#define MZX_VERSION      (VSOURCE)
 #endif
 
 enum val_result
@@ -138,7 +170,7 @@ enum val_result
 
 CORE_LIBSPEC int world_magic(const char magic_string[3]);
 CORE_LIBSPEC int save_magic(const char magic_string[5]);
-CORE_LIBSPEC int get_version_string(char buffer[16], int world_version);
+CORE_LIBSPEC int get_version_string(char buffer[16], enum mzx_version version);
 
 CORE_LIBSPEC int save_world(struct world *mzx_world, const char *file,
  int savegame, int world_version);


### PR DESCRIPTION
All (hopefully) raw version magic numbers in version checks across MZX have been replaced with enum values in world.h to make them more readable.  The macros WORLD_VERSION, WORLD_VERSION_PREV, and WORLD_LEGACY_FORMAT_VERSION have been replaced with MZX_VERSION, MZX_VERSION_PREV, and MZX_LEGACY_FORMAT_VERSION, respectively.  Finally, the function counter list has been reformatted to be infinitely more readable.