### PR TITLE
Fixed libmodplug compilation.

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -240,6 +240,7 @@ endif
 
 ifeq (${BUILD_MODPLUG},1)
 core_cflags += -I${gdm2s3m_src}
+core_cxxflags += -I${gdm2s3m_src}
 core_cobjs += ${gdm2s3m_objs}
 core_flags += -I${libmodplug_src} -I${libmodplug_src}/libmodplug
 core_cxxobjs += ${audio_obj}/audio_modplug.o ${libmodplug_objs}

--- a/src/audio/audio_modplug.cpp
+++ b/src/audio/audio_modplug.cpp
@@ -26,6 +26,7 @@
 #include "audio.h"
 #include "audio_modplug.h"
 #include "ext.h"
+#include "gdm2s3m.h"
 #include "sampled_stream.h"
 
 #include "../const.h"


### PR DESCRIPTION
I needed to do this in order to get a working libmodplug build. Dunno if this is a refactor-related regression (not sure when the last Modplug build was created) or some other oddity, but here ya go.