### PR TITLE
Remove WAV from list of mod extensions, add WAV filesize warnings

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -49,6 +49,8 @@ FEATURES
   It should perform significantly better and be more portable.
 - SDL 2 support for the overlay renderers has been removed. When
   specified for video_output, softscale will be enabled instead.
+- Removed WAV from the list of board mod extensions. Attempting
+  to bypass this or using large WAV files now prints a warning.
 
 FIXES
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -49,8 +49,7 @@ FEATURES
   It should perform significantly better and be more portable.
 - SDL 2 support for the overlay renderers has been removed. When
   specified for video_output, softscale will be enabled instead.
-- Removed WAV from the list of board mod extensions. Attempting
-  to bypass this or using large WAV files now prints a warning.
+- Removed WAV from the list of board mod extensions.
 
 FIXES
 

--- a/src/audio/audio_wav.c
+++ b/src/audio/audio_wav.c
@@ -37,6 +37,8 @@
 #endif
 
 // If the WAV/SAM is larger than this, print a warning to the console.
+// (Right now only do this for debug builds because a lot more games than
+// anticipated use big WAVs and it could get annoying for end users.)
 #define WARN_FILESIZE (1<<22)
 
 // WAV sample types
@@ -386,7 +388,7 @@ static int load_sam_file(const char *file, struct wav_info *spec,
   source_length = ftell_and_rewind(fp);
   if(source_length > WARN_FILESIZE)
   {
-    warn("Size of SAM file '%s' is %zu; OGG should be used instead.\n",
+    debug("Size of SAM file '%s' is %zu; OGG should be used instead.\n",
      file, source_length);
   }
 
@@ -446,7 +448,7 @@ static int load_wav_file(const char *file, struct wav_info *spec,
   if(file_size > WARN_FILESIZE)
   {
     debug("This WAV is too big sempai OwO;;;\n");
-    warn("Size of WAV file '%s' is %zu; OGG should be used instead.\n",
+    debug("Size of WAV file '%s' is %zu; OGG should be used instead.\n",
      file, file_size);
   }
 

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -88,9 +88,9 @@ static const char *const chr_ext[] = { ".CHR", NULL };
 static const char *const pal_ext[] = { ".PAL", NULL };
 static const char *const idx_ext[] = { ".PALIDX", NULL };
 static const char *const mod_ext[] =
-{ ".ogg", ".mod", ".s3m", ".xm", ".it", ".gdm",
-  ".669", ".amf", ".dsm", ".far", ".med",
-  ".mtm", ".okt", ".stm", ".ult", ".wav",
+{ ".ogg", ".mod", ".s3m", ".xm", ".it",
+  ".669", ".amf", ".dsm", ".far", ".gdm",
+  ".med", ".mtm", ".okt", ".stm", ".ult",
   NULL
 };
 static const char *const sam_ext[] =
@@ -2853,6 +2853,13 @@ static boolean editor_key(context *ctx, int *key)
             if(!choose_file(mzx_world, mod_ext, new_mod,
              "Choose a module file", 2)) // 2:subdirsonly
             {
+              const char *ext_pos = new_mod + strlen(new_mod) - 4;
+              if(ext_pos > new_mod && !strcmp(ext_pos, ".wav"))
+              {
+                error("Using OGG instead of WAV is recommended.",
+                 ERROR_T_WARNING, ERROR_OPT_OK, 0xc0c5);
+              }
+
               strcpy(cur_board->mod_playing, new_mod);
               strcpy(mzx_world->real_mod_playing, new_mod);
               fix_mod(editor);

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -2854,7 +2854,7 @@ static boolean editor_key(context *ctx, int *key)
              "Choose a module file", 2)) // 2:subdirsonly
             {
               const char *ext_pos = new_mod + strlen(new_mod) - 4;
-              if(ext_pos > new_mod && !strcmp(ext_pos, ".wav"))
+              if(ext_pos >= new_mod && !strcasecmp(ext_pos, ".WAV"))
               {
                 error("Using OGG instead of WAV is recommended.",
                  ERROR_T_WARNING, ERROR_OPT_OK, 0xc0c5);


### PR DESCRIPTION
This removes WAV from the list of extensions to display when selecting a board mod and adds some ~~warnings~~ debug messages when attempting to use SAM or WAV files over a sufficient size (currently 4MiB). This is meant to deter users from using massive WAV files instead of OGG. Some or all of this might not get merged.