### PR TITLE
Add 'fullscreen_windowed' config option

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -372,7 +372,7 @@ if [ "$PLATFORM" = "win32"   -o "$PLATFORM" = "win64" \
 	# provided. This helps avoid errors that occur when gcc or libs exist in
 	# /usr, which is used by MSYS2 for the MSYS environment.
 	if [ "$PREFIX_IS_SET" = "false" -a -n "$MSYSTEM" \
-	 -a $(uname -o | grep "Msys") -a $(uname -r | grep "^2\.") ]; then
+	 -a "$(uname -o)" == "Msys" ]; then
 		if [ "$MSYSTEM" = "MINGW32" -o "$MSYSTEM" = "MINGW64" ]; then
 			[ "$PLATFORM" = "win32" ] && PREFIX="/mingw32"
 			[ "$PLATFORM" = "win64" ] && PREFIX="/mingw64"

--- a/config.txt
+++ b/config.txt
@@ -136,6 +136,12 @@
 # fullscreen_resolution = 1280,720
 # fullscreen_resolution = 640,480
 
+# If this setting is enabled, instead of regular fullscreen MZX will create
+# a borderless window with the current desktop resolution when fullscreen
+# is enabled. This overrides fullscreen_resolution. Disabled by default.
+
+# fullscreen_windowed = 0
+
 # The resolution MZX uses in a window. If you renderer supports
 # it, MZX will be scaled to fit this specification. Otherwise
 # the setting is ignored.

--- a/config.txt
+++ b/config.txt
@@ -130,10 +130,9 @@
 #
 # Give in x,y format. Use this if the defaults are giving you problems,
 # especially in the software renderer.
-# The resolution "1280,720" is the default for all scalable renderers;
+# The current desktop resolution is the default for all scalable renderers;
 # "640,480" is the default for the software renderer.
 
-# fullscreen_resolution = 1280,720
 # fullscreen_resolution = 640,480
 
 # If this setting is enabled, instead of regular fullscreen MZX will create

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -33,6 +33,9 @@ FEATURES
   function to produce sharper edges. This shader can scale up to
   any size larger than 640x350 and is comparable to hqscale
   (though it should look and perform a little better).
++ Added the config setting "fullscreen_windowed". When set to 1,
+  MZX will create a borderless window with the current desktop
+  resolution instead of regular fullscreen. Disabled by default.
 + The current renderer can now be set from the settings menu.
 + Added the 'softscale' renderer. This renderer is a generalized
   rewrite of the former SDL 2 overlay renderer implementation.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -33,6 +33,10 @@ FEATURES
   function to produce sharper edges. This shader can scale up to
   any size larger than 640x350 and is comparable to hqscale
   (though it should look and perform a little better).
++ Fullscreen mode will now attempt to match a supported screen
+  resolution if no "fullscreen_resolution" setting is specified.
+  For scaling renderers, this favors the current desktop
+  resolution. For "software", this favors smaller resolutions.
 + Added the config setting "fullscreen_windowed". When set to 1,
   MZX will create a borderless window with the current desktop
   resolution instead of regular fullscreen. Disabled by default.

