### PR TITLE
[WIP] Player structure array + initial multiplayer support

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -874,7 +874,7 @@ fi
 #
 # Force disable networking (no applications enabled)
 #
-if [ "$NETWORK" = "true" -a "$UPDATER" = "false" -a "$MULTIPLAYER" = "false" ]; then
+if [ "$NETWORK" = "true" -a "$UPDATER" = "false" ]; then
 	echo "Force-disabling networking (no network-dependent features enabled)."
 	NETWORK="false"
 fi

--- a/config.sh
+++ b/config.sh
@@ -82,6 +82,7 @@ usage() {
 	echo "  --disable-check-alloc   Disables memory allocator error handling."
 	echo "  --disable-khash         Disables using khash for counter/string lookups."
 	echo "  --enable-debytecode     Enable experimental 'debytecode' transform."
+	echo "  --enable-multiplayer    Enable experimental multiplayer support."
 	echo "  --disable-libsdl2       Disable SDL 2.0 support (falls back on 1.2)."
 	echo "  --enable-stdio-redirect Redirect console output to stdout.txt/stderr.txt."
 	echo "  --enable-fps            Enable frames-per-second counter."
@@ -154,6 +155,7 @@ GLES="false"
 CHECK_ALLOC="true"
 KHASH="true"
 DEBYTECODE="false"
+MULTIPLAYER="false"
 LIBSDL2="true"
 STDIO_REDIRECT="false"
 GAMECONTROLLERDB="true"
@@ -357,6 +359,9 @@ while [ "$1" != "" ]; do
 
 	[ "$1" = "--enable-debytecode" ]  && DEBYTECODE="true"
 	[ "$1" = "--disable-debytecode" ] && DEBYTECODE="false"
+
+	[ "$1" = "--enable-multiplayer" ]  && MULTIPLAYER="true"
+	[ "$1" = "--disable-multiplayer" ] && MULTIPLAYER="false"
 
 	[ "$1" = "--enable-libsdl2" ]  && LIBSDL2="true"
 	[ "$1" = "--disable-libsdl2" ] && LIBSDL2="false"
@@ -869,7 +874,7 @@ fi
 #
 # Force disable networking (no applications enabled)
 #
-if [ "$NETWORK" = "true" -a "$UPDATER" = "false" ]; then
+if [ "$NETWORK" = "true" -a "$UPDATER" = "false" -a "$MULTIPLAYER" = "false" ]; then
 	echo "Force-disabling networking (no network-dependent features enabled)."
 	NETWORK="false"
 fi
@@ -1344,6 +1349,17 @@ if [ "$DEBYTECODE" = "true" ]; then
 	echo "BUILD_DEBYTECODE=1" >> platform.inc
 else
 	echo "Experimental 'debytecode' transform disabled."
+fi
+
+#
+# Experimental multiplayer, if enabled
+#
+if [ "$MULTIPLAYER" = "true" ]; then
+	echo "Experimental multiplayer enabled."
+	echo "#define CONFIG_MULTIPLAYER" >> src/config.h
+	echo "BUILD_MULTIPLAYER=1" >> platform.inc
+else
+	echo "Experimental multiplayer disabled."
 fi
 
 #

--- a/docs/multiplayer_support.txt
+++ b/docs/multiplayer_support.txt
@@ -1,0 +1,122 @@
+Multiplayer support
+
+This version of MegaZeux may have limited support for native multiplayer. If you used default settings to build this then it does not have this support. If you used --enable-multiplayer then it probably has this support.
+
+----------------------------------------------------------------------------
+
+How it works
+
+Here's the basics:
+
+- You have N players, where N is at least 1, although for this to actually be multiplayer, this would have to be at least 2.
+- Players are numbered from 0 onwards because numbering from 0 consistently is going to be less of a pain than numbering from 1 consistently, or doing a mixture of the two.
+- The first player is the primary player, which will always be player 0.
+- The other N-1 players are secondary players.
+- The parameter of a player object indicates which player this is. Player 0 is, of course, p00, which is what hopefully all player objects will have as their parameter.
+
+Now, if player 0 is the only player doing any moving then players 1 through 255 do not appear and this plays exactly like a single-player game, assuming the game is multiplayer-unaware of course.
+
+However, once the other players start to move, we get to cover the concepts of separation and merging:
+
+- A player can be "merged", "separated", xor "player 0".
+- All players start out as "merged" - that is, they share player 0's position and are effectively not there at all. Think of player 0 as a clown car.
+- A merged player, if it successfully can move from player 0's position, creates a new player object on the board with the parameter being equal to that player's player ID, and the player is now "separated".
+- Certain actions will merge all players with player 0, these are:
+  - Moving to a different board
+  - Dying where "restart on board" is set
+  - Teleporting to a specific position (TODO: Ensure that this is the case)
+  - Some actions which are undesireable, but require further code to make these not cause a full merge:
+    - Doing a "die item"
+
+----------------------------------------------------------------------------
+
+Goals
+
+The initial goal is to be able to play the original MegaZeux quartet mostly coherently:
+
+- If a player clone forms under ANY circumstances, this is a bug that MUST get squished.
+- If you can cause sequence breaks and/or softlocks by being several players, this is completely fine. These games do have softlocks in them anyway, and they're less of a softlock and more of a soft-game-over.
+- The side-scrolling sections in Catacombs are probably best left to the primary player to play them.
+
+The next goal is to allow game creators to make multiplayer-aware games that can be non-coop games.
+
+TODO: put some notes here.
+
+Everything after that is more like a stretch goal. This includes:
+
+- Split-screen viewport handling
+- Networked multiplayer
+
+----------------------------------------------------------------------------
+
+[UNIMPLEMENTED] Input handling
+
+This one's going to be hard to get right.
+
+? Should each player be presented as a virtual joystick?
+  - The joystick code could do with less pain, not more.
+? Should each player be presented as its own keyboard? mouse? both?
+? Do we separate (up|down|left|right|space|del)pressed from their respective keys and then have some way to map these to the respective players?
+  + This is probably going to have to happen regardless.
+? Do we have extra virtual keys for (up|down|left|right|space|del)?
+  ? Do we also have an extra one for insert, or do we all share that button, or do we leave that to player 0?
+
+----------------------------------------------------------------------------
+
+[UNIMPLEMENTED] Counters
+
+Some ideas:
+
+TODO. There's definitely ideas to go into here, but this text file has a lot of others I need to get off my chest. --GM
+
+----------------------------------------------------------------------------
+
+[UNIMPLEMENTED] Viewports and split screen
+
+Some ideas for multiplayer-unaware games:
+
+- If the camera is locked, we use a single viewport and the camera's position.
+- Otherwise, if any players are far enough apart we split the screen as needed.
+- Ideally we'd exercise some intelligence based on where the players are when splitting the viewport.
+- Or alternatively we could keep the viewport split if the board isn't large enough relative to the viewport size to warrant it, or maybe just keep it split regardless of the board size.
+- I have a proof of concept for split screen in my first attempt at multiplayer. Since then there were a lot of overhauls applied to the mainline code and I've basically had to redo this from the ground up. Therefore, this is my second attempt. --GM
+
+Some ideas for multiplayer-aware games:
+
+- It should be possible to limit sprite visibility on a per-player basis.
+  - Alternatively, providing a "per player index x/y offset" would mean that we don't spam the sprite list.
+  - But if we do that, I'd be inclined to cap it to a min/max player range.
+- Per-viewport control as well as size awareness should be a possibility.
+  - For sprites, would it be worth coming up with a way to anchor them based on left/right, top/bottom corners for both the viewport and the sprite itself?
+    - If yes, would it be worth having these separately controllable?
+    - Also, what about allowing centres for both axes, too?
+    - All of this combined would also open the floor to having >80x25 viewports working nicely...
+
+- Due to the added complexity and the amount of thinking ahead required, I'd be tempted to allow a game to enforce a player count limit, possibly even a players-per-client limit.
+
+----------------------------------------------------------------------------
+
+[UNIMPLEMENTED] Networked multiplayer
+
+The main idea for this is as follows:
+
+- For a game, there exists one server and any number of clients.
+  - The server dictates the game frame state.
+  - The server and the clients run all the game logic.
+  - The primary player is the authority as to what gets loaded and what gets inputted and whatnot.
+  - A client or a server can have any number of players.
+- We start with a save file which all clients must load.
+- All clients provide their inputs to the server.
+- The server dictates the inputs for every frame.
+- All nodes operate in lockstep.
+
+If we make it possible to dump the network logs to a file and then play them back, we also get a demo format For Free(tm).
+
+----------------------------------------------------------------------------
+
+TODO:
+
+- Per-player inputs.
+- Expose multiplayer counters.
+- Actual networked multiplayer support. config.sh will leave the networking code intact here if multiplayer is enabled, but it will not be used at this stage.
+

--- a/src/block.c
+++ b/src/block.c
@@ -491,8 +491,8 @@ void copy_replace_player(struct world *mzx_world, int x, int y)
     clear_storage_object(cur_board, src_id, cur_board->level_param[offset]);
 
   id_place(mzx_world, x, y, PLAYER, 0, 0);
-  mzx_world->player_x = x;
-  mzx_world->player_y = y;
+  mzx_world->players[0].x = x;
+  mzx_world->players[0].y = y;
 }
 
 // This goes here so the block buffer monstrosity can be inlined.
