### PR TITLE
Fix more Emscripten frontend issues

### DIFF
--- a/arch/emscripten/web/res/index.html
+++ b/arch/emscripten/web/res/index.html
@@ -15,15 +15,18 @@
 </style>
 </head>
 <body>
-<canvas id="mzx_canvas" width="640" height="350" oncontextmenu="event.preventDefault()"></canvas>
+<canvas id="mzx_canvas" width="640" height="350" oncontextmenu="event.preventDefault()" tabindex="0"></canvas>
 <script type="text/javascript" src="./mzxrun_loader.js"></script>
 <script type="text/javascript">
 (function() {
 	var mzxCanvas = document.getElementById("mzx_canvas");
 	var mzxLoadAttempted = false;
 
-	// the initialization process should be triggered by a click - audio enabling!
-	mzxCanvas.onclick = function() {
+	// The initialization process should be triggered by a click - audio enabling!
+	// If you're embedding this on itch.io, you can safely comment this line out;
+	// the click itch.io uses to initialize the game iframe is sufficient.
+	mzxCanvas.onclick = function()
+	{
 		if (mzxLoadAttempted) return;
 		mzxLoadAttempted = true;
 		mzxCanvas.style.backgroundImage = "none";

--- a/arch/emscripten/web/src/index.js
+++ b/arch/emscripten/web/src/index.js
@@ -212,6 +212,14 @@ window.MzxrunInitialize = function(options) {
             FS.createFolder(FS.root, "data", true, true);
             FS.mount(wrapStorageForEmscripten(vfs), null, "/data");
             console.log("Filesystem initialization complete!");
+
+            // This event handler refocuses MZX when clicked if it's inside of
+            // an iframe (e.g. embedded on itch.io). This is necessary to regain
+            // keyboard control after focus is lost (though tab can be used too).
+            // This needs to be done HERE since Emscripten clobbers all event
+            // handlers added to the canvas.
+            canvas.addEventHandler("mousedown", function(){ canvas.focus(); });
+
             resolve();
         });
     })).then(_ => true).catch(reason => {

--- a/arch/emscripten/web/src/index.js
+++ b/arch/emscripten/web/src/index.js
@@ -218,7 +218,7 @@ window.MzxrunInitialize = function(options) {
             // keyboard control after focus is lost (though tab can be used too).
             // This needs to be done HERE since Emscripten clobbers all event
             // handlers added to the canvas.
-            canvas.addEventHandler("mousedown", function(){ canvas.focus(); });
+            canvas.addEventListener("mousedown", function(){ canvas.focus(); });
 
             resolve();
         });

--- a/arch/emscripten/web/src/index.js
+++ b/arch/emscripten/web/src/index.js
@@ -205,9 +205,9 @@ window.MzxrunInitialize = function(options) {
                 } else {
                     throw "Unknown storage type: " + options.storage.type;
                 }
-           }
-        } catch(str) {
-            console.log(str);
+            }
+        } catch(reason) {
+            console.log(reason);
         }
 
         return initMemoryStorage();
@@ -235,11 +235,11 @@ window.MzxrunInitialize = function(options) {
             FS.mount(wrapStorageForEmscripten(vfs), null, "/data");
             console.log("Filesystem initialization complete!");
 
-            // This event handler refocuses MZX when clicked if it's inside of
+            // This event listener refocuses MZX when clicked if it's inside of
             // an iframe (e.g. embedded on itch.io). This is necessary to regain
             // keyboard control after focus is lost (though tab can be used too).
-            // This needs to be done HERE since Emscripten clobbers all event
-            // handlers added to the canvas.
+            // This needs to be done HERE since something clobbers all event
+            // listeners added to the canvas.
             canvas.addEventListener("mousedown", function(){ canvas.focus(); });
 
             resolve();

--- a/arch/emscripten/web/src/storage.js
+++ b/arch/emscripten/web/src/storage.js
@@ -223,7 +223,7 @@ class IndexedDbBackedAsyncStorage {
 				resolve();
 			}
 			dbRequest.onerror = event => {
-				reject();
+				reject("Failed to open IndexedDB database (is this a private window?)");
 			}
 		});
 	}

--- a/arch/emscripten/web/src/storage_emscripten.js
+++ b/arch/emscripten/web/src/storage_emscripten.js
@@ -34,6 +34,8 @@ function vfs_get_type(vfs, path) {
     if (contents !== null) {
         return "file";
     } else {
+        if (!path.endsWith("/"))
+            path += "/";
         const list = vfs.list(a => a.startsWith(path));
         if (list.length >= 1) return "dir";
     }

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -18,6 +18,9 @@ USERS
   the "Click to Play" splash.
 + Fixed Emscripten frontend issues when MegaZeux is embedded in
   an iframe making it difficult to regain focus after losing it.
++ Fixed an Emscripten frontend bug where certain filenames could
+  cause false positives when checking for a directory name. This
+  would prevent fsafetranslate from detecting the correct path.
 
 
 September 23rd, 2019 - MZX 2.92b

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -14,6 +14,10 @@ USERS
   correctly from this setting and instead would always reset to
   "linear". The default for this setting in config.txt has been
   corrected (the default has been "cubic" since 2.82b).
++ Added a comment to the Emscripten frontend for how to disable
+  the "Click to Play" splash.
++ Fixed Emscripten frontend issues when MegaZeux is embedded in
+  an iframe making it difficult to regain focus after losing it.
 
 
 September 23rd, 2019 - MZX 2.92b

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -19,8 +19,8 @@ USERS
 + Fixed Emscripten frontend issues when MegaZeux is embedded in
   an iframe making it difficult to regain focus after losing it.
 + Fixed an Emscripten frontend bug where certain filenames could
-  cause false positives when checking for a directory name. This
-  would prevent fsafetranslate from detecting the correct path.
+  cause false positives when checking for a directory name,
+  preventing fsafetranslate from detecting the correct path.
   This fixes various things in Eternal Eclipse Taoyarin.
 + The Emscripten frontend should now fall back to memory storage
   if IndexedDB or local storage fails to initialize. This fixes

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -21,6 +21,10 @@ USERS
 + Fixed an Emscripten frontend bug where certain filenames could
   cause false positives when checking for a directory name. This
   would prevent fsafetranslate from detecting the correct path.
+  This fixes various things in Eternal Eclipse Taoyarin.
++ The Emscripten frontend should now fall back to memory storage
+  if IndexedDB or local storage fails to initialize. This fixes
+  an error when using MZX in a private browser window.
 
 
 September 23rd, 2019 - MZX 2.92b


### PR DESCRIPTION
This branch fixes some bugs that have been found in the Emscripten frontend since MZX 2.92b's release.

- [x] Fix bug when focusing while inside of an iframe.
- [x] Add comment indicating how to disable the click requirement when already handled (e.g. itch.io).
- [x] Fix [Eternal Eclipse Taoyarin stat bug](https://www.digitalmzx.net/forums/index.php?app=tracker&showissue=792) (looks fairly easy).
- [x] Fall back to RAM filesystem when local storage can't be initialized (also looks easy).
- [x] (More) testing...