--- a/src/configure.c
+++ b/src/configure.c
@@ -140,6 +140,7 @@ static const struct config_info user_conf_default =
 {
   // Video options
   FULLSCREEN_DEFAULT,           // fullscreen
+  false,                        // fullscreen_windowed
   FULLSCREEN_WIDTH_DEFAULT,     // resolution_width
   FULLSCREEN_HEIGHT_DEFAULT,    // resolution_height
   640,                          // window_width
@@ -298,6 +299,13 @@ static void config_set_fullscreen(struct config_info *conf, char *name,
 {
   // FIXME sloppy validation
   conf->fullscreen = strtoul(value, NULL, 10);
+}
+
+static void config_set_fullscreen_windowed(struct config_info *conf, char *name,
+ char *value, char *extended_data)
+{
+  // FIXME sloppy validation
+  conf->fullscreen_windowed = strtoul(value, NULL, 10);
 }
 
 static void config_set_music(struct config_info *conf, char *name,
@@ -751,6 +759,7 @@ static const struct config_entry config_options[] =
   { "force_bpp", config_force_bpp, false },
   { "fullscreen", config_set_fullscreen, false },
   { "fullscreen_resolution", config_set_resolution, false },
+  { "fullscreen_windowed", config_set_fullscreen_windowed, false },
 #ifdef CONFIG_SDL
 #if SDL_VERSION_ATLEAST(2,0,0)
   { "gamecontroller.*", config_sdl_gc_set, false },

--- a/src/configure.h
+++ b/src/configure.h
@@ -51,6 +51,7 @@ struct config_info
 {
   // Video options
   boolean fullscreen;
+  boolean fullscreen_windowed;
   int resolution_width;
   int resolution_height;
   int window_width;

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1511,6 +1511,7 @@ boolean init_video(struct config_info *conf, const char *caption)
 {
   graphics.screen_mode = 0;
   graphics.fullscreen = conf->fullscreen;
+  graphics.fullscreen_windowed = conf->fullscreen_windowed;
   graphics.resolution_width = conf->resolution_width;
   graphics.resolution_height = conf->resolution_height;
   graphics.window_width = conf->window_width;

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1628,6 +1628,18 @@ boolean set_video_mode(void)
   boolean resize = graphics.allow_resize;
   boolean ret;
 
+#ifdef CONFIG_SDL
+  if(fullscreen && graphics.fullscreen_windowed)
+  {
+    // TODO maybe be able to communicate with the renderer instead of this hack
+    if(sdl_get_fullscreen_resolution(&target_width, &target_height, true))
+    {
+      graphics.resolution_width = target_width;
+      graphics.resolution_height = target_height;
+    }
+  }
+#endif
+
   if(fullscreen)
   {
     target_width = graphics.resolution_width;

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1531,21 +1531,26 @@ boolean init_video(struct config_info *conf, const char *caption)
   if(!set_graphics_output(conf))
     return false;
 
-  // FIXME- We should communicate with the renderer to get the desktop resolution.
   if(conf->resolution_width == -1 && conf->resolution_height == -1)
   {
-    // FIXME hack- default resolution assignment should occur
-    // somewhere else on a per-renderer basis (probably init_video)
-    if(strcmp(conf->video_output, "software"))
-    {
-      // "Safe" resolution for scalable renderers
-      graphics.resolution_width = 1280;
-      graphics.resolution_height = 720;
-    }
+#ifdef CONFIG_SDL
+    // TODO maybe be able to communicate with the renderer instead of this hack
+    boolean is_scaling = true;
+    int width;
+    int height;
 
-    else
+    if(!strcmp(conf->video_output, "software"))
+      is_scaling = false;
+
+    if(sdl_get_fullscreen_resolution(&width, &height, is_scaling))
     {
-      // "Safe" resolution for software renderer
+      graphics.resolution_width = width;
+      graphics.resolution_height = height;
+    }
+    else
+#endif
+    {
+      // "Safe" resolution
       graphics.resolution_width = 640;
       graphics.resolution_height = 480;
     }

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -183,6 +183,7 @@ struct graphics_data
   boolean mouse_status;
   boolean system_mouse;
   boolean fullscreen;
+  boolean fullscreen_windowed;
   Uint32 resolution_width;
   Uint32 resolution_height;
   Uint32 window_width;

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -196,15 +196,6 @@ boolean sdl_set_video_mode(struct graphics_data *graphics, int width,
 
   sdl_destruct_window(graphics);
 
-  if(fullscreen && fullscreen_windowed)
-  {
-    if(sdl_get_fullscreen_resolution(&width, &height, true))
-    {
-      graphics->resolution_width = width;
-      graphics->resolution_height = height;
-    }
-  }
-
   render_data->window = SDL_CreateWindow("MegaZeux",
    SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height,
    sdl_flags(depth, fullscreen, fullscreen_windowed, resize));
@@ -371,15 +362,6 @@ boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, req_ver.major);
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, req_ver.minor);
 #endif
-
-  if(fullscreen && fullscreen_windowed)
-  {
-    if(sdl_get_fullscreen_resolution(&width, &height, true))
-    {
-      graphics->resolution_width = width;
-      graphics->resolution_height = height;
-    }
-  }
 
   render_data->window = SDL_CreateWindow("MegaZeux",
    SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height,

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -323,7 +323,13 @@ boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
 #endif
 
   if(fullscreen && fullscreen_windowed)
+  {
     sdl_get_native_resolution(&width, &height);
+
+    // Need to store these because the GL renderers actually need them.
+    graphics->resolution_width = width;
+    graphics->resolution_height = height;
+  }
 
   render_data->window = SDL_CreateWindow("MegaZeux",
    SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height,

--- a/src/render_sdl.h
+++ b/src/render_sdl.h
@@ -45,8 +45,9 @@ struct sdl_render_data
 
 extern CORE_LIBSPEC Uint32 sdl_window_id;
 
-int sdl_flags(int depth, boolean fullscreen, boolean resize);
-
+int sdl_flags(int depth, boolean fullscreen, boolean fullscreen_windowed,
+ boolean resize);
+void sdl_get_native_resolution(int *width, int *height);
 void sdl_destruct_window(struct graphics_data *graphics);
 
 boolean sdl_set_video_mode(struct graphics_data *graphics, int width,
@@ -59,8 +60,15 @@ boolean sdl_check_video_mode(struct graphics_data *graphics, int width,
 
 #include "render_gl.h"
 
-#define GL_STRIP_FLAGS(A) \
-  ((A & (SDL_WINDOW_FULLSCREEN | SDL_WINDOW_RESIZABLE)) | SDL_WINDOW_OPENGL)
+#if SDL_VERSION_ATLEAST(2,0,0)
+#define GL_ALLOW_FLAGS \
+ (SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP | \
+  SDL_WINDOW_BORDERLESS | SDL_WINDOW_RESIZABLE)
+#else
+#define GL_ALLOW_FLAGS (SDL_WINDOW_FULLSCREEN | SDL_WINDOW_RESIZABLE)
+#endif
+
+#define GL_STRIP_FLAGS(A) ((A & GL_ALLOW_FLAGS) | SDL_WINDOW_OPENGL)
 
 boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
  int depth, boolean fullscreen, boolean resize, struct gl_version req_ver);

--- a/src/render_sdl.h
+++ b/src/render_sdl.h
@@ -47,7 +47,7 @@ extern CORE_LIBSPEC Uint32 sdl_window_id;
 
 int sdl_flags(int depth, boolean fullscreen, boolean fullscreen_windowed,
  boolean resize);
-void sdl_get_native_resolution(int *width, int *height);
+boolean sdl_get_fullscreen_resolution(int *width, int *height, boolean scaling);
 void sdl_destruct_window(struct graphics_data *graphics);
 
 boolean sdl_set_video_mode(struct graphics_data *graphics, int width,

--- a/src/render_softscale.c
+++ b/src/render_softscale.c
@@ -309,7 +309,7 @@ static boolean softscale_set_video_mode(struct graphics_data *graphics,
  int width, int height, int depth, boolean fullscreen, boolean resize)
 {
   struct softscale_render_data *render_data = graphics->render_data;
-  boolean fullscreen_window = graphics->fullscreen_windowed;
+  boolean fullscreen_windowed = graphics->fullscreen_windowed;
 
   sdl_destruct_window(graphics);
 
@@ -319,12 +319,12 @@ static boolean softscale_set_video_mode(struct graphics_data *graphics,
   else
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "1");
 
-  if(fullscreen && fullscreen_window)
+  if(fullscreen && fullscreen_windowed)
     sdl_get_native_resolution(&width, &height);
 
   render_data->sdl.window = SDL_CreateWindow("MegaZeux",
    SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height,
-   sdl_flags(depth, fullscreen, fullscreen_window, resize));
+   sdl_flags(depth, fullscreen, fullscreen_windowed, resize));
 
   if(!render_data->sdl.window)
   {

--- a/src/render_softscale.c
+++ b/src/render_softscale.c
@@ -320,7 +320,13 @@ static boolean softscale_set_video_mode(struct graphics_data *graphics,
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "1");
 
   if(fullscreen && fullscreen_windowed)
-    sdl_get_native_resolution(&width, &height);
+  {
+    if(sdl_get_fullscreen_resolution(&width, &height, true))
+    {
+      graphics->resolution_width = width;
+      graphics->resolution_height = height;
+    }
+  }
 
   render_data->sdl.window = SDL_CreateWindow("MegaZeux",
    SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height,

--- a/src/render_softscale.c
+++ b/src/render_softscale.c
@@ -319,15 +319,6 @@ static boolean softscale_set_video_mode(struct graphics_data *graphics,
   else
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "1");
 
-  if(fullscreen && fullscreen_windowed)
-  {
-    if(sdl_get_fullscreen_resolution(&width, &height, true))
-    {
-      graphics->resolution_width = width;
-      graphics->resolution_height = height;
-    }
-  }
-
   render_data->sdl.window = SDL_CreateWindow("MegaZeux",
    SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height,
    sdl_flags(depth, fullscreen, fullscreen_windowed, resize));

--- a/src/render_softscale.c
+++ b/src/render_softscale.c
@@ -309,6 +309,7 @@ static boolean softscale_set_video_mode(struct graphics_data *graphics,
  int width, int height, int depth, boolean fullscreen, boolean resize)
 {
   struct softscale_render_data *render_data = graphics->render_data;
+  boolean fullscreen_window = graphics->fullscreen_windowed;
 
   sdl_destruct_window(graphics);
 
@@ -318,9 +319,12 @@ static boolean softscale_set_video_mode(struct graphics_data *graphics,
   else
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "1");
 
+  if(fullscreen && fullscreen_window)
+    sdl_get_native_resolution(&width, &height);
+
   render_data->sdl.window = SDL_CreateWindow("MegaZeux",
    SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height,
-   sdl_flags(depth, fullscreen, resize));
+   sdl_flags(depth, fullscreen, fullscreen_window, resize));
 
   if(!render_data->sdl.window)
   {

--- a/src/render_yuv.c
+++ b/src/render_yuv.c
@@ -55,7 +55,7 @@ static boolean yuv_set_video_mode_size(struct graphics_data *graphics,
 
   // the YUV renderer _requires_ 32bit colour
   render_data->sdl.screen = SDL_SetVideoMode(width, height, 32,
-   sdl_flags(depth, fullscreen, resize) | SDL_ANYFORMAT);
+   sdl_flags(depth, fullscreen, false, resize) | SDL_ANYFORMAT);
 
   if(!render_data->sdl.screen)
     goto err_free;
@@ -152,7 +152,7 @@ static boolean yuv_check_video_mode(struct graphics_data *graphics,
  int width, int height, int depth, boolean fullscreen, boolean resize)
 {
   return SDL_VideoModeOK(width, height, 32,
-   sdl_flags(depth, fullscreen, resize) | SDL_ANYFORMAT);
+   sdl_flags(depth, fullscreen, false, resize) | SDL_ANYFORMAT);
 }
 
 static void yuv_update_colors(struct graphics_data *graphics,


### PR DESCRIPTION
This adds a config option to make fullscreen mode a borderless window the size of the current desktop, which should be very useful for people who use multiple monitors or who hate fullscreen messing up their other windows. Only works for SDL 2.0 right now.

- [x] ~~SDL 1.2?~~ getting the desktop resolution was added in SDL 2.
- [x] ~~`SDL_WINDOW_OPENGL` windows will use normal fullscreen until focus is lost, at which point they'll switch to windowed fullscreen until they regain focus. This switch happens faster than a regular switch out of fullscreen but will still e.g. cover up the Alt+Tab popup in Windows.~~ Not fixing.
- [x] ~~`SDL_WINDOW_OPENGL` windows also seem to not center correctly in my 1280x960 Windows XP virtual machine when windowed fullscreen is enabled.~~ Fixed this issue for windowed fullscreen and regular fullscreen by getting the current display resolution by default and properly storing it.