### PR TITLE
Add support for mapping joysticks to key names

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -523,6 +523,8 @@
 # and one POV hat. Axes/buttons/hats are mapped to keys using a number
 # corresponding to the a given key. This number is the same as the
 # KEY_PRESSED value for that key (see keycodes.html or mzx_help.html).
+# For convenience, "key_X" can be provided in place of a key number
+# (without the quotes), where X is the name of the key.
 
 # The option to map a joystick axis is
 

--- a/config.txt
+++ b/config.txt
@@ -505,6 +505,10 @@
 
 # Joystick options
 
+# NOTE: As of MZX 2.92, it is not recommended to bind joystick controls
+# to keys directly. See the sections about joystick actions and SDL 2.0
+# gamecontroller support below.
+
 # It is possible to emulate key presses using a joystick. This can be
 # achieved with the following config options globally or (for options
 # starting with "joyX" only) on a per-game basis. To configure joysticks
@@ -610,7 +614,7 @@
 # joyX.act_Y = A
 
 # where X is the number of the joystick, Y is the name of the joystick action
-# (e.g. "shoot"), and A is the number of the key to assign to that action.
+# (e.g. "shoot"), and A is the number (or name) of the key to assign.
 
 # For platforms MegaZeux supports via SDL 2, joystick mapping can be automated
 # for the numerous controllers recognized by SDL 2. This means that, if your

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -16,6 +16,8 @@ FEATURES
   and the functions they perform can be found in the config
   file. The NDS, 3DS, Wii, PSP, and GP2X pad.config files have
   been updated to use joystick actions.
++ Joystick inputs can also be bound to key names now in the
+  format of "key_X" (without quotes), where X is the key name.
 + Added automatic joystick mapping for Windows/Mac/Linux/etc.
   Joysticks recognized as SDL game controllers are automatically
   assigned joystick actions when detected. This behavior can be

--- a/docs/keycodes.html
+++ b/docs/keycodes.html
@@ -160,7 +160,32 @@
     color: #A5A;
    }
 
