### PR TITLE
Add checkres wildcard matching and verbose output, sorting, status options

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -57,6 +57,9 @@ FEATURES
   (default), only display created (-C), only display found (-F),
   also display missing (-m), also display created (-c), and also
   display found (-f).
++ checkres can now wildcard match resources from commands that
+  use expressions or interpolation in filenames. This can be
+  enabled with -w or enabled exclusively with -W.
 + checkres can now display unused resources in a path/zip after
   the other resources are listed (-u), or display only unused
   resources (-U).
@@ -68,7 +71,7 @@ FEATURES
 + checkres can now sort its output either by the name of the
   expected resource file (-N) (default) or by the location in
   the world the file was referenced (-L).
-+ checkres option flags can now be combined (e.g. -auL). This
++ checkres option flags can now be combined (e.g. -aL). This
   does not apply to the "-extra" and "-in" flags.
 - SDL 2 support for the overlay renderers has been removed. When
   specified for video_output, softscale will be enabled instead.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -49,13 +49,25 @@ FEATURES
   It should perform significantly better and be more portable.
 + checkres now displays the board, sfx, and robot (with line and
   position on the board) each file was referenced in.
++ checkres can now be used with a directory as the base file.
+  Like a ZIP archive, checkres will recursively search the
+  directory for .MZX/.MZB files and display information for all
+  of them.
++ checkres has more display options: only display missing (-M)
+  (default), only display created (-C), only display found (-F),
+  also display missing (-m), also display created (-c), and also
+  display found (-f).
++ checkres can now display unused resources in a path/zip after
+  the other resources are listed (-u), or display only unused
+  resources (-U).
 + checkres can now display every reference to a particular
-  resource in a world instead of just the first (-r) (default).
-  An option has been added to display only the first reference
-  as in older versions (-u).
+  resource in a world instead of just the first with varying
+  levels of information (-vvv (default), -vv, -v). The option
+  -v is equivalent to older versions of checkres. Added -1 as
+  an alternate flag for -q.
 + checkres can now sort its output either by the name of the
-  expected resource file (-F) or by the location in the world
-  the file was referenced (-W) (default).
+  expected resource file (-N) (default) or by the location in
+  the world the file was referenced (-L).
 + checkres option flags can now be combined (e.g. -auL). This
   does not apply to the "-extra" and "-in" flags.
 - SDL 2 support for the overlay renderers has been removed. When

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -47,6 +47,17 @@ FEATURES
 + Added the 'softscale' renderer. This renderer is a generalized
   rewrite of the former SDL 2 overlay renderer implementation.
   It should perform significantly better and be more portable.
++ checkres now displays the board, sfx, and robot (with line and
+  position on the board) each file was referenced in.
++ checkres can now display every reference to a particular
+  resource in a world instead of just the first (-r) (default).
+  An option has been added to display only the first reference
+  as in older versions (-u).
++ checkres can now sort its output either by the name of the
+  expected resource file (-F) or by the location in the world
+  the file was referenced (-W) (default).
++ checkres option flags can now be combined (e.g. -auL). This
+  does not apply to the "-extra" and "-in" flags.
 - SDL 2 support for the overlay renderers has been removed. When
   specified for video_output, softscale will be enabled instead.
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -65,9 +65,9 @@ FEATURES
   resources (-U).
 + checkres can now display every reference to a particular
   resource in a world instead of just the first with varying
-  levels of information (-vvv (default), -vv, -v). The option
-  -v is equivalent to older versions of checkres. Added -1 as
-  an alternate flag for -q.
+  levels of information (-v, -vv). Added the option -s, which
+  is the default and equivalent to older versions of checkres,
+  and -1 as an alternate flag for -q.
 + checkres can now sort its output either by the name of the
   expected resource file (-N) (default) or by the location in
   the world the file was referenced (-L).

--- a/src/utils/checkres.c
+++ b/src/utils/checkres.c
@@ -21,7 +21,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "../config.h"
+
 #define USAGE \
+ "checkres (MegaZeux " VERSION ")\n" \
  "Usage: checkres [options] " \
  "mzx/mzb/dir/zip file [-extra path/zip file [-in relative path] ...] ... \n" \
  "\n" \
@@ -55,10 +58,10 @@
  " -u   Also display unused files.\n"                                       \
  " -w   Also display wildcard-matched files.\n"                             \
  "\nDetail options:\n" \
