### PR TITLE
remove further unused libxmp functionality

### DIFF
--- a/contrib/libxmp/src/common.h
+++ b/contrib/libxmp/src/common.h
@@ -39,10 +39,6 @@ typedef unsigned long long uint64;
 typedef signed long long int64;
 #endif
 
-#ifndef LIBXMP_CORE_PLAYER
-#define LIBXMP_PAULA_SIMULATOR
-#endif
-
 /* Constants */
 #define PAL_RATE	250.0		/* 1 / (50Hz * 80us)		  */
 #define NTSC_RATE	208.0		/* 1 / (60Hz * 80us)		  */
@@ -213,9 +209,6 @@ struct ord_data {
 	int gvl;
 	int time;
 	int start_row;
-#ifndef LIBXMP_CORE_PLAYER
-	int st26_speed;
-#endif
 };
 
 
@@ -352,9 +345,6 @@ struct player_data {
 		char *in_buffer;
 	} buffer_data;
 
-#ifndef LIBXMP_CORE_PLAYER
-	int st26_speed;			/* For IceTracker speed effect */
-#endif
 	int filter;			/* Amiga led filter */
 };
 

--- a/contrib/libxmp/src/effects.c
+++ b/contrib/libxmp/src/effects.c
@@ -522,9 +522,6 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 	    fx_s3m_speed:
 		if (fxp) {
 			p->speed = fxp;
-#ifndef LIBXMP_CORE_PLAYER
-			p->st26_speed = 0;
-#endif
 		}
 		break;
 	case FX_S3M_BPM:	/* Set S3M BPM */
@@ -878,24 +875,6 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 		xc->porta.dir = -1;
 		break;
 