-   div:before
+   /* Config file key name */
+   table.keyboard td span.keyname
+   {
+    display: none;
+    position: absolute;
+    left: -4px;
+    bottom: -20px;
+    background-color: #444;
+    color: white;
+    font-family: monospace;
+    text-align: center;
+    padding: 3px 5px;
+    border-radius: 5px;
+   }
+   table.keyboard td span.keyname.rhs
+   {
+    left: auto;
+    right: -6px;
+   }
+   table.keyboard td:hover span.keyname
+   {
+    display: inline-block;
+    z-index: 1;
+   }
+
+   div:before, b:before, p:before
    {
     font-size: 60%;
     position: absolute;
@@ -296,30 +321,34 @@
       NumL.
       <b class="badkey">n/a</b>
       <p class="badkey">n/a</p>
+      <span class="keyname">key_numlock</span>
      </div>
     </td>
 
     <td>
      <div class="warn">
       /
-      <b>53</p>
+      <b>53</b>
       <p>267</p>
+      <span class="keyname">key_kp_divide</span>
      </div>
     </td>
 
     <td>
      <div class="warn">
       *
-      <b>55</p>
+      <b>55</b>
       <p>268</p>
+      <span class="keyname rhs">key_kp_multiply</span>
      </div>
     </td>
 
     <td>
      <div class="warn">
       -
-      <b>74</p>
+      <b>74</b>
       <p>269</p>
+      <span class="keyname rhs">key_kp_minus</span>
      </div>
     </td>
 
@@ -331,6 +360,7 @@
       7<sup> Home</sup>
       <b>71</b>
       <p>263</p>
+      <span class="keyname">key_kp7</span>
      </div>
     </td>
 
@@ -339,6 +369,7 @@
        8<sup> &#x25b2;</sup>
       <b>72</b>
       <p>264</p>
+      <span class="keyname">key_kp8</span>
      </div>
     </td>
 
@@ -347,6 +378,7 @@
       9<sup> PgUp</sup>
       <b>73</b>
       <p>265</p>
+      <span class="keyname">key_kp9</span>
      </div>
     </td>
 
@@ -355,6 +387,7 @@
       +
       <b>78</b>
       <p>270</p>
+      <span class="keyname rhs">key_kp_plus</span>
      </div>
     </td>
 
@@ -366,6 +399,7 @@
        4<sup> &#x25c0;</sup>
       <b>75</b>
       <p>260</p>
+      <span class="keyname">key_kp4</span>
      </div>
     </td>
 
@@ -374,6 +408,7 @@
       5
       <b>76</b>
       <p>261</p>
+      <span class="keyname">key_kp5</span>
      </div>
     </td>
 
@@ -382,6 +417,7 @@
        6<sup> &#x25b6;</sup>
       <b>77</b>
       <p>262</p>
+      <span class="keyname">key_kp6</span>
      </div>
     </td>
 
@@ -393,6 +429,7 @@
       1<sup> End</sup>
       <b>79</b>
       <p>257</p>
+      <span class="keyname">key_kp1</span>
      </div>
     </td>
 
@@ -401,6 +438,7 @@
        2<sup> &#x25bc;</sup>
       <b>80</b>
       <p>258</p>
+      <span class="keyname">key_kp2</span>
      </div>
     </td>
 
@@ -409,6 +447,7 @@
       3<sup> PgDn</sup>
       <b>81</b>
       <p>259</p>
+      <span class="keyname">key_kp3</span>
      </div>
     </td>
 
@@ -417,6 +456,7 @@
       Enter
       <b>28</b>
       <p>271</p>
+      <span class="keyname rhs">key_kp_enter</span>
      </div>
     </td>
 
@@ -428,6 +468,7 @@
       0<sup> Insert</sup>
       <b>82</b>
       <p>256</p>
+      <span class="keyname">key_kp0</span>
      </div>
     </td>
 
@@ -436,6 +477,7 @@
       .<sup>Delete</sup>
       <b>83</b>
       <p>266</p>
+      <span class="keyname">key_kp_period</span>
      </div>
     </td>
 
@@ -456,6 +498,7 @@
       SysRq
       <b class="badkey">n/a</b>
       <p class="badkey">1</p>
+      <span class="keyname">key_sysreq</span>
      </div>
     </td>
 
@@ -464,6 +507,7 @@
       Scr.L.
       <b>70</b>
       <p>302</p>
+      <span class="keyname">key_scrolllock</span>
      </div>
     </td>
 
@@ -472,6 +516,7 @@
       Break
       <b>197</b>
       <p>318</p>
+      <span class="keyname">key_break</span>
      </div>
     </td>
 
@@ -487,6 +532,7 @@
       Insert
       <b>82</b>
       <p>277</p>
+      <span class="keyname">key_insert</span>
      </div>
     </td>
 
@@ -495,6 +541,7 @@
       Home
       <b>71</b>
       <p>278</p>
+      <span class="keyname">key_home</span>
      </div>
     </td>
 
@@ -503,6 +550,7 @@
       PgUp
       <b>73</b>
       <p>280</p>
+      <span class="keyname">key_pageup</span>
      </div>
     </td>
 
@@ -516,6 +564,7 @@
       Delete
       <b>83</b>
       <p>127</p>
+      <span class="keyname">key_delete</span>
      </div>
     </td>
 
@@ -524,6 +573,7 @@
       End
       <b>79</b>
       <p>279</p>
+      <span class="keyname">key_end</span>
      </div>
     </td>
 
@@ -532,6 +582,7 @@
       PgDn
       <b>81</b>
       <p>281</p>
+      <span class="keyname">key_pagedown</span>
      </div>
     </td>
 
@@ -561,6 +612,7 @@
       &#x25b2;
       <b>72</b>
       <p>273</p>
+      <span class="keyname">key_up</span>
      </div>
     </td>
 
@@ -578,6 +630,7 @@
       &#x25c0;
       <b>75</b>
       <p>276</p>
+      <span class="keyname">key_left</span>
      </div>
     </td>
 
@@ -587,6 +640,7 @@
       &#x25bc;
       <b>80</b>
       <p>274</p>
+      <span class="keyname">key_down</span>
      </div>
     </td>
 
@@ -596,6 +650,7 @@
       &#x25b6;
       <b>77</b>
       <p>275</p>
+      <span class="keyname">key_right</span>
      </div>
     </td>
 
@@ -620,6 +675,7 @@
       Esc
       <b>1</b>
       <p>27</p>
+      <span class="keyname">key_escape</span>
      </div>
     </td>
 
@@ -631,6 +687,7 @@
       F1
       <b>59</b>
       <p>282</p>
+      <span class="keyname">key_f1</span>
      </div>
     </td>
 
@@ -639,6 +696,7 @@
       F2
       <b>60</b>
       <p>283</p>
+      <span class="keyname">key_f2</span>
      </div>
     </td>
 
@@ -647,6 +705,7 @@
       F3
       <b>61</b>
       <p>284</p>
+      <span class="keyname">key_f3</span>
      </div>
     </td>
 
@@ -655,6 +714,7 @@
       F4
       <b>62</b>
       <p>285</p>
+      <span class="keyname">key_f4</span>
      </div>
     </td>
 
@@ -666,6 +726,7 @@
       F5
       <b>63</b>
       <p>286</p>
+      <span class="keyname">key_f5</span>
      </div>
     </td>
 
@@ -674,6 +735,7 @@
       F6
       <b>64</b>
       <p>287</p>
+      <span class="keyname">key_f6</span>
      </div>
     </td>
 
@@ -682,6 +744,7 @@
       F7
       <b>65</b>
       <p>288</p>
+      <span class="keyname">key_f7</span>
      </div>
     </td>
 
@@ -690,6 +753,7 @@
       F8
       <b>66</b>
       <p>289</p>
+      <span class="keyname">key_f8</span>
      </div>
     </td>
 
@@ -701,6 +765,7 @@
       F9
       <b>67</b>
       <p>290</p>
+      <span class="keyname">key_f9</span>
      </div>
     </td>
 
@@ -709,6 +774,7 @@
       F10
       <b>68</b>
       <p>291</p>
+      <span class="keyname">key_f10</span>
      </div>
     </td>
 
@@ -717,6 +783,7 @@
       F11
       <b>87</b>
       <p>292</p>
+      <span class="keyname">key_f11</span>
      </div>
     </td>
 
@@ -725,6 +792,7 @@
       F12
       <b>88</b>
       <p>293</p>
+      <span class="keyname">key_f12</span>
      </div>
     </td>
 
@@ -742,6 +810,7 @@
       `
       <b>41</b>
       <p>96</p>
+      <span class="keyname">key_backquote</span>
      </div>
     </td>
 
@@ -750,6 +819,7 @@
       1
       <b>2</b>
       <p>49</p>
+      <span class="keyname">key_1</span>
      </div>
     </td>
 
@@ -758,6 +828,7 @@
       2
       <b>3</b>
       <p>50</p>
+      <span class="keyname">key_2</span>
      </div>
     </td>
 
@@ -766,6 +837,7 @@
       3
       <b>4</b>
       <p>51</p>
+      <span class="keyname">key_3</span>
      </div>
     </td>
 
@@ -774,6 +846,7 @@
       4
       <b>5</b>
       <p>52</p>
+      <span class="keyname">key_4</span>
      </div>
     </td>
 
@@ -782,6 +855,7 @@
       5
       <b>6</b>
       <p>53</p>
+      <span class="keyname">key_5</span>
      </div>
     </td>
 
@@ -790,6 +864,7 @@
       6
       <b>7</b>
       <p>54</p>
+      <span class="keyname">key_6</span>
      </div>
     </td>
 
@@ -798,6 +873,7 @@
       7
       <b>8</b>
       <p>55</p>
+      <span class="keyname">key_7</span>
      </div>
     </td>
 
@@ -806,6 +882,7 @@
       8
       <b>9</b>
       <p>56</p>
+      <span class="keyname">key_8</span>
      </div>
     </td>
 
@@ -814,6 +891,7 @@
       9
       <b>10</b>
       <p>57</p>
+      <span class="keyname">key_9</span>
      </div>
     </td>
 
@@ -822,6 +900,7 @@
       0
       <b>11</b>
       <p>48</p>
+      <span class="keyname">key_0</span>
      </div>
     </td>
 
@@ -830,6 +909,7 @@
       -
       <b>12</b>
       <p>45</p>
+      <span class="keyname">key_minus</span>
      </div>
     </td>
 
@@ -838,6 +918,7 @@
       =
       <b>13</b>
       <p>61</p>
+      <span class="keyname">key_equals</span>
      </div>
     </td>
 
@@ -846,6 +927,7 @@
       BackSp.
       <b>14</b>
       <p>8</p>
+      <span class="keyname">key_backspace</span>
      </div>
     </td>
 
@@ -861,6 +943,7 @@
       Tab
       <b>15</b>
       <p>9</p>
+      <span class="keyname">key_tab</span>
      </div>
     </td>
 
@@ -869,6 +952,7 @@
       Q
       <b>16</b>
       <p>113</p>
+      <span class="keyname">key_q</span>
      </div>
     </td>
 
@@ -877,6 +961,7 @@
       W
       <b>17</b>
       <p>119</p>
+      <span class="keyname">key_w</span>
      </div>
     </td>
 
@@ -885,6 +970,7 @@
       E
       <b>18</b>
       <p>101</p>
+      <span class="keyname">key_e</span>
      </div>
     </td>
 
@@ -893,6 +979,7 @@
       R
       <b>19</b>
       <p>114</p>
+      <span class="keyname">key_r</span>
      </div>
     </td>
 
@@ -901,6 +988,7 @@
       T
       <b>20</b>
       <p>116</p>
+      <span class="keyname">key_t</span>
      </div>
     </td>
 
@@ -909,6 +997,7 @@
       Y
       <b>21</b>
       <p>121</p>
+      <span class="keyname">key_y</span>
      </div>
     </td>
 
@@ -917,6 +1006,7 @@
       U
       <b>22</b>
       <p>117</p>
+      <span class="keyname">key_u</span>
      </div>
     </td>
 
@@ -925,6 +1015,7 @@
       I
       <b>23</b>
       <p>105</p>
+      <span class="keyname">key_i</span>
      </div>
     </td>
 
@@ -933,6 +1024,7 @@
       O
       <b>24</b>
       <p>111</p>
+      <span class="keyname">key_o</span>
      </div>
     </td>
 
@@ -941,6 +1033,7 @@
       P
       <b>25</b>
       <p>112</p>
+      <span class="keyname">key_p</span>
      </div>
     </td>
 
@@ -949,6 +1042,7 @@
       [
       <b>26</b>
       <p>91</p>
+      <span class="keyname">key_leftbracket</span>
      </div>
     </td>
 
@@ -957,6 +1051,7 @@
       ]
       <b>27</b>
       <p>93</p>
+      <span class="keyname">key_rightbracket</span>
      </div>
     </td>
 
@@ -965,6 +1060,7 @@
       \
       <b>43</b>
       <p>92</p>
+      <span class="keyname">key_backslash</span>
      </div>
     </td>
 
@@ -980,6 +1076,7 @@
       <span id="capslocktext"></span>
       <b>58</b>
       <p>301</p>
+      <span class="keyname">key_capslock</span>
      </div>
     </td>
 
@@ -988,6 +1085,7 @@
       A
       <b>30</b>
       <p>97</p>
+      <span class="keyname">key_a</span>
      </div>
     </td>
 
@@ -996,6 +1094,7 @@
       S
       <b>31</b>
       <p>115</p>
+      <span class="keyname">key_s</span>
      </div>
     </td>
 
@@ -1004,6 +1103,7 @@
       D
       <b>32</b>
       <p>100</p>
+      <span class="keyname">key_d</span>
      </div>
     </td>
 
@@ -1012,6 +1112,7 @@
       F
       <b>33</b>
       <p>102</p>
+      <span class="keyname">key_f</span>
      </div>
     </td>
 
@@ -1020,6 +1121,7 @@
       G
       <b>34</b>
       <p>103</p>
+      <span class="keyname">key_g</span>
      </div>
     </td>
 
@@ -1028,6 +1130,7 @@
       H
       <b>35</b>
       <p>104</p>
+      <span class="keyname">key_h</span>
      </div>
     </td>
 
@@ -1036,6 +1139,7 @@
       J
       <b>36</b>
       <p>106</p>
+      <span class="keyname">key_j</span>
      </div>
     </td>
 
@@ -1044,6 +1148,7 @@
       K
       <b>37</b>
       <p>107</p>
+      <span class="keyname">key_k</span>
      </div>
     </td>
 
@@ -1052,6 +1157,7 @@
       L
       <b>38</b>
       <p>108</p>
+      <span class="keyname">key_l</span>
      </div>
     </td>
 
@@ -1060,6 +1166,7 @@
       ;
       <b>39</b>
       <p>59</p>
+      <span class="keyname">key_semicolon</span>
      </div>
     </td>
 
@@ -1068,6 +1175,7 @@
       '
       <b>40</b>
       <p>39</p>
+      <span class="keyname">key_quote</span>
      </div>
     </td>
 
@@ -1076,6 +1184,7 @@
       Enter
       <b>28</b>
       <p>13</p>
+      <span class="keyname">key_return</span>
      </div>
     </td>
 
@@ -1091,6 +1200,7 @@
       L.&nbsp;Shift
       <b>42</b>
       <p>304</p>
+      <span class="keyname">key_lshift</span>
      </div>
     </td>
 
@@ -1099,6 +1209,7 @@
       Z
       <b>44</b>
       <p>122</p>
+      <span class="keyname">key_z</span>
      </div>
     </td>
 
@@ -1107,6 +1218,7 @@
       X
       <b>45</b>
       <p>120</p>
+      <span class="keyname">key_x</span>
      </div>
     </td>
 
@@ -1115,6 +1227,7 @@
       C
       <b>46</b>
       <p>99</p>
+      <span class="keyname">key_c</span>
      </div>
     </td>
 
@@ -1123,6 +1236,7 @@
       V
       <b>47</b>
       <p>118</p>
+      <span class="keyname">key_v</span>
      </div>
     </td>
 
@@ -1131,6 +1245,7 @@
       B
       <b>48</b>
       <p>98</p>
+      <span class="keyname">key_b</span>
      </div>
     </td>
 
@@ -1139,6 +1254,7 @@
       N
       <b>49</b>
       <p>110</p>
+      <span class="keyname">key_n</span>
      </div>
     </td>
 
@@ -1147,6 +1263,7 @@
       M
       <b>50</b>
       <p>109</p>
+      <span class="keyname">key_m</span>
      </div>
     </td>
 
@@ -1155,6 +1272,7 @@
       ,
       <b>51</b>
       <p>44</p>
+      <span class="keyname">key_comma</span>
      </div>
     </td>
 
@@ -1163,6 +1281,7 @@
       .
       <b>52</b>
       <p>46</p>
+      <span class="keyname">key_period</span>
      </div>
     </td>
 
@@ -1171,6 +1290,7 @@
       /
       <b>53</b>
       <p>47</p>
+      <span class="keyname">key_slash</span>
      </div>
     </td>
 
@@ -1179,6 +1299,7 @@
       R.&nbsp;Shift
       <b>54</b>
       <p>303</p>
+      <span class="keyname">key_rshift</span>
      </div>
     </td>
 
@@ -1194,6 +1315,7 @@
       L.&nbsp;Ctrl
       <b>29</b>
       <p>306</p>
+      <span class="keyname">key_lctrl</span>
      </div>
     </td>
 
@@ -1202,6 +1324,7 @@
       L.&nbsp;Win
       <b>91</b>
       <p>311</p>
+      <span class="keyname">key_lsuper</span>
      </div>
     </td>
 
@@ -1210,6 +1333,7 @@
       L.&nbsp;Alt
       <b>56</b>
       <p>308</p>
+      <span class="keyname">key_lalt</span>
      </div>
     </td>
 
@@ -1217,6 +1341,7 @@
       Space
       <b>57</b>
       <p>32</p>
+      <span class="keyname">key_space</span>
      </div>
     </td>
 
@@ -1225,6 +1350,7 @@
       R.&nbsp;Alt
       <b>56</b>
       <p>307</p>
+      <span class="keyname">key_ralt</span>
      </div>
     </td>
 
@@ -1233,6 +1359,7 @@
       R.&nbsp;Win
       <b>92</b>
       <p>312</p>
+      <span class="keyname">key_rsuper</span>
      </div>
     </td>
 
@@ -1241,6 +1368,7 @@
       R.&nbsp;Click
       <b class="badkey">n/a</b>
       <p class="badkey">1</p>
+      <span class="keyname">key_menu</span>
      </div>
     </td>
 
@@ -1249,6 +1377,7 @@
       R.&nbsp;Ctrl
       <b>29</b>
       <p>305</p>
+      <span class="keyname">key_rctrl</span>
      </div>
     </td>
 
@@ -1272,8 +1401,13 @@
     <td class="spacebar">
      <div class="none">
       Key:
-      <b>key_code / key(n)</b>
-      <p>key_pressed</p>
+      <b>key_code / key(n) <span style="font-size: 75%">[PC XT]</span></b>
+      <p>key_pressed <span style="font-size: 75%">[internal]</span></p>
+      <i style="display: block; text-align: center">(hover: config file key name)</i>
+      <span class="keyname">
+       Key names can be used instead of key_pressed numbers in the config file.
+       To get the config file name for a key, hover over it.
+      </span>
      </div>
     </td>
     <td class="space">

--- a/src/configure.c
+++ b/src/configure.c
@@ -508,8 +508,8 @@ static void joy_action_set(struct config_info *conf, char *name,
  char *value, char *extended_data)
 {
   unsigned int joy_num;
-  unsigned int key;
   char joy_action[16];
+  char key[16];
   int read = 0;
 
   if(sscanf(name, "joy%u." JOY_ENUM "%n", &joy_num, joy_action, &read) != 2
@@ -517,7 +517,7 @@ static void joy_action_set(struct config_info *conf, char *name,
     return;
 
   read = 0;
-  if(sscanf(value, "%u%n", &key, &read) != 1 || (value[read] != 0))
+  if(sscanf(value, JOY_ENUM "%n", key, &read) != 1 || (value[read] != 0))
     return;
 
   // Right now do a global binding at startup and a game binding otherwise.

--- a/src/event.c
+++ b/src/event.c
@@ -1276,9 +1276,9 @@ static enum joystick_action find_joystick_action(const char *name)
 }
 
 /**
- * A joystick can be mapped to either an int from 0 to 32767 (a key binding)
- * or to a joystick enum string (action binding). Read either from an input
- * value string.
+ * A joystick can be mapped to either an int from 0 to 32767 (a key binding),
+ * a key enum string (also a key binding), or to a joystick action enum string
+ * (action binding). Read either from an input value string.
  */
 boolean joystick_parse_map_value(const char *value, Sint16 *binding)
 {
@@ -1426,26 +1426,30 @@ void joystick_map_hat(int joystick, const char *up, const char *down,
 
 /**
  * Map a generic action to a key. The input action should be null-terminated.
+ * Only allow key bindings; if value resolves to an action, it is ignored.
  */
-void joystick_map_action(int joystick, const char *action, int value,
+void joystick_map_action(int joystick, const char *action, const char *value,
  boolean is_global)
 {
-  if((joystick >= 0) && (joystick < MAX_JOYSTICKS) &&
-   (value >= 0) && (value <= SHRT_MAX))
+  if((joystick >= 0) && (joystick < MAX_JOYSTICKS))
   {
-    if(!strncmp(action, "act_", 4))
+    Sint16 binding;
+
+    if(!strncmp(action, "act_", 4) &&
+     joystick_parse_map_value(value, &binding) &&
+     binding > 0)
     {
       enum joystick_action action_value = find_joystick_action(action + 4);
 
       if(action_value)
       {
         /*debug("[JOYSTICK] (%s) %d.%s -> %d\n", is_global ? "G" : "L",
-         joystick, action, value);*/
+         joystick, action, binding);*/
 
         if(is_global)
-          input.joystick_global_map.action[joystick][action_value] = value;
+          input.joystick_global_map.action[joystick][action_value] = binding;
         else
-          input.joystick_game_map.action[joystick][action_value] = value;
+          input.joystick_game_map.action[joystick][action_value] = binding;
       }
     }
   }

--- a/src/event.c
+++ b/src/event.c
@@ -144,7 +144,7 @@ void init_event(void)
   // Config has already loaded, so there might be user mappings here already.
   for(i = 0; i < MAX_JOYSTICKS; i++)
     for(i2 = 0; i2 < NUM_JOYSTICK_ACTIONS; i2++)
-      if(input.joystick_global_map.action[i][i2] == 0)
+      if(!input.joystick_global_map.action_is_conf[i][i2])
         input.joystick_global_map.action[i][i2] =
          joystick_action_map_default[i2];
 
@@ -1437,7 +1437,7 @@ void joystick_map_action(int joystick, const char *action, const char *value,
 
     if(!strncmp(action, "act_", 4) &&
      joystick_parse_map_value(value, &binding) &&
-     binding > 0)
+     binding >= 0)
     {
       enum joystick_action action_value = find_joystick_action(action + 4);
 
@@ -1447,7 +1447,10 @@ void joystick_map_action(int joystick, const char *action, const char *value,
          joystick, action, binding);*/
 
         if(is_global)
+        {
           input.joystick_global_map.action[joystick][action_value] = binding;
+          input.joystick_global_map.action_is_conf[joystick][action_value] = true;
+        }
         else
           input.joystick_game_map.action[joystick][action_value] = binding;
       }

--- a/src/event.c
+++ b/src/event.c
@@ -1073,10 +1073,124 @@ boolean set_exit_status(boolean value)
   return exit_status;
 }
 
+struct keycode_name
+{
+  const char * const name;
+  const enum keycode value;
+};
+
 struct joystick_action_name
 {
   const char * const name;
   const enum joystick_action value;
+};
+
+static const struct keycode_name keycode_names[] =
+{
+  { "0",            IKEY_0 },
+  { "1",            IKEY_1 },
+  { "2",            IKEY_2 },
+  { "3",            IKEY_3 },
+  { "4",            IKEY_4 },
+  { "5",            IKEY_5 },
+  { "6",            IKEY_6 },
+  { "7",            IKEY_7 },
+  { "8",            IKEY_8 },
+  { "9",            IKEY_9 },
+  { "a",            IKEY_a },
+  { "b",            IKEY_b },
+  { "backquote",    IKEY_BACKQUOTE },
+  { "backslash",    IKEY_BACKSLASH },
+  { "backspace",    IKEY_BACKSPACE },
+  { "break",        IKEY_BREAK },
+  { "c",            IKEY_c },
+  { "capslock",     IKEY_CAPSLOCK },
+  { "comma",        IKEY_COMMA },
+  { "d",            IKEY_d },
+  { "delete",       IKEY_DELETE },
+  { "down",         IKEY_DOWN },
+  { "e",            IKEY_e },
+  { "end",          IKEY_END },
+  { "equals",       IKEY_EQUALS },
+  { "escape",       IKEY_ESCAPE },
+  { "f",            IKEY_f },
+  { "f1",           IKEY_F1 },
+  { "f10",          IKEY_F10 },
+  { "f11",          IKEY_F11 },
+  { "f12",          IKEY_F12 },
+  { "f2",           IKEY_F2 },
+  { "f3",           IKEY_F3 },
+  { "f4",           IKEY_F4 },
+  { "f5",           IKEY_F5 },
+  { "f6",           IKEY_F6 },
+  { "f7",           IKEY_F7 },
+  { "f8",           IKEY_F8 },
+  { "f9",           IKEY_F9 },
+  { "g",            IKEY_g },
+  { "h",            IKEY_h },
+  { "home",         IKEY_HOME },
+  { "i",            IKEY_i },
+  { "insert",       IKEY_INSERT },
+  { "j",            IKEY_j },
+  { "k",            IKEY_k },
+  { "kp0",          IKEY_KP0 },
+  { "kp1",          IKEY_KP1 },
+  { "kp2",          IKEY_KP2 },
+  { "kp3",          IKEY_KP3 },
+  { "kp4",          IKEY_KP4 },
+  { "kp5",          IKEY_KP5 },
+  { "kp6",          IKEY_KP6 },
+  { "kp7",          IKEY_KP7 },
+  { "kp8",          IKEY_KP8 },
+  { "kp9",          IKEY_KP9 },
+  { "kp_divide",    IKEY_KP_DIVIDE },
+  { "kp_enter",     IKEY_KP_ENTER },
+  { "kp_minus",     IKEY_KP_MINUS },
+  { "kp_multiply",  IKEY_KP_MULTIPLY },
+  { "kp_period",    IKEY_KP_PERIOD },
+  { "kp_plus",      IKEY_KP_PLUS },
+  { "l",            IKEY_l },
+  { "lalt",         IKEY_LALT },
+  { "lctrl",        IKEY_LCTRL },
+  { "left",         IKEY_LEFT },
+  { "leftbracket",  IKEY_LEFTBRACKET },
+  { "lshift",       IKEY_LSHIFT },
+  { "lsuper",       IKEY_LSUPER },
+  { "m",            IKEY_m },
+  { "menu",         IKEY_MENU },
+  { "minus",        IKEY_MINUS },
+  { "n",            IKEY_n },
+  { "numlock",      IKEY_NUMLOCK },
+  { "o",            IKEY_o },
+  { "p",            IKEY_p },
+  { "pagedown",     IKEY_PAGEDOWN },
+  { "pageup",       IKEY_PAGEUP },
+  { "period",       IKEY_PERIOD },
+  { "q",            IKEY_q },
+  { "quote",        IKEY_QUOTE },
+  { "r",            IKEY_r },
+  { "ralt",         IKEY_RALT },
+  { "rctrl",        IKEY_RCTRL },
+  { "return",       IKEY_RETURN },
+  { "right",        IKEY_RIGHT },
+  { "rightbracket", IKEY_RIGHTBRACKET },
+  { "rshift",       IKEY_RSHIFT },
+  { "rsuper",       IKEY_RSUPER },
+  { "s",            IKEY_s },
+  { "scrolllock",   IKEY_SCROLLOCK },
+  { "semicolon",    IKEY_SEMICOLON },
+  { "slash",        IKEY_SLASH },
+  { "space",        IKEY_SPACE },
+  { "sysreq",       IKEY_SYSREQ },
+  { "t",            IKEY_t },
+  { "tab",          IKEY_TAB },
+  { "u",            IKEY_u },
+  { "up",           IKEY_UP },
+  { "v",            IKEY_v },
+  { "w",            IKEY_w },
+  { "x",            IKEY_x },
+  { "y",            IKEY_y },
+  { "z",            IKEY_z },
 };
 
 static const struct joystick_action_name joystick_action_names[] =
@@ -1110,6 +1224,31 @@ static const struct joystick_action_name joystick_action_names[] =
   { "x",        JOY_X },
   { "y",        JOY_Y }
 };
+
+static enum keycode find_keycode(const char *name)
+{
+  int top = ARRAY_SIZE(keycode_names) - 1;
+  int bottom = 0;
+  int middle;
+  int cmpval;
+
+  while(bottom <= top)
+  {
+    middle = (bottom + top) / 2;
+    cmpval = strcasecmp(name, keycode_names[middle].name);
+
+    if(cmpval > 0)
+      bottom = middle + 1;
+    else
+
+    if(cmpval < 0)
+      top = middle - 1;
+
+    else
+      return keycode_names[middle].value;
+  }
+  return IKEY_UNKNOWN;
+}
 
 static enum joystick_action find_joystick_action(const char *name)
 {
@@ -1160,6 +1299,17 @@ boolean joystick_parse_map_value(const char *value, Sint16 *binding)
     if(action_value)
     {
       *binding = -((Sint16)action_value);
+      return true;
+    }
+  }
+  else
+
+  if(!strncmp(value, "key_", 4))
+  {
+    key_value = find_keycode(value + 4);
+    if(key_value)
+    {
+      *binding = key_value;
       return true;
     }
   }

--- a/src/event.h
+++ b/src/event.h
@@ -145,6 +145,7 @@ struct joystick_map
   boolean button_is_conf[MAX_JOYSTICKS][MAX_JOYSTICK_BUTTONS];
   boolean axis_is_conf[MAX_JOYSTICKS][MAX_JOYSTICK_AXES];
   boolean hat_is_conf[MAX_JOYSTICKS];
+  boolean action_is_conf[MAX_JOYSTICKS][NUM_JOYSTICK_ACTIONS];
 };
 
 struct input_status

--- a/src/event.h
+++ b/src/event.h
@@ -248,7 +248,7 @@ void joystick_map_axis(int joystick, int axis, const char *neg,
  const char *pos, boolean is_global);
 void joystick_map_hat(int joystick, const char *up, const char *down,
  const char *left, const char *right, boolean is_global);
-void joystick_map_action(int joystick, const char *action, int value,
+void joystick_map_action(int joystick, const char *action, const char *value,
  boolean is_global);
 void joystick_reset_game_map(void);
 void joystick_set_game_mode(boolean enable);


### PR DESCRIPTION
Allow mapping joystick values and joystick actions to keys by name instead of by value.

- [x] Set the key of a joystick control by key name
- [x] Set the key of a joystick action by key name
- [x] Set the default key of a gamecontroller control by key name
- [x] There needs to be some sort of documentation to this since there are a lot of keys and the names for some of them might not be obvious
- [x] Needs more testing