### PR TITLE
Cleanup and improvements to configure.c

### DIFF
--- a/src/configure.c
+++ b/src/configure.c
@@ -149,7 +149,7 @@ static const struct config_info user_conf_default =
   VIDEO_OUTPUT_DEFAULT,         // video_output
   FORCE_BPP_DEFAULT,            // force_bpp
   RATIO_MODERN_64_35,           // video_ratio
-  "linear",                     // opengl filter method
+  CONFIG_GL_FILTER_LINEAR,      // opengl filter method
   "",                           // opengl default scaling shader
   GL_VSYNC_DEFAULT,             // opengl vsync mode
   true,                         // allow screenshots
@@ -226,8 +226,8 @@ static const struct mapped_enum_entry force_bpp_values[] =
 
 static const struct mapped_enum_entry gl_filter_method_values[] =
 {
-  { "nearest", 0 },
-  { "linear", 1 }
+  { "nearest", CONFIG_GL_FILTER_NEAREST },
+  { "linear", CONFIG_GL_FILTER_LINEAR }
 };
 
 static const struct mapped_enum_entry gl_vsync_values[] =
@@ -256,8 +256,7 @@ static const struct mapped_enum_entry resample_mode_values[] =
 static const struct mapped_enum_entry system_mouse_values[] =
 {
   { "0", 0 },
-  { "1", 1 },
-  { "both", 2 }
+  { "1", 1 }
 };
 
 static const struct mapped_enum_entry update_auto_check_values[] =

--- a/src/configure.c
+++ b/src/configure.c
@@ -167,6 +167,11 @@ static const struct config_info user_conf_default =
   true,                         // music_on
   true,                         // pc_speaker_on
 
+  // Event options
+  true,                         // allow_gamecontroller
+  false,                        // pause_on_unfocus
+  1,                            // num_buffered_events
+
   // Game options
   "",                           // startup_path
   "caverns.mzx",                // startup_file
@@ -449,25 +454,8 @@ static void config_sdl_gc_add(struct config_info *conf, char *name,
   gamecontroller_add_mapping(value);
 }
 
-static void config_sdl_gc_enable(struct config_info *conf, char *name,
- char *value, char *extended_data)
-{
-  if(!strcmp(value, "0"))
-    gamecontroller_set_enabled(false);
-
-  else if(!strcmp(value, "1"))
-    gamecontroller_set_enabled(true);
-}
-
 #endif // SDL_VERSION_ATLEAST(2,0,0)
 #endif // CONFIG_SDL
-
-static void pause_on_unfocus(struct config_info *conf, char *name,
- char *value, char *extended_data)
-{
-  // FIXME sloppy validation
-  set_unfocus_pause(strtoul(value, NULL, 10) > 0);
-}
 
 static void include_config(struct config_info *conf, char *name,
  char *value, char *extended_data)
@@ -490,14 +478,6 @@ static void config_window_resolution(struct config_info *conf, char *name,
   char *next;
   conf->window_width = strtoul(value, &next, 10);
   conf->window_height = strtoul(next + 1, NULL, 10);
-}
-
-static void config_set_num_buffered_events(struct config_info *conf,
- char *name, char *value, char *extended_data)
-{
-  // FIXME sloppy validation also wtf?
-  Uint8 v = (Uint8)strtoul(value, NULL, 10);
-  set_num_buffered_events(v);
 }
 
 #define INT(field, min, max) CONF_INT(struct config_info, field, min, max)
@@ -531,7 +511,7 @@ static const struct config_entry config_options[] =
 #if SDL_VERSION_ATLEAST(2,0,0)
   { "gamecontroller.*",         FN(config_sdl_gc_set), false },
   { "gamecontroller_add",       FN(config_sdl_gc_add), false },
-  { "gamecontroller_enable",    FN(config_sdl_gc_enable), false },
+  { "gamecontroller_enable",    BOOL(allow_gamecontroller), false },
 #endif
 #endif
   { "gl_filter_method",         ENUM(gl_filter_method), false },
@@ -554,8 +534,8 @@ static const struct config_entry config_options[] =
   { "network_enabled",          BOOL(network_enabled), false },
 #endif
   { "no_titlescreen",           BOOL(no_titlescreen), false },
-  { "num_buffered_events",      FN(config_set_num_buffered_events), false },
-  { "pause_on_unfocus",         FN(pause_on_unfocus), false },
+  { "num_buffered_events",      INT(num_buffered_events, 1, 256), false },
+  { "pause_on_unfocus",         BOOL(pause_on_unfocus), false },
   { "pc_speaker_on",            BOOL(pc_speaker_on), false },
   { "pc_speaker_volume",        INT(pc_speaker_volume, 0, 10), false },
   { "resample_mode",            ENUM(resample_mode), false },

--- a/src/configure.c
+++ b/src/configure.c
@@ -204,33 +204,33 @@ static const struct config_info user_conf_default =
  * arrays are generated automatically with the option name in the config struct.
  */
 
-static const struct config_enum boolean_values[] =
+static const struct mapped_enum_entry boolean_values[] =
 {
   { "0", false },
   { "1", true }
 };
 
-static const struct config_enum allow_cheats_values[] =
+static const struct mapped_enum_entry allow_cheats_values[] =
 {
   { "0", ALLOW_CHEATS_NEVER },
   { "1", ALLOW_CHEATS_ALWAYS },
   { "mzxrun", ALLOW_CHEATS_MZXRUN }
 };
 