-	/* Saga Musix says:
-	 *
-	 * "When both nibbles of an Fxx command are set, SoundTracker 2.6
-	 * applies the both values alternatingly, first the high nibble,
-	 * then the low nibble on the next row, then the high nibble again...
-	 * If only the high nibble is set, it should act like if only the low
-	 * nibble is set (i.e. F30 is the same as F03).
-	 */
-	case FX_ICE_SPEED:
-		if (fxp) {
-			if (LSN(fxp)) {
-				p->st26_speed = (MSN(fxp) << 8) | LSN(fxp);
-			} else {
-				p->st26_speed = MSN(fxp);
-			}
-		}
-		break;
-
 	case FX_VOLSLIDE_UP:	/* Vol slide with uint8 arg */
 		if (HAS_QUIRK(QUIRK_FINEFX)) {
 			h = MSN(fxp);
@@ -1021,7 +1000,6 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 	case FX_SPEED_CP:	/* Set speed and ... */
 		if (fxp) {
 			p->speed = fxp;
-			p->st26_speed = 0;
 		}
 		/* fall through */
 	case FX_PER_CANCEL:	/* Cancel persistent effects */

--- a/contrib/libxmp/src/loaders/it_load.c
+++ b/contrib/libxmp/src/loaders/it_load.c
@@ -322,90 +322,18 @@ static void read_envelope(struct xmp_envelope *ei, struct it_envelope *env,
 
 static void identify_tracker(struct module_data *m, struct it_file_header *ifh)
 {
-#ifndef LIBXMP_CORE_PLAYER
-	char tracker_name[40];
 	int sample_mode = ~ifh->flags & IT_USE_INST;
 
 	switch (ifh->cwt >> 8) {
-	case 0x00:
-		strcpy(tracker_name, "unmo3");
-		break;
-	case 0x01:
 	case 0x02:		/* test from Schism Tracker sources */
-		if (ifh->cmwt == 0x0200 && ifh->cwt == 0x0214
-		    && ifh->flags == 9 && ifh->special == 0
-		    && ifh->hilite_maj == 0 && ifh->hilite_min == 0
-		    && ifh->insnum == 0 && ifh->patnum + 1 == ifh->ordnum
-		    && ifh->gv == 128 && ifh->mv == 100 && ifh->is == 1
-		    && ifh->sep == 128 && ifh->pwd == 0
-		    && ifh->msglen == 0 && ifh->msgofs == 0 && ifh->rsvd == 0) {
-			strcpy(tracker_name, "OpenSPC conversion");
-		} else if (ifh->cmwt == 0x0200 && ifh->cwt == 0x0217) {
-			strcpy(tracker_name, "ModPlug Tracker 1.16");
+		if (ifh->cmwt == 0x0200 && ifh->cwt == 0x0217) {
 			/* ModPlug Tracker files aren't really IMPM 2.00 */
 			ifh->cmwt = sample_mode ? 0x100 : 0x214;
-		} else if (ifh->cwt == 0x0216) {
-			strcpy(tracker_name, "Impulse Tracker 2.14v3");
-		} else if (ifh->cwt == 0x0217) {
-			strcpy(tracker_name, "Impulse Tracker 2.14v5");
-		} else if (ifh->cwt == 0x0214 && !memcmp(&ifh->rsvd, "CHBI", 4)) {
-			strcpy(tracker_name, "Chibi Tracker");
-		} else {
-			snprintf(tracker_name, 40, "Impulse Tracker %d.%02x",
-				 (ifh->cwt & 0x0f00) >> 8, ifh->cwt & 0xff);
 		}
 		break;
-	case 0x08:
-	case 0x7f:
-		if (ifh->cwt == 0x0888) {
-			strcpy(tracker_name, "OpenMPT 1.17");
-		} else if (ifh->cwt == 0x7fff) {
-			strcpy(tracker_name, "munch.py");
-		} else {
-			snprintf(tracker_name, 40, "unknown (%04x)", ifh->cwt);
-		}
-		break;
-	default:
-		switch (ifh->cwt >> 12) {
-		case 0x1:{
-			uint16 cwtv = ifh->cwt & 0x0fff;
-			struct tm version;
-			time_t version_sec;
-
-			if (cwtv > 0x50) {
-				version_sec = ((cwtv - 0x050) * 86400) + 1254355200;
-				if (localtime_r(&version_sec, &version)) {
-					snprintf(tracker_name, 40,
-						 "Schism Tracker %04d-%02d-%02d",
-						 version.tm_year + 1900,
-						 version.tm_mon + 1,
-						 version.tm_mday);
-				}
-			} else {
-				snprintf(tracker_name, 40,
-					 "Schism Tracker 0.%x", cwtv);
-			}
-			break; }
-		case 0x5:
-			snprintf(tracker_name, 40, "OpenMPT %d.%02x",
-				 (ifh->cwt & 0x0f00) >> 8, ifh->cwt & 0xff);
-			if (memcmp(&ifh->rsvd, "OMPT", 4))
-				strncat(tracker_name, " (compat.)", 39);
-			break;
-		case 0x06:
-			snprintf(tracker_name, 40, "BeRoTracker %d.%02x",
-				 (ifh->cwt & 0x0f00) >> 8, ifh->cwt & 0xff);
-			break;
-		default:
-			snprintf(tracker_name, 40, "unknown (%04x)", ifh->cwt);
-		}
 	}
 
-	libxmp_set_type(m, "%s IT %d.%02x", tracker_name, ifh->cmwt >> 8,
-						ifh->cmwt & 0xff);
-#else
 	libxmp_set_type(m, "Impulse Tracker");
-#endif
 }
 
 static int load_old_it_instrument(struct xmp_instrument *xxi, HIO_HANDLE *f)

--- a/contrib/libxmp/src/loaders/s3m_load.c
+++ b/contrib/libxmp/src/loaders/s3m_load.c
@@ -383,54 +383,16 @@ static int s3m_load(struct module_data *m, HIO_HANDLE * f, const int start)
 		m->quirk |= QUIRK_VSALL;
 	}
 
-#ifndef LIBXMP_CORE_PLAYER
 	switch (sfh.version >> 12) {
 	case 1:
-		snprintf(tracker_name, 40, "Scream Tracker %d.%02x",
-			 (sfh.version & 0x0f00) >> 8, sfh.version & 0xff);
 		m->quirk |= QUIRK_ST3BUGS;
-		break;
-	case 2:
-		snprintf(tracker_name, 40, "Imago Orpheus %d.%02x",
-			 (sfh.version & 0x0f00) >> 8, sfh.version & 0xff);
-		break;
-	case 3:
-		if (sfh.version == 0x3216) {
-			strcpy(tracker_name, "Impulse Tracker 2.14v3");
-		} else if (sfh.version == 0x3217) {
-			strcpy(tracker_name, "Impulse Tracker 2.14v5");
-		} else {
-			snprintf(tracker_name, 40, "Impulse Tracker %d.%02x",
-				 (sfh.version & 0x0f00) >> 8,
-				 sfh.version & 0xff);
-		}
 		break;
 	case 5:
-		snprintf(tracker_name, 40, "OpenMPT %d.%02x",
-			 (sfh.version & 0x0f00) >> 8, sfh.version & 0xff);
 		m->quirk |= QUIRK_ST3BUGS;
 		break;
-	case 4:
-		if (sfh.version != 0x4100) {
-			snprintf(tracker_name, 40, "Schism Tracker %d.%02x",
-				 (sfh.version & 0x0f00) >> 8,
-				 sfh.version & 0xff);
-			break;
-		}
-		/* fall through */
-	case 6:
-		snprintf(tracker_name, 40, "BeRoTracker %d.%02x",
-			 (sfh.version & 0x0f00) >> 8, sfh.version & 0xff);
-		break;
-	default:
-		snprintf(tracker_name, 40, "unknown (%04x)", sfh.version);
 	}
 
-	libxmp_set_type(m, "%s S3M", tracker_name);
-#else
 	libxmp_set_type(m, "Scream Tracker 3");
-	m->quirk |= QUIRK_ST3BUGS;
-#endif
 
 	MODULE_INFO();
 

--- a/contrib/libxmp/src/loaders/sample.c
+++ b/contrib/libxmp/src/loaders/sample.c
@@ -25,56 +25,11 @@
 
 #ifndef LIBXMP_CORE_PLAYER
 
-/*
- * From the Audio File Formats (version 2.5)
- * Submitted-by: Guido van Rossum <guido@cwi.nl>
- * Last-modified: 27-Aug-1992
- *
- * The Acorn Archimedes uses a variation on U-LAW with the bit order
- * reversed and the sign bit in bit 0.  Being a 'minority' architecture,
- * Arc owners are quite adept at converting sound/image formats from
- * other machines, and it is unlikely that you'll ever encounter sound in
- * one of the Arc's own formats (there are several).
- */
-static const int8 vdic_table[128] = {
-	/*   0 */	  0,   0,   0,   0,   0,   0,   0,   0,
-	/*   8 */	  0,   0,   0,   0,   0,   0,   0,   0,
-	/*  16 */	  0,   0,   0,   0,   0,   0,   0,   0,
-	/*  24 */	  1,   1,   1,   1,   1,   1,   1,   1,
-	/*  32 */	  1,   1,   1,   1,   2,   2,   2,   2,
-	/*  40 */	  2,   2,   2,   2,   3,   3,   3,   3,
-	/*  48 */	  3,   3,   4,   4,   4,   4,   5,   5,
-	/*  56 */	  5,   5,   6,   6,   6,   6,   7,   7,
-	/*  64 */	  7,   8,   8,   9,   9,  10,  10,  11,
-	/*  72 */	 11,  12,  12,  13,  13,  14,  14,  15,
-	/*  80 */	 15,  16,  17,  18,  19,  20,  21,  22,
-	/*  88 */	 23,  24,  25,  26,  27,  28,  29,  30,
-	/*  96 */	 31,  33,  34,  36,  38,  40,  42,  44,
-	/* 104 */	 46,  48,  50,  52,  54,  56,  58,  60,
-	/* 112 */	 62,  65,  68,  72,  77,  80,  84,  91,
-	/* 120 */	 95,  98, 103, 109, 114, 120, 126, 127
-};
-
-
 /* Convert 7 bit samples to 8 bit */
 static void convert_7bit_to_8bit(uint8 *p, int l)
 {
 	for (; l--; p++) {
 		*p <<= 1;
-	}
-}
-
-/* Convert Archimedes VIDC samples to linear */
-static void convert_vidc_to_linear(uint8 *p, int l)
-{
-	int i;
-	uint8 x;
-
-	for (i = 0; i < l; i++) {
-		x = p[i];
-		p[i] = vdic_table[x >> 1];
-		if (x & 0x01)
-			p[i] *= -1;
 	}
 }
 
@@ -343,12 +298,6 @@ int libxmp_load_sample(struct module_data *m, HIO_HANDLE *f, int flags, struct x
 		convert_stereo_to_mono(xxs->data, xxs->len,
 					xxs->flg & XMP_SAMPLE_16BIT);
 		xxs->len /= 2;
-	}
-#endif
-
-#ifndef LIBXMP_CORE_PLAYER
-	if (flags & SAMPLE_FLAG_VIDC) {
-		convert_vidc_to_linear(xxs->data, xxs->len);
 	}
 #endif
 

--- a/contrib/libxmp/src/player.c
+++ b/contrib/libxmp/src/player.c
@@ -1463,10 +1463,6 @@ static void update_from_ord_info(struct context_data *ctx)
 	p->gvol = oinfo->gvl;
 	p->current_time = oinfo->time;
 	p->frame_time = m->time_factor * m->rrate / p->bpm;
-
-#ifndef LIBXMP_CORE_PLAYER
-	p->st26_speed = oinfo->st26_speed;
-#endif
 }
 
 int xmp_start_player(xmp_context opaque, int rate, int format)
@@ -1678,17 +1674,6 @@ int xmp_play_frame(xmp_context opaque)
 	if (p->frame == 0) {			/* first frame in row */
 		check_end_of_module(ctx);
 		read_row(ctx, mod->xxo[p->ord], p->row);
-
-#ifndef LIBXMP_CORE_PLAYER
-		if (p->st26_speed) {
-			if  (p->st26_speed & 0x10000) {
-				p->speed = (p->st26_speed & 0xff00) >> 8;
-			} else {
-				p->speed = p->st26_speed & 0xff;
-			}
-			p->st26_speed ^= 0x10000;
-		}
-#endif
 	}
 
 	inject_event(ctx);

--- a/contrib/libxmp/src/scan.c
+++ b/contrib/libxmp/src/scan.c
@@ -66,9 +66,6 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
     int i, pat;
     int has_marker;
     struct ord_data *info;
-#ifndef LIBXMP_CORE_PLAYER
-    int st26_speed;
-#endif
 
     if (mod->len == 0)
 	return 0;
@@ -91,9 +88,6 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
 
     speed = mod->spd;
     base_time = m->rrate;
-#ifndef LIBXMP_CORE_PLAYER
-    st26_speed = 0;
-#endif
 
     has_marker = HAS_QUIRK(QUIRK_MARKER);
 
@@ -174,9 +168,6 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
             info->bpm = bpm;
             info->speed = speed;
             info->time = time + m->time_factor * frame_count * base_time / bpm;
-#ifndef LIBXMP_CORE_PLAYER
-            info->st26_speed = st26_speed;
-#endif
         }
 
 	if (info->start_row == 0 && ord != 0) {
@@ -278,9 +269,6 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
 			if (HAS_QUIRK(QUIRK_NOBPM) || p->flags & XMP_FLAGS_VBLANK || parm < 0x20) {
 			    if (parm > 0) {
 			        speed = parm;
-#ifndef LIBXMP_CORE_PLAYER
-			        st26_speed = 0;
-#endif
                             }
 			} else {
 			    time += m->time_factor * frame_count * base_time / bpm;
@@ -297,16 +285,6 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
 		if (f2 == FX_SPEED_CP) {
 		    f2 = FX_S3M_SPEED;
 		}
-
-		/* ST2.6 speed processing */
-
-		if (f1 == FX_ICE_SPEED && p1) {
-		    if (LSN(p1)) {
-		        st26_speed = (MSN(p1) << 8) | LSN(p1);
-		    } else {
-			st26_speed = MSN(p1);
-		    }
-		}
 #endif
 
 		if ((f1 == FX_S3M_SPEED && p1) || (f2 == FX_S3M_SPEED && p2)) {
@@ -315,9 +293,6 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
 		        frame_count += row_count * speed;
 		        row_count  = 0;
 		        speed = parm;
-#ifndef LIBXMP_CORE_PLAYER
-		        st26_speed = 0;
-#endif
 		    }
 		}
 
@@ -439,19 +414,6 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
 		row = loop_row[loop_chn];
 		loop_chn = -1;
 	    }
