### PR TITLE
Enable runtime renderer switching

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -4,6 +4,7 @@ FEATURES
 
 + The default boot.dol for Wii builds with the editor enabled
   is now MegaZeux instead of MZXRun.
++ The current renderer can now be set from the settings menu.
 
 FIXES
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -40,6 +40,10 @@ DEVELOPERS
   or /mingw64 by default if $MSYSTEM is "MINGW32" or "MINGW64"
   and either the "win32" or "win64" arch is selected.
 + MegaZeux now uses the renderer free_video function on exit.
++ GL_LoadLibrary no longer fails if the library is already
+  loaded in SDL 1.2. (Lancer-X)
++ GL renderers free textures and revert to fixed function
+  pipeline where appropriate. (Lancer-X)
 
 
 February 20th, 2019 - MZX 2.91j

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1203,6 +1203,7 @@ static boolean set_graphics_output(struct config_info *conf)
 {
   const char *video_output = conf->video_output;
   const struct renderer_data *renderer = renderers;
+  int i = 0;
 
   // The first renderer was NULL, this shouldn't happen
   if(!renderer->name)
@@ -1216,13 +1217,18 @@ static boolean set_graphics_output(struct config_info *conf)
     if(!strcasecmp(video_output, renderer->name))
       break;
     renderer++;
+    i++;
   }
 
   // If no match found, use first renderer in the renderer list
   if(!renderer->name)
+  {
     renderer = renderers;
+    i = 0;
+  }
 
   renderer->reg(&graphics.renderer);
+  graphics.renderer_num = i;
 
   debug("Video: using '%s' renderer.\n", renderer->name);
   return true;
@@ -1650,9 +1656,7 @@ boolean set_video_mode(void)
   return ret;
 }
 
-#if 0
-
-static boolean change_video_output(struct config_info *conf, const char *output)
+boolean change_video_output(struct config_info *conf, const char *output)
 {
   char old_video_output[16];
 
@@ -1683,10 +1687,29 @@ static boolean change_video_output(struct config_info *conf, const char *output)
     }
   }
 
+  update_palette();
   return true;
 }
 
