### PR TITLE
Improve compile times on Windows

### DIFF
--- a/arch/mingw/Makefile.in
+++ b/arch/mingw/Makefile.in
@@ -81,4 +81,4 @@ endif
 	@arch/manifest.sh ${build}
 
 SUBARCH := ${shell echo ${SUBPLATFORM} | sed 's,windows-,,'}
-include arch/zip.inc 
+include arch/zip.inc

--- a/src/audio/audio_vorbis.c
+++ b/src/audio/audio_vorbis.c
@@ -20,6 +20,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <stdlib.h>
+#include <string.h>
+
 #include "audio.h"
 #include "audio_vorbis.h"
 #include "ext.h"

--- a/src/audio/audio_wav.c
+++ b/src/audio/audio_wav.c
@@ -20,6 +20,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "audio.h"
 #include "audio_wav.h"
 #include "ext.h"

--- a/src/audio/ext.c
+++ b/src/audio/ext.c
@@ -20,6 +20,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <stdlib.h>
+#include <string.h>
+
 #include "audio.h"
 #include "ext.h"
 

--- a/src/audio/sampled_stream.c
+++ b/src/audio/sampled_stream.c
@@ -23,6 +23,8 @@
 // Common functions for sampled streams.
 
 #include <math.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "audio.h"
 #include "sampled_stream.h"

--- a/src/audio/sampled_stream.c
+++ b/src/audio/sampled_stream.c
@@ -22,6 +22,8 @@
 
 // Common functions for sampled streams.
 
+#include <math.h>
+
 #include "audio.h"
 #include "sampled_stream.h"
 

--- a/src/compat.h
+++ b/src/compat.h
@@ -86,11 +86,6 @@ typedef enum
 #include "msvc.h"
 #endif
 
-#ifdef __WIN32__
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#endif
-
 #ifdef ANDROID
 #define HAVE_SYS_UIO_H
 #define LOG_TAG "MegaZeux"
@@ -136,7 +131,7 @@ __M_BEGIN_DECLS
 // to properly audit calls to it.
 //
 // Any case where a file to open is specified by a game, the path must first
-// be translated, so that any case-insensitive matches will be used and 
+// be translated, so that any case-insensitive matches will be used and
 // safety checks will be applied. Callers should use either
 // fsafetranslate()+fopen_unsafe(), or call fsafeopen() directly.
 //
@@ -197,114 +192,6 @@ static inline void *crealloc(void *ptr, size_t size)
 }
 
 #endif /* CONFIG_CHECK_ALLOC */
