### PR TITLE
Add config option to enable OpenGL ES compatibility hacks

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -70,6 +70,7 @@ usage() {
 	echo "  --enable-meter          Enable load/save meter display."
 	echo "  --disable-sdl           Disables SDL dependencies and features."
 	echo "  --enable-egl            Enables EGL backend (if SDL disabled)."
+	echo "  --enable-gles           Enable hacks for OpenGL ES platforms."
 	echo "  --disable-check-alloc   Disables memory allocator error handling."
 	echo "  --disable-khash         Disables using khash for counter/string lookups."
 	echo "  --enable-uthash         Enables using uthash for counter/string lookups."
@@ -137,6 +138,7 @@ VERBOSE="false"
 METER="false"
 SDL="true"
 EGL="false"
+GLES="false"
 CHECK_ALLOC="true"
 KHASH="true"
 UTHASH="false"
@@ -314,6 +316,9 @@ while [ "$1" != "" ]; do
 
 	[ "$1" = "--enable-egl" ]  && EGL="true"
 	[ "$1" = "--disable-egl" ] && EGL="false"
+
+	[ "$1" = "--enable-gles" ]  && GLES="true"
+	[ "$1" = "--disable-gles" ] && GLES="false"
 
 	[ "$1" = "--disable-check-alloc" ] && CHECK_ALLOC="false"
 	[ "$1" = "--enable-check-alloc" ]  && CHECK_ALLOC="true"
@@ -587,18 +592,23 @@ else
 fi
 
 #
-# We have EGL support
+# Use an EGL backend in place of SDL.
+# For now, also force-enable OpenGL ES hacks, since that's most
+# likely what is being used with EGL.
 #
 if [ "$EGL" = "true" ]; then
 	echo "#define CONFIG_EGL" >> src/config.h
 	echo "BUILD_EGL=1" >> platform.inc
+
+	echo "Force-enabling OpenGL ES support (EGL)."
+	GLES="true"
 fi
 
 #
 # We need either SDL or EGL for OpenGL
 #
 if [ "$SDL" = "false" -a "$EGL" = "false" ]; then
-	echo "Force-disabling OpenGL (no SDL or EGL support)."
+	echo "Force-disabling OpenGL (no SDL or EGL backend)."
 	GL="false"
 fi
 
@@ -698,6 +708,7 @@ if [ "$GL" = "false" ]; then
 	echo "Force-disabling OpenGL."
 	GL_FIXED="false"
 	GL_PROGRAM="false"
+	GLES="false"
 fi
 
 #
@@ -912,6 +923,16 @@ if [ "$ICON" = "true" ]; then
 		echo "Force-disabling icon branding (redundant)."
 		ICON="false"
 	fi
+fi
+
+#
+# Enable OpenGL ES hacks if required.
+#
+if [ "$GLES" = "true" ]; then
+	echo "OpenGL ES support enabled."
+	echo "#define CONFIG_GLES" >> src/config.h
+else
+	echo "OpenGL ES support disabled."
 fi
 
 #

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -70,6 +70,9 @@ DEVELOPERS
   loaded in SDL 1.2. (Lancer-X)
 + GL renderers free textures and revert to fixed function
   pipeline where appropriate. (Lancer-X)
++ OpenGL ES support can now be enabled for SDL builds with the
+  --enable-gles option. This option is force-enabled for
+  platforms that only support OpenGL ES.
 
 
 February 20th, 2019 - MZX 2.91j

--- a/src/render_egl.c
+++ b/src/render_egl.c
@@ -123,7 +123,7 @@ static const EGLint gles_v2_attribs[] =
 };
 
 boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
- int depth, boolean fullscreen, boolean resize)
+ int depth, boolean fullscreen, boolean resize, struct gl_version req_ver)
 {
   struct egl_render_data *egl_render_data = graphics->render_data;
   const EGLint *attribs = gles_v1_attribs;

--- a/src/render_egl.h
+++ b/src/render_egl.h
@@ -28,8 +28,8 @@ __M_BEGIN_DECLS
 
 #include <EGL/egl.h>
 
-boolean gl_set_video_mode(struct graphics_data *graphics, int width,
- int height, int depth, boolean fullscreen, boolean resize);
+boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
+ int depth, boolean fullscreen, boolean resize, struct gl_version req_ver);
 boolean gl_check_video_mode(struct graphics_data *graphics, int width,
  int height, int depth, boolean fullscreen, boolean resize);
 void gl_set_attributes(struct graphics_data *graphics);

--- a/src/render_gl.h
+++ b/src/render_gl.h
@@ -29,8 +29,17 @@ __M_BEGIN_DECLS
 #include "graphics.h"
 #include "util.h"
 
