### PR TITLE
Various Emscripten frontend fixes

### DIFF
--- a/arch/emscripten/web/src/index.js
+++ b/arch/emscripten/web/src/index.js
@@ -74,7 +74,11 @@ window.MzxrunInitShortcuts = function() {
                 || key == 'R' // Rename file/directory
             ))
             || key == 'F1'  // Help
-            || key == 'F3'  // Save/Load World
+            || key == 'F2'  // Settings
+            || key == 'F3'  // Save, Load World
+            || key == 'F4'  // Load save
+            || key == 'F9'  // Quicksave
+            || key == 'F10' // Quickload Save
 
         ) event.preventDefault()
     })

--- a/arch/emscripten/web/src/index.js
+++ b/arch/emscripten/web/src/index.js
@@ -61,6 +61,25 @@ class LoadingScreen {
     }
 }
 
+window.MzxrunInitShortcuts = function() {
+    /* Disable the default functions for several common MegaZeux shortcuts.
+     * FIXME: Opera defaults for left alt and F3 can't be disabled this way (as of 63).
+     */
+    document.body.addEventListener('keydown', event => {
+        let key = event.key.toUpperCase();
+        if ((event.altKey && (
+                   key == 'C' // Select char
+                || key == 'D' // Delete file/directory
+                || key == 'N' // New directory
+                || key == 'R' // Rename file/directory
+            ))
+            || key == 'F1'  // Help
+            || key == 'F3'  // Save/Load World
+
+        ) event.preventDefault()
+    })
+}
+
 window.MzxrunInitialize = function(options) {
     console.log("Initializing MegaZeux web frontend");
 
@@ -76,6 +95,8 @@ window.MzxrunInitialize = function(options) {
         drawErrorMessage(canvas, ctx, 'Error: WebGL context lost!');
         e.preventDefault();
     }, false);
+
+    MzxrunInitShortcuts();
 
     try {
         if (!options.path) throw "Missing option: path!";

--- a/arch/emscripten/web/src/index.js
+++ b/arch/emscripten/web/src/index.js
@@ -61,7 +61,22 @@ class LoadingScreen {
     }
 }
 
-window.MzxrunInitShortcuts = function() {
+window.MzxrunInitialize = function(options) {
+    console.log("Initializing MegaZeux web frontend");
+
+    if (!options.render) throw "Missing option: render!";
+    if (!options.render.canvas) throw "Missing option: render.canvas!";
+
+    let canvas = options.render.canvas;
+    canvas.contentEditable = true;
+    let ctx = canvas.getContext('2d', {alpha: false});
+    ctx.imageSmoothingEnabled = false;
+
+    canvas.addEventListener("webglcontextlost", e => {
+        drawErrorMessage(canvas, ctx, 'Error: WebGL context lost!');
+        e.preventDefault();
+    }, false);
+
     /* Disable the default functions for several common MegaZeux shortcuts.
      * FIXME: Opera defaults for left alt and F3 can't be disabled this way (as of 63).
      */
@@ -82,25 +97,6 @@ window.MzxrunInitShortcuts = function() {
 
         ) event.preventDefault()
     })
-}
-
-window.MzxrunInitialize = function(options) {
-    console.log("Initializing MegaZeux web frontend");
-
-    if (!options.render) throw "Missing option: render!";
-    if (!options.render.canvas) throw "Missing option: render.canvas!";
-
-    let canvas = options.render.canvas;
-    canvas.contentEditable = true;
-    let ctx = canvas.getContext('2d', {alpha: false});
-    ctx.imageSmoothingEnabled = false;
-
-    canvas.addEventListener("webglcontextlost", e => {
-        drawErrorMessage(canvas, ctx, 'Error: WebGL context lost!');
-        e.preventDefault();
-    }, false);
-
-    MzxrunInitShortcuts();
 
     try {
         if (!options.path) throw "Missing option: path!";

--- a/arch/emscripten/web/src/storage.js
+++ b/arch/emscripten/web/src/storage.js
@@ -60,6 +60,12 @@ class InMemoryStorage {
 		this.map[key] = value;
 		return true;
 	}
+
+	remove(key) {
+		if (this.readonly) return false;
+		delete this.map[key];
+		return true;
+	}
 }
 
 class CompositeStorage {
@@ -105,6 +111,15 @@ class CompositeStorage {
 		}
 		return false;
 	}
+
+	remove(key) {
+		let promise = Promise.resolve(false); // FIXME not sure this is even necessary.
+		for (var p = this.providers.length - 1; p >= 0; p--) {
+			let provider = this.providers[p];
+			if (provider.remove(key)) return true;
+		}
+		return false;
+	}
 }
 
 class AsyncStorageWrapper extends InMemoryStorage {
@@ -139,6 +154,15 @@ class AsyncStorageWrapper extends InMemoryStorage {
 			return false;
 		}
 	}
