### PR TITLE
emscripten: fix IndexedDB support on certain/older browsers

### DIFF
--- a/arch/emscripten/web/src/storage.js
+++ b/arch/emscripten/web/src/storage.js
@@ -249,12 +249,35 @@ class IndexedDbBackedAsyncStorage {
 	list(filter) {
 		const transaction = this.database.transaction(["files"], "readonly");
 		return new Promise((resolve, reject) => {
-			const request = transaction.objectStore("files").getAllKeys();
-			request.onsuccess = event => {
-				resolve(filterKeys(request.result, filter));
-			}
-			request.onerror = event => {
-				resolve([]);
+			const store = transaction.objectStore("files");
+			if (typeof store.getAllKeys === 'function') {
+				const request = store.getAllKeys();
+				request.onsuccess = event => {
+					resolve(filterKeys(request.result, filter));
+				}
+				request.onerror = event => {
+					resolve([]);
+				}
+			} else {
+				var result = [];
+				var request;
+				if (typeof store.openKeyCursor === 'function') {
+					request = store.openKeyCursor();
+				} else {
+					request = store.openCursor();
+				}
+				request.onsuccess = event => {
+					var cursor = event.target.result;
+					if (cursor) {
+						result.push(cursor.key);
+						cursor.continue();
+					} else {
+						resolve(filterKeys(result, filter));
+					}
+				}
+				request.onerror = event => {
+					resolve(result);
+				}
 			}
 		});
 	}


### PR DESCRIPTION
Apparently, this mostly means "pre-Chromiumified Edge" in practice, so you might want to skip it - just putting it out there as Zeta has a matching fix.