-
-#if defined(CONFIG_SDL) && !defined(SKIP_SDL)
-
-#include <SDL.h>
-#include <SDL_syswm.h>
-
-#if !SDL_VERSION_ATLEAST(2,0,0)
-
-// This block remaps anything that is EXACTLY equivalent to its new SDL 2.0
-// counterpart. More complex changes are handled with #ifdefs "in situ".
-
-// Data types
-
-typedef SDLKey SDL_Keycode;
-typedef void   SDL_Window;
-
-// Macros / enumerants
-
-#define SDLK_KP_0         SDLK_KP0
-#define SDLK_KP_1         SDLK_KP1
-#define SDLK_KP_2         SDLK_KP2
-#define SDLK_KP_3         SDLK_KP3
-#define SDLK_KP_4         SDLK_KP4
-#define SDLK_KP_5         SDLK_KP5
-#define SDLK_KP_6         SDLK_KP6
-#define SDLK_KP_7         SDLK_KP7
-#define SDLK_KP_8         SDLK_KP8
-#define SDLK_KP_9         SDLK_KP9
-#define SDLK_NUMLOCKCLEAR SDLK_NUMLOCK
-#define SDLK_SCROLLLOCK   SDLK_SCROLLOCK
-#define SDLK_LGUI         SDLK_LSUPER
-#define SDLK_RGUI         SDLK_RSUPER
-#define SDLK_PAUSE        SDLK_BREAK
-
-#define SDL_WINDOW_FULLSCREEN  SDL_FULLSCREEN
-#define SDL_WINDOW_RESIZABLE   SDL_RESIZABLE
-#define SDL_WINDOW_OPENGL      SDL_OPENGL
-
-// API functions
-
-#define SDL_SetEventFilter(filter, userdata) SDL_SetEventFilter(filter)
-
-static inline SDL_bool SDL_GetWindowWMInfo(SDL_Window *window,
-                                           SDL_SysWMinfo *info)
-{
-  return SDL_GetWMInfo(info) == 1 ? SDL_TRUE : SDL_FALSE;
-}
-
-static inline SDL_Window *SDL_GetWindowFromID(Uint32 id)
-{
-  return NULL;
-}
-
-static inline void SDL_WarpMouseInWindow(SDL_Window *window, int x, int y)
-{
-  SDL_WarpMouse(x, y);
-}
-
-static inline void SDL_SetWindowTitle(SDL_Window *window, const char *title)
-{
-  SDL_WM_SetCaption(title, "");
-}
-
-static inline void SDL_SetWindowIcon(SDL_Window *window, SDL_Surface *icon)
-{
-   SDL_WM_SetIcon(icon, NULL);
-}
-
-#if defined(CONFIG_RENDER_GL_FIXED) || defined(CONFIG_RENDER_GL_PROGRAM)
-static inline int SDL_GL_SetSwapInterval(int interval)
-{
-  return SDL_GL_SetAttribute(SDL_GL_SWAP_CONTROL, interval);
-}
-#endif
-
-#ifdef CONFIG_X11
-static inline XEvent *SDL_SysWMmsg_GetXEvent(SDL_SysWMmsg *msg)
-{
-  return &msg->event.xevent;
-}
-#endif /* CONFIG_X11 */
-
-#if defined(CONFIG_ICON) && defined(__WIN32__)
-static inline HWND SDL_SysWMinfo_GetWND(SDL_SysWMinfo *info)
-{
-  return info->window;
-}
-#endif /* CONFIG_ICON && __WIN32__ */
-
-#else /* SDL_VERSION_ATLEAST(2,0,0) */
-
-#ifdef CONFIG_X11
-static inline XEvent *SDL_SysWMmsg_GetXEvent(SDL_SysWMmsg *msg)
-{
-  return &msg->msg.x11.event;
-}
-#endif /* CONFIG_X11 */
-
-#if defined(CONFIG_ICON) && defined(__WIN32__)
-static inline HWND SDL_SysWMinfo_GetWND(SDL_SysWMinfo *info)
-{
-  return info->info.win.window;
-}
-#endif /* CONFIG_ICON && __WIN32__ */
-
-#endif /* SDL_VERSION_ATLEAST(2,0,0) */
-
-#endif /* CONFIG_SDL && !SKIP_SDL */
 
 __M_END_DECLS
 