-
-#ifndef LIBXMP_CORE_PLAYER
-	    if (st26_speed) {
-	        frame_count += row_count * speed;
-	        row_count  = 0;
-		if (st26_speed & 0x10000) {
-			speed = (st26_speed & 0xff00) >> 8;
-		} else {
-			speed = st26_speed & 0xff;
-		}
-		st26_speed ^= 0x10000;
-	    }
-#endif
 	}
 
 	if (break_row && pdelay) {

--- a/contrib/patches/libxmp/07-libxmp-4.4.1-disable-paula-emulation.patch
+++ b/contrib/patches/libxmp/07-libxmp-4.4.1-disable-paula-emulation.patch
@@ -1,0 +1,14 @@
+diff -Nrup libxmp-4.4.1-orig/src/common.h libxmp-4.4.1/src/common.h
+--- libxmp-4.4.1-orig/src/common.h	2019-10-17 08:40:06.636009255 +0200
++++ libxmp-4.4.1/src/common.h	2019-10-17 08:40:17.285009381 +0200
+@@ -38,10 +38,6 @@ typedef unsigned long long uint64;
+ typedef signed long long int64;
+ #endif
+ 
+-#ifndef LIBXMP_CORE_PLAYER
+-#define LIBXMP_PAULA_SIMULATOR
+-#endif
+-
+ /* Constants */
+ #define PAL_RATE	250.0		/* 1 / (50Hz * 80us)		  */
+ #define NTSC_RATE	208.0		/* 1 / (60Hz * 80us)		  */

--- a/contrib/patches/libxmp/08-libxmp-4.4.1-remove-icetracker-speed-quirk.patch
+++ b/contrib/patches/libxmp/08-libxmp-4.4.1-remove-icetracker-speed-quirk.patch
@@ -1,0 +1,191 @@
+diff -Nrup libxmp-4.4.1-07/src/common.h libxmp-4.4.1/src/common.h
+--- libxmp-4.4.1-07/src/common.h	2019-10-17 08:40:52.034009792 +0200
++++ libxmp-4.4.1/src/common.h	2019-10-17 08:43:41.567011797 +0200
+@@ -206,9 +206,6 @@ struct ord_data {
+ 	int gvl;
+ 	int time;
+ 	int start_row;
+-#ifndef LIBXMP_CORE_PLAYER
+-	int st26_speed;
+-#endif
+ };
+ 
+ 
+@@ -345,9 +342,6 @@ struct player_data {
+ 		char *in_buffer;
+ 	} buffer_data;
+ 
+-#ifndef LIBXMP_CORE_PLAYER
+-	int st26_speed;			/* For IceTracker speed effect */
+-#endif
+ 	int filter;			/* Amiga led filter */
+ };
+ 
+diff -Nrup libxmp-4.4.1-07/src/effects.c libxmp-4.4.1/src/effects.c
+--- libxmp-4.4.1-07/src/effects.c	2019-10-17 08:40:52.034009792 +0200
++++ libxmp-4.4.1/src/effects.c	2019-10-17 08:42:59.083011294 +0200
+@@ -522,9 +522,6 @@ void libxmp_process_fx(struct context_da
+ 	    fx_s3m_speed:
+ 		if (fxp) {
+ 			p->speed = fxp;
+-#ifndef LIBXMP_CORE_PLAYER
+-			p->st26_speed = 0;
+-#endif
+ 		}
+ 		break;
+ 	case FX_S3M_BPM:	/* Set S3M BPM */
+@@ -873,24 +870,6 @@ void libxmp_process_fx(struct context_da
+ 		xc->porta.dir = -1;
+ 		break;
+ 
+-	/* Saga Musix says:
+-	 *
+-	 * "When both nibbles of an Fxx command are set, SoundTracker 2.6
+-	 * applies the both values alternatingly, first the high nibble,
+-	 * then the low nibble on the next row, then the high nibble again...
+-	 * If only the high nibble is set, it should act like if only the low
+-	 * nibble is set (i.e. F30 is the same as F03).
+-	 */
+-	case FX_ICE_SPEED:
+-		if (fxp) {
+-			if (LSN(fxp)) {
+-				p->st26_speed = (MSN(fxp) << 8) | LSN(fxp);
+-			} else {
+-				p->st26_speed = MSN(fxp);
+-			}
+-		}
+-		break;
+-
+ 	case FX_VOLSLIDE_UP:	/* Vol slide with uint8 arg */
+ 		if (HAS_QUIRK(QUIRK_FINEFX)) {
+ 			h = MSN(fxp);
+@@ -1016,7 +995,6 @@ void libxmp_process_fx(struct context_da
+ 	case FX_SPEED_CP:	/* Set speed and ... */
+ 		if (fxp) {
+ 			p->speed = fxp;
+-			p->st26_speed = 0;
+ 		}
+ 		/* fall through */
+ 	case FX_PER_CANCEL:	/* Cancel persistent effects */
+diff -Nrup libxmp-4.4.1-07/src/player.c libxmp-4.4.1/src/player.c
+--- libxmp-4.4.1-07/src/player.c	2019-10-17 08:40:52.034009792 +0200
++++ libxmp-4.4.1/src/player.c	2019-10-17 08:43:22.520011571 +0200
+@@ -1463,10 +1463,6 @@ static void update_from_ord_info(struct
+ 	p->gvol = oinfo->gvl;
+ 	p->current_time = oinfo->time;
+ 	p->frame_time = m->time_factor * m->rrate / p->bpm;
+-
+-#ifndef LIBXMP_CORE_PLAYER
+-	p->st26_speed = oinfo->st26_speed;
+-#endif
+ }
+ 
+ int xmp_start_player(xmp_context opaque, int rate, int format)
+@@ -1678,17 +1674,6 @@ int xmp_play_frame(xmp_context opaque)
+ 	if (p->frame == 0) {			/* first frame in row */
+ 		check_end_of_module(ctx);
+ 		read_row(ctx, mod->xxo[p->ord], p->row);
+-
+-#ifndef LIBXMP_CORE_PLAYER
+-		if (p->st26_speed) {
+-			if  (p->st26_speed & 0x10000) {
+-				p->speed = (p->st26_speed & 0xff00) >> 8;
+-			} else {
+-				p->speed = p->st26_speed & 0xff;
+-			}
+-			p->st26_speed ^= 0x10000;
+-		}
+-#endif
+ 	}
+ 
+ 	inject_event(ctx);
+diff -Nrup libxmp-4.4.1-07/src/scan.c libxmp-4.4.1/src/scan.c
+--- libxmp-4.4.1-07/src/scan.c	2019-10-17 08:40:52.034009792 +0200
++++ libxmp-4.4.1/src/scan.c	2019-10-17 08:43:15.917011493 +0200
+@@ -66,9 +66,6 @@ static int scan_module(struct context_da
+     int i, pat;
+     int has_marker;
+     struct ord_data *info;
+-#ifndef LIBXMP_CORE_PLAYER
+-    int st26_speed;
+-#endif
+ 
+     if (mod->len == 0)
+ 	return 0;
+@@ -91,9 +88,6 @@ static int scan_module(struct context_da
+ 
+     speed = mod->spd;
+     base_time = m->rrate;
+-#ifndef LIBXMP_CORE_PLAYER
+-    st26_speed = 0;
+-#endif
+ 
+     has_marker = HAS_QUIRK(QUIRK_MARKER);
+ 
+@@ -174,9 +168,6 @@ static int scan_module(struct context_da
+             info->bpm = bpm;
+             info->speed = speed;
+             info->time = time + m->time_factor * frame_count * base_time / bpm;
+-#ifndef LIBXMP_CORE_PLAYER
+-            info->st26_speed = st26_speed;
+-#endif
+         }
+ 
+ 	if (info->start_row == 0 && ord != 0) {
+@@ -278,9 +269,6 @@ static int scan_module(struct context_da
+ 			if (HAS_QUIRK(QUIRK_NOBPM) || p->flags & XMP_FLAGS_VBLANK || parm < 0x20) {
+ 			    if (parm > 0) {
+ 			        speed = parm;
+-#ifndef LIBXMP_CORE_PLAYER
+-			        st26_speed = 0;
+-#endif
+                             }
+ 			} else {
+ 			    time += m->time_factor * frame_count * base_time / bpm;
+@@ -297,16 +285,6 @@ static int scan_module(struct context_da
+ 		if (f2 == FX_SPEED_CP) {
+ 		    f2 = FX_S3M_SPEED;
+ 		}
+-
+-		/* ST2.6 speed processing */
+-
+-		if (f1 == FX_ICE_SPEED && p1) {
+-		    if (LSN(p1)) {
+-		        st26_speed = (MSN(p1) << 8) | LSN(p1);
+-		    } else {
+-			st26_speed = MSN(p1);
+-		    }
+-		}
+ #endif
+ 
+ 		if ((f1 == FX_S3M_SPEED && p1) || (f2 == FX_S3M_SPEED && p2)) {
+@@ -315,9 +293,6 @@ static int scan_module(struct context_da
+ 		        frame_count += row_count * speed;
+ 		        row_count  = 0;
+ 		        speed = parm;
+-#ifndef LIBXMP_CORE_PLAYER
+-		        st26_speed = 0;
+-#endif
+ 		    }
+ 		}
+ 
+@@ -439,19 +414,6 @@ static int scan_module(struct context_da
+ 		row = loop_row[loop_chn];
+ 		loop_chn = -1;
+ 	    }
+-
+-#ifndef LIBXMP_CORE_PLAYER
+-	    if (st26_speed) {
+-	        frame_count += row_count * speed;
+-	        row_count  = 0;
+-		if (st26_speed & 0x10000) {
+-			speed = (st26_speed & 0xff00) >> 8;
+-		} else {
+-			speed = st26_speed & 0xff;
+-		}
+-		st26_speed ^= 0x10000;
+-	    }
+-#endif
+ 	}
+ 
+ 	if (break_row && pdelay) {

--- a/contrib/patches/libxmp/09-libxmp-4.4.1-remove-tracker-name-detection.patch
+++ b/contrib/patches/libxmp/09-libxmp-4.4.1-remove-tracker-name-detection.patch
@@ -1,0 +1,153 @@
+diff -rup libxmp-4.4.1-orig/src/loaders/it_load.c libxmp-4.4.1/src/loaders/it_load.c
+--- libxmp-4.4.1-orig/src/loaders/it_load.c	2019-10-17 08:44:14.141012182 +0200
++++ libxmp-4.4.1/src/loaders/it_load.c	2019-10-17 08:49:34.216015967 +0200
+@@ -322,90 +322,18 @@ static void read_envelope(struct xmp_env
+ 
+ static void identify_tracker(struct module_data *m, struct it_file_header *ifh)
+ {
+-#ifndef LIBXMP_CORE_PLAYER
+-	char tracker_name[40];
+ 	int sample_mode = ~ifh->flags & IT_USE_INST;
+ 
+ 	switch (ifh->cwt >> 8) {
+-	case 0x00:
+-		strcpy(tracker_name, "unmo3");
+-		break;
+-	case 0x01:
+ 	case 0x02:		/* test from Schism Tracker sources */
+-		if (ifh->cmwt == 0x0200 && ifh->cwt == 0x0214
+-		    && ifh->flags == 9 && ifh->special == 0
+-		    && ifh->hilite_maj == 0 && ifh->hilite_min == 0
+-		    && ifh->insnum == 0 && ifh->patnum + 1 == ifh->ordnum
+-		    && ifh->gv == 128 && ifh->mv == 100 && ifh->is == 1
+-		    && ifh->sep == 128 && ifh->pwd == 0
+-		    && ifh->msglen == 0 && ifh->msgofs == 0 && ifh->rsvd == 0) {
+-			strcpy(tracker_name, "OpenSPC conversion");
+-		} else if (ifh->cmwt == 0x0200 && ifh->cwt == 0x0217) {
+-			strcpy(tracker_name, "ModPlug Tracker 1.16");
++		if (ifh->cmwt == 0x0200 && ifh->cwt == 0x0217) {
+ 			/* ModPlug Tracker files aren't really IMPM 2.00 */
+ 			ifh->cmwt = sample_mode ? 0x100 : 0x214;
+-		} else if (ifh->cwt == 0x0216) {
+-			strcpy(tracker_name, "Impulse Tracker 2.14v3");
+-		} else if (ifh->cwt == 0x0217) {
+-			strcpy(tracker_name, "Impulse Tracker 2.14v5");
+-		} else if (ifh->cwt == 0x0214 && !memcmp(&ifh->rsvd, "CHBI", 4)) {
+-			strcpy(tracker_name, "Chibi Tracker");
+-		} else {
+-			snprintf(tracker_name, 40, "Impulse Tracker %d.%02x",
+-				 (ifh->cwt & 0x0f00) >> 8, ifh->cwt & 0xff);
+-		}
+-		break;
+-	case 0x08:
+-	case 0x7f:
+-		if (ifh->cwt == 0x0888) {
+-			strcpy(tracker_name, "OpenMPT 1.17");
+-		} else if (ifh->cwt == 0x7fff) {
+-			strcpy(tracker_name, "munch.py");
+-		} else {
+-			snprintf(tracker_name, 40, "unknown (%04x)", ifh->cwt);
+ 		}
+ 		break;
+-	default:
+-		switch (ifh->cwt >> 12) {
+-		case 0x1:{
+-			uint16 cwtv = ifh->cwt & 0x0fff;
+-			struct tm version;
+-			time_t version_sec;
+-
+-			if (cwtv > 0x50) {
+-				version_sec = ((cwtv - 0x050) * 86400) + 1254355200;
+-				if (localtime_r(&version_sec, &version)) {
+-					snprintf(tracker_name, 40,
+-						 "Schism Tracker %04d-%02d-%02d",
+-						 version.tm_year + 1900,
+-						 version.tm_mon + 1,
+-						 version.tm_mday);
+-				}
+-			} else {
+-				snprintf(tracker_name, 40,
+-					 "Schism Tracker 0.%x", cwtv);
+-			}
+-			break; }
+-		case 0x5:
+-			snprintf(tracker_name, 40, "OpenMPT %d.%02x",
+-				 (ifh->cwt & 0x0f00) >> 8, ifh->cwt & 0xff);
+-			if (memcmp(&ifh->rsvd, "OMPT", 4))
+-				strncat(tracker_name, " (compat.)", 39);
+-			break;
+-		case 0x06:
+-			snprintf(tracker_name, 40, "BeRoTracker %d.%02x",
+-				 (ifh->cwt & 0x0f00) >> 8, ifh->cwt & 0xff);
+-			break;
+-		default:
+-			snprintf(tracker_name, 40, "unknown (%04x)", ifh->cwt);
+-		}
+ 	}
+ 
+-	libxmp_set_type(m, "%s IT %d.%02x", tracker_name, ifh->cmwt >> 8,
+-						ifh->cmwt & 0xff);
+-#else
+ 	libxmp_set_type(m, "Impulse Tracker");
+-#endif
+ }
+ 
+ static int load_old_it_instrument(struct xmp_instrument *xxi, HIO_HANDLE *f)
+diff -rup libxmp-4.4.1-orig/src/loaders/s3m_load.c libxmp-4.4.1/src/loaders/s3m_load.c
+--- libxmp-4.4.1-orig/src/loaders/s3m_load.c	2019-10-17 08:44:14.141012182 +0200
++++ libxmp-4.4.1/src/loaders/s3m_load.c	2019-10-17 08:51:42.779017487 +0200
+@@ -383,54 +383,16 @@ static int s3m_load(struct module_data *
+ 		m->quirk |= QUIRK_VSALL;
+ 	}
+ 
+-#ifndef LIBXMP_CORE_PLAYER
+ 	switch (sfh.version >> 12) {
+ 	case 1:
+-		snprintf(tracker_name, 40, "Scream Tracker %d.%02x",
+-			 (sfh.version & 0x0f00) >> 8, sfh.version & 0xff);
+ 		m->quirk |= QUIRK_ST3BUGS;
+ 		break;
+-	case 2:
+-		snprintf(tracker_name, 40, "Imago Orpheus %d.%02x",
+-			 (sfh.version & 0x0f00) >> 8, sfh.version & 0xff);
+-		break;
+-	case 3:
+-		if (sfh.version == 0x3216) {
+-			strcpy(tracker_name, "Impulse Tracker 2.14v3");
+-		} else if (sfh.version == 0x3217) {
+-			strcpy(tracker_name, "Impulse Tracker 2.14v5");
+-		} else {
+-			snprintf(tracker_name, 40, "Impulse Tracker %d.%02x",
+-				 (sfh.version & 0x0f00) >> 8,
+-				 sfh.version & 0xff);
+-		}
+-		break;
+ 	case 5:
+-		snprintf(tracker_name, 40, "OpenMPT %d.%02x",
+-			 (sfh.version & 0x0f00) >> 8, sfh.version & 0xff);
+ 		m->quirk |= QUIRK_ST3BUGS;
+ 		break;
+-	case 4:
+-		if (sfh.version != 0x4100) {
+-			snprintf(tracker_name, 40, "Schism Tracker %d.%02x",
+-				 (sfh.version & 0x0f00) >> 8,
+-				 sfh.version & 0xff);
+-			break;
+-		}
+-		/* fall through */
+-	case 6:
+-		snprintf(tracker_name, 40, "BeRoTracker %d.%02x",
+-			 (sfh.version & 0x0f00) >> 8, sfh.version & 0xff);
+-		break;
+-	default:
+-		snprintf(tracker_name, 40, "unknown (%04x)", sfh.version);
+ 	}
+ 
+-	libxmp_set_type(m, "%s S3M", tracker_name);
+-#else
+ 	libxmp_set_type(m, "Scream Tracker 3");
+-	m->quirk |= QUIRK_ST3BUGS;
+-#endif
+ 
+ 	MODULE_INFO();
+ 

--- a/contrib/patches/libxmp/0A-libxmp-4.4.1-remove-archimedes-sample-loader.patch
+++ b/contrib/patches/libxmp/0A-libxmp-4.4.1-remove-archimedes-sample-loader.patch
@@ -1,0 +1,75 @@
+diff -rup libxmp-4.4.1-orig/src/loaders/sample.c libxmp-4.4.1/src/loaders/sample.c
+--- libxmp-4.4.1-orig/src/loaders/sample.c	2019-10-17 08:53:34.139018804 +0200
++++ libxmp-4.4.1/src/loaders/sample.c	2019-10-17 08:54:12.045019252 +0200
+@@ -25,37 +25,6 @@
+ 
+ #ifndef LIBXMP_CORE_PLAYER
+ 
+-/*
+- * From the Audio File Formats (version 2.5)
+- * Submitted-by: Guido van Rossum <guido@cwi.nl>
+- * Last-modified: 27-Aug-1992
+- *
+- * The Acorn Archimedes uses a variation on U-LAW with the bit order
+- * reversed and the sign bit in bit 0.  Being a 'minority' architecture,
+- * Arc owners are quite adept at converting sound/image formats from
+- * other machines, and it is unlikely that you'll ever encounter sound in
+- * one of the Arc's own formats (there are several).
+- */
+-static const int8 vdic_table[128] = {
+-	/*   0 */	  0,   0,   0,   0,   0,   0,   0,   0,
+-	/*   8 */	  0,   0,   0,   0,   0,   0,   0,   0,
+-	/*  16 */	  0,   0,   0,   0,   0,   0,   0,   0,
+-	/*  24 */	  1,   1,   1,   1,   1,   1,   1,   1,
+-	/*  32 */	  1,   1,   1,   1,   2,   2,   2,   2,
+-	/*  40 */	  2,   2,   2,   2,   3,   3,   3,   3,
+-	/*  48 */	  3,   3,   4,   4,   4,   4,   5,   5,
+-	/*  56 */	  5,   5,   6,   6,   6,   6,   7,   7,
+-	/*  64 */	  7,   8,   8,   9,   9,  10,  10,  11,
+-	/*  72 */	 11,  12,  12,  13,  13,  14,  14,  15,
+-	/*  80 */	 15,  16,  17,  18,  19,  20,  21,  22,
+-	/*  88 */	 23,  24,  25,  26,  27,  28,  29,  30,
+-	/*  96 */	 31,  33,  34,  36,  38,  40,  42,  44,
+-	/* 104 */	 46,  48,  50,  52,  54,  56,  58,  60,
+-	/* 112 */	 62,  65,  68,  72,  77,  80,  84,  91,
+-	/* 120 */	 95,  98, 103, 109, 114, 120, 126, 127
+-};
+-
+-
+ /* Convert 7 bit samples to 8 bit */
+ static void convert_7bit_to_8bit(uint8 *p, int l)
+ {
+@@ -64,20 +33,6 @@ static void convert_7bit_to_8bit(uint8 *
+ 	}
+ }
+ 
+-/* Convert Archimedes VIDC samples to linear */
+-static void convert_vidc_to_linear(uint8 *p, int l)
+-{
+-	int i;
+-	uint8 x;
+-
+-	for (i = 0; i < l; i++) {
+-		x = p[i];
+-		p[i] = vdic_table[x >> 1];
+-		if (x & 0x01)
+-			p[i] *= -1;
+-	}
+-}
+-
+ static void adpcm4_decoder(uint8 *inp, uint8 *outp, char *tab, int len)
+ {
+ 	char delta = 0;
+@@ -346,12 +301,6 @@ int libxmp_load_sample(struct module_dat
+ 	}
+ #endif
+ 
+-#ifndef LIBXMP_CORE_PLAYER
+-	if (flags & SAMPLE_FLAG_VIDC) {
+-		convert_vidc_to_linear(xxs->data, xxs->len);
+-	}
+-#endif
+-
+ 	/* Check for full loop samples */
+ 	if (flags & SAMPLE_FLAG_FULLREP) {
+ 	    if (xxs->lps == 0 && xxs->len > xxs->lpe)


### PR DESCRIPTION
This should trim the filesize even more. It's possible to trim some more of the effect code, probably, but I'm not sure if it's worth the effort.