### PR TITLE
Add config flags for AddressSanitizer/MemorySanitizer/ThreadSanitizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,9 +181,11 @@ ifeq (${DEBUG},1)
 ifeq (${SANITIZER},address)
 DEBUG_CFLAGS := -fsanitize=address -O1 -fno-omit-frame-pointer
 else ifeq (${SANITIZER},thread)
-DEBUG_CFLAGS := -fsanitize=thread -O2 -fno-omit-frame-pointer -fPIE -pie
+DEBUG_CFLAGS := -fsanitize=thread -O2 -fno-omit-frame-pointer -fPIE
+ARCH_EXE_LDFLAGS += -pie
 else ifeq (${SANITIZER},memory)
-DEBUG_CFLAGS := -fsanitize=memory -O1 -fno-omit-frame-pointer -fPIE -pie
+DEBUG_CFLAGS := -fsanitize=memory -O1 -fno-omit-frame-pointer -fPIE
+ARCH_EXE_LDFLAGS += -pie
 else
 DEBUG_CFLAGS ?= -O0
 endif

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,11 @@ else ifeq (${SANITIZER},thread)
 DEBUG_CFLAGS := -fsanitize=thread -O2 -fno-omit-frame-pointer -fPIE
 ARCH_EXE_LDFLAGS += -pie
 else ifeq (${SANITIZER},memory)
-DEBUG_CFLAGS := -fsanitize=memory -O1 -fno-omit-frame-pointer -fPIE
+# FIXME I don't think there's a way to make this one work properly right now.
+# SDL_Init generates an error immediately and if sanitize-recover is used it
+# seems to get stuck printing endless errors.
+DEBUG_CFLAGS := -fsanitize=memory -O1 -fno-omit-frame-pointer -fPIE \
+ -fsanitize-recover=memory -fsanitize-memory-track-origins
 ARCH_EXE_LDFLAGS += -pie
 else
 DEBUG_CFLAGS ?= -O0

--- a/config.sh
+++ b/config.sh
@@ -41,6 +41,9 @@ usage() {
 	echo "  --enable-release        Optimize and remove debugging code."
 	echo "  --enable-verbose        Build system is always verbose (V=1)."
 	echo "  --optimize-size         Perform size optimizations (-Os)."
+	echo "  --enable-asan           Enable AddressSanitizer for debug builds"
+	echo "  --enable-msan           Enable MemorySanitizer for debug builds"
+	echo "  --enable-tsan           Enable ThreadSanitizer for debug builds"
 	echo "  --disable-datestamp     Disable adding date to version."
 	echo "  --disable-editor        Disable the built-in editor."
 	echo "  --disable-mzxrun        Disable generation of separate MZXRun."
@@ -112,6 +115,7 @@ DATE_STAMP="true"
 AS_NEEDED="false"
 RELEASE="false"
 OPT_SIZE="false"
+SANITIZER="false"
 EDITOR="true"
 MZXRUN="true"
 HELPSYS="true"
@@ -224,6 +228,15 @@ while [ "$1" != "" ]; do
 
 	[ "$1" = "--optimize-size" ]  && OPT_SIZE="true"
 	[ "$1" = "--optimize-speed" ] && OPT_SIZE="false"
+
+	[ "$1" = "--enable-asan" ]  && SANITIZER="address"
+	[ "$1" = "--disable-asan" ] && SANITIZER="false"
+
+	[ "$1" = "--enable-msan" ]  && SANITIZER="memory"
+	[ "$1" = "--disable-msan" ] && SANITIZER="false"
+
+	[ "$1" = "--enable-tsan" ] &&  SANITIZER="thread"
+	[ "$1" = "--disable-tsan" ] && SANITIZER="false"
 
 	[ "$1" = "--disable-datestamp" ] && DATE_STAMP="false"
 	[ "$1" = "--enable-datestamp" ]  && DATE_STAMP="true"
@@ -865,6 +878,11 @@ if [ "$RELEASE" = "true" ]; then
 else
 	echo "Disabling optimization, debug enabled."
 	echo "DEBUG=1" >> platform.inc
+
+	if [ "$SANITIZER" != "false" ]; then
+		echo "Enabling $SANITIZER sanitizer (may enable some optimizations)"
+		echo "SANITIZER=$SANITIZER" >> platform.inc
+	fi
 fi
 
 #

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -101,6 +101,8 @@ DEVELOPERS
 + Added debug build sanitizer options for AddressSanitizer,
   MemorySanitizer, and ThreadSanitizer. MemorySanitizer requires
   clang and all currently require Linux/BSD/Mac OS X/similar.
+  Support for all three is very experimental; they may require
+  disabling options like modular builds or may not work at all.
 - Removed uthash as a build option.
 
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -98,6 +98,9 @@ DEVELOPERS
   opengl2 and glsl. This provides a tiny performance improvement
   on most cards and a massive performance improvement on some
   other cards. (Lancer-X)
++ Added debug build sanitizer options for AddressSanitizer,
+  MemorySanitizer, and ThreadSanitizer. MemorySanitizer requires
+  clang and all currently require Linux/BSD/Mac OS X/similar.
 - Removed uthash as a build option.
 
 


### PR DESCRIPTION
Adds config flags to build with some sanitizers. These add runtime instrumentation code to check for invalid memory use/leaks/race conditions/uninitialized memory use/etc. and currently require Linux, FreeBSD, or Mac OS X to use. MemorySanitizer additionally requires clang.