--- a/src/compat_sdl.h
+++ b/src/compat_sdl.h
@@ -1,0 +1,143 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2007 Alistair John Strachan <alistair@devzero.co.uk>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+// Split from compat.h because it's only needed in one place and it was making
+// the build process much slower.
+
+#ifndef __COMPAT_SDL_H
+#define __COMPAT_SDL_H
+
+#include "compat.h"
+
+__M_BEGIN_DECLS
+
+#if defined(CONFIG_SDL)
+
+#include <SDL.h>
+#include <SDL_syswm.h>
+
+#if !SDL_VERSION_ATLEAST(2,0,0)
+
+// This block remaps anything that is EXACTLY equivalent to its new SDL 2.0
+// counterpart. More complex changes are handled with #ifdefs "in situ".
+
+// This is included EVERYWHERE, so only include SDL headers that are absolutely
+// necessary.
+
+// Data types
+
+typedef SDLKey SDL_Keycode;
+typedef void   SDL_Window;
+
+// Macros / enumerants
+
+#define SDLK_KP_0         SDLK_KP0
+#define SDLK_KP_1         SDLK_KP1
+#define SDLK_KP_2         SDLK_KP2
+#define SDLK_KP_3         SDLK_KP3
+#define SDLK_KP_4         SDLK_KP4
+#define SDLK_KP_5         SDLK_KP5
+#define SDLK_KP_6         SDLK_KP6
+#define SDLK_KP_7         SDLK_KP7
+#define SDLK_KP_8         SDLK_KP8
+#define SDLK_KP_9         SDLK_KP9
+#define SDLK_NUMLOCKCLEAR SDLK_NUMLOCK
+#define SDLK_SCROLLLOCK   SDLK_SCROLLOCK
+#define SDLK_LGUI         SDLK_LSUPER
+#define SDLK_RGUI         SDLK_RSUPER
+#define SDLK_PAUSE        SDLK_BREAK
+
+#define SDL_WINDOW_FULLSCREEN  SDL_FULLSCREEN
+#define SDL_WINDOW_RESIZABLE   SDL_RESIZABLE
+#define SDL_WINDOW_OPENGL      SDL_OPENGL
+
+// API functions
+
+#define SDL_SetEventFilter(filter, userdata) SDL_SetEventFilter(filter)
+
+static inline SDL_bool SDL_GetWindowWMInfo(SDL_Window *window,
+                                           SDL_SysWMinfo *info)
+{
+  return SDL_GetWMInfo(info) == 1 ? SDL_TRUE : SDL_FALSE;
+}
+
+static inline SDL_Window *SDL_GetWindowFromID(Uint32 id)
+{
+  return NULL;
+}
+
+static inline void SDL_WarpMouseInWindow(SDL_Window *window, int x, int y)
+{
+  SDL_WarpMouse(x, y);
+}
+
+static inline void SDL_SetWindowTitle(SDL_Window *window, const char *title)
+{
+  SDL_WM_SetCaption(title, "");
+}
+
+static inline void SDL_SetWindowIcon(SDL_Window *window, SDL_Surface *icon)
+{
+   SDL_WM_SetIcon(icon, NULL);
+}
+
+#if defined(CONFIG_RENDER_GL_FIXED) || defined(CONFIG_RENDER_GL_PROGRAM)
+static inline int SDL_GL_SetSwapInterval(int interval)
+{
+  return SDL_GL_SetAttribute(SDL_GL_SWAP_CONTROL, interval);
+}
+#endif
+
+#ifdef CONFIG_X11
+static inline XEvent *SDL_SysWMmsg_GetXEvent(SDL_SysWMmsg *msg)
+{
+  return &msg->event.xevent;
+}
+#endif /* CONFIG_X11 */
+
+#if defined(CONFIG_ICON) && defined(__WIN32__)
+static inline HWND SDL_SysWMinfo_GetWND(SDL_SysWMinfo *info)
+{
+  return info->window;
+}
+#endif /* CONFIG_ICON && __WIN32__ */
+
+#else /* SDL_VERSION_ATLEAST(2,0,0) */
+
+#ifdef CONFIG_X11
+static inline XEvent *SDL_SysWMmsg_GetXEvent(SDL_SysWMmsg *msg)
+{
+  return &msg->msg.x11.event;
+}
+#endif /* CONFIG_X11 */
+
+#if defined(CONFIG_ICON) && defined(__WIN32__)
+static inline HWND SDL_SysWMinfo_GetWND(SDL_SysWMinfo *info)
+{
+  return info->info.win.window;
+}
+#endif /* CONFIG_ICON && __WIN32__ */
+
+#endif /* SDL_VERSION_ATLEAST(2,0,0) */
+
+#endif /* CONFIG_SDL */
+
+__M_END_DECLS
+
+#endif /* __COMPAT_SDL_H */

--- a/src/editor/clipboard_win32.c
+++ b/src/editor/clipboard_win32.c
@@ -21,8 +21,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
 #include "clipboard.h"
-#include "../compat.h"
 
 void copy_buffer_to_clipboard(char **buffer, int lines, int total_length)
 {

--- a/src/event.c
+++ b/src/event.c
@@ -19,8 +19,8 @@
 
 #include "event.h"
 #include "graphics.h"
-#include "util.h"
 #include "platform.h"
+#include "util.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -314,7 +314,13 @@ static enum keycode convert_xt_internal(Uint32 key, enum keycode *second)
   }
 }
 