- " -vvv Display all references with all information (default).\n"           \
- " -vv  Display all references with board# and robot#.\n"                   \
- " -v   Display unique expected filenames, status, source, and world.\n"    \
- " -1   Display unique expected filenames, one per line, no other info.\n"  \
+ " -s   Summary: unique filenames, status, source, world file (default).\n" \
+ " -v   Display all references with sfx#, board#, robot#.\n"                \
+ " -vv  Display all references with sfx#, board#, robot#, line#, coords.\n" \
+ " -1   Display unique filenames, one per line, with no other info.\n"      \
  "\nSorting options:\n" \
  " -N   Sort by referenced filename, then by location (default).\n"         \
  " -L   Sort by location of reference: world, board#, robot#.\n"            \
@@ -132,9 +135,9 @@ static boolean display_wildcard = false;
 
 // Detail options
 static boolean display_filename_only = false;
-static boolean display_first_only = false;
-static boolean display_details = true;
-static boolean display_all_details = true;
+static boolean display_first_only = true;
+static boolean display_details = false;
+static boolean display_all_details = false;
 
 static enum
 {
@@ -2936,29 +2939,26 @@ int main(int argc, char *argv[])
             display_wildcard = true;
             break;
 
+          case 's':
+            display_filename_only = false;
+            display_first_only = true;
+            display_details = false;
+            display_all_details = false;
+            break;
+
           case 'v':
           {
             if(param[1] == 'v')
             {
-              if(param[2] == 'v')
-              {
-                display_all_details = true;
-                param++;
-              }
-              else
-                display_all_details = false;
-
-              display_details = true;
-              display_first_only = false;
+              display_all_details = true;
               param++;
             }
             else
-            {
-              display_details = false;
-              display_first_only = true;
-            }
+              display_all_details = false;
 
             display_filename_only = false;
+            display_first_only = false;
+            display_details = true;
             break;
           }
 
@@ -2966,6 +2966,8 @@ int main(int argc, char *argv[])
           case 'q': // Legacy equivalent of -1
             display_first_only = true;
             display_filename_only = true;
+            display_details = false;
+            display_all_details = false;
             break;
 
           case 'L':

--- a/src/utils/checkres.c
+++ b/src/utils/checkres.c
@@ -281,10 +281,7 @@ static boolean is_simple_path(char *src, boolean allow_expressions)
       {
         if(isdigit(*tpos)) continue;
         if(*tpos == '.' || *tpos == '\0')
-        {
-          info("wildcard me pls: %s\n", src);
           return false;
-        }
       }
     }
   }
