### PR TITLE
Add config option to start MZX in test mode

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -696,6 +696,16 @@
 
 # system_mouse = 0
 
+# Set to 1 to start MZX in testing mode, exactly as if Alt+T was pressed in
+# the editor. MegaZeux will exit after gameplay ends. This is intended to be
+# used with the command line or exec(), and only works with the "megazeux"
+# executable. Testing will start in the world's first board; a different
+# board can be chosen by setting the second option to a valid board number.
+
+# test_mode = 0
+# test_mode_start_board = 0
+
+
 ###################
 # NETWORK OPTIONS #
 ###################

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -73,6 +73,12 @@ FEATURES
   the world the file was referenced (-L).
 + checkres option flags can now be combined (e.g. -aL). This
   does not apply to the "-extra" and "-in" flags.
++ New config options: "test_mode" and "test_mode_start_board".
+  If "test_mode" is set to 1, MegaZeux will start the given file
+  in testing mode, exactly as if the user used Alt+T on the
+  first board from the editor. Setting "test_mode_start_board"
+  to a valid board number in the world will start instead from
+  that board. Exiting testing will exit MegaZeux entirely.
 - SDL 2 support for the overlay renderers has been removed. When
   specified for video_output, softscale will be enabled instead.
 - Removed WAV from the list of board mod extensions.

--- a/src/configure.c
+++ b/src/configure.c
@@ -192,6 +192,8 @@ static const struct config_info user_conf_default =
   false,                        // system_mouse
 
   // Editor options
+  false,                        // test_mode
+  NO_BOARD,                     // test_mode_start_board
   true,                         // mask_midchars
 
 #ifdef CONFIG_NETWORK
@@ -757,6 +759,22 @@ static void config_max_simultaneous_samples(struct config_info *conf,
   conf->max_simultaneous_samples = v;
 }
 
+static void config_test_mode(struct config_info *conf,
+ char *name, char *value, char *extended_data)
+{
+  // FIXME sloppy validation
+  unsigned long test_mode = strtoul(value, NULL, 10);
+  conf->test_mode = !!test_mode;
+}
+
+static void config_test_mode_start_board(struct config_info *conf,
+ char *name, char *value, char *extended_data)
+{
+  // FIXME sloppy validation
+  unsigned long start_board = MIN(strtoul(value, NULL, 10), MAX_BOARDS-1);
+  conf->test_mode_start_board = start_board;
+}
+
 /* NOTE: This is searched as a binary tree, the nodes must be
  *       sorted alphabetically, or they risk being ignored.
  */
@@ -816,6 +834,8 @@ static const struct config_entry config_options[] =
   { "startup_file", config_startup_file, false },
   { "startup_path", config_startup_path, false },
   { "system_mouse", config_system_mouse, false },
+  { "test_mode", config_test_mode, false },
+  { "test_mode_start_board", config_test_mode_start_board, false },
 #ifdef CONFIG_UPDATER
   { "update_auto_check", config_update_auto_check, false },
   { "update_branch_pin", config_update_branch_pin, false },

--- a/src/configure.h
+++ b/src/configure.h
@@ -90,6 +90,8 @@ struct config_info
   boolean system_mouse;
 
   // Editor options
+  boolean test_mode;
+  unsigned char test_mode_start_board;
   // TODO: two places outside of the editor currently require access to this.
   boolean mask_midchars;
 

--- a/src/game.c
+++ b/src/game.c
@@ -200,9 +200,11 @@ static inline void load_vquick_fadeout(void)
 /**
  * Load a world and prepare it for gameplay.
  * On failure, make sure the title's fade setting is restored (if applicable).
+ * If the provided start board parameter is a valid board in the loaded world,
+ * gameplay will start on the given board.
  */
-
-static boolean load_world_gameplay(struct game_context *game, char *name)
+static boolean load_world_gameplay_ext(struct game_context *game, char *name,
+ int start_board)
 {
   struct world *mzx_world = ((context *)game)->world;
   boolean was_faded = get_fade_status();
@@ -222,10 +224,14 @@ static boolean load_world_gameplay(struct game_context *game, char *name)
 
   if(reload_world(mzx_world, name, &ignore))
   {
-    if(mzx_world->current_board_id != mzx_world->first_board)
+    if((start_board < 0) || (start_board >= mzx_world->num_boards) ||
+     !(mzx_world->board_list[start_board]))
     {
-      change_board(mzx_world, mzx_world->first_board);
+      start_board = mzx_world->first_board;
     }
+
+    if(mzx_world->current_board_id != start_board)
+      change_board(mzx_world, start_board);
 
     cur_board = mzx_world->current_board;
 
@@ -250,6 +256,15 @@ static boolean load_world_gameplay(struct game_context *game, char *name)
     game->fade_in = false;
 
   return false;
+}
+
+/**
+ * Load a world and prepare it for gameplay.
+ * On failure, make sure the title's fade setting is restored (if applicable).
+ */
+static boolean load_world_gameplay(struct game_context *game, char *name)
+{
+  return load_world_gameplay_ext(game, name, -1);
 }
 
 /**
@@ -1071,19 +1086,29 @@ void title_screen(context *parent)
 {
   struct config_info *conf = get_config();
   struct game_context *title;
+  struct game_context tmp;
   struct context_spec spec;
+
+  tmp.ctx.world = parent->world;
 
   if(edit_world)
   {
     conf->standalone_mode = false;
+
+    if(conf->test_mode)
+    {
+      if(load_world_gameplay_ext(&tmp, curr_file, conf->test_mode_start_board))
+      {
+        parent->world->editing = true;
+        play_game(parent, NULL);
+      }
+      return;
+    }
   }
 
   if(conf->standalone_mode && conf->no_titlescreen)
   {
-    struct game_context dummy;
-    dummy.ctx.world = parent->world;
-
-    if(load_world_gameplay(&dummy, curr_file))
+    if(load_world_gameplay(&tmp, curr_file))
     {
       play_game(parent, NULL);
       return;


### PR DESCRIPTION
This adds a [config option to start MegaZeux in test mode](https://www.digitalmzx.net/forums/index.php?app=tracker&showissue=769), as if the user pressed Alt+T in the editor. As with normal testing, all debug features are available, but exiting testing will exit MZX. This only works with the "megazeux" executable specifically. A second config option allows the user to specify a particular start board.

Example:
```megazeux caverns.mzx test_mode=1 test_mode_start_board=20```

This tests Caverns of Zeux starting from the Golden Warrior board.