-#endif
+int get_available_video_output_list(const char **buffer, int buffer_len)
+{
+  const struct renderer_data *renderer = renderers;
+  int i;
+
+  for(i = 0; i < buffer_len; i++, renderer++)
+  {
+    if(!renderer->name)
+      break;
+
+    buffer[i] = renderer->name;
+  }
+  return i;
+}
+
+int get_current_video_output(void)
+{
+  return (int)(graphics.renderer_num);
+}
 
 boolean is_fullscreen(void)
 {

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -203,6 +203,7 @@ struct graphics_data
   Uint32 protected_pal_position;
   struct renderer renderer;
   void *render_data;
+  Uint32 renderer_num;
 
 #ifdef CONFIG_EDITOR
   char editor_backup_indices[SMZX_PAL_SIZE * 4];
@@ -315,6 +316,10 @@ void write_line_mask(const char *str, Uint32 x, Uint32 y,
 Uint8 get_color_linear(Uint32 offset);
 
 void cursor_underline(void);
+
+boolean change_video_output(struct config_info *conf, const char *output);
+int get_available_video_output_list(const char **buffer, int buffer_len);
+int get_current_video_output(void);
 
 boolean set_video_mode(void);
 boolean is_fullscreen(void);

--- a/src/render_gl2.c
+++ b/src/render_gl2.c
@@ -87,6 +87,7 @@ static struct
   void (GL_APIENTRY *glCopyTexImage2D)(GLenum target, GLint level,
    GLenum internalFormat, GLint x, GLint y, GLsizei width, GLsizei height,
    GLint border);
+  void (GL_APIENTRY *glDeleteTextures)(GLsizei n, GLuint *textures);
   void (GL_APIENTRY *glDisable)(GLenum cap);
   void (GL_APIENTRY *glDisableClientState)(GLenum cap);
   void (GL_APIENTRY *glDrawArrays)(GLenum mode, GLint first, GLsizei count);
@@ -120,6 +121,7 @@ static const struct dso_syms_map gl2_syms_map[] =
   { "glClear",              (fn_ptr *)&gl2.glClear },
   { "glColorPointer",       (fn_ptr *)&gl2.glColorPointer },
   { "glCopyTexImage2D",     (fn_ptr *)&gl2.glCopyTexImage2D },
+  { "glDeleteTextures",     (fn_ptr *)&gl2.glDeleteTextures },
   { "glDisable",            (fn_ptr *)&gl2.glDisable },
   { "glDisableClientState", (fn_ptr *)&gl2.glDisableClientState },
   { "glDrawArrays",         (fn_ptr *)&gl2.glDrawArrays },
@@ -216,9 +218,14 @@ err_out:
 
 static void gl2_free_video(struct graphics_data *graphics)
 {
+  struct gl2_render_data *render_data = graphics->render_data;
+  gl2.glDeleteTextures(NUM_TEXTURES, render_data->textures);
+  gl_check_error();
+
   gl_cleanup(graphics);
 
-  free(graphics->render_data);
+  free(render_data->pixels);
+  free(render_data);
   graphics->render_data = NULL;
 }
 
@@ -277,6 +284,10 @@ static void gl2_resize_screen(struct graphics_data *graphics,
    v_width, v_height);
   gl_check_error();
   render_data->viewport_shrunk = false;
+
+  // Free any preexisting textures if they exist
+  gl2.glDeleteTextures(NUM_TEXTURES, render_data->textures);
+  gl_check_error();
 
   gl2.glGenTextures(NUM_TEXTURES, render_data->textures);
   gl_check_error();

--- a/src/render_glsl.c
+++ b/src/render_glsl.c
@@ -638,6 +638,9 @@ static void glsl_free_video(struct graphics_data *graphics)
     glsl.glDeleteTextures(NUM_TEXTURES, render_data->textures);
     gl_check_error();
 
+    glsl.glUseProgram(0);
+    gl_check_error();
+
     gl_cleanup(graphics);
     free(render_data->pixels);
     free(render_data);

--- a/src/render_sdl.h
+++ b/src/render_sdl.h
@@ -78,7 +78,13 @@ static inline void gl_cleanup(struct graphics_data *graphics)
 
 static inline boolean GL_LoadLibrary(enum gl_lib_type type)
 {
-  return SDL_GL_LoadLibrary(NULL) == 0;
+  if(!SDL_GL_LoadLibrary(NULL)) return true;
+#if !SDL_VERSION_ATLEAST(2,0,0)
+  // If the context already exists, don't reload the library
+  // This is for SDL 1.2 which doesn't let us unload OpenGL
+  if(strcmp(SDL_GetError(), "OpenGL context already created") == 0) return true;
+#endif
+  return false;
 }
 
 static inline void *GL_GetProcAddress(const char *proc)

--- a/src/settings.c
+++ b/src/settings.c
@@ -54,13 +54,45 @@
 
 //  [OK]  [Cancel]  [Shader]  //
 
+enum
+{
+  RESULT_CANCEL,
+  RESULT_CONFIRM,
+  RESULT_KEEP_OPEN,
+  RESULT_SET_VIDEO_OUTPUT,
+  RESULT_SET_SHADER
+};
+
 #ifdef CONFIG_RENDER_GL_PROGRAM
 // Note- we search for .frags, then load the matching .vert too if present.
 static const char *shader_exts[] = { ".frag", NULL };
 static char shader_default_text[20];
 static char shader_path[MAX_PATH];
 static char shader_name[MAX_PATH];
+static boolean is_glsl = false;
 #endif
+
+static int choose_video_output(struct world *mzx_world, const char **vo,
+ int num_vo, int current_vo)
+{
+  int retval;
+  struct dialog di;
+  struct element *elements[1] =
+  {
+    construct_list_box(2, 1, vo, num_vo, 12, 20, 0, &current_vo, NULL, false)
+  };
+
+  construct_dialog(&di, "Choose renderer...", 28, 5, 24, 14,
+   elements, ARRAY_SIZE(elements), 0);
+
+  retval = run_dialog(mzx_world, &di);
+  destruct_dialog(&di);
+
+  if(!retval)
+    return current_vo;
+  else
+    return -1;
+}
 
 void game_settings(struct world *mzx_world)
 {
@@ -69,14 +101,13 @@ void game_settings(struct world *mzx_world)
   int music_volume, sound_volume, pcs_volume;
   struct dialog di;
   int dialog_result;
-  int speed_option = 0;
-  int shader_option = 0;
-  int num_elements = 8;
+  int y_offset;
+  int y_offset_buttons;
+  int window_height;
+  int num_elements;
   int start_option = 0;
 
   int ok_pos;
-  int cancel_pos;
-  int speed_pos;
 
   const char *radio_strings_1[2] =
   {
@@ -86,35 +117,17 @@ void game_settings(struct world *mzx_world)
   {
     "PC speaker SFX on", "PC speaker SFX off"
   };
-  struct element *elements[10];
+  struct element *elements[11];
 
-#ifdef CONFIG_RENDER_GL_PROGRAM
   struct config_info *conf = get_config();
-  boolean is_glsl = !strcmp(conf->video_output, "glsl");
 
-  if(is_glsl)
-  {
-    if(!shader_default_text[0])
-    {
-      if(conf->gl_scaling_shader[0])
-        snprintf(shader_default_text, 20, "<conf: %.11s>",
-         conf->gl_scaling_shader);
+  const char *available_video_outputs[32];
+  int num_available_video_outputs = 0;
+  int cur_video_output = get_current_video_output();
 
-      else
-        strcpy(shader_default_text, "<default: semisoft>");
-    }
-
-    shader_option = 3;
-    num_elements++;
-  }
-#endif
-
-  if(!mzx_world->lock_speed)
-  {
-    speed_option = 2;
-    start_option = num_elements;
-    num_elements++;
-  }
+  num_available_video_outputs =
+   get_available_video_output_list(available_video_outputs,
+    ARRAY_SIZE(available_video_outputs));
 
   mzx_speed = mzx_world->mzx_speed;
   music = !audio_get_music_on();
@@ -131,51 +144,91 @@ void game_settings(struct world *mzx_world)
   do
   {
     ok_pos = 6;
-    cancel_pos = 7;
-    speed_pos = 8;
+    num_elements = 8;
+    y_offset = 0;
+    y_offset_buttons = 0;
 
-#ifdef CONFIG_RENDER_GL_PROGRAM
-    if(is_glsl)
+    if(!mzx_world->lock_speed)
     {
-      strcpy(shader_path, mzx_res_get_by_id(GLSL_SHADER_SCALER_DIRECTORY));
+      y_offset += 2;
+      y_offset_buttons += 2;
+      num_elements++;
+    }
 
-      elements[6] = construct_file_selector(3, 13 + speed_option,
-       "Scaling shader-", "Choose a scaling shader...", shader_exts,
-       shader_default_text, 21, 0, shader_path, shader_name, 2);
+    if(num_available_video_outputs > 1)
+    {
+      elements[ok_pos] = construct_button(4, 13 + y_offset_buttons,
+       " Select renderer... ", RESULT_SET_VIDEO_OUTPUT);
 
       ok_pos++;
-      cancel_pos++;
-      speed_pos++;
+      num_elements++;
+      y_offset_buttons += 2;
+    }
+
+#ifdef CONFIG_RENDER_GL_PROGRAM
+    {
+      const char *cur_output_name = conf->video_output;
+
+      if(num_available_video_outputs)
+        cur_output_name = available_video_outputs[cur_video_output];
+
+      is_glsl = strstr(cur_output_name, "glsl") ? true : false;
+    }
+
+    if(is_glsl)
+    {
+      if(!shader_default_text[0])
+      {
+        if(conf->gl_scaling_shader[0])
+          snprintf(shader_default_text, 20, "<conf: %.11s>",
+           conf->gl_scaling_shader);
+
+        else
+          strcpy(shader_default_text, "<default: semisoft>");
+      }
+      strcpy(shader_path, mzx_res_get_by_id(GLSL_SHADER_SCALER_DIRECTORY));
+
+      elements[ok_pos] = construct_file_selector(3, 13 + y_offset_buttons,
+       "Scaling shader-", "Choose a scaling shader...", shader_exts,
+       shader_default_text, 21, 0, shader_path, shader_name, RESULT_SET_SHADER);
+
+      ok_pos++;
+      num_elements++;
+      y_offset_buttons += 3;
     }
 #endif
 
     if(!mzx_world->lock_speed)
     {
-      elements[speed_pos] = construct_number_box(2, 2, "Speed- ", 1, 16,
+      elements[ok_pos + 2] = construct_number_box(2, 2, "Speed- ", 1, 16,
        NUMBER_SLIDER, &mzx_speed);
     }
 
-    elements[0] = construct_radio_button(4, 2 + speed_option,
+    if(!start_option)
+      start_option = ok_pos + 2;
+
+    elements[0] = construct_radio_button(4, 2 + y_offset,
      radio_strings_1, 2, 20, &music);
-    elements[1] = construct_radio_button(4, 5 + speed_option,
+    elements[1] = construct_radio_button(4, 5 + y_offset,
      radio_strings_2, 2, 18, &pcs);
-    elements[2] = construct_label(2, 8 + speed_option,
+    elements[2] = construct_label(2, 8 + y_offset,
      "Audio volumes-");
-    elements[3] = construct_number_box(2, 9 + speed_option,
+    elements[3] = construct_number_box(2, 9 + y_offset,
      "     Music- ", 0, 10, NUMBER_SLIDER, &music_volume);
-    elements[4] = construct_number_box(2, 10 + speed_option,
+    elements[4] = construct_number_box(2, 10 + y_offset,
      "   Samples- ", 0, 10, NUMBER_SLIDER, &sound_volume);
-    elements[5] = construct_number_box(2, 11 + speed_option,
+    elements[5] = construct_number_box(2, 11 + y_offset,
      "PC Speaker- ", 0, 10, NUMBER_SLIDER, &pcs_volume);
 
-    elements[ok_pos] = construct_button(6, 13 + speed_option + shader_option,
-     "OK", 0);
+    elements[ok_pos] = construct_button(7, 13 + y_offset_buttons,
+     "OK", RESULT_CONFIRM);
 
-    elements[cancel_pos] = construct_button(15, 13 + speed_option + shader_option,
-     "Cancel", 1);
+    elements[ok_pos + 1] = construct_button(15, 13 + y_offset_buttons,
+     "Cancel", RESULT_CANCEL);
 
-    construct_dialog(&di, "Game Settings", 25, 4 - ((speed_option+shader_option) / 2),
-     30, 16 + speed_option + shader_option, elements, num_elements, start_option);
+    window_height = (16 + y_offset_buttons);
+    construct_dialog(&di, "Game Settings", 25, (25 - window_height) / 2,
+     30, window_height, elements, num_elements, start_option);
 
     dialog_result = run_dialog(mzx_world, &di);
     start_option = di.current_element;
@@ -184,7 +237,7 @@ void game_settings(struct world *mzx_world)
     // Prevent UI keys from carrying through.
     force_release_all_keys();
 
-    if(!dialog_result)
+    if(dialog_result == RESULT_CONFIRM)
     {
       audio_set_pcs_volume(pcs_volume);
 
@@ -221,12 +274,25 @@ void game_settings(struct world *mzx_world)
       audio_set_music_on(music);
       mzx_world->mzx_speed = mzx_speed;
     }
+    else
+
+    if(dialog_result == RESULT_SET_VIDEO_OUTPUT)
+    {
+      int new_video_output = choose_video_output(mzx_world,
+       available_video_outputs, num_available_video_outputs, cur_video_output);
+
+      if(new_video_output >= 0)
+      {
+        change_video_output(conf, available_video_outputs[new_video_output]);
+        cur_video_output = new_video_output;
+      }
+    }
 
 #ifdef CONFIG_RENDER_GL_PROGRAM
     else
 
     // Shader selection
-    if(dialog_result == 2 && shader_name[0])
+    if(is_glsl && (dialog_result == RESULT_SET_SHADER) && shader_name[0])
     {
       size_t offset = strlen(shader_path) + 1;
       boolean shader_res;
@@ -250,7 +316,7 @@ void game_settings(struct world *mzx_world)
     }
 #endif
   }
-  while(dialog_result > 1);
+  while(dialog_result >= RESULT_KEEP_OPEN);
 
   pop_context();
 }

--- a/src/settings.c
+++ b/src/settings.c
@@ -22,6 +22,7 @@
 
 #include "configure.h"
 #include "core.h"
+#include "error.h"
 #include "event.h"
 #include "game.h"
 #include "graphics.h"
@@ -77,7 +78,7 @@ static int choose_video_output(struct world *mzx_world, const char **vo,
 {
   int retval;
   struct dialog di;
-  struct element *elements[1] =
+  struct element *elements[] =
   {
     construct_list_box(2, 1, vo, num_vo, 12, 20, 0, &current_vo, NULL, false)
   };
@@ -283,8 +284,10 @@ void game_settings(struct world *mzx_world)
 
       if(new_video_output >= 0)
       {
-        change_video_output(conf, available_video_outputs[new_video_output]);
-        cur_video_output = new_video_output;
+        if(!change_video_output(conf, available_video_outputs[new_video_output]))
+          error("Failed to set renderer.", ERROR_T_ERROR, ERROR_OPT_OK, 0x6000);
+
+        cur_video_output = get_current_video_output();
       }
     }
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -106,7 +106,7 @@ void game_settings(struct world *mzx_world)
   int y_offset_buttons;
   int window_height;
   int num_elements;
-  int start_option = 0;
+  int start_option = -1;
 
   int ok_pos;
 
@@ -203,10 +203,15 @@ void game_settings(struct world *mzx_world)
     {
       elements[ok_pos + 2] = construct_number_box(2, 2, "Speed- ", 1, 16,
        NUMBER_SLIDER, &mzx_speed);
+
+      // Start at the Speed setting if enabled.
+      if(start_option < 0)
+        start_option = ok_pos + 2;
     }
 
-    if(!start_option)
-      start_option = ok_pos + 2;
+    // Start at the music/samples toggle by default.
+    if(start_option < 0)
+      start_option = 0;
 
     elements[0] = construct_radio_button(4, 2 + y_offset,
      radio_strings_1, 2, 20, &music);

--- a/src/settings.c
+++ b/src/settings.c
@@ -156,6 +156,9 @@ void game_settings(struct world *mzx_world)
       num_elements++;
     }
 
+#if !defined(CONFIG_WII)
+    // Wii has multiple renderers but shouldn't display this option.
+    // FIXME this is a hack. Fix the Wii renderers so they're switchable.
     if(num_available_video_outputs > 1)
     {
       elements[ok_pos] = construct_button(4, 13 + y_offset_buttons,
@@ -165,6 +168,7 @@ void game_settings(struct world *mzx_world)
       num_elements++;
       y_offset_buttons += 2;
     }
+#endif
 
 #ifdef CONFIG_RENDER_GL_PROGRAM
     {

--- a/src/window.c
+++ b/src/window.c
@@ -2382,7 +2382,7 @@ struct element *construct_file_selector(int x, int y,
   return (struct element *)src;
 }
 
-__editor_maybe_static struct element *construct_list_box(int x, int y,
+struct element *construct_list_box(int x, int y,
  const char **choices, int num_choices, int num_choices_visible,
  int choice_length, int return_value, int *result, int *result_offset,
  boolean respect_color_codes)

--- a/src/window.h
+++ b/src/window.h
@@ -237,6 +237,10 @@ CORE_LIBSPEC struct element *construct_file_selector(int x, int y,
  const char *const *file_manager_exts, const char *none_mesg,
  int show_width, int allow_unset, const char *base_path, char *result,
  int return_value);
+CORE_LIBSPEC struct element *construct_list_box(int x, int y,
+ const char **choices, int num_choices, int num_choices_visible,
+ int choice_length, int return_value, int *result, int *result_offset,
+ boolean respect_color_codes);
 
 CORE_LIBSPEC int choose_file_ch(struct world *mzx_world,
  const char *const *wildcards, char *ret, const char *title, int dirs_okay);
@@ -317,10 +321,6 @@ CORE_LIBSPEC void construct_element(struct element *e, int x, int y,
   struct element *e));
 CORE_LIBSPEC struct element *construct_input_box(int x, int y,
  const char *question, int max_length, char *result);
-CORE_LIBSPEC struct element *construct_list_box(int x, int y,
- const char **choices, int num_choices, int num_choices_visible,
- int choice_length, int return_value, int *result, int *result_offset,
- boolean respect_color_codes);
 CORE_LIBSPEC void construct_dialog_ext(struct dialog *src, const char *title,
  int x, int y, int width, int height, struct element **elements,
  int num_elements, int sfx_test_for_input, int pad_space, int start_element,


### PR DESCRIPTION
Enables switching renderers at runtime and adds an option to the settings menu to do so. This feature is **experimental**.

- [x] Make sure the GL renderers clean up everything they ought to (Lancer-X volunteered to do this).
- [x] Fix bug with SDL 1.2 builds where switching from a GL renderer to a GL renderer always fails.
- [x] Test for SDL 1.2 builds.
- [x] ~~Test or disable for Wii builds.~~ Added hack to disable this for Wii builds.
- [x] Make sure this option is hidden on platforms with only one renderer.