-#ifndef CONFIG_EGL
+#ifdef CONFIG_SDL
+#ifdef CONFIG_GLES
+#ifdef CONFIG_RENDER_GL_FIXED
+#include <SDL_opengles.h>
+#endif
+#ifdef CONFIG_RENDER_GL_PROGRAM
+#include <SDL_opengles2.h>
+#endif
+#else
 #include "SDL_opengl.h"
+#endif
 #endif
 
 #ifndef GLAPIENTRY
@@ -65,6 +74,15 @@ void gl_set_filter_method(const char *method,
   GLfloat param));
 void get_context_width_height(struct graphics_data *graphics,
  int *width, int *height);
+
+// Used to request an OpenGL API version with gl_set_video_mode.
+// Currently this is only used to configure SDL on platforms that require
+// OpenGL ES, as OpenGL ES 1 and OpenGL ES 2 are not compatible.
+struct gl_version
+{
+  int major;
+  int minor;
+};
 
 enum gl_lib_type
 {

--- a/src/render_gl1.c
+++ b/src/render_gl1.c
@@ -45,6 +45,8 @@
 //       OpenGL ES 1.x. The latter API lacks many functions present in
 //       desktop OpenGL. GL ES is typically used on cellphones.
 
+static const struct gl_version gl_required_version = { 1, 1 };
+
 static struct
 {
   void (GL_APIENTRY *glBindTexture)(GLenum target, GLuint texture);
@@ -183,7 +185,8 @@ static boolean gl1_set_video_mode(struct graphics_data *graphics,
 
   gl_set_attributes(graphics);
 
-  if(!gl_set_video_mode(graphics, width, height, depth, fullscreen, resize))
+  if(!gl_set_video_mode(graphics, width, height, depth, fullscreen, resize,
+   gl_required_version))
     return false;
 
   gl_set_attributes(graphics);
@@ -193,10 +196,10 @@ static boolean gl1_set_video_mode(struct graphics_data *graphics,
 
   // We need a specific version of OpenGL; desktop GL must be 1.1.
   // All OpenGL ES 1.x implementations are supported, so don't do
-  // the check with EGL configurations (EGL implies OpenGL ES).
+  // the check with these configurations.
   // No OpenGL ES 1.x supports NPOT textures, so we can also skip
   // the extension check.
-#ifndef CONFIG_EGL
+#ifndef CONFIG_GLES
   {
     static boolean initialized = false;
 

--- a/src/render_gl2.c
+++ b/src/render_gl2.c
@@ -47,6 +47,8 @@
 //       OpenGL ES 1.x. The latter API lacks many functions present in
 //       desktop OpenGL. GL ES is typically used on cellphones.
 
+static const struct gl_version gl_required_version = { 1, 1 };
+
 // We need to keep two versions of each char: the regular char, and an
 // inverted version for foreground transparency with layer rendering.
 #define CHAR_2W (CHAR_W * 2)
@@ -345,7 +347,8 @@ static boolean gl2_set_video_mode(struct graphics_data *graphics,
 {
   gl_set_attributes(graphics);
 
-  if(!gl_set_video_mode(graphics, width, height, depth, fullscreen, resize))
+  if(!gl_set_video_mode(graphics, width, height, depth, fullscreen, resize,
+   gl_required_version))
     return false;
 
   gl_set_attributes(graphics);
@@ -355,8 +358,8 @@ static boolean gl2_set_video_mode(struct graphics_data *graphics,
 
   // We need a specific version of OpenGL; desktop GL must be 1.1.
   // All OpenGL ES 1.x implementations are supported, so don't do
-  // the check with EGL configurations (EGL implies OpenGL ES).
-#ifndef CONFIG_EGL
+  // the check with these configurations.
+#ifndef CONFIG_GLES
   {
     static boolean initialized = false;
 

--- a/src/render_glsl.c
+++ b/src/render_glsl.c
@@ -39,12 +39,17 @@
 #ifdef CONFIG_EGL
 #include <GLES2/gl2.h>
 #include "render_egl.h"
+#endif
+
+#ifdef CONFIG_GLES
 typedef GLenum GLiftype;
 #else
 typedef GLint GLiftype;
 #endif
 
 #include "render_gl.h"
+
+static const struct gl_version gl_required_version = { 2, 0 };
 
 #define CHARSET_COLS 64
 #define CHARSET_ROWS (FULL_CHARSET_SIZE / CHARSET_COLS)
@@ -385,7 +390,7 @@ static GLuint glsl_load_shader(struct graphics_data *graphics,
 
   shader = glsl.glCreateShader(type);
 
-#ifdef CONFIG_EGL
+#ifdef CONFIG_GLES
   {
     /**
      * OpenGL ES really doesn't like '#version 110' being specified. This
@@ -404,9 +409,9 @@ static GLuint glsl_load_shader(struct graphics_data *graphics,
       pos[1] = '/';
     }
   }
-#endif // CONFIG_EGL
+#endif // CONFIG_GLES
 
-#ifdef CONFIG_EGL
+#ifdef CONFIG_GLES
   {
     const GLchar *sources[2];
     GLint lengths[2];
@@ -715,7 +720,8 @@ static boolean glsl_set_video_mode(struct graphics_data *graphics,
 {
   gl_set_attributes(graphics);
 
-  if(!gl_set_video_mode(graphics, width, height, depth, fullscreen, resize))
+  if(!gl_set_video_mode(graphics, width, height, depth, fullscreen, resize,
+   gl_required_version))
     return false;
 
   gl_set_attributes(graphics);
@@ -725,8 +731,8 @@ static boolean glsl_set_video_mode(struct graphics_data *graphics,
 
   // We need a specific version of OpenGL; desktop GL must be 2.0.
   // All OpenGL ES 2.0 implementations are supported, so don't do
-  // the check with EGL configurations (EGL implies OpenGL ES).
-#ifndef CONFIG_EGL
+  // the check with these configurations.
+#ifndef CONFIG_GLES
   {
     static boolean initialized = false;
 

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -276,11 +276,10 @@ boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
   sdl_destruct_window(graphics);
 
 #ifdef CONFIG_GLES
-#if defined(SDL_VIDEO_DRIVER_WINDOWS) || defined(SDL_VIDEO_DRIVER_X11)
   // Hints to make SDL use OpenGL ES drivers (e.g. ANGLE) on Windows/Linux.
+  // These may be ignored by SDL unless using the Windows or X11 video drivers.
   SDL_SetHint(SDL_HINT_OPENGL_ES_DRIVER, "1");
   SDL_SetHint(SDL_HINT_VIDEO_WIN_D3DCOMPILER, "none");
-#endif
 
   // Declare the OpenGL version to source functions from. This is necessary
   // since OpenGL ES 1.x and OpenGL ES 2.x are not compatible. This must be

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -267,13 +267,28 @@ boolean sdl_check_video_mode(struct graphics_data *graphics, int width,
 #if defined(CONFIG_RENDER_GL_FIXED) || defined(CONFIG_RENDER_GL_PROGRAM)
 
 boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
- int depth, boolean fullscreen, boolean resize)
+ int depth, boolean fullscreen, boolean resize, struct gl_version req_ver)
 {
   struct sdl_render_data *render_data = graphics->render_data;
 
 #if SDL_VERSION_ATLEAST(2,0,0)
 
   sdl_destruct_window(graphics);
+
+#ifdef CONFIG_GLES
+#if defined(SDL_VIDEO_DRIVER_WINDOWS) || defined(SDL_VIDEO_DRIVER_X11)
+  // Hints to make SDL use OpenGL ES drivers (e.g. ANGLE) on Windows/Linux.
+  SDL_SetHint(SDL_HINT_OPENGL_ES_DRIVER, "1");
+  SDL_SetHint(SDL_HINT_VIDEO_WIN_D3DCOMPILER, "none");
+#endif
+
+  // Declare the OpenGL version to source functions from. This is necessary
+  // since OpenGL ES 1.x and OpenGL ES 2.x are not compatible. This must be
+  // done after old windows are destroyed and before new windows are created.
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, req_ver.major);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, req_ver.minor);
+#endif
 
   render_data->window = SDL_CreateWindow("MegaZeux",
    SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height,

--- a/src/render_sdl.h
+++ b/src/render_sdl.h
@@ -64,8 +64,8 @@ boolean sdl_check_video_mode(struct graphics_data *graphics, int width,
 #define GL_STRIP_FLAGS(A) \
   ((A & (SDL_WINDOW_FULLSCREEN | SDL_WINDOW_RESIZABLE)) | SDL_WINDOW_OPENGL)
 
-boolean gl_set_video_mode(struct graphics_data *graphics, int width,
- int height, int depth, boolean fullscreen, boolean resize);
+boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
+ int depth, boolean fullscreen, boolean resize, struct gl_version req_ver);
 boolean gl_check_video_mode(struct graphics_data *graphics, int width,
  int height, int depth, boolean fullscreen, boolean resize);
 void gl_set_attributes(struct graphics_data *graphics);


### PR DESCRIPTION
The OpenGL ES compatibility hacks in MZX are currently tied to the `CONFIG_EGL` define, which exists for using an EGL platform without SDL (at one point necessary for Android). This is problematic since the OpenGL ES hacks are required for the Switch #166, Emscripten #169, and Android #142 ports, all of which are now based on SDL2 but use OpenGL ES (or compatible) implementations under the hood.

This pull request adds a new config.sh option `--enable-gles` that generalizes the OpenGL ES fixes @asiekierka and I have had to implement for these branches. These platforms can now just force enable this option. This option may also be useful for future ports or Linux on embedded platforms.