### PR TITLE
fix counter char writes on certain renderers when BYTE >= 14

### DIFF
--- a/src/counter.c
+++ b/src/counter.c
@@ -1686,10 +1686,17 @@ static int char_byte_read(struct world *mzx_world,
   // Normalize byte values (see: Day of Zeux Invitation)
   if(byte_num >= 14)
   {
-    char_num += byte_num / 14;
-    byte_num %= 14;
-    if(mzx_world->version < V290 && char_num > 0xFF)
-      return 0;
+    if(mzx_world->version >= V280)
+    {
+      char_num += byte_num / 14;
+      byte_num %= 14;
+      if(mzx_world->version < V290 && char_num > 0xFF)
+        return 0;
+    }
+    else
+    {
+      byte_num %= 14;
+    }
   }
 
   return ec_read_byte(char_num, byte_num);
@@ -1707,10 +1714,17 @@ static void char_byte_write(struct world *mzx_world,
   // Normalize byte values (see: Day of Zeux Invitation)
   if(byte_num >= 14)
   {
-    char_num += byte_num / 14;
-    byte_num %= 14;
-    if(mzx_world->version < V290 && char_num > 0xFF)
-      return;
+    if(mzx_world->version >= V280)
+    {
+      char_num += byte_num / 14;
+      byte_num %= 14;
+      if(mzx_world->version < V290 && char_num > 0xFF)
+        return;
+    }
+    else
+    {
+      byte_num %= 14;
+    }
   }
 
   if(char_num > 0xFF && !layer_renderer_check(true)) return;

--- a/src/counter.c
+++ b/src/counter.c
@@ -1678,25 +1678,44 @@ static int char_byte_read(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int id)
 {
   Uint16 char_num = get_counter(mzx_world, "CHAR", id);
+  Uint8 byte_num = get_counter(mzx_world, "BYTE", id);
 
   // Prior to 2.90 char params are clipped
   if(mzx_world->version < V290) char_num &= 0xFF;
 
-  return ec_read_byte(char_num,
-   get_counter(mzx_world, "BYTE", id));
+  // Normalize byte values (see: Day of Zeux Invitation)
+  if(byte_num >= 14)
+  {
+    char_num += byte_num / 14;
+    byte_num %= 14;
+    if(mzx_world->version < V290 && char_num > 0xFF)
+      return 0;
+  }
+
+  return ec_read_byte(char_num, byte_num);
 }
 
 static void char_byte_write(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int value, int id)
 {
   Uint16 char_num = get_counter(mzx_world, "CHAR", id);
+  Uint8 byte_num = get_counter(mzx_world, "BYTE", id);
 
   // Prior to 2.90 char params are clipped
   if(mzx_world->version < V290) char_num &= 0xFF;
+
+  // Normalize byte values (see: Day of Zeux Invitation)
+  if(byte_num >= 14)
+  {
+    char_num += byte_num / 14;
+    byte_num %= 14;
+    if(mzx_world->version < V290 && char_num > 0xFF)
+      return;
+  }
+
   if(char_num > 0xFF && !layer_renderer_check(true)) return;
 
-  ec_change_byte(char_num,
-   get_counter(mzx_world, "BYTE", id), value);
+  ec_change_byte(char_num, byte_num, value);
 }
 
 static int pixel_read(struct world *mzx_world,


### PR DESCRIPTION
This behaviour (using BYTE >= 14 to write into succeeding characters) is something actually done in production (by Logicow's Summer DoZ 2005 invitation; listed on DigitalMZX as "Day of Zeux Invitation"). To reproduce, compare the .MZX file's intro screen in "software" and "glsl".

Special care is taken to not allow overflowing into the 2.90+ additional charsets. (I wonder what the behaviour was in 2.8x - out-of-bounds read/write?)