+
+	remove(key) {
+		if (super.remove(key)) {
+			this.parent.remove(key);
+			return true;
+		} else {
+			return false;
+		}
+	}
 }
 
 class BrowserBackedStorage {
@@ -153,7 +177,7 @@ class BrowserBackedStorage {
 
 	get(key) {
 		const result = this.storage.getItem(this.prefix + key);
-		if (result) {
+		if (result !== null) {
 			return result.split(",").map(s => parseInt(s));
 		} else {
 			return null;
@@ -173,6 +197,11 @@ class BrowserBackedStorage {
 
 	set(key, value) {
 		this.storage.setItem(this.prefix + key, value.join(","));
+		return true;
+	}
+
+	remove(key) {
+		this.storage.removeItem(this.prefix + key);
 		return true;
 	}
 }
@@ -239,6 +268,19 @@ class IndexedDbBackedAsyncStorage {
 				"filename": key,
 				"value": value
 			});
+			request.onsuccess = event => {
+				resolve(true);
+			}
+			request.onerror = event => {
+				resolve(false);
+			}
+		});
+	}
+
+	remove(key) {
+		const transaction = this.database.transaction(["files"], "readwrite");
+		return new Promise((resolve, reject) => {
+			const request = transaction.objectStore("files").delete(key);
 			request.onsuccess = event => {
 				resolve(true);
 			}

--- a/arch/emscripten/web/src/storage.js
+++ b/arch/emscripten/web/src/storage.js
@@ -104,7 +104,6 @@ class CompositeStorage {
 	}
 
 	set(key, value) {
-		let promise = Promise.resolve(false);
 		for (var p = this.providers.length - 1; p >= 0; p--) {
 			let provider = this.providers[p];
 			if (provider.set(key, value)) return true;
@@ -113,7 +112,6 @@ class CompositeStorage {
 	}
 
 	remove(key) {
-		let promise = Promise.resolve(false); // FIXME not sure this is even necessary.
 		for (var p = this.providers.length - 1; p >= 0; p--) {
 			let provider = this.providers[p];
 			if (provider.remove(key)) return true;

--- a/arch/emscripten/web/src/storage_emscripten.js
+++ b/arch/emscripten/web/src/storage_emscripten.js
@@ -113,20 +113,14 @@ export function wrapStorageForEmscripten(vfs) {
                 if (attr.size !== undefined) {
                     // Used to implement O_TRUNC by the Emscripten FS API.
                     // console.log("FS setattr size " + n.vfs_path + " " + attr.size);
-
-                    if (attr.size) {
-                        // Note: not sure this can ever be reached from the FS API...
-                        let old_data = vfs.get(n.vfs_path);
-                        if (!old_data)
-                            throw new FS.ErrnoError(ENOENT);
-
-                        let new_data = new Uint8Array(attr.size).set(old_data);
-                        if (!vfs.set(n.vfs_path, new_data))
-                            throw new FS.ErrnoError(EPERM);
-                    } else {
-                        if (!vfs.set(n.vfs_path, new Uint8Array(0)))
-                            throw new FS.ErrnoError(EPERM);
+                    let old_data = vfs.get(n.vfs_path);
+                    let new_data = new Uint8Array(attr.size);
+                    if (attr.size > 0 && old_data) {
+                        // Note: not sure sizes > 0 will reach here from the FS API...
+                        new_data.set(old_data.slice(0, attr.size));
                     }
+                    if (!vfs.set(n.vfs_path, new_data))
+                        throw new FS.ErrnoError(EPERM);
                 }
             }
 

--- a/arch/emscripten/web/src/storage_emscripten.js
+++ b/arch/emscripten/web/src/storage_emscripten.js
@@ -166,9 +166,6 @@ export function wrapStorageForEmscripten(vfs) {
                 };
                 node.node_ops.unlink = (parent, name) => {
                     // console.log("FS unlink " + name);
-                    let file = vfs.get(node.vfs_path + name);
-                    if (!file)
-                        throw new FS.ErrnoError(ENOENT);
                     if (!vfs.remove(node.vfs_path + name))
                         throw new FS.ErrnoError(EPERM);
                 };

--- a/arch/emscripten/web/src/storage_emscripten.js
+++ b/arch/emscripten/web/src/storage_emscripten.js
@@ -40,15 +40,15 @@ function vfs_get_type(vfs, path) {
     return "empty";
 }
 
-function next_power_of_two(n) {
-    var i = 1;
+function vfs_next_power_of_two(n) {
+    var i = 4096;
     while (i < n) i *= 2;
     return i;
 }
 
 function vfs_expand_array(array, newLength) {
     if (newLength <= array.length) return array;
-    newLength = next_power_of_two(newLength);
+    newLength = vfs_next_power_of_two(newLength);
 
     var newArrayBuffer = new ArrayBuffer(newLength);
     var newArray = new Uint8Array(newArrayBuffer);


### PR DESCRIPTION
This fixes various issues with the Emscripten port's frontend blocking the release of HTML5 builds.

- [x] [Prevent browsers from blocking certain useful MZX shortcuts](https://www.digitalmzx.net/forums/index.php?app=tracker&showissue=790) (tested and works in Firefox and Chrome; Opera won't disable F3 or left alt behavior).
- [x] [Fix save corruption bug caused by not handling `O_TRUNC`](https://www.digitalmzx.net/forums/index.php?app=tracker&showissue=789) (tested with memory, localStorage, and IndexedDB). Overwriting save files with a new save file would fail to wipe the data after the end of the file, causing MZX to detect a corrupt ZIP.
- [x] Fix issues with creating new files when using localStorage. Empty files would get converted to the empty string when entering localStorage. Empty strings evaluate to `false`, so some checks would fail to detect the existence of the empty file when retrieving it later. This seems to have been a problem even before this branch but the `O_TRUNC` fix made it worse.
- [x] Fix performance issues encountered with writing particularly large files by expanding the underlying data buffer to powers of two and tracking the real file length separately. This issue could be encountered when saving in DOOMZX and with the autosaves in Depot Dungeons.
- [x] Implement `unlink`. It seems to work fine but could be tested more.
- [x] Implement `rmdir`. Same as above.

Would be nice, but probably won't bother with:

* Implement `rename`. For now it just prints a console error instead of crashing MZX. Prevented by FS API nightmare code
* Fix mkdir. This uses `mknod` which intentionally fails for directories currently. The `createNode` function also ignores the incoming mode and errors when creating a directory. It'd be nice to create directories even if they aren't stored, but I'm not sure it's worth the effort and potentially breaking something right now.