### PR TITLE
Added a link to the better build instructions on the wiki, as well as…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ src/utils/png2smzx
 src/utils/*.debug
 stdout.txt
 stderr.txt
+Thumbs.db
 *.debug
 *.mzx
 *.sav

--- a/README.md
+++ b/README.md
@@ -149,4 +149,5 @@ GitHub, or the DigitalMZX forums.
 
 [Official MegaZeux game archive](http://vault.digitalmzx.net/) <br/>
 [MegaZeux help file](http://vault.digitalmzx.net/help.php) <br/>
-[Development roadmap](http://www.digitalmzx.net/forums/index.php?showtopic=15226)
+[Development roadmap](http://www.digitalmzx.net/forums/index.php?showtopic=15226) <br/>
+[Compiling MegaZeux on the official Wiki](https://www.digitalmzx.net/wiki/index.php?title=Compiling)


### PR DESCRIPTION
… a gitignore entry for Thumbs.db which can appear if a Windows user has preview thumbs enabled in Explorer