-static bool update_autorepeat(void)
+// event_sdl.c needs to call this for SDL 1.2 to catch autorepeat non-events
+// while performing wait_event with a timeout.
+
+#if !defined(CONFIG_SDL)
+static
+#endif
+bool update_autorepeat(void)
 {
   // The repeat key may not be a "valid" keycode due to the unbounded nature
   // of joypad support.  All invalid keys use the last position because that's
@@ -328,13 +334,13 @@ static bool update_autorepeat(void)
   Uint8 last_key_state = status->keymap[status_key];
   Uint8 last_mouse_state = status->mouse_repeat_state;
 
-#ifdef CONFIG_SDL
-#if SDL_VERSION_ATLEAST(2,0,0)
   // If you enable SDL 2.0 key repeat, uncomment these lines:
+//#ifdef CONFIG_SDL
+//#if SDL_VERSION_ATLEAST(2,0,0)
   //last_key_state = 0;
   //input.repeat_stack_pointer = 0;
-#endif
-#endif
+//#endif
+//#endif
 
   if(last_key_state)
   {
@@ -411,18 +417,6 @@ static bool update_autorepeat(void)
   bump_status();
   return rval;
 }
-
-// event_sdl.c needs this in SDL 1.2 for catching autorepeat non-events while
-// performing wait_event with a timeout.
-
-#if defined(CONFIG_SDL)
-#if !SDL_VERSION_ATLEAST(2,0,0)
-bool update_autorepeat_sdl(void)
-{
-  return update_autorepeat();
-}
-#endif /*SDL_VERSION_ATLEAST*/
-#endif /*CONFIG_SDL*/
 
 bool update_event_status(void)
 {

--- a/src/event.h
+++ b/src/event.h
@@ -51,6 +51,8 @@ __M_BEGIN_DECLS
 
 #elif defined(CONFIG_SDL)
 
+#include <SDL_version.h>
+
 // SDL 2 maps X1 and X2, but has a separate wheel event that we map.
 #if SDL_VERSION_ATLEAST(2,0,0)
 #define MOUSE_BUTTON_X1         4
@@ -110,7 +112,7 @@ struct input_status
   enum keycode key_repeat_stack[KEY_REPEAT_STACK_SIZE];
   Uint16 unicode_repeat_stack[KEY_REPEAT_STACK_SIZE];
   Uint32 repeat_stack_pointer;
-  
+
   enum keycode joystick_button_map[16][256];
   enum keycode joystick_axis_map[16][16][2];
   enum keycode joystick_hat_map[16][4];
@@ -163,9 +165,13 @@ CORE_LIBSPEC bool peek_exit_input(void);
 void __wait_event(int timeout);
 bool __update_event_status(void);
 
-// This one is SDL-only
 #ifdef CONFIG_SDL
+// Currently only supported by SDL.
 bool __peek_exit_input(void);
+
+// Older SDL versions lack SDL_WaitEventTimeout, and our compatibility
+// implementation needs this function to work properly.
+bool update_autorepeat(void);
 #endif
 
 #ifdef CONFIG_NDS
@@ -195,12 +201,6 @@ void joystick_key_release(struct buffered_status *status,
  enum keycode key);
 
 void real_warp_mouse(int x, int y);
-
-#if defined(CONFIG_SDL)
-#if !SDL_VERSION_ATLEAST(2,0,0)
-bool update_autorepeat_sdl(void);
-#endif
-#endif
 
 __M_END_DECLS
 

--- a/src/event_sdl.c
+++ b/src/event_sdl.c
@@ -21,6 +21,7 @@
 #include "event.h"
 #include "platform.h"
 #include "graphics.h"
+#include "compat_sdl.h"
 #include "render_sdl.h"
 
 #include "SDL.h"
@@ -518,7 +519,7 @@ static bool process_event(SDL_Event *event)
 
       break;
     }
-    
+
     case SDL_JOYHATMOTION:
     {
       int which = event->jhat.which;
@@ -527,7 +528,7 @@ static bool process_event(SDL_Event *event)
       enum keycode key_down = input.joystick_hat_map[which][1];
       enum keycode key_left = input.joystick_hat_map[which][2];
       enum keycode key_right = input.joystick_hat_map[which][3];
-      
+
       //if(dir & SDL_HAT_CENTERED)
       {
         joystick_key_release(status, key_up);
@@ -535,31 +536,31 @@ static bool process_event(SDL_Event *event)
         joystick_key_release(status, key_left);
         joystick_key_release(status, key_right);
       }
-    
+
       if(dir & SDL_HAT_UP)
       {
         if (key_up)
           joystick_key_press(status, key_up, key_up);
       }
-      
+
       if(dir & SDL_HAT_DOWN)
       {
         if (key_down)
           joystick_key_press(status, key_down, key_down);
       }
-      
+
       if(dir & SDL_HAT_LEFT)
       {
         if (key_left)
           joystick_key_press(status, key_left, key_left);
       }
-      
+
       if(dir & SDL_HAT_RIGHT)
       {
         if (key_right)
           joystick_key_press(status, key_right, key_right);
       }
-      
+
       break;
     }
 
@@ -585,27 +586,39 @@ bool __update_event_status(void)
 // Proper polling should be performed if the answer is yes.
 bool __peek_exit_input(void)
 {
-  #if SDL_VERSION_ATLEAST(2,0,0)
+#if SDL_VERSION_ATLEAST(2,0,0)
   SDL_Event events[256];
   int num_events, i;
+
   SDL_PumpEvents();
   num_events = SDL_PeepEvents(events, 256, SDL_PEEKEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT);
-  for (i = 0; i < num_events; i++) {
-    if (events[i].type == SDL_QUIT) return true;
-    if (events[i].type == SDL_KEYDOWN) {
+
+  for(i = 0; i < num_events; i++)
+  {
+    if(events[i].type == SDL_QUIT)
+      return true;
+
+    if(events[i].type == SDL_KEYDOWN)
+    {
       SDL_KeyboardEvent *ev = (SDL_KeyboardEvent *) &events[i];
-      if (ev->keysym.sym == SDLK_ESCAPE) return true;
-      if (ev->keysym.sym == SDLK_c && ev->keysym.mod & KMOD_CTRL) return true;
-      if (ev->keysym.sym == SDLK_F4 && ev->keysym.mod & KMOD_ALT) return true;
+
+      if(ev->keysym.sym == SDLK_ESCAPE)
+        return true;
+
+      if(ev->keysym.sym == SDLK_c && (ev->keysym.mod & KMOD_CTRL))
+        return true;
+
+      if(ev->keysym.sym == SDLK_F4 && (ev->keysym.mod & KMOD_ALT))
+        return true;
     }
   }
 
-  #else /* !SDL_VERSION_ATLEAST(2,0,0) */
+#else /* !SDL_VERSION_ATLEAST(2,0,0) */
 
   // FIXME: SDL supports SDL_PeepEvents but the implementation is
   // different
 
-  #endif /* SDL_VERSION_ATLEAST(2,0,0) */
+#endif /* SDL_VERSION_ATLEAST(2,0,0) */
 
   return false;
 }
@@ -627,7 +640,7 @@ static int SDL_WaitEventTimeout(SDL_Event *event, int timeout)
     anyEvent = SDL_PollEvent(event);
 
     // If an autorepeat triggers, it needs to be processed.
-    if(update_autorepeat_sdl())
+    if(update_autorepeat())
       break;
 
     // "Fix" awful intake cursor blinking

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -50,6 +50,7 @@
 #ifdef CONFIG_ICON
 #include "SDL_syswm.h"
 #endif // CONFIG_ICON
+#include "compat_sdl.h"
 #include "render_sdl.h"
 #endif // CONFIG_SDL
 

--- a/src/main.c
+++ b/src/main.c
@@ -50,6 +50,10 @@
 #include "audio/sfx.h"
 #include "network/network.h"
 
+#ifdef CONFIG_SDL
+#include <SDL.h>
+#endif
+
 #ifndef VERSION
 #error Must define VERSION for MegaZeux version string
 #endif

--- a/src/network/dns.h
+++ b/src/network/dns.h
@@ -24,6 +24,7 @@
 
 __M_BEGIN_DECLS
 
+#include "../platform.h"
 #include "socksyms.h"
 
 int dns_getaddrinfo(const char *node, const char *service,

--- a/src/network/socksyms.c
+++ b/src/network/socksyms.c
@@ -23,6 +23,7 @@
 #include "../util.h"
 
 #include <assert.h>
+#include <inttypes.h>
 
 #if defined(__WIN32__) || defined(__amigaos__)
 

--- a/src/network/socksyms.h
+++ b/src/network/socksyms.h
@@ -26,6 +26,7 @@
 __M_BEGIN_DECLS
 
 #include "../configure.h"
+#include "../platform.h"
 
 #include <errno.h>
 

--- a/src/platform.h
+++ b/src/platform.h
@@ -28,7 +28,7 @@ __M_BEGIN_DECLS
 
 #ifdef CONFIG_SDL
 
-#include "SDL.h"
+#include "SDL_stdinc.h"
 
 #else // !CONFIG_SDL
 

--- a/src/platform_endian.h
+++ b/src/platform_endian.h
@@ -30,7 +30,7 @@
 
 #if defined(CONFIG_SDL) && !defined(SKIP_SDL)
 
-#include <SDL.h>
+#include <SDL_endian.h>
 
 #if SDL_BYTEORDER == SDL_BIG_ENDIAN
 #define PLATFORM_BYTE_ORDER PLATFORM_BIG_ENDIAN

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -17,6 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "compat_sdl.h"
 #include "render_sdl.h"
 
 #include "SDL.h"

--- a/src/thread_sdl.h
+++ b/src/thread_sdl.h
@@ -24,7 +24,12 @@
 
 __M_BEGIN_DECLS
 
-#include "SDL_thread.h"
+#include <SDL_thread.h>
+#include <SDL_version.h>
+
+#if !SDL_VERSION_ATLEAST(2,0,0)
+typedef int(*SDL_ThreadFunction)(void *);
+#endif
 
 typedef SDL_cond* platform_cond;
 typedef SDL_mutex* platform_mutex;
@@ -98,7 +103,12 @@ static inline bool platform_cond_broadcast(platform_cond *cond)
 static inline int platform_thread_create(platform_thread *thread,
  platform_thread_fn start_function, void *data)
 {
+#if SDL_VERSION_ATLEAST(2,0,0)
   *thread = SDL_CreateThread(start_function, "", data);
+#else
+  *thread = SDL_CreateThread(start_function, data);
+#endif
+
   if(*thread)
     return 0;
   return -1;
@@ -112,7 +122,6 @@ static inline void platform_thread_join(platform_thread *thread)
 static inline void platform_yield(void)
 {
   // FIXME
-  SDL_Delay(1);
 }
 
 __M_END_DECLS

--- a/src/utils/checkres.c
+++ b/src/utils/checkres.c
@@ -43,7 +43,6 @@
 #include <utcasehash.h>
 
 // From MZX itself:
-#define SKIP_SDL
 
 // Safe- self sufficient or completely macros/static inlines
 #include "../const.h"
@@ -701,7 +700,7 @@ static enum status parse_legacy_bytecode(struct memfile *mf,
 
   char src[256];
   size_t src_len;
-  
+
   // skip 0xff marker
   if(mfgetc(mf) != 0xff)
     return CORRUPT_WORLD;

--- a/src/utils/png2smzx.c
+++ b/src/utils/png2smzx.c
@@ -20,7 +20,6 @@
 #include <string.h>
 #include <errno.h>
 
-#define SKIP_SDL
 #include "pngops.h"
 #include "smzxconv.h"
 

--- a/src/window.c
+++ b/src/window.c
@@ -33,6 +33,16 @@
 #include <unistd.h>
 #endif
 
+#ifdef __WIN32__
+// Required for GetLogicalDrives()
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
+#ifdef CONFIG_WII
+#include <sys/iosupport.h>
+#endif
+
 #include "board.h"
 #include "const.h"
 #include "context_enum.h"
@@ -49,10 +59,6 @@
 #include "util.h"
 
 #include "audio/sfx.h"
-
-#ifdef CONFIG_WII
-#include <sys/iosupport.h>
-#endif
 
 // This context stuff was originally in helpsys, but it's actually
 // more of a property of the windowing system.

--- a/src/zip.c
+++ b/src/zip.c
@@ -127,13 +127,6 @@ static int _fseekwrapper(void *vp, long int offset, int code)
   return fseek((FILE *)vp, offset, code);
 }
 
-// devkitARM's ftell has a nonstandard signature and needs to be wrapped, too.
-
-static long _ftellwrapper(FILE *fp)
-{
-  return (long)ftell(fp);
-}
-
 static long int _fstatlen(FILE *fp)
 {
   struct stat file_info;
@@ -2542,7 +2535,7 @@ static struct zip_archive *zip_get_archive_file(FILE *fp)
   zp->vread = (size_t(*)(void *, size_t, size_t, void *)) fread;
   zp->vwrite = (size_t(*)(const void *, size_t, size_t, void *)) fwrite;
   zp->vseek = (int(*)(void *, long int, int)) _fseekwrapper;
-  zp->vtell = (long int(*)(void *)) _ftellwrapper;
+  zp->vtell = (long int(*)(void *)) ftell;
   zp->verror = (int(*)(void *)) ferror;
   zp->vclose = (int(*)(void *)) fclose;
   return zp;


### PR DESCRIPTION
Changes `compat.h`, `platform.h`, and `platform_endian.h` to reduce the number of times `SDL.h` and `windows.h` are needlessly included.  This improves compile times on Windows somewhat.

Also included are misc. fixes for problems encountered during this.