### PR TITLE
Removed deprecated elements/categories from .desktop files.

### DIFF
--- a/arch/unix/megazeux.desktop
+++ b/arch/unix/megazeux.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=MegaZeux
 Exec=megazeux
 Icon=megazeux

--- a/arch/unix/megazeux.desktop
+++ b/arch/unix/megazeux.desktop
@@ -5,4 +5,4 @@ Exec=megazeux
 Icon=megazeux
 Terminal=false
 Type=Application
-Categories=Application;Game;
+Categories=Game;

--- a/arch/unix/mzxrun.desktop
+++ b/arch/unix/mzxrun.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=MegaZeux (Runtime Only)
 Exec=mzxrun
 Icon=megazeux

--- a/arch/unix/mzxrun.desktop
+++ b/arch/unix/mzxrun.desktop
@@ -5,4 +5,4 @@ Exec=mzxrun
 Icon=megazeux
 Terminal=false
 Type=Application
-Categories=Application;Game;
+Categories=Game;


### PR DESCRIPTION
At some point, freedesktop.org deprecated the Encoding element and the Application category. This PR removes those from our desktop files.