@@ -538,17 +538,17 @@ void move_board_block(struct world *mzx_world,
   int player_y = 0;
 
   // Work around to move the player
-  if((mzx_world->player_x >= src_x) &&
-   (mzx_world->player_y >= src_y) &&
-   (mzx_world->player_x < (src_x + clear_width)) &&
-   (mzx_world->player_y < (src_y + clear_height)) &&
+  if((mzx_world->players[0].x >= src_x) &&
+   (mzx_world->players[0].y >= src_y) &&
+   (mzx_world->players[0].x < (src_x + clear_width)) &&
+   (mzx_world->players[0].y < (src_y + clear_height)) &&
    (src_board == dest_board))
   {
-    player_x = mzx_world->player_x - src_x + dest_x;
-    player_y = mzx_world->player_y - src_y + dest_y;
+    player_x = mzx_world->players[0].x - src_x + dest_x;
+    player_y = mzx_world->players[0].y - src_y + dest_y;
     replace_player = true;
 
-    id_remove_top(mzx_world, mzx_world->player_x, mzx_world->player_y);
+    id_remove_top(mzx_world, mzx_world->players[0].x, mzx_world->players[0].y);
   }
 
   copy_board_to_board_buffer(mzx_world,

--- a/src/counter.c
+++ b/src/counter.c
@@ -190,8 +190,8 @@ static int playerdist_read(struct world *mzx_world,
   struct board *src_board = mzx_world->current_board;
   struct robot *cur_robot = src_board->robot_list[id];
 
-  int player_x = mzx_world->player_x;
-  int player_y = mzx_world->player_y;
+  int player_x = mzx_world->players[0].x;
+  int player_y = mzx_world->players[0].y;
   int thisx, thisy;
   get_robot_position(cur_robot, &thisx, &thisy);
 
@@ -299,7 +299,7 @@ static int thisx_read(struct world *mzx_world,
   get_robot_position(cur_robot, &thisx, &thisy);
 
   if(mzx_world->mid_prefix == 2)
-    return thisx - mzx_world->player_x;
+    return thisx - mzx_world->players[0].x;
 
   return thisx;
 }
@@ -312,7 +312,7 @@ static int thisy_read(struct world *mzx_world,
   get_robot_position(cur_robot, &thisx, &thisy);
 
   if(mzx_world->mid_prefix == 2)
-    return thisy - mzx_world->player_y;
+    return thisy - mzx_world->players[0].y;
 
   return thisy;
 }
@@ -320,13 +320,13 @@ static int thisy_read(struct world *mzx_world,
 static int playerx_read(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int id)
 {
-  return mzx_world->player_x;
+  return mzx_world->players[0].x;
 }
 
 static int playery_read(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int id)
 {
-  return mzx_world->player_y;
+  return mzx_world->players[0].y;
 }
 
 static int this_char_read(struct world *mzx_world,
@@ -439,7 +439,7 @@ static int horizpld_read(struct world *mzx_world,
   int thisx, thisy;
   get_robot_position(cur_robot, &thisx, &thisy);
 
-  return abs(mzx_world->player_x - thisx);
+  return abs(mzx_world->players[0].x - thisx);
 }
 
 static int vertpld_read(struct world *mzx_world,
@@ -449,7 +449,7 @@ static int vertpld_read(struct world *mzx_world,
   int thisx, thisy;
   get_robot_position(cur_robot, &thisx, &thisy);
 
-  return abs(mzx_world->player_y - thisy);
+  return abs(mzx_world->players[0].y - thisy);
 }
 
 static int board_char_read(struct world *mzx_world,
@@ -3481,8 +3481,8 @@ static int hurt_player(struct world *mzx_world, int value)
     {
       int player_restart_x = mzx_world->player_restart_x;
       int player_restart_y = mzx_world->player_restart_y;
-      int player_x = mzx_world->player_x;
-      int player_y = mzx_world->player_y;
+      int player_x = mzx_world->players[0].x;
+      int player_y = mzx_world->players[0].y;
       //Restart since we were hurt
       if((player_restart_x != player_x) || (player_restart_y != player_y))
       {
@@ -3491,8 +3491,8 @@ static int hurt_player(struct world *mzx_world, int value)
         player_y = player_restart_y;
         id_place(mzx_world, player_x, player_y, PLAYER, 0, 0);
         mzx_world->was_zapped = true;
-        mzx_world->player_x = player_x;
-        mzx_world->player_y = player_y;
+        mzx_world->players[0].x = player_x;
+        mzx_world->players[0].y = player_y;
       }
     }
   }

--- a/src/editor/buffer.c
+++ b/src/editor/buffer.c
@@ -287,9 +287,9 @@ int place_current_at_xy(struct world *mzx_world, struct buffer_info *buffer,
 
       if(buffer->id == PLAYER)
       {
-        id_remove_top(mzx_world, mzx_world->player_x, mzx_world->player_y);
-        mzx_world->player_x = x;
-        mzx_world->player_y = y;
+        id_remove_top(mzx_world, mzx_world->players[0].x, mzx_world->players[0].y);
+        mzx_world->players[0].x = x;
+        mzx_world->players[0].y = y;
       }
       else
 

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -2976,8 +2976,8 @@ static boolean editor_key(context *ctx, int *key)
           }
 
           // Uh oh, we might need a new player
-          if((mzx_world->player_x >= cur_board->board_width) ||
-           (mzx_world->player_y >= cur_board->board_height))
+          if((mzx_world->players[0].x >= cur_board->board_width) ||
+           (mzx_world->players[0].y >= cur_board->board_height))
             replace_player(mzx_world);
 
           editor->modified = true;

--- a/src/editor/undo.c
+++ b/src/editor/undo.c
@@ -495,7 +495,7 @@ static void apply_board_undo(struct undo_frame *f)
   // done for both types of operations, as either may require relocating the
   // player to the player's previous position.
   if(current->move_player)
-    id_remove_top(mzx_world, mzx_world->player_x, mzx_world->player_y);
+    id_remove_top(mzx_world, mzx_world->players[0].x, mzx_world->players[0].y);
 
   switch(f->type)
   {
@@ -584,7 +584,7 @@ static void apply_board_redo(struct undo_frame *f)
 
       // Copy won't overwrite the player, so remove the player first.
       if(current->move_player)
-        id_remove_top(mzx_world, mzx_world->player_x, mzx_world->player_y);
+        id_remove_top(mzx_world, mzx_world->players[0].x, mzx_world->players[0].y);
 
       copy_board_to_board(current->mzx_world,
        current->current_board, 0, current->src_board, current->src_offset,
@@ -636,8 +636,8 @@ static void apply_board_update(struct undo_frame *f)
   }
 
   // Handle player position changes
-  current->current_player_x = current->mzx_world->player_x;
-  current->current_player_y = current->mzx_world->player_y;
+  current->current_player_x = current->mzx_world->players[0].x;
+  current->current_player_y = current->mzx_world->players[0].y;
 
   if((current->current_player_x != current->prev_player_x) ||
    (current->current_player_y != current->prev_player_y))
@@ -769,8 +769,8 @@ void add_board_undo_frame(struct world *mzx_world, struct undo_history *h,
 
     // The player might be moved by the frame, so back up the position
     current->mzx_world = mzx_world;
-    current->prev_player_x = mzx_world->player_x;
-    current->prev_player_y = mzx_world->player_y;
+    current->prev_player_x = mzx_world->players[0].x;
+    current->prev_player_y = mzx_world->players[0].y;
     current->move_player = 0;
 
     // We only care about a handful of things here
@@ -814,8 +814,8 @@ void add_block_undo_frame(struct world *mzx_world, struct undo_history *h,
 
     // The player might be moved by the frame, so back up the position
     current->mzx_world = mzx_world;
-    current->prev_player_x = mzx_world->player_x;
-    current->prev_player_y = mzx_world->player_y;
+    current->prev_player_x = mzx_world->players[0].x;
+    current->prev_player_y = mzx_world->players[0].y;
     current->move_player = 0;
 
     current->width = width;

--- a/src/game_ops.c
+++ b/src/game_ops.c
@@ -699,6 +699,9 @@ int push(struct world *mzx_world, int x, int y, int dir, int checking)
         }
       }
     }
+
+    // Update player positions just in case any players moved.
+    find_player(mzx_world);
   }
 
   play_sfx(mzx_world, SFX_PUSH);

--- a/src/game_ops.c
+++ b/src/game_ops.c
@@ -251,8 +251,8 @@ void calculate_xytop(struct world *mzx_world, int *x, int *y)
   {
     // Calculate from player position
     // Center screen around player, add scroll factor
-    nx = mzx_world->player_x - (viewport_width / 2);
-    ny = mzx_world->player_y - (viewport_height / 2);
+    nx = mzx_world->players[0].x - (viewport_width / 2);
+    ny = mzx_world->players[0].y - (viewport_height / 2);
 
     if(nx < 0)
       nx = 0;
@@ -291,8 +291,8 @@ void calculate_xytop(struct world *mzx_world, int *x, int *y)
 int find_seek(struct world *mzx_world, int x, int y)
 {
   int dir;
-  int player_x = mzx_world->player_x;
-  int player_y = mzx_world->player_y;
+  int player_x = mzx_world->players[0].x;
+  int player_y = mzx_world->players[0].y;
 
   if(y == player_y)
   {

--- a/src/game_player.c
+++ b/src/game_player.c
@@ -1029,6 +1029,12 @@ void move_one_player(struct world *mzx_world, int player_id, int dir)
 
   player->moved = false;
 
+  // Don't move a non-primary player if we're teleporting.
+  if(player_id != 0 && mzx_world->target_where != TARGET_NONE)
+  {
+    return;
+  }
+
   switch(dir)
   {
     case 0:

--- a/src/game_player.c
+++ b/src/game_player.c
@@ -607,11 +607,6 @@ static void place_one_player(struct world *mzx_world, int player_id, int x, int 
   mzx_world->players[player_id].moved = true;
 }
 
-static void place_player(struct world *mzx_world, int x, int y, int dir)
-{
-  abort(); // TODO: unify players!
-}
-
 // mzx_world->players[0].moved will be true if the player moved, otherwise false.
 // This function is guaranteed to keep the player position correctly updated;
 // using find_player after using this function is not necessary.
@@ -887,7 +882,7 @@ void grab_item_for_player(struct world *mzx_world, int player_id, int item_x, in
       else
       {
         cur_board->level_id[offset] = (char)FLOOR;
-        place_player(mzx_world, item_x, item_y, src_dir);
+        place_one_player(mzx_world, player_id, item_x, item_y, src_dir);
       }
       break;
     }

--- a/src/game_player.c
+++ b/src/game_player.c
@@ -1006,11 +1006,6 @@ void grab_item_for_player(struct world *mzx_world, int player_id, int item_x, in
   return;
 }
 
-void grab_item(struct world *mzx_world, int item_x, int item_y, int src_dir)
-{
-  abort(); // TODO: unify players!
-}
-
 // mzx_world->players[0].moved will be true if the player moved, otherwise false.
 // This function is guaranteed to keep the player position correctly updated;
 // using find_player after using this function is not necessary.

--- a/src/game_player.c
+++ b/src/game_player.c
@@ -1266,17 +1266,14 @@ void find_one_player(struct world *mzx_world, int player_id)
   int board_height = src_board->board_height;
   char *level_id = src_board->level_id;
   char *level_param = src_board->level_param;
-  int dx, dy, offset;
   struct player *player = &mzx_world->players[player_id];
+  int search_id = player_id;
+  int dx, dy, offset;
 
-  // Don't attempt to find this player if it
-  // hasn't separated from the primary player
+  // Follow the primary player if we aren't separated
   if(player_id != 0 && !player->separated)
   {
-    struct player *parent = &mzx_world->players[0];
-    player->x = parent->x;
-    player->y = parent->y;
-    return;
+    search_id = 0;
   }
 
   if(player->x >= board_width)
@@ -1288,14 +1285,14 @@ void find_one_player(struct world *mzx_world, int player_id)
   offset = (player->x + (player->y * board_width));
 
   if((enum thing)level_id[offset] != PLAYER
-   || level_param[offset] != player_id)
+   || level_param[offset] != search_id)
   {
     for(dy = 0, offset = 0; dy < board_height; dy++)
     {
       for(dx = 0; dx < board_width; dx++, offset++)
       {
         if((enum thing)level_id[offset] == PLAYER
-         && level_param[offset] == player_id)
+         && level_param[offset] == search_id)
         {
           player->x = dx;
           player->y = dy;
@@ -1304,14 +1301,7 @@ void find_one_player(struct world *mzx_world, int player_id)
       }
     }
 
-    if(player_id == 0)
-    {
-      replace_one_player(mzx_world, player_id);
-    }
-    else
-    {
-      merge_one_player(mzx_world, player_id);
-    }
+    replace_one_player(mzx_world, player_id);
   }
 }
 

--- a/src/game_player.c
+++ b/src/game_player.c
@@ -1271,8 +1271,6 @@ void find_one_player(struct world *mzx_world, int player_id)
 
   // Don't attempt to find this player if it
   // hasn't separated from the primary player
-  //
-  // The primary
   if(player_id != 0 && !player->separated)
   {
     struct player *parent = &mzx_world->players[0];

--- a/src/game_player.c
+++ b/src/game_player.c
@@ -604,10 +604,10 @@ static void place_player(struct world *mzx_world, int x, int y, int dir)
   mzx_world->players[0].y = y;
   src_board->player_last_dir =
    (src_board->player_last_dir & 240) | (dir + 1);
-  mzx_world->player_moved = true;
+  mzx_world->players[0].moved = true;
 }
 
-// mzx_world->player_moved will be true if the player moved, otherwise false.
+// mzx_world->players[0].moved will be true if the player moved, otherwise false.
 // This function is guaranteed to keep the player position correctly updated;
 // using find_player after using this function is not necessary.
 void grab_item(struct world *mzx_world, int item_x, int item_y, int src_dir)
@@ -622,7 +622,7 @@ void grab_item(struct world *mzx_world, int item_x, int item_y, int src_dir)
 
   char tmp[81];
 
-  mzx_world->player_moved = false;
+  mzx_world->players[0].moved = false;
 
   switch(id)
   {
@@ -842,7 +842,7 @@ void grab_item(struct world *mzx_world, int item_x, int item_y, int src_dir)
         mzx_world->under_player_color = under_player_color;
         mzx_world->under_player_param = under_player_param;
         cur_board->player_last_dir = (player_last_dir & 240) + src_dir + 1;
-        mzx_world->player_moved = true;
+        mzx_world->players[0].moved = true;
 
         // Figure out the player's new position so we don't get player clones.
         find_player(mzx_world);
@@ -1006,7 +1006,7 @@ void grab_item(struct world *mzx_world, int item_x, int item_y, int src_dir)
   return;
 }
 
-// mzx_world->player_moved will be true if the player moved, otherwise false.
+// mzx_world->players[0].moved will be true if the player moved, otherwise false.
 // This function is guaranteed to keep the player position correctly updated;
 // using find_player after using this function is not necessary.
 void move_player(struct world *mzx_world, int dir)
@@ -1019,7 +1019,7 @@ void move_player(struct world *mzx_world, int dir)
   int new_y = player_y;
   int edge = 0;
 
-  mzx_world->player_moved = false;
+  mzx_world->players[0].moved = false;
 
   switch(dir)
   {
@@ -1089,7 +1089,7 @@ void move_player(struct world *mzx_world, int dir)
     src_board->player_last_dir =
      (src_board->player_last_dir & 240) + dir + 1;
 
-    mzx_world->player_moved = true;
+    mzx_world->players[0].moved = true;
     return;
   }
   else

--- a/src/game_player.c
+++ b/src/game_player.c
@@ -1208,9 +1208,6 @@ void move_one_player(struct world *mzx_world, int player_id, int dir)
         if(!push(mzx_world, player_x, player_y, dir, 0))
         {
           place_one_player(mzx_world, player_id, new_x, new_y, dir);
-          // Update the player list just in case we pushed a player
-          // (otherwise we get yet another player clone)
-          find_player(mzx_world);
           return;
         }
       }

--- a/src/game_player.c
+++ b/src/game_player.c
@@ -74,7 +74,7 @@ boolean player_can_save(struct world *mzx_world)
 
   if(cur_board->save_mode == CAN_SAVE_ON_SENSOR)
   {
-    offset = xy_to_offset(cur_board, mzx_world->player_x, mzx_world->player_y);
+    offset = xy_to_offset(cur_board, mzx_world->players[0].x, mzx_world->players[0].y);
 
     if(cur_board->level_under_id[offset] != SENSOR)
       return false;
@@ -134,8 +134,8 @@ void player_cheat_give_all(struct world *mzx_world)
 
 void player_cheat_zap(struct world *mzx_world)
 {
-  int player_x = mzx_world->player_x;
-  int player_y = mzx_world->player_y;
+  int player_x = mzx_world->players[0].x;
+  int player_y = mzx_world->players[0].y;
   int board_width = mzx_world->current_board->board_width;
   int board_height = mzx_world->current_board->board_height;
 
@@ -595,13 +595,13 @@ static void open_chest(struct world *mzx_world, int chest_x, int chest_y)
 static void place_player(struct world *mzx_world, int x, int y, int dir)
 {
   struct board *src_board = mzx_world->current_board;
-  if((mzx_world->player_x != x) || (mzx_world->player_y != y))
+  if((mzx_world->players[0].x != x) || (mzx_world->players[0].y != y))
   {
-    id_remove_top(mzx_world, mzx_world->player_x, mzx_world->player_y);
+    id_remove_top(mzx_world, mzx_world->players[0].x, mzx_world->players[0].y);
   }
   id_place(mzx_world, x, y, PLAYER, 0, 0);
-  mzx_world->player_x = x;
-  mzx_world->player_y = y;
+  mzx_world->players[0].x = x;
+  mzx_world->players[0].y = y;
   src_board->player_last_dir =
    (src_board->player_last_dir & 240) | (dir + 1);
   mzx_world->player_moved = true;
@@ -837,7 +837,7 @@ void grab_item(struct world *mzx_world, int item_x, int item_y, int src_dir)
         int under_player_param = mzx_world->under_player_param;
         int player_last_dir = cur_board->player_last_dir;
 
-        id_remove_top(mzx_world, mzx_world->player_x, mzx_world->player_y);
+        id_remove_top(mzx_world, mzx_world->players[0].x, mzx_world->players[0].y);
         mzx_world->under_player_id = under_player_id;
         mzx_world->under_player_color = under_player_color;
         mzx_world->under_player_param = under_player_param;
@@ -1013,8 +1013,8 @@ void move_player(struct world *mzx_world, int dir)
 {
   struct board *src_board = mzx_world->current_board;
   // Dir is from 0 to 3
-  int player_x = mzx_world->player_x;
-  int player_y = mzx_world->player_y;
+  int player_x = mzx_world->players[0].x;
+  int player_y = mzx_world->players[0].y;
   int new_x = player_x;
   int new_y = player_y;
   int edge = 0;
@@ -1251,14 +1251,14 @@ void find_player(struct world *mzx_world)
   char *level_id = src_board->level_id;
   int dx, dy, offset;
 
-  if(mzx_world->player_x >= board_width)
-    mzx_world->player_x = 0;
+  if(mzx_world->players[0].x >= board_width)
+    mzx_world->players[0].x = 0;
 
-  if(mzx_world->player_y >= board_height)
-    mzx_world->player_y = 0;
+  if(mzx_world->players[0].y >= board_height)
+    mzx_world->players[0].y = 0;
 
-  if((enum thing)level_id[mzx_world->player_x +
-   (mzx_world->player_y * board_width)] != PLAYER)
+  if((enum thing)level_id[mzx_world->players[0].x +
+   (mzx_world->players[0].y * board_width)] != PLAYER)
   {
     for(dy = 0, offset = 0; dy < board_height; dy++)
     {
@@ -1266,8 +1266,8 @@ void find_player(struct world *mzx_world)
       {
         if((enum thing)level_id[offset] == PLAYER)
         {
-          mzx_world->player_x = dx;
-          mzx_world->player_y = dy;
+          mzx_world->players[0].x = dx;
+          mzx_world->players[0].y = dy;
           return;
         }
       }

--- a/src/game_player.c
+++ b/src/game_player.c
@@ -1126,7 +1126,8 @@ void move_one_player(struct world *mzx_world, int player_id, int dir)
     {
       // Entrance
       entrance(mzx_world, new_x, new_y);
-      place_one_player(mzx_world, player_id, new_x, new_y, dir);
+      merge_all_players(mzx_world);
+      place_one_player(mzx_world, 0, new_x, new_y, dir);
       return;
     }
     else

--- a/src/game_player.c
+++ b/src/game_player.c
@@ -1199,6 +1199,9 @@ void move_one_player(struct world *mzx_world, int player_id, int dir)
         if(!push(mzx_world, player_x, player_y, dir, 0))
         {
           place_one_player(mzx_world, player_id, new_x, new_y, dir);
+          // Update the player list just in case we pushed a player
+          // (otherwise we get yet another player clone)
+          find_player(mzx_world);
           return;
         }
       }
@@ -1268,21 +1271,22 @@ void find_one_player(struct world *mzx_world, int player_id)
   if(mzx_world->players[player_id].y >= board_height)
     mzx_world->players[player_id].y = 0;
 
-  if((enum thing)level_id[mzx_world->players[player_id].x +
-   (mzx_world->players[player_id].y * board_width)] != PLAYER)
+  offset = (mzx_world->players[player_id].x +
+    (mzx_world->players[player_id].y * board_width));
+
+  if((enum thing)level_id[offset] != PLAYER
+   || level_param[offset] != player_id)
   {
     for(dy = 0, offset = 0; dy < board_height; dy++)
     {
       for(dx = 0; dx < board_width; dx++, offset++)
       {
-        if((enum thing)level_id[offset] == PLAYER)
+        if((enum thing)level_id[offset] == PLAYER
+         && level_param[offset] == player_id)
         {
-          if(level_param[offset] == player_id)
-          {
-            mzx_world->players[player_id].x = dx;
-            mzx_world->players[player_id].y = dy;
-            return;
-          }
+          mzx_world->players[player_id].x = dx;
+          mzx_world->players[player_id].y = dy;
+          return;
         }
       }
     }

--- a/src/game_player.c
+++ b/src/game_player.c
@@ -599,7 +599,10 @@ static void place_one_player(struct world *mzx_world, int player_id, int x, int 
 
   if((player->x != x) || (player->y != y))
   {
-    id_remove_top(mzx_world, player->x, player->y);
+    if(player_id == 0 || player->separated)
+    {
+      id_remove_top(mzx_world, player->x, player->y);
+    }
   }
   id_place(mzx_world, x, y, PLAYER, 0, player_id);
   player->x = x;
@@ -1014,15 +1017,17 @@ void grab_item_for_player(struct world *mzx_world, int player_id, int item_x, in
 // using find_player after using this function is not necessary.
 void move_one_player(struct world *mzx_world, int player_id, int dir)
 {
+  struct player *player = &mzx_world->players[player_id];
+  struct player *src_player = (player->separated ? player : &mzx_world->players[0]);
   struct board *src_board = mzx_world->current_board;
   // Dir is from 0 to 3
-  int player_x = mzx_world->players[player_id].x;
-  int player_y = mzx_world->players[player_id].y;
+  int player_x = src_player->x;
+  int player_y = src_player->y;
   int new_x = player_x;
   int new_y = player_y;
   int edge = 0;
 
-  mzx_world->players[player_id].moved = false;
+  player->moved = false;
 
   switch(dir)
   {
@@ -1092,7 +1097,7 @@ void move_one_player(struct world *mzx_world, int player_id, int dir)
     src_board->player_last_dir =
      (src_board->player_last_dir & 240) + dir + 1;
 
-    mzx_world->players[player_id].moved = true;
+    player->moved = true;
     return;
   }
   else

--- a/src/game_player.c
+++ b/src/game_player.c
@@ -1243,22 +1243,23 @@ void entrance(struct world *mzx_world, int x, int y)
   }
 }
 
-void find_player(struct world *mzx_world)
+void find_one_player(struct world *mzx_world, int player_id)
 {
   struct board *src_board = mzx_world->current_board;
   int board_width = src_board->board_width;
   int board_height = src_board->board_height;
   char *level_id = src_board->level_id;
+  char *level_param = src_board->level_param;
   int dx, dy, offset;
 
-  if(mzx_world->players[0].x >= board_width)
-    mzx_world->players[0].x = 0;
+  if(mzx_world->players[player_id].x >= board_width)
+    mzx_world->players[player_id].x = 0;
 
-  if(mzx_world->players[0].y >= board_height)
-    mzx_world->players[0].y = 0;
+  if(mzx_world->players[player_id].y >= board_height)
+    mzx_world->players[player_id].y = 0;
 
-  if((enum thing)level_id[mzx_world->players[0].x +
-   (mzx_world->players[0].y * board_width)] != PLAYER)
+  if((enum thing)level_id[mzx_world->players[player_id].x +
+   (mzx_world->players[player_id].y * board_width)] != PLAYER)
   {
     for(dy = 0, offset = 0; dy < board_height; dy++)
     {
@@ -1266,13 +1267,26 @@ void find_player(struct world *mzx_world)
       {
         if((enum thing)level_id[offset] == PLAYER)
         {
-          mzx_world->players[0].x = dx;
-          mzx_world->players[0].y = dy;
-          return;
+          if(level_param[offset] == player_id)
+          {
+            mzx_world->players[player_id].x = dx;
+            mzx_world->players[player_id].y = dy;
+            return;
+          }
         }
       }
     }
 
-    replace_player(mzx_world);
+    replace_one_player(mzx_world, player_id);
+  }
+}
+
+void find_player(struct world *mzx_world)
+{
+  int player_id;
+
+  for(player_id = 0; player_id < NUM_PLAYERS; player_id++)
+  {
+    find_one_player(mzx_world, player_id);
   }
 }

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -29,6 +29,7 @@ __M_BEGIN_DECLS
 
 #include "world_struct.h"
 
+CORE_LIBSPEC void find_one_player(struct world *mzx_world, int player_id);
 CORE_LIBSPEC void find_player(struct world *mzx_world);
 
 void set_mesg(struct world *mzx_world, const char *str);

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -44,7 +44,6 @@ void hurt_player(struct world *mzx_world, enum thing damage_src);
 int take_key(struct world *mzx_world, int color);
 int give_key(struct world *mzx_world, int color);
 void grab_item_for_player(struct world *mzx_world, int player_id, int item_x, int item_y, int src_dir);
-void grab_item(struct world *mzx_world, int item_x, int item_y, int src_dir);
 void move_one_player(struct world *mzx_world, int player_id, int dir);
 void move_player(struct world *mzx_world, int dir);
 void entrance(struct world *mzx_world, int x, int y);

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -43,7 +43,9 @@ void player_cheat_zap(struct world *mzx_world);
 void hurt_player(struct world *mzx_world, enum thing damage_src);
 int take_key(struct world *mzx_world, int color);
 int give_key(struct world *mzx_world, int color);
+void grab_item_for_player(struct world *mzx_world, int player_id, int item_x, int item_y, int src_dir);
 void grab_item(struct world *mzx_world, int item_x, int item_y, int src_dir);
+void move_one_player(struct world *mzx_world, int player_id, int dir);
 void move_player(struct world *mzx_world, int dir);
 void entrance(struct world *mzx_world, int x, int y);
 

--- a/src/game_update.c
+++ b/src/game_update.c
@@ -253,7 +253,7 @@ static void update_player_under(struct world *mzx_world)
         move_player(mzx_world, (player_last_dir & 0x0F) - 1);
 
         // FIXME has_context_changed
-        if(!mzx_world->player_moved)
+        if(!mzx_world->players[0].moved)
           cur_board->player_last_dir = player_last_dir & 0xF0;
       }
       return;

--- a/src/game_update.c
+++ b/src/game_update.c
@@ -379,20 +379,20 @@ static void update_player_input(struct world *mzx_world)
   // Player movement
   if(up_pressed && !cur_board->player_ns_locked)
   {
-    int key_up_delay = mzx_world->key_up_delay;
+    int key_up_delay = mzx_world->players[0].key_up_delay;
     if((key_up_delay == 0) || (key_up_delay > REPEAT_WAIT))
     {
       move_player(mzx_world, 0);
       cur_board->player_last_dir = (cur_board->player_last_dir & 0x0F);
     }
     if(key_up_delay <= REPEAT_WAIT)
-      mzx_world->key_up_delay = key_up_delay + 1;
+      mzx_world->players[0].key_up_delay = key_up_delay + 1;
   }
   else
 
   if(down_pressed && !cur_board->player_ns_locked)
   {
-    int key_down_delay = mzx_world->key_down_delay;
+    int key_down_delay = mzx_world->players[0].key_down_delay;
     if((key_down_delay == 0) || (key_down_delay > REPEAT_WAIT))
     {
       move_player(mzx_world, 1);
@@ -400,13 +400,13 @@ static void update_player_input(struct world *mzx_world)
        (cur_board->player_last_dir & 0x0F) + 0x10;
     }
     if(key_down_delay <= REPEAT_WAIT)
-      mzx_world->key_down_delay = key_down_delay + 1;
+      mzx_world->players[0].key_down_delay = key_down_delay + 1;
   }
   else
 
   if(right_pressed && !cur_board->player_ew_locked)
   {
-    int key_right_delay = mzx_world->key_right_delay;
+    int key_right_delay = mzx_world->players[0].key_right_delay;
     if((key_right_delay == 0) || (key_right_delay > REPEAT_WAIT))
     {
       move_player(mzx_world, 2);
@@ -414,13 +414,13 @@ static void update_player_input(struct world *mzx_world)
        (cur_board->player_last_dir & 0x0F) + 0x20;
     }
     if(key_right_delay <= REPEAT_WAIT)
-      mzx_world->key_right_delay = key_right_delay + 1;
+      mzx_world->players[0].key_right_delay = key_right_delay + 1;
   }
   else
 
   if(left_pressed && !cur_board->player_ew_locked)
   {
-    int key_left_delay = mzx_world->key_left_delay;
+    int key_left_delay = mzx_world->players[0].key_left_delay;
     if((key_left_delay == 0) || (key_left_delay > REPEAT_WAIT))
     {
       move_player(mzx_world, 3);
@@ -428,7 +428,7 @@ static void update_player_input(struct world *mzx_world)
        (cur_board->player_last_dir & 0x0F) + 0x30;
     }
     if(key_left_delay <= REPEAT_WAIT)
-      mzx_world->key_left_delay = key_left_delay + 1;
+      mzx_world->players[0].key_left_delay = key_left_delay + 1;
   }
 
   // Reset timers when all of the movement keys are released. Some games rely
@@ -438,10 +438,10 @@ static void update_player_input(struct world *mzx_world)
   // From user feedback, this behavior generally seems preferred.
   if(!up_pressed && !down_pressed && !right_pressed && !left_pressed)
   {
-    mzx_world->key_up_delay = 0;
-    mzx_world->key_down_delay = 0;
-    mzx_world->key_right_delay = 0;
-    mzx_world->key_left_delay = 0;
+    mzx_world->players[0].key_up_delay = 0;
+    mzx_world->players[0].key_down_delay = 0;
+    mzx_world->players[0].key_right_delay = 0;
+    mzx_world->players[0].key_left_delay = 0;
   }
 
   // Bomb

--- a/src/game_update.c
+++ b/src/game_update.c
@@ -206,11 +206,12 @@ static void update_mod_volume(struct world *mzx_world)
  * May result in a context change.
  */
 
-static void update_player_under(struct world *mzx_world)
+static void update_one_player_under(struct world *mzx_world, int player_id)
 {
   struct board *cur_board = mzx_world->current_board;
-  int player_x = mzx_world->players[0].x;
-  int player_y = mzx_world->players[0].y;
+  struct player *player = &mzx_world->players[player_id];
+  int player_x = player->x;
+  int player_y = player->y;
   int offset = xy_to_offset(cur_board, player_x, player_y);
   enum thing under_id = (enum thing)cur_board->level_under_id[offset];
 
@@ -223,25 +224,25 @@ static void update_player_under(struct world *mzx_world)
   {
     case N_WATER:
     {
-      move_player(mzx_world, 0);
+      move_one_player(mzx_world, player_id, 0);
       return;
     }
 
     case S_WATER:
     {
-      move_player(mzx_world, 1);
+      move_one_player(mzx_world, player_id, 1);
       return;
     }
 
     case E_WATER:
     {
-      move_player(mzx_world, 2);
+      move_one_player(mzx_world, player_id, 2);
       return;
     }
 
     case W_WATER:
     {
-      move_player(mzx_world, 3);
+      move_one_player(mzx_world, player_id, 3);
       return;
     }
 
@@ -250,10 +251,10 @@ static void update_player_under(struct world *mzx_world)
       int player_last_dir = cur_board->player_last_dir;
       if(player_last_dir & 0x0F)
       {
-        move_player(mzx_world, (player_last_dir & 0x0F) - 1);
+        move_one_player(mzx_world, player_id, (player_last_dir & 0x0F) - 1);
 
         // FIXME has_context_changed
-        if(!mzx_world->players[0].moved)
+        if(!player->moved)
           cur_board->player_last_dir = player_last_dir & 0xF0;
       }
       return;
@@ -288,12 +289,22 @@ static void update_player_under(struct world *mzx_world)
   }
 }
 
+static void update_player_under(struct world *mzx_world)
+{
+  int player_id;
+
+  for(player_id = 0; player_id < NUM_PLAYERS; player_id++)
+  {
+    update_one_player_under(mzx_world, player_id);
+  }
+}
+
 /**
  * Apply wind to the player if wind is currently active.
  * May result in a context change.
  */
 
-static void update_player_wind(struct world *mzx_world)
+static void update_one_player_wind(struct world *mzx_world, int player_id)
 {
   struct board *cur_board = mzx_world->current_board;
 
@@ -305,8 +316,18 @@ static void update_player_wind(struct world *mzx_world)
       // No wind this turn if above 3
       cur_board->player_last_dir =
        (cur_board->player_last_dir & 0xF0) + wind_dir;
-      move_player(mzx_world, wind_dir);
+      move_one_player(mzx_world, player_id, wind_dir);
     }
+  }
+}
+
+static void update_player_wind(struct world *mzx_world)
+{
+  int player_id;
+
+  for(player_id = 0; player_id < NUM_PLAYERS; player_id++)
+  {
+    update_one_player_wind(mzx_world, player_id);
   }
 }
 
@@ -315,9 +336,10 @@ static void update_player_wind(struct world *mzx_world)
  * May result in a context change.
  */
 
-static void update_player_input(struct world *mzx_world)
+static void update_one_player_input(struct world *mzx_world, int player_id)
 {
   struct board *cur_board = mzx_world->current_board;
+  struct player *player = &mzx_world->players[player_id];
   int space_pressed = get_key_status(keycode_internal_wrt_numlock, IKEY_SPACE);
   int up_pressed = get_key_status(keycode_internal_wrt_numlock, IKEY_UP);
   int down_pressed = get_key_status(keycode_internal_wrt_numlock, IKEY_DOWN);
@@ -328,7 +350,7 @@ static void update_player_input(struct world *mzx_world)
   // Shoot
   if(space_pressed && mzx_world->bi_shoot_status)
   {
-    if(!mzx_world->players[0].shoot_cooldown && !cur_board->player_attack_locked)
+    if(!player->shoot_cooldown && !cur_board->player_attack_locked)
     {
       int move_dir = -1;
 
@@ -365,9 +387,9 @@ static void update_player_input(struct world *mzx_world)
         {
           dec_counter(mzx_world, "AMMO", 1, 0);
           play_sfx(mzx_world, SFX_SHOOT);
-          shoot(mzx_world, mzx_world->players[0].x, mzx_world->players[0].y,
+          shoot(mzx_world, player->x, player->y,
            move_dir, PLAYER_BULLET);
-          mzx_world->players[0].shoot_cooldown = MAX_PLAYER_SHOT_COOLDOWN;
+          player->shoot_cooldown = MAX_PLAYER_SHOT_COOLDOWN;
           cur_board->player_last_dir =
            (cur_board->player_last_dir & 0x0F) | (move_dir << 4);
         }
@@ -379,56 +401,56 @@ static void update_player_input(struct world *mzx_world)
   // Player movement
   if(up_pressed && !cur_board->player_ns_locked)
   {
-    int key_up_delay = mzx_world->players[0].key_up_delay;
+    int key_up_delay = player->key_up_delay;
     if((key_up_delay == 0) || (key_up_delay > REPEAT_WAIT))
     {
-      move_player(mzx_world, 0);
+      move_one_player(mzx_world, player_id, 0);
       cur_board->player_last_dir = (cur_board->player_last_dir & 0x0F);
     }
     if(key_up_delay <= REPEAT_WAIT)
-      mzx_world->players[0].key_up_delay = key_up_delay + 1;
+      player->key_up_delay = key_up_delay + 1;
   }
   else
 
   if(down_pressed && !cur_board->player_ns_locked)
   {
-    int key_down_delay = mzx_world->players[0].key_down_delay;
+    int key_down_delay = player->key_down_delay;
     if((key_down_delay == 0) || (key_down_delay > REPEAT_WAIT))
     {
-      move_player(mzx_world, 1);
+      move_one_player(mzx_world, player_id, 1);
       cur_board->player_last_dir =
        (cur_board->player_last_dir & 0x0F) + 0x10;
     }
     if(key_down_delay <= REPEAT_WAIT)
-      mzx_world->players[0].key_down_delay = key_down_delay + 1;
+      player->key_down_delay = key_down_delay + 1;
   }
   else
 
   if(right_pressed && !cur_board->player_ew_locked)
   {
-    int key_right_delay = mzx_world->players[0].key_right_delay;
+    int key_right_delay = player->key_right_delay;
     if((key_right_delay == 0) || (key_right_delay > REPEAT_WAIT))
     {
-      move_player(mzx_world, 2);
+      move_one_player(mzx_world, player_id, 2);
       cur_board->player_last_dir =
        (cur_board->player_last_dir & 0x0F) + 0x20;
     }
     if(key_right_delay <= REPEAT_WAIT)
-      mzx_world->players[0].key_right_delay = key_right_delay + 1;
+      player->key_right_delay = key_right_delay + 1;
   }
   else
 
   if(left_pressed && !cur_board->player_ew_locked)
   {
-    int key_left_delay = mzx_world->players[0].key_left_delay;
+    int key_left_delay = player->key_left_delay;
     if((key_left_delay == 0) || (key_left_delay > REPEAT_WAIT))
     {
-      move_player(mzx_world, 3);
+      move_one_player(mzx_world, player_id, 3);
       cur_board->player_last_dir =
        (cur_board->player_last_dir & 0x0F) + 0x30;
     }
     if(key_left_delay <= REPEAT_WAIT)
-      mzx_world->players[0].key_left_delay = key_left_delay + 1;
+      player->key_left_delay = key_left_delay + 1;
   }
 
   // Reset timers when all of the movement keys are released. Some games rely
@@ -438,17 +460,17 @@ static void update_player_input(struct world *mzx_world)
   // From user feedback, this behavior generally seems preferred.
   if(!up_pressed && !down_pressed && !right_pressed && !left_pressed)
   {
-    mzx_world->players[0].key_up_delay = 0;
-    mzx_world->players[0].key_down_delay = 0;
-    mzx_world->players[0].key_right_delay = 0;
-    mzx_world->players[0].key_left_delay = 0;
+    player->key_up_delay = 0;
+    player->key_down_delay = 0;
+    player->key_right_delay = 0;
+    player->key_left_delay = 0;
   }
 
   // Bomb
   if(del_pressed && !cur_board->player_attack_locked)
   {
     int offset =
-     xy_to_offset(cur_board, mzx_world->players[0].x, mzx_world->players[0].y);
+     xy_to_offset(cur_board, player->x, player->y);
     enum thing under_id = (enum thing)cur_board->level_under_id[offset];
     char under_param = cur_board->level_under_param[offset];
     char under_color = cur_board->level_under_color[offset];
@@ -499,8 +521,18 @@ static void update_player_input(struct world *mzx_world)
     }
   }
 
-  if(mzx_world->players[0].shoot_cooldown)
-    mzx_world->players[0].shoot_cooldown--;
+  if(player->shoot_cooldown)
+    player->shoot_cooldown--;
+}
+
+static void update_player_input(struct world *mzx_world)
+{
+  int player_id;
+
+  for(player_id = 0; player_id < NUM_PLAYERS; player_id++)
+  {
+    update_one_player_input(mzx_world, player_id);
+  }
 }
 
 /**

--- a/src/game_update.c
+++ b/src/game_update.c
@@ -209,8 +209,8 @@ static void update_mod_volume(struct world *mzx_world)
 static void update_player_under(struct world *mzx_world)
 {
   struct board *cur_board = mzx_world->current_board;
-  int player_x = mzx_world->player_x;
-  int player_y = mzx_world->player_y;
+  int player_x = mzx_world->players[0].x;
+  int player_y = mzx_world->players[0].y;
   int offset = xy_to_offset(cur_board, player_x, player_y);
   enum thing under_id = (enum thing)cur_board->level_under_id[offset];
 
@@ -328,7 +328,7 @@ static void update_player_input(struct world *mzx_world)
   // Shoot
   if(space_pressed && mzx_world->bi_shoot_status)
   {
-    if(!mzx_world->player_shoot_cooldown && !cur_board->player_attack_locked)
+    if(!mzx_world->players[0].shoot_cooldown && !cur_board->player_attack_locked)
     {
       int move_dir = -1;
 
@@ -365,9 +365,9 @@ static void update_player_input(struct world *mzx_world)
         {
           dec_counter(mzx_world, "AMMO", 1, 0);
           play_sfx(mzx_world, SFX_SHOOT);
-          shoot(mzx_world, mzx_world->player_x, mzx_world->player_y,
+          shoot(mzx_world, mzx_world->players[0].x, mzx_world->players[0].y,
            move_dir, PLAYER_BULLET);
-          mzx_world->player_shoot_cooldown = MAX_PLAYER_SHOT_COOLDOWN;
+          mzx_world->players[0].shoot_cooldown = MAX_PLAYER_SHOT_COOLDOWN;
           cur_board->player_last_dir =
            (cur_board->player_last_dir & 0x0F) | (move_dir << 4);
         }
@@ -448,7 +448,7 @@ static void update_player_input(struct world *mzx_world)
   if(del_pressed && !cur_board->player_attack_locked)
   {
     int offset =
-     xy_to_offset(cur_board, mzx_world->player_x, mzx_world->player_y);
+     xy_to_offset(cur_board, mzx_world->players[0].x, mzx_world->players[0].y);
     enum thing under_id = (enum thing)cur_board->level_under_id[offset];
     char under_param = cur_board->level_under_param[offset];
     char under_color = cur_board->level_under_color[offset];
@@ -499,8 +499,8 @@ static void update_player_input(struct world *mzx_world)
     }
   }
 
-  if(mzx_world->player_shoot_cooldown)
-    mzx_world->player_shoot_cooldown--;
+  if(mzx_world->players[0].shoot_cooldown)
+    mzx_world->players[0].shoot_cooldown--;
 }
 
 /**
@@ -510,8 +510,8 @@ static void update_player_input(struct world *mzx_world)
 static boolean player_on_entrance(struct world *mzx_world)
 {
   struct board *cur_board = mzx_world->current_board;
-  int player_x = mzx_world->player_x;
-  int player_y = mzx_world->player_y;
+  int player_x = mzx_world->players[0].x;
+  int player_y = mzx_world->players[0].y;
   int offset = xy_to_offset(cur_board, player_x, player_y);
 
   int under_id = cur_board->level_under_id[offset];
@@ -542,8 +542,8 @@ static void hide_player(struct world *mzx_world)
 
 static void focus_on_player(struct world *mzx_world)
 {
-  int player_x   = mzx_world->player_x;
-  int player_y   = mzx_world->player_y;
+  int player_x   = mzx_world->players[0].x;
+  int player_y   = mzx_world->players[0].y;
   int viewport_x = mzx_world->current_board->viewport_x;
   int viewport_y = mzx_world->current_board->viewport_y;
   int top_x, top_y;
@@ -571,11 +571,11 @@ static void end_game(struct world *mzx_world)
     // Jump to given board
     if(mzx_world->current_board_id == endgame_board)
     {
-      id_remove_top(mzx_world, mzx_world->player_x,
-        mzx_world->player_y);
+      id_remove_top(mzx_world, mzx_world->players[0].x,
+        mzx_world->players[0].y);
       id_place(mzx_world, endgame_x, endgame_y, PLAYER, 0, 0);
-      mzx_world->player_x = endgame_x;
-      mzx_world->player_y = endgame_y;
+      mzx_world->players[0].x = endgame_x;
+      mzx_world->players[0].y = endgame_y;
     }
     else
     {
@@ -646,10 +646,10 @@ static void end_life(struct world *mzx_world)
         player_restart_y = cur_board->board_height - 1;
 
       // Return to entry x/y
-      id_remove_top(mzx_world, mzx_world->player_x, mzx_world->player_y);
+      id_remove_top(mzx_world, mzx_world->players[0].x, mzx_world->players[0].y);
       id_place(mzx_world, player_restart_x, player_restart_y, PLAYER, 0, 0);
-      mzx_world->player_x = player_restart_x;
-      mzx_world->player_y = player_restart_y;
+      mzx_world->players[0].x = player_restart_x;
+      mzx_world->players[0].y = player_restart_y;
     }
     else
     {
@@ -659,10 +659,10 @@ static void end_life(struct world *mzx_world)
         int death_x = mzx_world->death_x;
         int death_y = mzx_world->death_y;
 
-        id_remove_top(mzx_world, mzx_world->player_x, mzx_world->player_y);
+        id_remove_top(mzx_world, mzx_world->players[0].x, mzx_world->players[0].y);
         id_place(mzx_world, death_x, death_y, PLAYER, 0, 0);
-        mzx_world->player_x = death_x;
-        mzx_world->player_y = death_y;
+        mzx_world->players[0].x = death_x;
+        mzx_world->players[0].y = death_y;
       }
       else
       {
@@ -722,7 +722,7 @@ void update_world(context *ctx, boolean is_title)
       // Pushed onto an entrance
       // There's often a pushed sound in this case, so clear the current SFX
       sfx_clear_queue();
-      entrance(mzx_world, mzx_world->player_x, mzx_world->player_y);
+      entrance(mzx_world, mzx_world->players[0].x, mzx_world->players[0].y);
     }
   }
   else
@@ -861,8 +861,8 @@ boolean draw_world(context *ctx, boolean is_title)
   // Draw screen
   if(mzx_world->blind_dur > 0)
   {
-    int player_x = mzx_world->player_x;
-    int player_y = mzx_world->player_y;
+    int player_x = mzx_world->players[0].x;
+    int player_y = mzx_world->players[0].y;
 
     // Only draw the player during gameplay
     if(is_title)
@@ -917,8 +917,8 @@ boolean draw_world(context *ctx, boolean is_title)
   // Add debug box
   if(draw_debug_box && mzx_world->debug_mode)
   {
-    draw_debug_box(mzx_world, 60, 19, mzx_world->player_x,
-     mzx_world->player_y, 1);
+    draw_debug_box(mzx_world, 60, 19, mzx_world->players[0].x,
+     mzx_world->players[0].y, 1);
   }
   return true;
 }
@@ -1023,8 +1023,8 @@ boolean update_resolve_target(struct world *mzx_world,
           if(d_id == PLAYER)
           {
             // Remove the player, maybe readd
-            mzx_world->player_x = x;
-            mzx_world->player_y = y;
+            mzx_world->players[0].x = x;
+            mzx_world->players[0].y = y;
             id_remove_top(mzx_world, x, y);
             // Grab again - might have revealed an entrance
             d_id = (enum thing)level_id[offset];
@@ -1095,12 +1095,12 @@ boolean update_resolve_target(struct world *mzx_world,
 
       if(i < 5)
       {
-        mzx_world->player_x = tmp_x[i];
-        mzx_world->player_y = tmp_y[i];
+        mzx_world->players[0].x = tmp_x[i];
+        mzx_world->players[0].y = tmp_y[i];
       }
 
-      id_place(mzx_world, mzx_world->player_x,
-       mzx_world->player_y, PLAYER, 0, 0);
+      id_place(mzx_world, mzx_world->players[0].x,
+       mzx_world->players[0].y, PLAYER, 0, 0);
     }
     else
     {
@@ -1134,8 +1134,8 @@ boolean update_resolve_target(struct world *mzx_world,
      (saved_player_last_dir & 0xF0);
 
     // ...and if player ended up on ICE, set last dir pressed as well
-    if((enum thing)level_under_id[mzx_world->player_x +
-     (mzx_world->player_y * board_width)] == ICE)
+    if((enum thing)level_under_id[mzx_world->players[0].x +
+     (mzx_world->players[0].y * board_width)] == ICE)
     {
       src_board->player_last_dir = saved_player_last_dir;
     }

--- a/src/game_update.c
+++ b/src/game_update.c
@@ -977,6 +977,9 @@ boolean update_resolve_target(struct world *mzx_world,
     int target_board = mzx_world->target_board;
     boolean load_assets = false;
 
+    // Merge players before proceeding
+    merge_all_players(mzx_world);
+
     // TELEPORT or ENTRANCE.
     // Destroy message, bullets, spitfire?
 

--- a/src/game_update.c
+++ b/src/game_update.c
@@ -679,6 +679,7 @@ static void end_life(struct world *mzx_world)
 
       // Return to entry x/y
       id_remove_top(mzx_world, mzx_world->players[0].x, mzx_world->players[0].y);
+      merge_all_players(mzx_world);
       id_place(mzx_world, player_restart_x, player_restart_y, PLAYER, 0, 0);
       mzx_world->players[0].x = player_restart_x;
       mzx_world->players[0].y = player_restart_y;
@@ -692,6 +693,7 @@ static void end_life(struct world *mzx_world)
         int death_y = mzx_world->death_y;
 
         id_remove_top(mzx_world, mzx_world->players[0].x, mzx_world->players[0].y);
+        merge_all_players(mzx_world);
         id_place(mzx_world, death_x, death_y, PLAYER, 0, 0);
         mzx_world->players[0].x = death_x;
         mzx_world->players[0].y = death_y;

--- a/src/game_update_board.c
+++ b/src/game_update_board.c
@@ -1384,8 +1384,8 @@ void update_board(context *ctx)
           {
             int sensitivity = ((current_param & 0x07) + 1) << 1;
             int player_distance;
-            int player_dist_x = mzx_world->player_x - x;
-            int player_dist_y = mzx_world->player_y - y;
+            int player_dist_x = mzx_world->players[0].x - x;
+            int player_dist_y = mzx_world->players[0].y - y;
 
             // Zero out move cycle
             level_param[level_offset] &= 0x9F;

--- a/src/idput.c
+++ b/src/idput.c
@@ -374,7 +374,17 @@ static unsigned char get_special_id_color(struct board *src_board,
       break;
 
     case PLAYER: /* player */
-      return id_chars[player_color];
+      if(param == 0)
+      {
+        // This is the primary player.
+        return id_chars[player_color];
+      }
+      else
+      {
+        // This is not the primary player.
+        // Swap the foreground and background colours.
+        return (id_chars[player_color]>>4)|((id_chars[player_color]&0xF)<<4);
+      }
 
     default:
       return color;

--- a/src/player_struct.h
+++ b/src/player_struct.h
@@ -25,7 +25,12 @@
 
 __M_BEGIN_DECLS
 
+#ifdef CONFIG_MULTIPLAYER
+// TODO: A lot of things, check doc/multiplayer_support.txt
+#define NUM_PLAYERS 16
+#else
 #define NUM_PLAYERS 1
+#endif
 
 struct player
 {

--- a/src/player_struct.h
+++ b/src/player_struct.h
@@ -32,6 +32,9 @@ struct player
   int x;
   int y;
   int shoot_cooldown;
+
+  // Did the player just move?
+  boolean moved;
 };
 
 __M_END_DECLS

--- a/src/player_struct.h
+++ b/src/player_struct.h
@@ -33,6 +33,9 @@ struct player
   int y;
   int shoot_cooldown;
 
+  // Has this player separated from the primary player?
+  boolean separated;
+
   // Did the player just move?
   boolean moved;
 

--- a/src/player_struct.h
+++ b/src/player_struct.h
@@ -1,0 +1,39 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2004 Gilead Kutnick <exophase@adelphia.net>
+ * Copyright (C) 2019 Ben Russell <thematrixeatsyou@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef __PLAYER_STRUCT_H
+#define __PLAYER_STRUCT_H
+
+#include "compat.h"
+
+__M_BEGIN_DECLS
+
+#define NUM_PLAYERS 1
+
+struct player
+{
+  int x;
+  int y;
+  int shoot_cooldown;
+};
+
+__M_END_DECLS
+
+#endif // __WORLD_STRUCT_H

--- a/src/player_struct.h
+++ b/src/player_struct.h
@@ -35,6 +35,12 @@ struct player
 
   // Did the player just move?
   boolean moved;
+
+  // For use in repeat delays for player movement
+  int key_up_delay;
+  int key_down_delay;
+  int key_right_delay;
+  int key_left_delay;
 };
 
 __M_END_DECLS

--- a/src/robot.c
+++ b/src/robot.c
@@ -1448,8 +1448,8 @@ static void send_sensor_command(struct world *mzx_world, int id, int command)
   char *level_color = src_board->level_color;
   int board_width = src_board->board_width;
   int board_height = src_board->board_height;
-  int player_x = mzx_world->player_x;
-  int player_y = mzx_world->player_y;
+  int player_x = mzx_world->players[0].x;
+  int player_y = mzx_world->players[0].y;
   int player_offset = player_x + (player_y * board_width);
   int offset;
   int move_status;
@@ -1514,8 +1514,8 @@ static void send_sensor_command(struct world *mzx_world, int id, int command)
         {
           // Find player...
           find_player(mzx_world);
-          player_x = mzx_world->player_x;
-          player_y = mzx_world->player_y;
+          player_x = mzx_world->players[0].x;
+          player_y = mzx_world->players[0].y;
           player_offset = player_x + (player_y * board_width);
 
           move_status = HIT_PLAYER;
@@ -1958,8 +1958,8 @@ void prefix_first_last_xy(struct world *mzx_world, int *fx, int *fy,
     case 6:
     {
       find_player(mzx_world);
-      tfx += mzx_world->player_x;
-      tfy += mzx_world->player_y;
+      tfx += mzx_world->players[0].x;
+      tfy += mzx_world->players[0].y;
       break;
     }
 
@@ -1992,8 +1992,8 @@ void prefix_first_last_xy(struct world *mzx_world, int *fx, int *fy,
     case 6:
     {
       find_player(mzx_world);
-      tlx += mzx_world->player_x;
-      tly += mzx_world->player_y;
+      tlx += mzx_world->players[0].x;
+      tly += mzx_world->players[0].y;
       break;
     }
 
@@ -2067,8 +2067,8 @@ void prefix_first_xy_var(struct world *mzx_world, int *fx, int *fy,
     case 6:
     {
       find_player(mzx_world);
-      tfx += mzx_world->player_x;
-      tfy += mzx_world->player_y;
+      tfx += mzx_world->players[0].x;
+      tfy += mzx_world->players[0].y;
       break;
     }
 
@@ -2123,8 +2123,8 @@ void prefix_last_xy_var(struct world *mzx_world, int *lx, int *ly,
     case 6:
     {
       find_player(mzx_world);
-      tlx += mzx_world->player_x;
-      tly += mzx_world->player_y;
+      tlx += mzx_world->players[0].x;
+      tly += mzx_world->players[0].y;
       break;
     }
 
@@ -2177,8 +2177,8 @@ void prefix_mid_xy_var(struct world *mzx_world, int *mx, int *my,
     case 2:
     {
       find_player(mzx_world);
-      tmx += mzx_world->player_x;
-      tmy += mzx_world->player_y;
+      tmx += mzx_world->players[0].x;
+      tmy += mzx_world->players[0].y;
       break;
     }
 
@@ -2224,8 +2224,8 @@ void prefix_mid_xy_unbound(struct world *mzx_world, int *mx, int *my, int x, int
     case 2:
     {
       find_player(mzx_world);
-      tmx += mzx_world->player_x;
-      tmy += mzx_world->player_y;
+      tmx += mzx_world->players[0].x;
+      tmy += mzx_world->players[0].y;
       break;
     }
 

--- a/src/robot.h
+++ b/src/robot.h
@@ -107,6 +107,7 @@ CORE_LIBSPEC int place_at_xy(struct world *mzx_world, enum thing id,
 CORE_LIBSPEC int place_player_xy(struct world *mzx_world, int x, int y);
 CORE_LIBSPEC void setup_overlay(struct board *src_board, int mode);
 CORE_LIBSPEC void merge_one_player(struct world *mzx_world, int player_id);
+CORE_LIBSPEC void merge_all_players(struct world *mzx_world);
 CORE_LIBSPEC void replace_one_player(struct world *mzx_world, int player_id);
 CORE_LIBSPEC void replace_player(struct world *mzx_world);
 

--- a/src/robot.h
+++ b/src/robot.h
@@ -106,6 +106,7 @@ CORE_LIBSPEC int place_at_xy(struct world *mzx_world, enum thing id,
  int color, int param, int x, int y);
 CORE_LIBSPEC int place_player_xy(struct world *mzx_world, int x, int y);
 CORE_LIBSPEC void setup_overlay(struct board *src_board, int mode);
+CORE_LIBSPEC void replace_one_player(struct world *mzx_world, int player_id);
 CORE_LIBSPEC void replace_player(struct world *mzx_world);
 
 void load_robot(struct world *mzx_world, struct robot *cur_robot,

--- a/src/robot.h
+++ b/src/robot.h
@@ -106,6 +106,7 @@ CORE_LIBSPEC int place_at_xy(struct world *mzx_world, enum thing id,
  int color, int param, int x, int y);
 CORE_LIBSPEC int place_player_xy(struct world *mzx_world, int x, int y);
 CORE_LIBSPEC void setup_overlay(struct board *src_board, int mode);
+CORE_LIBSPEC void merge_one_player(struct world *mzx_world, int player_id);
 CORE_LIBSPEC void replace_one_player(struct world *mzx_world, int player_id);
 CORE_LIBSPEC void replace_player(struct world *mzx_world);
 

--- a/src/run_robot.c
+++ b/src/run_robot.c
@@ -2597,7 +2597,10 @@ void run_robot(context *ctx, int id, int x, int y)
                 int offset = x + (y * board_width);
                 enum thing old_id = (enum thing)level_id[offset];
                 level_id[offset] = (char)ROBOT_PUSHABLE;
-                grab_item(mzx_world, new_x, new_y, 0);
+
+                // Do this as the primary player.
+                // TODO: Investigate what this is actually doing.
+                grab_item_for_player(mzx_world, 0, new_x, new_y, 0);
 
                 // If a door opened in the direction of the robot, the robot
                 // was pushed and its position needs to be updated. This might

--- a/src/run_robot.c
+++ b/src/run_robot.c
@@ -874,6 +874,13 @@ void replace_one_player(struct world *mzx_world, int player_id)
   struct player *player = &mzx_world->players[player_id];
   int dx, dy, offset;
 
+  if(player_id != 0)
+  {
+    // Merge this player with the primary player.
+    merge_one_player(mzx_world, player_id);
+    return;
+  }
+
   for(dy = 0, offset = 0; dy < board_height; dy++)
   {
     for(dx = 0; dx < board_width; dx++, offset++)
@@ -901,16 +908,7 @@ void replace_player(struct world *mzx_world)
 
   for(player_id = 0; player_id < NUM_PLAYERS; player_id++)
   {
-    if(player_id == 0)
-    {
-      // Replace this player.
-      replace_one_player(mzx_world, player_id);
-    }
-    else
-    {
-      // Merge this player with the primary player.
-      merge_one_player(mzx_world, player_id);
-    }
+    replace_one_player(mzx_world, player_id);
   }
 }
 

--- a/src/run_robot.c
+++ b/src/run_robot.c
@@ -855,12 +855,23 @@ static int copy_block_param_special(struct world *mzx_world, int id,
   return 0;
 }
 
+void merge_one_player(struct world *mzx_world, int player_id)
+{
+  struct player *player = &mzx_world->players[player_id];
+  struct player *primary_player = &mzx_world->players[0];
+
+  player->x = primary_player->x;
+  player->y = primary_player->y;
+  player->separated = false;
+}
+
 void replace_one_player(struct world *mzx_world, int player_id)
 {
   struct board *src_board = mzx_world->current_board;
   char *level_id = src_board->level_id;
   int board_width = src_board->board_width;
   int board_height = src_board->board_height;
+  struct player *player = &mzx_world->players[player_id];
   int dx, dy, offset;
 
   for(dy = 0, offset = 0; dy < board_height; dy++)
@@ -870,8 +881,8 @@ void replace_one_player(struct world *mzx_world, int player_id)
       if(A_UNDER & flags[(int)level_id[offset]])
       {
         // Place the player here
-        mzx_world->players[player_id].x = dx;
-        mzx_world->players[player_id].y = dy;
+        player->x = dx;
+        player->y = dy;
         id_place(mzx_world, dx, dy, PLAYER, 0, player_id);
         return;
       }
@@ -879,8 +890,8 @@ void replace_one_player(struct world *mzx_world, int player_id)
   }
 
   // Place the player here
-  mzx_world->players[player_id].x = 0;
-  mzx_world->players[player_id].y = 0;
+  player->x = 0;
+  player->y = 0;
   place_at_xy(mzx_world, PLAYER, 0, 0, 0, player_id);
 }
 
@@ -890,7 +901,16 @@ void replace_player(struct world *mzx_world)
 
   for(player_id = 0; player_id < NUM_PLAYERS; player_id++)
   {
-    replace_one_player(mzx_world, player_id);
+    if(player_id == 0)
+    {
+      // Replace this player.
+      replace_one_player(mzx_world, player_id);
+    }
+    else
+    {
+      // Merge this player with the primary player.
+      merge_one_player(mzx_world, player_id);
+    }
   }
 }
 

--- a/src/run_robot.c
+++ b/src/run_robot.c
@@ -855,7 +855,7 @@ static int copy_block_param_special(struct world *mzx_world, int id,
   return 0;
 }
 
-void replace_player(struct world *mzx_world)
+void replace_one_player(struct world *mzx_world, int player_id)
 {
   struct board *src_board = mzx_world->current_board;
   char *level_id = src_board->level_id;
@@ -870,18 +870,28 @@ void replace_player(struct world *mzx_world)
       if(A_UNDER & flags[(int)level_id[offset]])
       {
         // Place the player here
-        mzx_world->players[0].x = dx;
-        mzx_world->players[0].y = dy;
-        id_place(mzx_world, dx, dy, PLAYER, 0, 0);
+        mzx_world->players[player_id].x = dx;
+        mzx_world->players[player_id].y = dy;
+        id_place(mzx_world, dx, dy, PLAYER, 0, player_id);
         return;
       }
     }
   }
 
   // Place the player here
-  mzx_world->players[0].x = 0;
-  mzx_world->players[0].y = 0;
-  place_at_xy(mzx_world, PLAYER, 0, 0, 0, 0);
+  mzx_world->players[player_id].x = 0;
+  mzx_world->players[player_id].y = 0;
+  place_at_xy(mzx_world, PLAYER, 0, 0, 0, player_id);
+}
+
+void replace_player(struct world *mzx_world)
+{
+  int player_id;
+
+  for(player_id = 0; player_id < NUM_PLAYERS; player_id++)
+  {
+    replace_one_player(mzx_world, player_id);
+  }
 }
 
 // Returns the numeric value pointed to OR the numeric value represented

--- a/src/run_robot.c
+++ b/src/run_robot.c
@@ -101,8 +101,8 @@ static void magic_load_mod(struct world *mzx_world, char *filename)
 
 static void save_player_position(struct world *mzx_world, int pos)
 {
-  mzx_world->pl_saved_x[pos] = mzx_world->player_x;
-  mzx_world->pl_saved_y[pos] = mzx_world->player_y;
+  mzx_world->pl_saved_x[pos] = mzx_world->players[0].x;
+  mzx_world->pl_saved_y[pos] = mzx_world->players[0].y;
   mzx_world->pl_saved_board[pos] = mzx_world->current_board_id;
 }
 
@@ -282,7 +282,7 @@ static int place_dir_xy(struct world *mzx_world, enum thing id, int color,
 
 int place_player_xy(struct world *mzx_world, int x, int y)
 {
-  if((mzx_world->player_x != x) || (mzx_world->player_y != y))
+  if((mzx_world->players[0].x != x) || (mzx_world->players[0].y != y))
   {
     struct board *src_board = mzx_world->current_board;
     int offset = x + (y * src_board->board_width);
@@ -306,10 +306,10 @@ int place_player_xy(struct world *mzx_world, int x, int y)
       step_sensor(mzx_world, dparam);
     }
 
-    id_remove_top(mzx_world, mzx_world->player_x, mzx_world->player_y);
+    id_remove_top(mzx_world, mzx_world->players[0].x, mzx_world->players[0].y);
     id_place(mzx_world, x, y, PLAYER, 0, 0);
-    mzx_world->player_x = x;
-    mzx_world->player_y = y;
+    mzx_world->players[0].x = x;
+    mzx_world->players[0].y = y;
 
     return 1;
   }
@@ -870,8 +870,8 @@ void replace_player(struct world *mzx_world)
       if(A_UNDER & flags[(int)level_id[offset]])
       {
         // Place the player here
-        mzx_world->player_x = dx;
-        mzx_world->player_y = dy;
+        mzx_world->players[0].x = dx;
+        mzx_world->players[0].y = dy;
         id_place(mzx_world, dx, dy, PLAYER, 0, 0);
         return;
       }
@@ -879,8 +879,8 @@ void replace_player(struct world *mzx_world)
   }
 
   // Place the player here
-  mzx_world->player_x = 0;
-  mzx_world->player_y = 0;
+  mzx_world->players[0].x = 0;
+  mzx_world->players[0].y = 0;
   place_at_xy(mzx_world, PLAYER, 0, 0, 0, 0);
 }
 
@@ -1823,8 +1823,8 @@ void run_robot(context *ctx, int id, int x, int y)
                 new_y = y;
                 if(!move_dir(src_board, &new_x, &new_y, direction))
                 {
-                  if((mzx_world->player_x == new_x) &&
-                   (mzx_world->player_y == new_y))
+                  if((mzx_world->players[0].x == new_x) &&
+                   (mzx_world->players[0].y == new_y))
                   {
                     success = 1;
                   }
@@ -1845,8 +1845,8 @@ void run_robot(context *ctx, int id, int x, int y)
                     new_y = y;
                     if(!move_dir(src_board, &new_x, &new_y, int_to_dir(i)))
                     {
-                      if((mzx_world->player_x == new_x) &&
-                       (mzx_world->player_y == new_y))
+                      if((mzx_world->players[0].x == new_x) &&
+                       (mzx_world->players[0].y == new_y))
                       {
                         success = 1;
                       }
@@ -1878,8 +1878,8 @@ void run_robot(context *ctx, int id, int x, int y)
               {
                 // Give an ID of -1 to throw it off from not
                 // allowing global robot.
-                calculate_blocked(mzx_world, mzx_world->player_x,
-                 mzx_world->player_y, -1, new_bl);
+                calculate_blocked(mzx_world, mzx_world->players[0].x,
+                 mzx_world->players[0].y, -1, new_bl);
                 update_blocked = 1;
                 break;
               }
@@ -1925,7 +1925,7 @@ void run_robot(context *ctx, int id, int x, int y)
           {
             if(id)
             {
-              if((mzx_world->player_x == x) || (mzx_world->player_y == y))
+              if((mzx_world->players[0].x == x) || (mzx_world->players[0].y == y))
                 success = 1;
             }
             break;
@@ -1935,7 +1935,7 @@ void run_robot(context *ctx, int id, int x, int y)
           {
             if(id)
             {
-              if(mzx_world->player_x == x)
+              if(mzx_world->players[0].x == x)
                 success = 1;
             }
             break;
@@ -1945,7 +1945,7 @@ void run_robot(context *ctx, int id, int x, int y)
           {
             if(id)
             {
-              if(mzx_world->player_y == y)
+              if(mzx_world->players[0].y == y)
                 success = 1;
             }
             break;
@@ -2307,7 +2307,7 @@ void run_robot(context *ctx, int id, int x, int y)
         int check_param = parse_param(mzx_world, p4, id);
 
         if(check_dir_xy(mzx_world, check_id, check_color,
-         check_param, mzx_world->player_x, mzx_world->player_y,
+         check_param, mzx_world->players[0].x, mzx_world->players[0].y,
          direction, cur_robot, _bl))
         {
           char *p5 = next_param_pos(p4);
@@ -2717,8 +2717,8 @@ void run_robot(context *ctx, int id, int x, int y)
         direction = parsedir(direction, x, y, cur_robot->walk_dir);
         if(is_cardinal_dir(direction))
         {
-          int old_x = mzx_world->player_x;
-          int old_y = mzx_world->player_y;
+          int old_x = mzx_world->players[0].x;
+          int old_y = mzx_world->players[0].y;
           int old_board = mzx_world->current_board_id;
           enum board_target old_target = mzx_world->target_where;
 
@@ -2738,8 +2738,8 @@ void run_robot(context *ctx, int id, int x, int y)
           move_player(mzx_world, dir_to_int(direction));
 
           if((cmd == ROBOTIC_CMD_MOVE_PLAYER_DIR_OR) &&
-           (mzx_world->player_x == old_x) &&
-           (mzx_world->player_y == old_y) &&
+           (mzx_world->players[0].x == old_x) &&
+           (mzx_world->players[0].y == old_y) &&
            (mzx_world->current_board_id == old_board) &&
            (mzx_world->target_where == old_target))
           {
@@ -2764,7 +2764,7 @@ void run_robot(context *ctx, int id, int x, int y)
         if(place_player_xy(mzx_world, put_x, put_y))
         {
           done = 1;
-          if((mzx_world->player_x == x) && (mzx_world->player_y == y))
+          if((mzx_world->players[0].x == x) && (mzx_world->players[0].y == y))
           {
             // Robot no longer exists; exit
             return;
@@ -2780,8 +2780,8 @@ void run_robot(context *ctx, int id, int x, int y)
         int check_y = parse_param(mzx_world, p2, id);
         prefix_mid_xy(mzx_world, &check_x, &check_y, x, y);
 
-        if((check_x == mzx_world->player_x) &&
-         (check_y == mzx_world->player_y))
+        if((check_x == mzx_world->players[0].x) &&
+         (check_y == mzx_world->players[0].y))
         {
           char *p3 = next_param_pos(p2);
           gotoed = send_self_label_tr(mzx_world, p3 + 1, id);
@@ -2802,7 +2802,7 @@ void run_robot(context *ctx, int id, int x, int y)
           {
             if(place_player_xy(mzx_world, put_x, put_y))
             {
-              if((mzx_world->player_x == x) && (mzx_world->player_y == y))
+              if((mzx_world->players[0].x == x) && (mzx_world->players[0].y == y))
               {
                 // Robot no longer exists; exit
                 return;
@@ -3502,8 +3502,8 @@ void run_robot(context *ctx, int id, int x, int y)
 
       case ROBOTIC_CMD_SEND_DIR_PLAYER: // Send DIR of player "label"
       {
-        int send_x = mzx_world->player_x;
-        int send_y = mzx_world->player_y;
+        int send_x = mzx_world->players[0].x;
+        int send_y = mzx_world->players[0].y;
         enum dir direction = parse_param_dir(mzx_world, cmd_ptr + 1);
         direction = parsedir(direction, send_x, send_y,
          cur_robot->walk_dir);
@@ -3533,11 +3533,11 @@ void run_robot(context *ctx, int id, int x, int y)
         {
           int player_bl[4];
 
-          calculate_blocked(mzx_world, mzx_world->player_x,
-           mzx_world->player_y, 1, player_bl);
+          calculate_blocked(mzx_world, mzx_world->players[0].x,
+           mzx_world->players[0].y, 1, player_bl);
 
           place_dir_xy(mzx_world, put_id, put_color, put_param,
-           mzx_world->player_x, mzx_world->player_y, direction,
+           mzx_world->players[0].x, mzx_world->players[0].y, direction,
            cur_robot, player_bl);
 
           /* Ensure that if the put involves overwriting this robot,
@@ -4706,8 +4706,8 @@ void run_robot(context *ctx, int id, int x, int y)
       case ROBOTIC_CMD_RESTORE_PLAYER_POSITION_N_DUPLICATE_SELF:
       {
         int pos = parse_param(mzx_world, cmd_ptr + 1, id) - 1;
-        int duplicate_x = mzx_world->player_x;
-        int duplicate_y = mzx_world->player_y;
+        int duplicate_x = mzx_world->players[0].x;
+        int duplicate_y = mzx_world->players[0].y;
         int duplicate_color, duplicate_id, dest_id;
         int offset;
 
@@ -4756,8 +4756,8 @@ void run_robot(context *ctx, int id, int x, int y)
       case ROBOTIC_CMD_EXCHANGE_PLAYER_POSITION_N_DUPLICATE_SELF:
       {
         int pos = parse_param(mzx_world, cmd_ptr + 1, id) - 1;
-        int duplicate_x = mzx_world->player_x;
-        int duplicate_y = mzx_world->player_y;
+        int duplicate_x = mzx_world->players[0].x;
+        int duplicate_y = mzx_world->players[0].y;
         int duplicate_color, duplicate_id, dest_id;
         int offset;
 

--- a/src/run_robot.c
+++ b/src/run_robot.c
@@ -288,6 +288,7 @@ int place_player_xy(struct world *mzx_world, int x, int y)
     int offset = x + (y * src_board->board_width);
     int did = src_board->level_id[offset];
     int dparam = src_board->level_param[offset];
+    merge_all_players(mzx_world);
 
     if(is_robot(did))
     {

--- a/src/run_robot.c
+++ b/src/run_robot.c
@@ -857,12 +857,54 @@ static int copy_block_param_special(struct world *mzx_world, int id,
 
 void merge_one_player(struct world *mzx_world, int player_id)
 {
+  struct board *src_board = mzx_world->current_board;
+  int board_width = src_board->board_width;
+  int board_height = src_board->board_height;
+  char *level_id = src_board->level_id;
+  char *level_param = src_board->level_param;
   struct player *player = &mzx_world->players[player_id];
   struct player *primary_player = &mzx_world->players[0];
+
+  // If we are the primary player, do nothing.
+  if(player_id == 0)
+  {
+    return;
+  }
+
+  // Are we separated?
+  if(player->separated)
+  {
+    // Do we have a position that's within the board bounds?
+    int dx = player->x;
+    int dy = player->y;
+    if(dx >= 0 && dx < board_width && dy >= 0 && dy < board_height)
+    {
+      // Are we actually on the board?
+      int offset = dx + (dy*board_width);
+      enum thing d_id = (enum thing)level_id[offset];
+      int d_param = level_param[offset];
+
+      if(d_id == PLAYER && d_param == player_id)
+      {
+        // Remove the old player
+        id_remove_top(mzx_world, player->x, player->y);
+      }
+    }
+  }
 
   player->x = primary_player->x;
   player->y = primary_player->y;
   player->separated = false;
+}
+
+void merge_all_players(struct world *mzx_world)
+{
+  int player_id;
+
+  for(player_id = 1; player_id < NUM_PLAYERS; player_id++)
+  {
+    merge_one_player(mzx_world, player_id);
+  }
 }
 
 void replace_one_player(struct world *mzx_world, int player_id)

--- a/src/world.c
+++ b/src/world.c
@@ -2989,8 +2989,8 @@ void change_board_set_values(struct world *mzx_world)
 
   // Set the player restart position.
   find_player(mzx_world);
-  mzx_world->player_restart_x = mzx_world->player_x;
-  mzx_world->player_restart_y = mzx_world->player_y;
+  mzx_world->player_restart_x = mzx_world->players[0].x;
+  mzx_world->player_restart_y = mzx_world->players[0].y;
 }
 
 void change_board_load_assets(struct world *mzx_world)
@@ -3297,7 +3297,7 @@ void clear_world(struct world *mzx_world)
 
   mzx_world->current_cycle_odd = false;
   mzx_world->current_cycle_frozen = false;
-  mzx_world->player_shoot_cooldown = 0;
+  mzx_world->players[0].shoot_cooldown = 0;
   mzx_world->active = 0;
 
   audio_end_sample();

--- a/src/world_struct.h
+++ b/src/world_struct.h
@@ -172,9 +172,6 @@ struct world
   // Toggle used by certain built-in mechanics that update every other cycle.
   boolean current_cycle_odd;
 
-  // Did the player just move?
-  boolean player_moved;
-
   // Was the player on an entrance before the board scan?
   boolean player_was_on_entrance;
 

--- a/src/world_struct.h
+++ b/src/world_struct.h
@@ -26,6 +26,7 @@ __M_BEGIN_DECLS
 
 #include "board_struct.h"
 #include "robot_struct.h"
+#include "player_struct.h"
 #include "counter_struct.h"
 #include "sprite_struct.h"
 
@@ -146,9 +147,7 @@ struct world
   char custom_sfx[NUM_SFX * SFX_SIZE];
 
   // Not part of world/save files, but runtime globals
-  int player_x;
-  int player_y;
-  int player_shoot_cooldown;
+  struct player players[NUM_PLAYERS];
 
   // For moving the player between boards
   enum board_target target_where;

--- a/src/world_struct.h
+++ b/src/world_struct.h
@@ -178,12 +178,6 @@ struct world
   // Was the player damaged while 'restart if hurt' is active?
   boolean was_zapped;
 
-  // For use in repeat delays for player movement
-  int key_up_delay;
-  int key_down_delay;
-  int key_right_delay;
-  int key_left_delay;
-
   // 1-3 normal 5-7 is 1-3 but from a REL FIRST cmd
   int first_prefix;
   // Just 1-3


### PR DESCRIPTION
WIP, but I'd like to get some eyes over the code so I have a better idea of how this should be done.

My earlier attempt at adding multiplayer to MegaZeux dates back to early-to-mid 2018 and since then the code's had a clue-by-4-rocket-machine-launcher-steamroller applied to it so good luck getting that to apply.

So far this contains enough to... well, work normally when you don't enable multiplayer support. However when you do enable it, you get something which behaves similarly to the previous attempt except every player uses the exact same inputs.

I'm considering getting a little bit more clone-b-gone into this before dropping the WIP tag but I'm tempted to do the input support in a separate PR. Consider this PR impractical for actually playing multiplayer but there isn't an obvious way to do multiplayer input well with MZX.

Either way, this does end up moving stuff into a player structure with the wonderful power of `sed -i`, and some of the code has been refactored to take advantage of this. Also, unlike the previous attempt, moving the primary player doesn't require moving all of the other merged players at the same time.