-static const struct config_enum force_bpp_values[] =
+static const struct mapped_enum_entry force_bpp_values[] =
 {
   { "8", 8 },
   { "16", 16 },
   { "32", 32 }
 };
 
-static const struct config_enum gl_filter_method_values[] =
+static const struct mapped_enum_entry gl_filter_method_values[] =
 {
   { "nearest", 0 },
   { "linear", 1 }
 };
 
-static const struct config_enum gl_vsync_values[] =
+static const struct mapped_enum_entry gl_vsync_values[] =
 {
   { "-1", -1 },
   { "0", 0 },
@@ -238,7 +238,7 @@ static const struct config_enum gl_vsync_values[] =
   { "default", -1 }
 };
 
-static const struct config_enum modplug_resample_mode_values[] =
+static const struct mapped_enum_entry modplug_resample_mode_values[] =
 {
   { "none", 0 },
   { "linear", 1 },
@@ -246,21 +246,21 @@ static const struct config_enum modplug_resample_mode_values[] =
   { "fir", 3 }
 };
 
-static const struct config_enum resample_mode_values[] =
+static const struct mapped_enum_entry resample_mode_values[] =
 {
   { "none", 0 },
   { "linear", 1 },
   { "cubic", 2 }
 };
 
-static const struct config_enum system_mouse_values[] =
+static const struct mapped_enum_entry system_mouse_values[] =
 {
   { "0", 0 },
   { "1", 1 },
   { "both", 2 }
 };
 
-static const struct config_enum update_auto_check_values[] =
+static const struct mapped_enum_entry update_auto_check_values[] =
 {
   { "0", UPDATE_AUTO_CHECK_OFF },
   { "1", UPDATE_AUTO_CHECK_ON },
@@ -269,7 +269,7 @@ static const struct config_enum update_auto_check_values[] =
   { "silent", UPDATE_AUTO_CHECK_SILENT }
 };
 