@@ -354,7 +351,6 @@ static boolean get_wildcard_path(char dest[MAX_PATH], char *src)
     {
       // Truncated DOS filename--replace ~### with wildcard
       size_t backup = i;
-      info("ty\n");
       if(i + 1 < len && isdigit(src[i + 1]))
       {
         while(i + 1 < len && isdigit(src[i + 1])) i++;

--- a/src/utils/checkres.c
+++ b/src/utils/checkres.c
@@ -1147,7 +1147,7 @@ static void process_requirements(struct base_path **path_list,
           });
 
           // See: note above.
-          if(!display_unused && !display_wildcard)
+          if(found && !display_unused && !display_wildcard)
             break;
 
           continue;

--- a/src/utils/checkres.c
+++ b/src/utils/checkres.c
@@ -179,6 +179,8 @@ static const char *decode_status(enum status status)
 {
   switch(status)
   {
+    case INVALID_ARGUMENTS:
+      return "Invalid file or argument provided.";
     case CORRUPT_WORLD:
       return "World corruption or truncation detected.";
     case FOPEN_FAILED:
@@ -1058,7 +1060,7 @@ struct base_file_list_data
 static void base_file_found_fn(void *data, const char *name, size_t name_len)
 {
   struct base_file_list_data *d = (struct base_file_list_data *)data;
-  const char *ext = name_len > 4 ? name + name_len - 4 : NULL;
+  const char *ext = name_len >= 4 ? name + name_len - 4 : NULL;
 
   if(ext && (!strcasecmp(ext, ".MZX") || !strcasecmp(ext, ".MZB")))
   {
@@ -1316,7 +1318,7 @@ static void process_requirements(struct base_path **path_list,
 
             // Don't print "unused" MZX/MZB files.
             len = strlen(file_path);
-            if(len > 4 &&
+            if(len >= 4 &&
              (!strcasecmp(file_path + len - 4, ".MZX") ||
               !strcasecmp(file_path + len - 4, ".MZB")))
               continue;
@@ -2572,7 +2574,7 @@ static enum status parse_file(const char *file_name,
 
   fp = fopen_unsafe(file_name, "rb");
   len = strlen(file_name);
-  ext = len > 4 ? (char *)file_name + len - 4 : NULL;
+  ext = len >= 4 ? (char *)file_name + len - 4 : NULL;
 
   _get_path(file_dir, file_name);
 
@@ -2727,7 +2729,7 @@ static enum status parse_file(const char *file_name,
 
       fp = fopen_unsafe(name_buffer, "rb");
       len = strlen(current_file->file_name);
-      ext = len > 4 ? current_file->file_name + len - 4 : NULL;
+      ext = len >= 4 ? current_file->file_name + len - 4 : NULL;
       if(fp)
       {
         // NOTE: the relative paths of these are automatically added in

--- a/src/utils/checkres.c
+++ b/src/utils/checkres.c
@@ -28,11 +28,10 @@
  " -h   Display this message and exit.\n"                                   \
  "\nStatus options:\n" \
  " -a   Display all found, created, missing, and unused files.\n"           \
- " -A   Display missing files and files that may be created only.\n"        \
- " -C   Display created files only.\n"                                      \
- " -F   Display found files only.\n"                                        \
- " -M   Display missing files only (default).\n"                            \
- " -U   Display unused files only.\n"                                       \
+ " -C   Only display created files.\n"                                      \
+ " -F   Only display found files.\n"                                        \
+ " -M   Only display missing files (default).\n"                            \
+ " -U   Only display unused files.\n"                                       \
  " -c   Also display created files.\n"                                      \
  " -f   Also display found files.\n"                                        \
  " -m   Also display missing files.\n"                                      \
@@ -935,11 +934,12 @@ static void process_requirements(struct base_path **path_list,
           {
             const char *file_path = bpf_sorted[k]->file_path;
 
-            // Don't print "unused" MZX/MZB files.
+            // Don't print "unused" MZX/MZB files or directories.
             size_t len = strlen(file_path);
             if(len > 4 &&
              (!strcasecmp(file_path + len - 4, ".MZX") ||
-              !strcasecmp(file_path + len - 4, ".MZB")))
+              !strcasecmp(file_path + len - 4, ".MZB") ||
+              file_path[len - 1] == '/'))
               continue;
 
             output("", DONT_PRINT, -1, -1, bpf_sorted[k]->file_path,
@@ -2298,7 +2298,7 @@ int main(int argc, char *argv[])
             fprintf(stderr, USAGE);
             return SUCCESS;
 
-          case 'A':
+          case 'A': // Legacy equivalent of -Mc
             display_not_found = true;
             display_found = false;
             display_created = true;
@@ -2383,7 +2383,7 @@ int main(int argc, char *argv[])
           }
 
           case '1':
-          case 'q':
+          case 'q': // Legacy equivalent of -1
             display_first_only = true;
             display_filename_only = true;
             break;

--- a/src/utils/checkres.c
+++ b/src/utils/checkres.c
@@ -24,7 +24,7 @@
 #include "../config.h"
 
 #define USAGE \
- "checkres (MegaZeux " VERSION ")\n" \
+ "checkres :: MegaZeux " VERSION VERSION_DATE "\n" \
  "Usage: checkres [options] " \
  "mzx/mzb/dir/zip file [-extra path/zip file [-in relative path] ...] ... \n" \
  "\n" \

--- a/src/utils/checkres.c
+++ b/src/utils/checkres.c
@@ -291,7 +291,7 @@ static boolean is_simple_path(char *src, boolean allow_expressions)
   return true;
 }
 
-static boolean get_wildcard_path(char dest[MAX_PATH], char *src)
+static boolean get_wildcard_path(char dest[MAX_PATH], const char *src)
 {
   size_t len = strlen(src);
   size_t i;
@@ -310,7 +310,7 @@ static boolean get_wildcard_path(char dest[MAX_PATH], char *src)
   {
     if(src[i] == '&' && src[i+1] != '&')
     {
-      char s = src[i + 1];
+      size_t start = i + 1;
       while(i < len)
       {
         i++;
@@ -322,7 +322,12 @@ static boolean get_wildcard_path(char dest[MAX_PATH], char *src)
         return false;
 
       // String (assume interpolation for now)
-      if(s == '$')
+      if(src[start] == '$')
+        dest[j++] = '*';
+
+      // Special: INPUT is also a string when interpolated.
+      else
+      if(!strncasecmp(src + start, "INPUT", strlen("INPUT")))
         dest[j++] = '*';
 
       // Counter

--- a/src/zip.c
+++ b/src/zip.c
@@ -210,12 +210,9 @@ static int zip_uncompress(char *dest, uint32_t *destLen, const char *src,
   int err;
 
   // Following uncompr.c from zlib pretty closely here...
+  memset(&stream, 0, sizeof(z_stream));
   stream.next_in = (Bytef *) src;
   stream.avail_in = (uInt) *srcLen;
-
-  stream.zalloc = (alloc_func)0;
-  stream.zfree = (free_func)0;
-  stream.opaque = (voidpf)0;
 
   /* The reason we can't just use uncompress() is because there's no way
    * to assign the number of window bits with it, and uncompress() expects
@@ -245,9 +242,7 @@ static int zip_compress(char **dest, uint32_t *destLen, const char *src,
   int _destLen;
   int err;
 
-  stream.zalloc = (alloc_func)0;
-  stream.zfree = (free_func)0;
-  stream.opaque = (voidpf)0;
+  memset(&stream, 0, sizeof(z_stream));
 
   /* The reason we can't just use compress() is because there's no way
    * to assign the number of window bits with it, and compress() expects
@@ -288,12 +283,9 @@ int zip_bound_data_usage(char *src, int srcLen)
   z_stream stream;
   int bound;
 
+  memset(&stream, 0, sizeof(z_stream));
   stream.next_in = (Bytef *) src;
   stream.avail_in = (uInt) srcLen;
-
-  stream.zalloc = (alloc_func)0;
-  stream.zfree = (free_func)0;
-  stream.opaque = (voidpf)0;
 
   // Note: aside from the windowbits, these are all defaults
   deflateInit2(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, -MAX_WBITS,


### PR DESCRIPTION
Adds some long-needed improvements to checkres:

* checkres can now be given a directory as a base file, which it will search for .MZX/.MZB files and report on as a whole.
* checkres now displays the board #, robot # (with line and x/y position on the board), or sfx # of the reference to a particular file.
* checkres now has a flag to display missing files only (`-M`). This is still the default option, but previously it couldn't be selected after selecting one of the other status options before.
* Other new flags: display created files only (`-C`), display found files only (`-F`), display unused files only (`-U`), also display created files (`-c`), also display found files (`-f`), also display missing files (`-m`), also display unused files (`-u`).
* checkres now has flags to control the uniqueness of each referenced resource printed: `-vvv` displays every reference to every resource with all available world info (now the default), `-vv` displays the same but only with board/sfx/robot number info, `-v` displays only one line per referenced resource (the default in older checkres builds), and `-1` displays only the filename of every referenced resource once, separated by newlines (this already existed before as `-q`).
* checkres now has flags to control the sorting of the printed resources (instead of printing them unordered, as before): `-L` sorts the resources by location (world filename, sfx/board number, robot number, line number, resource filename). `-N` sorts the resources by resource name, then by location (default)
* checkres now allows single character option flags to be combined into one flag, e.g. `-auF`.

Example output of `checkres.exe DE_Game.zip -extra DE_Sound.zip`:
```
Required by    B#    R#    Line     Position      Expected file   Status     Found in
-----------    ---   ---   ------   -----------   -------------   ------     --------
DE_START.MZX   b18   r3    10       2, 0          lightng2.sam    NOT FOUND
DE_START.MZX   b18   r3    14       2, 0          lightng2.sam    NOT FOUND
DE_START.MZX   b18   r3    18       2, 0          lightng2.sam    NOT FOUND
DE_START.MZX   b18   r3    22       2, 0          lightng2.sam    NOT FOUND
DE_MAIN.MZX    b9    r1    10       27, 10        room2.mzm       NOT FOUND
DE_MAIN.MZX    b9    r1    65       27, 10        room2.mzm       NOT FOUND

Finished processing 'DE_Game.zip'.
```

TODO
- [x] Probably make `-N` default instead of `-L`, it seems more useful after using the new options some more.
- [x] Unused files.
- [x] Directory searching.
- [x] Wildcard references.
- [x] More testing.