-static const struct config_enum video_ratio_values[] =
+static const struct mapped_enum_entry video_ratio_values[] =
 {
   { "classic", RATIO_CLASSIC_4_3 },
   { "modern", RATIO_MODERN_64_35 },
@@ -279,7 +279,7 @@ static const struct config_enum video_ratio_values[] =
 struct config_entry
 {
   char option_name[OPTION_NAME_LEN];
-  struct config_option dest;
+  struct mapped_field dest;
   boolean allow_in_game_config;
 };
 
@@ -480,84 +480,84 @@ static void config_window_resolution(struct config_info *conf, char *name,
   conf->window_height = strtoul(next + 1, NULL, 10);
 }
 
-#define INT(field, min, max) CONF_INT(struct config_info, field, min, max)
-#define ENUM(field) CONF_ENUM(struct config_info, field, field ## _values)
-#define BOOL(field) CONF_ENUM(struct config_info, field, boolean_values)
-#define STR(field) CONF_STR(struct config_info, field)
-#define FN(field) CONF_FN(struct config_info, field)
+#define Int(field, min, max) MAP_INT(struct config_info, field, min, max)
+#define Enum(field) MAP_ENUM(struct config_info, field, field ## _values)
+#define Bool(field) MAP_ENUM(struct config_info, field, boolean_values)
+#define Str(field) MAP_STR(struct config_info, field)
+#define Fn(field) MAP_FN(struct config_info, field)
 
 /* NOTE: This is searched as a binary tree, the nodes must be
  *       sorted alphabetically, or they risk being ignored.
  *
  * For values that can easily be written directly to the struct,
- * use the INT/ENUM/BOOL/STR macro functions. These generate offset
+ * use the Int/Enum/Bool/Str macro functions. These generate offset
  * and bounding information that allows config_option_set to reuse
  * the same code for similar options. For more complex options, the
- * FN macro can be used to provide a config_function instead.
+ * Fn macro can be used to provide a config_function instead.
  */
 static const struct config_entry config_options[] =
 {
-  { "allow_cheats",             ENUM(allow_cheats), false },
-  { "allow_screenshots",        BOOL(allow_screenshots), false },
-  { "audio_buffer",             INT(audio_buffer_samples, 16, INT_MAX), false },
-  { "audio_buffer_samples",     INT(audio_buffer_samples, 16, INT_MAX), false },
-  { "audio_sample_rate",        INT(output_frequency, 1, INT_MAX), false },
-  { "enable_oversampling",      BOOL(oversampling_on), false },
-  { "enable_resizing",          BOOL(allow_resize), false },
-  { "force_bpp",                ENUM(force_bpp), false },
-  { "fullscreen",               BOOL(fullscreen), false },
-  { "fullscreen_resolution",    FN(config_set_resolution), false },
+  { "allow_cheats",             Enum(allow_cheats), false },
+  { "allow_screenshots",        Bool(allow_screenshots), false },
+  { "audio_buffer",             Int(audio_buffer_samples, 16, INT_MAX), false },
+  { "audio_buffer_samples",     Int(audio_buffer_samples, 16, INT_MAX), false },
+  { "audio_sample_rate",        Int(output_frequency, 1, INT_MAX), false },
+  { "enable_oversampling",      Bool(oversampling_on), false },
+  { "enable_resizing",          Bool(allow_resize), false },
+  { "force_bpp",                Enum(force_bpp), false },
+  { "fullscreen",               Bool(fullscreen), false },
+  { "fullscreen_resolution",    Fn(config_set_resolution), false },
 #ifdef CONFIG_SDL
 #if SDL_VERSION_ATLEAST(2,0,0)
-  { "gamecontroller.*",         FN(config_sdl_gc_set), false },
-  { "gamecontroller_add",       FN(config_sdl_gc_add), false },
-  { "gamecontroller_enable",    BOOL(allow_gamecontroller), false },
+  { "gamecontroller.*",         Fn(config_sdl_gc_set), false },
+  { "gamecontroller_add",       Fn(config_sdl_gc_add), false },
+  { "gamecontroller_enable",    Bool(allow_gamecontroller), false },
 #endif
 #endif
-  { "gl_filter_method",         ENUM(gl_filter_method), false },
-  { "gl_scaling_shader",        STR(gl_scaling_shader), true },
-  { "gl_vsync",                 ENUM(gl_vsync), false },
-  { "include",                  FN(include2_config), true },
-  { "include*",                 FN(include_config), true },
-  { "joy!.*",                   FN(joy_action_set), true },
-  { "joy!axis!",                FN(joy_axis_set), true },
-  { "joy!button!",              FN(joy_button_set), true },
-  { "joy!hat",                  FN(joy_hat_set), true },
-  { "joy_axis_threshold",       FN(config_set_joy_axis_threshold), false },
-  { "mask_midchars",            BOOL(mask_midchars), false },
-  { "max_simultaneous_samples", INT(max_simultaneous_samples, -1, INT_MAX), false },
-  { "modplug_resample_mode",    ENUM(modplug_resample_mode), false },
-  { "music_on",                 BOOL(music_on), false },
-  { "music_volume",             INT(music_volume, 0, 10), false },
-  { "mzx_speed",                INT(mzx_speed, 1, 16), true },
+  { "gl_filter_method",         Enum(gl_filter_method), false },
+  { "gl_scaling_shader",        Str(gl_scaling_shader), true },
+  { "gl_vsync",                 Enum(gl_vsync), false },
+  { "include",                  Fn(include2_config), true },
+  { "include*",                 Fn(include_config), true },
+  { "joy!.*",                   Fn(joy_action_set), true },
+  { "joy!axis!",                Fn(joy_axis_set), true },
+  { "joy!button!",              Fn(joy_button_set), true },
+  { "joy!hat",                  Fn(joy_hat_set), true },
+  { "joy_axis_threshold",       Fn(config_set_joy_axis_threshold), false },
+  { "mask_midchars",            Bool(mask_midchars), false },
+  { "max_simultaneous_samples", Int(max_simultaneous_samples, -1, INT_MAX), false },
+  { "modplug_resample_mode",    Enum(modplug_resample_mode), false },
+  { "music_on",                 Bool(music_on), false },
+  { "music_volume",             Int(music_volume, 0, 10), false },
+  { "mzx_speed",                Int(mzx_speed, 1, 16), true },
 #ifdef CONFIG_NETWORK
-  { "network_enabled",          BOOL(network_enabled), false },
+  { "network_enabled",          Bool(network_enabled), false },
 #endif
-  { "no_titlescreen",           BOOL(no_titlescreen), false },
-  { "num_buffered_events",      INT(num_buffered_events, 1, 256), false },
-  { "pause_on_unfocus",         BOOL(pause_on_unfocus), false },
-  { "pc_speaker_on",            BOOL(pc_speaker_on), false },
-  { "pc_speaker_volume",        INT(pc_speaker_volume, 0, 10), false },
-  { "resample_mode",            ENUM(resample_mode), false },
-  { "sample_volume",            INT(sam_volume, 0, 10), false },
-  { "save_file",                STR(default_save_name), false },
+  { "no_titlescreen",           Bool(no_titlescreen), false },
+  { "num_buffered_events",      Int(num_buffered_events, 1, 256), false },
+  { "pause_on_unfocus",         Bool(pause_on_unfocus), false },
+  { "pc_speaker_on",            Bool(pc_speaker_on), false },
+  { "pc_speaker_volume",        Int(pc_speaker_volume, 0, 10), false },
+  { "resample_mode",            Enum(resample_mode), false },
+  { "sample_volume",            Int(sam_volume, 0, 10), false },
+  { "save_file",                Str(default_save_name), false },
 #ifdef CONFIG_NETWORK
-  { "socks_host",               STR(socks_host), false },
-  { "socks_port",               INT(socks_port, 0, 65535), false },
+  { "socks_host",               Str(socks_host), false },
+  { "socks_port",               Int(socks_port, 0, 65535), false },
 #endif
-  { "standalone_mode",          BOOL(standalone_mode), false },
-  { "startup_editor",           BOOL(startup_editor), false },
-  { "startup_file",             FN(config_startup_file), false },
-  { "startup_path",             FN(config_startup_path), false },
-  { "system_mouse",             ENUM(system_mouse), false },
+  { "standalone_mode",          Bool(standalone_mode), false },
+  { "startup_editor",           Bool(startup_editor), false },
+  { "startup_file",             Fn(config_startup_file), false },
+  { "startup_path",             Fn(config_startup_path), false },
+  { "system_mouse",             Enum(system_mouse), false },
 #ifdef CONFIG_UPDATER
-  { "update_auto_check",        ENUM(update_auto_check), false },
-  { "update_branch_pin",        STR(update_branch_pin), false },
-  { "update_host",              FN(config_update_host), false },
+  { "update_auto_check",        Enum(update_auto_check), false },
+  { "update_branch_pin",        Str(update_branch_pin), false },
+  { "update_host",              Fn(config_update_host), false },
 #endif
-  { "video_output",             STR(video_output), false },
-  { "video_ratio",              ENUM(video_ratio), false },
-  { "window_resolution",        FN(config_window_resolution), false },
+  { "video_output",             Str(video_output), false },
+  { "video_ratio",              Enum(video_ratio), false },
+  { "window_resolution",        Fn(config_window_resolution), false },
 };
 
 static const struct config_entry *find_option(char *name,
@@ -594,7 +594,7 @@ static int config_change_option(void *conf, char *name,
   {
     if(current_option->allow_in_game_config || is_startup)
     {
-      fn_ptr fn = config_option_set(&(current_option->dest), conf, name, value);
+      fn_ptr fn = mapped_field_set(&(current_option->dest), conf, name, value);
 
       if(fn)
         ((config_function)fn)(conf, name, value, extended_data);

--- a/src/configure.h
+++ b/src/configure.h
@@ -77,6 +77,11 @@ struct config_info
   boolean music_on;
   boolean pc_speaker_on;
 
+  // Event options
+  boolean allow_gamecontroller;
+  boolean pause_on_unfocus;
+  int num_buffered_events;
+
   // Game options
   char startup_path[256];
   char startup_file[256];

--- a/src/configure.h
+++ b/src/configure.h
@@ -33,6 +33,12 @@ enum ratio_type
   RATIO_STRETCH
 };
 
+enum gl_filter_type
+{
+  CONFIG_GL_FILTER_NEAREST,
+  CONFIG_GL_FILTER_LINEAR
+};
+
 enum allow_cheats_type
 {
   ALLOW_CHEATS_NEVER,
@@ -59,7 +65,7 @@ struct config_info
   char video_output[16];
   int force_bpp;
   enum ratio_type video_ratio;
-  char gl_filter_method[16];
+  enum gl_filter_type gl_filter_method;
   char gl_scaling_shader[32];
   int gl_vsync;
   boolean allow_screenshots;

--- a/src/configure_option.h
+++ b/src/configure_option.h
@@ -1,0 +1,175 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2019 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+// Macros/function to help reduce the number of config boilerplate functions.
+
+#ifndef __CONFIGURE_OPTION_H
+#define __CONFIGURE_OPTION_H
+
+#include "compat.h"
+
+__M_BEGIN_DECLS
+
+#include "platform.h"
+#include "util.h"
+
+#include <string.h>
+
+enum config_option_types
+{
+  CONF_OPT_INT,
+  CONF_OPT_ENUM,
+  CONF_OPT_STR,
+  CONF_OPT_FUNC
+};
+
+struct config_enum
+{
+  const char * const key;
+  const Uint8 value;
+};
+
+struct int_value
+{
+  int offset;
+  size_t offset_sz;
+  int min;
+  int max;
+};
+
+struct enum_value
+{
+  int offset;
+  size_t offset_sz;
+  const struct config_enum *list;
+  Uint8 list_len;
+};
+
+struct str_value
+{
+  int offset;
+  size_t offset_sz;
+};
+
+struct fn_value
+{
+  fn_ptr fn;
+};
+
+struct config_option
+{
+  enum config_option_types type;
+  union
+  {
+    struct int_value i;
+    struct enum_value e;
+    struct str_value s;
+    struct fn_value f;
+  } value;
+};
+
+#define OF(conf, field) offsetof(conf, field)
+#define SZ(conf, field) sizeof(((conf *)0)->field)
+
+#define CONF_INT(conf, field, min, max) \
+{ CONF_OPT_INT, { .i = { OF(conf, field), SZ(conf, field), min, max }}}
+
+#define CONF_ENUM(conf, field, en) \
+ { CONF_OPT_ENUM, { .e = { OF(conf, field), SZ(conf, field), en, ARRAY_SIZE(en) }}}
+
+#define CONF_STR(conf, field) \
+ { CONF_OPT_STR, { .s = { OF(conf, field), SZ(conf, field) }}}
+
+#define CONF_FN(conf, fn) \
+ { CONF_OPT_FUNC, { .f = { (fn_ptr)fn }}}
+
+/**
+ * Set a generic config setting. The config_option struct contains enough info
+ * about the location and size of the setting that knowing the actual config
+ * struct isn't necessary. If the option dest is a function call, return the
+ * function pointer to the handler that called this.
+ */
+static inline fn_ptr config_option_set(const struct config_option *dest,
+ void *_conf, char *name, char *value)
+{
+  Uint8 *conf = (Uint8 *)_conf;
+
+  switch(dest->type)
+  {
+    case CONF_OPT_INT:
+    {
+      const struct int_value *v = &(dest->value.i);
+      int result;
+      int n;
+
+      if(sscanf(value, "%d%n", &result, &n) != 1 || value[n] != 0)
+        break;
+
+      if(result < v->min || result > v->max)
+        break;
+
+      if(v->offset_sz == 1) *((Uint8 *)(conf + v->offset)) = (Uint8)result;
+      if(v->offset_sz == 4) *((int *)(conf + v->offset)) = result;
+      break;
+    }
+
+    case CONF_OPT_ENUM:
+    {
+      const struct enum_value *e = &(dest->value.e);
+      int result;
+      Uint8 i;
+
+      for(i = 0; i < e->list_len; i++)
+      {
+        if(!strcasecmp(value, e->list[i].key))
+        {
+          result = e->list[i].value;
+          if(e->offset_sz == 1) *((Uint8 *)(conf + e->offset)) = (Uint8)result;
+          if(e->offset_sz == 4) *((int *)(conf + e->offset)) = result;
+          break;
+        }
+      }
+      break;
+    }
+
+    case CONF_OPT_STR:
+    {
+      const struct str_value *s = &(dest->value.s);
+      char *dest = (char *)(conf + s->offset);
+      size_t stop = s->offset_sz - 1;
+      size_t i;
+
+      for(i = 0; value[i] && (i < stop); i++)
+        dest[i] = value[i];
+
+      dest[i] = 0;
+      break;
+    }
+
+    case CONF_OPT_FUNC:
+    {
+      return dest->value.f.fn;
+    }
+  }
+  return NULL;
+}
+
+__M_END_DECLS
+
+#endif // __CONFIGURE_OPTION>H

--- a/src/editor/configure.c
+++ b/src/editor/configure.c
@@ -249,6 +249,15 @@ static void config_board_viewport_y(struct editor_config_info *conf,
   conf->viewport_y = CLAMP(strtol(value, NULL, 10), 0, (25 - conf->viewport_h));
 }
 
+static void include_config(struct editor_config_info *conf,
+ char *name, char *value, char *extended_data)
+{
+  // TODO this only works from the config file.
+  // It will never be reached as a command line option because the option will
+  // be read and then removed from argv by the main config.
+  set_editor_config_from_file(name + 7);
+}
+
 #define Int(field, min, max) MAP_INT(struct editor_config_info, field, min, max)
 #define Enum(field) MAP_ENUM(struct editor_config_info, field, field ## _values)
 #define Bool(field) MAP_ENUM(struct editor_config_info, field, boolean_values)
@@ -321,6 +330,7 @@ static const struct editor_config_entry editor_config_options[] =
   { "editor_space_toggles",             Bool(editor_space_toggles) },
   { "editor_tab_focuses_view",          Bool(editor_tab_focuses_view) },
   { "editor_thing_menu_places",         Bool(editor_thing_menu_places) },
+  { "include*",                         Fn(include_config) },
   { "macro_*",                          Fn(config_macro) },
   { "palette_editor_hide_help",         Bool(palette_editor_hide_help) },
   { "robot_editor_hide_help",           Bool(robot_editor_hide_help) },

--- a/src/editor/configure.c
+++ b/src/editor/configure.c
@@ -107,20 +107,20 @@ static const struct editor_config_info editor_conf_default =
 
 };
 
-static const struct config_enum boolean_values[] =
+static const struct mapped_enum_entry boolean_values[] =
 {
   { "0", false },
   { "1", true }
 };
 
-static const struct config_enum explosions_leave_values[] =
+static const struct mapped_enum_entry explosions_leave_values[] =
 {
   { "space", EXPL_LEAVE_SPACE },
   { "ash", EXPL_LEAVE_ASH },
   { "fire", EXPL_LEAVE_FIRE }
 };
 
-static const struct config_enum overlay_enabled_values[] =
+static const struct mapped_enum_entry overlay_enabled_values[] =
 {
   { "disabled", OVERLAY_OFF },
   { "enabled", OVERLAY_ON },
@@ -128,21 +128,21 @@ static const struct config_enum overlay_enabled_values[] =
   { "transparent", OVERLAY_TRANSPARENT },
 };
 
-static const struct config_enum saving_enabled_values[] =
+static const struct mapped_enum_entry saving_enabled_values[] =
 {
   { "disabled", CANT_SAVE },
   { "enabled", CAN_SAVE },
   { "sensoronly", CAN_SAVE_ON_SENSOR }
 };
 
-static const struct config_enum default_invalid_status_values[] =
+static const struct mapped_enum_entry default_invalid_status_values[] =
 {
   { "ignore", invalid_uncertain },
   { "delete", invalid_discard },
   { "comment", invalid_comment }
 };
 
-static const struct config_enum disassemble_base_values[] =
+static const struct mapped_enum_entry disassemble_base_values[] =
 {
   { "10", 10 },
   { "16", 16 }
@@ -151,7 +151,7 @@ static const struct config_enum disassemble_base_values[] =
 struct editor_config_entry
 {
   char option_name[OPTION_NAME_LEN];
-  struct config_option dest;
+  struct mapped_field dest;
 };
 
 typedef void (* editor_config_function)(struct editor_config_info *conf,
@@ -249,11 +249,11 @@ static void config_board_viewport_y(struct editor_config_info *conf,
   conf->viewport_y = CLAMP(strtol(value, NULL, 10), 0, (25 - conf->viewport_h));
 }
 
-#define INT(field, min, max) CONF_INT(struct editor_config_info, field, min, max)
-#define ENUM(field) CONF_ENUM(struct editor_config_info, field, field ## _values)
-#define BOOL(field) CONF_ENUM(struct editor_config_info, field, boolean_values)
-#define STR(field) CONF_STR(struct editor_config_info, field)
-#define FN(field) CONF_FN(struct editor_config_info, field)
+#define Int(field, min, max) MAP_INT(struct editor_config_info, field, min, max)
+#define Enum(field) MAP_ENUM(struct editor_config_info, field, field ## _values)
+#define Bool(field) MAP_ENUM(struct editor_config_info, field, boolean_values)
+#define Str(field) MAP_STR(struct editor_config_info, field)
+#define Fn(field) MAP_FN(struct editor_config_info, field)
 
 /* NOTE: This is searched as a binary tree, the nodes must be
  *       sorted alphabetically, or they risk being ignored.
@@ -269,63 +269,63 @@ static void config_board_viewport_y(struct editor_config_info *conf,
  */
 static const struct editor_config_entry editor_config_options[] =
 {
-  { "backup_count",                     INT(backup_count, 0, INT_MAX) },
-  { "backup_ext",                       STR(backup_ext) },
-  { "backup_interval",                  INT(backup_interval, 0, INT_MAX) },
-  { "backup_name",                      STR(backup_name) },
-  { "board_default_can_bomb",           BOOL(can_bomb) },
-  { "board_default_can_shoot",          BOOL(can_shoot) },
-  { "board_default_charset_path",       STR(charset_path) },
-  { "board_default_collect_bombs",      BOOL(collect_bombs) },
-  { "board_default_explosions_leave",   ENUM(explosions_leave) },
-  { "board_default_fire_burns_brown",   BOOL(fire_burns_brown) },
-  { "board_default_fire_burns_fakes",   BOOL(fire_burns_fakes) },
-  { "board_default_fire_burns_forever", BOOL(fire_burns_forever) },
-  { "board_default_fire_burns_spaces",  BOOL(fire_burns_spaces) },
-  { "board_default_fire_burns_trees",   BOOL(fire_burns_trees) },
-  { "board_default_forest_to_floor",    BOOL(forest_to_floor) },
-  { "board_default_height",             FN(config_board_height) },
-  { "board_default_overlay",            ENUM(overlay_enabled) },
-  { "board_default_palette_path",       STR(palette_path) },
-  { "board_default_player_locked_att",  BOOL(player_locked_att) },
-  { "board_default_player_locked_ew",   BOOL(player_locked_ew) },
-  { "board_default_player_locked_ns",   BOOL(player_locked_ns) },
-  { "board_default_reset_on_entry",     BOOL(reset_on_entry) },
-  { "board_default_restart_if_hurt",    BOOL(restart_if_hurt) },
-  { "board_default_saving",             ENUM(saving_enabled) },
-  { "board_default_time_limit",         INT(time_limit, 0, 32767) },
-  { "board_default_viewport_h",         FN(config_board_viewport_h) },
-  { "board_default_viewport_w",         FN(config_board_viewport_w) },
-  { "board_default_viewport_x",         FN(config_board_viewport_x) },
-  { "board_default_viewport_y",         FN(config_board_viewport_y) },
-  { "board_default_width",              FN(config_board_width) },
-  { "board_editor_hide_help",           BOOL(board_editor_hide_help) },
-  { "ccode_colors",                     INT(color_codes[4], 0, 255) },
-  { "ccode_commands",                   INT(color_codes[13], 0, 15) },
-  { "ccode_conditions",                 INT(color_codes[10], 0, 15) },
-  { "ccode_current_line",               INT(color_codes[0], 0, 15) },
-  { "ccode_directions",                 INT(color_codes[5], 0, 15) },
-  { "ccode_equalities",                 INT(color_codes[9], 0, 15) },
-  { "ccode_extras",                     INT(color_codes[12], 0, 15) },
-  { "ccode_immediates",                 INT(color_codes[1], 0, 15) },//see note
-  { "ccode_items",                      INT(color_codes[11], 0, 15) },
-  { "ccode_params",                     INT(color_codes[7], 0, 15) },
-  { "ccode_strings",                    INT(color_codes[8], 0, 15) },
-  { "ccode_things",                     INT(color_codes[6], 0, 15) },
-  { "color_coding_on",                  BOOL(color_coding_on) },
-  { "default_invalid_status",           ENUM(default_invalid_status) },
-  { "disassemble_base",                 ENUM(disassemble_base) },
-  { "disassemble_extras",               BOOL(disassemble_extras) },
-  { "editor_enter_splits",              BOOL(editor_enter_splits) },
-  { "editor_load_board_assets",         BOOL(editor_load_board_assets) },
-  { "editor_space_toggles",             BOOL(editor_space_toggles) },
-  { "editor_tab_focuses_view",          BOOL(editor_tab_focuses_view) },
-  { "editor_thing_menu_places",         BOOL(editor_thing_menu_places) },
-  { "macro_*",                          FN(config_macro) },
-  { "palette_editor_hide_help",         BOOL(palette_editor_hide_help) },
-  { "robot_editor_hide_help",           BOOL(robot_editor_hide_help) },
-  { "saved_position!",                  FN(config_saved_positions) },
-  { "undo_history_size",                INT(undo_history_size, 0, 1000) },
+  { "backup_count",                     Int(backup_count, 0, INT_MAX) },
+  { "backup_ext",                       Str(backup_ext) },
+  { "backup_interval",                  Int(backup_interval, 0, INT_MAX) },
+  { "backup_name",                      Str(backup_name) },
+  { "board_default_can_bomb",           Bool(can_bomb) },
+  { "board_default_can_shoot",          Bool(can_shoot) },
+  { "board_default_charset_path",       Str(charset_path) },
+  { "board_default_collect_bombs",      Bool(collect_bombs) },
+  { "board_default_explosions_leave",   Enum(explosions_leave) },
+  { "board_default_fire_burns_brown",   Bool(fire_burns_brown) },
+  { "board_default_fire_burns_fakes",   Bool(fire_burns_fakes) },
+  { "board_default_fire_burns_forever", Bool(fire_burns_forever) },
+  { "board_default_fire_burns_spaces",  Bool(fire_burns_spaces) },
+  { "board_default_fire_burns_trees",   Bool(fire_burns_trees) },
+  { "board_default_forest_to_floor",    Bool(forest_to_floor) },
+  { "board_default_height",             Fn(config_board_height) },
+  { "board_default_overlay",            Enum(overlay_enabled) },
+  { "board_default_palette_path",       Str(palette_path) },
+  { "board_default_player_locked_att",  Bool(player_locked_att) },
+  { "board_default_player_locked_ew",   Bool(player_locked_ew) },
+  { "board_default_player_locked_ns",   Bool(player_locked_ns) },
+  { "board_default_reset_on_entry",     Bool(reset_on_entry) },
+  { "board_default_restart_if_hurt",    Bool(restart_if_hurt) },
+  { "board_default_saving",             Enum(saving_enabled) },
+  { "board_default_time_limit",         Int(time_limit, 0, 32767) },
+  { "board_default_viewport_h",         Fn(config_board_viewport_h) },
+  { "board_default_viewport_w",         Fn(config_board_viewport_w) },
+  { "board_default_viewport_x",         Fn(config_board_viewport_x) },
+  { "board_default_viewport_y",         Fn(config_board_viewport_y) },
+  { "board_default_width",              Fn(config_board_width) },
+  { "board_editor_hide_help",           Bool(board_editor_hide_help) },
+  { "ccode_colors",                     Int(color_codes[4], 0, 255) },
+  { "ccode_commands",                   Int(color_codes[13], 0, 15) },
+  { "ccode_conditions",                 Int(color_codes[10], 0, 15) },
+  { "ccode_current_line",               Int(color_codes[0], 0, 15) },
+  { "ccode_directions",                 Int(color_codes[5], 0, 15) },
+  { "ccode_equalities",                 Int(color_codes[9], 0, 15) },
+  { "ccode_extras",                     Int(color_codes[12], 0, 15) },
+  { "ccode_immediates",                 Int(color_codes[1], 0, 15) },//see note
+  { "ccode_items",                      Int(color_codes[11], 0, 15) },
+  { "ccode_params",                     Int(color_codes[7], 0, 15) },
+  { "ccode_strings",                    Int(color_codes[8], 0, 15) },
+  { "ccode_things",                     Int(color_codes[6], 0, 15) },
+  { "color_coding_on",                  Bool(color_coding_on) },
+  { "default_invalid_status",           Enum(default_invalid_status) },
+  { "disassemble_base",                 Enum(disassemble_base) },
+  { "disassemble_extras",               Bool(disassemble_extras) },
+  { "editor_enter_splits",              Bool(editor_enter_splits) },
+  { "editor_load_board_assets",         Bool(editor_load_board_assets) },
+  { "editor_space_toggles",             Bool(editor_space_toggles) },
+  { "editor_tab_focuses_view",          Bool(editor_tab_focuses_view) },
+  { "editor_thing_menu_places",         Bool(editor_thing_menu_places) },
+  { "macro_*",                          Fn(config_macro) },
+  { "palette_editor_hide_help",         Bool(palette_editor_hide_help) },
+  { "robot_editor_hide_help",           Bool(robot_editor_hide_help) },
+  { "saved_position!",                  Fn(config_saved_positions) },
+  { "undo_history_size",                Int(undo_history_size, 0, 1000) },
 };
 
 static const struct editor_config_entry *find_editor_option(char *name,
@@ -360,7 +360,7 @@ static int editor_config_change_option(void *conf, char *name, char *value,
 
   if(current_option)
   {
-    fn_ptr fn = config_option_set(&(current_option->dest), conf, name, value);
+    fn_ptr fn = mapped_field_set(&(current_option->dest), conf, name, value);
 
     if(fn)
       ((editor_config_function)fn)(conf, name, value, extended_data);

--- a/src/event.c
+++ b/src/event.c
@@ -18,6 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "configure.h"
 #include "event.h"
 #include "graphics.h"
 #include "platform.h"
@@ -133,9 +134,14 @@ static void bump_status(void)
          sizeof(struct buffered_status));
 }
 
-void init_event(void)
+void init_event(struct config_info *conf)
 {
   int i, i2;
+
+  // Get defaults from config.
+  num_buffered_events = MAX(1, conf->num_buffered_events);
+  input.unfocus_pause = conf->pause_on_unfocus;
+
   input.buffer = ccalloc(num_buffered_events, sizeof(struct buffered_status));
   input.load_offset = num_buffered_events - 1;
   input.store_offset = 0;
@@ -1019,11 +1025,14 @@ boolean get_ctrl_status(enum keycode_type type)
    get_key_status(type, IKEY_RCTRL);
 }
 
+// Nothing uses this right now, but it needs to be settable for networking.
 void set_unfocus_pause(boolean value)
 {
   input.unfocus_pause = value;
 }
 
+// Nothing uses this right now, but it needs to be settable for networking.
+// TODO: when set this ought to actually reallocate the buffered events.
 void set_num_buffered_events(Uint8 value)
 {
   num_buffered_events = MAX(1, value);

--- a/src/event.h
+++ b/src/event.h
@@ -24,6 +24,7 @@
 
 __M_BEGIN_DECLS
 
+#include "configure.h"
 #include "platform.h"
 #include "keysym.h"
 
@@ -172,7 +173,7 @@ enum keycode_type
   keycode_unicode
 };
 
-CORE_LIBSPEC void init_event(void);
+CORE_LIBSPEC void init_event(struct config_info *conf);
 
 struct buffered_status *store_status(void);
 
@@ -218,7 +219,6 @@ boolean __peek_exit_input(void);
 
 #if SDL_VERSION_ATLEAST(2,0,0)
 void gamecontroller_map_sym(const char *sym, const char *value);
-void gamecontroller_set_enabled(boolean enable);
 void gamecontroller_add_mapping(const char *mapping);
 #endif
 #endif

--- a/src/event_sdl.c
+++ b/src/event_sdl.c
@@ -19,6 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "configure.h"
 #include "event.h"
 #include "platform.h"
 #include "graphics.h"
@@ -191,7 +192,6 @@ static int get_pandora_joystick_button(SDL_Keycode key)
  */
 
 static SDL_GameController *gamecontrollers[MAX_JOYSTICKS];
-boolean allow_gamecontroller_mapping = true;
 
 /*
 static enum joystick_special_axis sdl_axis_map[SDL_CONTROLLER_AXIS_MAX] =
@@ -492,13 +492,14 @@ static void init_gamecontroller(int sdl_index, int joystick_index)
 
     if(gamecontroller)
     {
+      struct config_info *conf = get_config();
       char *mapping;
       gamecontrollers[joystick_index] = gamecontroller;
 
       mapping = (char *)SDL_GameControllerMappingForGUID(guid);
       info("[JOYSTICK] %d has an SDL mapping: %s\n", joystick_index, mapping);
 
-      if(allow_gamecontroller_mapping)
+      if(conf->allow_gamecontroller)
         parse_gamecontroller_map(joystick_index, mapping);
 
       SDL_free(mapping);
@@ -613,14 +614,6 @@ void gamecontroller_map_sym(const char *sym, const char *value)
   }
 
   // TODO analog axes
-}
-
-/**
- * Enable or disable the SDL to MZX mapping system.
- */
-void gamecontroller_set_enabled(boolean enable)
-{
-  allow_gamecontroller_mapping = enable;
 }
 
 /**

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -193,7 +193,7 @@ struct graphics_data
   Uint32 cursor_flipflop;
   Uint32 default_smzx_loaded;
   enum ratio_type ratio;
-  char *gl_filter_method;
+  enum gl_filter_type gl_filter_method;
   char *gl_scaling_shader;
   int gl_vsync;
 

--- a/src/main.c
+++ b/src/main.c
@@ -214,7 +214,7 @@ __libspec int main(int argc, char *argv[])
 
   set_mouse_mul(8, 14);
 
-  init_event();
+  init_event(conf);
 
   if(!init_video(conf, CAPTION))
     goto err_free_config;

--- a/src/render_gl.c
+++ b/src/render_gl.c
@@ -100,13 +100,13 @@ boolean gl_load_syms(const struct dso_syms_map *map)
   return true;
 }
 
-void gl_set_filter_method(const char *method,
+void gl_set_filter_method(enum gl_filter_type method,
  void (GL_APIENTRY *glTexParameterf_p)(GLenum target, GLenum pname,
   GLfloat param))
 {
   GLfloat gl_filter_method = GL_LINEAR;
 
-  if(!strcasecmp(method, CONFIG_GL_FILTER_NEAREST))
+  if(method == CONFIG_GL_FILTER_NEAREST)
     gl_filter_method = GL_NEAREST;
 
   glTexParameterf_p(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, gl_filter_method);

--- a/src/render_gl.h
+++ b/src/render_gl.h
@@ -26,6 +26,7 @@
 
 __M_BEGIN_DECLS
 
+#include "configure.h"
 #include "graphics.h"
 #include "util.h"
 
@@ -55,9 +56,6 @@ __M_BEGIN_DECLS
 // Next power of 2 over SCREEN_PIX_H
 #define GL_POWER_2_HEIGHT         512
 
-#define CONFIG_GL_FILTER_LINEAR   "linear"
-#define CONFIG_GL_FILTER_NEAREST  "nearest"
-
 extern const float vertex_array_single[2 * 4];
 
 #ifdef DEBUG
@@ -69,7 +67,7 @@ static inline void gl_error(const char *file, int line,
 #endif
 
 boolean gl_load_syms(const struct dso_syms_map *map);
-void gl_set_filter_method(const char *method,
+void gl_set_filter_method(enum gl_filter_type method,
  void (GL_APIENTRY *glTexParameterf_p)(GLenum target, GLenum pname,
   GLfloat param));
 void get_context_width_height(struct graphics_data *graphics,

--- a/src/render_gl2.c
+++ b/src/render_gl2.c
@@ -518,7 +518,7 @@ static int gl2_linear_filter_method(struct graphics_data *graphics)
 
   if(render_data->ignore_linear)
     return false;
-  return strcasecmp(graphics->gl_filter_method, CONFIG_GL_FILTER_LINEAR) == 0;
+  return graphics->gl_filter_method == CONFIG_GL_FILTER_LINEAR;
 }
 
 static inline Uint32 translate_layer_color(struct graphics_data *graphics,


### PR DESCRIPTION
Replaces the massive amount of boilerplate in `src/configure.c` and `src/editor/configure.c` with a horrifying hack that makes it less annoying to add new settings but makes you wonder at what cost

As a bonus, fixes a bug with the `ccode_extras` option.

- [x] Read `gamecontroller_enable`, `num_buffered_events`, `pause_on_unfocus` off of the config struct instead of having config call functions to write to these elsewhere.
- [x] Fix `gl_filter_method`—GL code expects a string, but this was changed to an enum (0-nearest, 1-linear).
- [x] ~~Implement `system_mouse = both`?~~ Removed from values array, can implement in the future.
- [x] Add `include` to editor config.
- [ ] Reduce the joystick functions more?