### PR TITLE
Save Slots

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -664,23 +664,20 @@
 # grab_mouse = 0
 
 # Set to 1 to use a save slot system (similar to emulator save states)
-# instead of allowing for freeform text entry. This value can be overridden
-# using a game.cnf file.
+# instead of allowing for freeform text entry.
 
 # save_slots = 0
 
 # The filename of the saved games used by the save slot system. The world
 # name can be inserted into this name by including "%w" in the value below.
 # To use a "%" symbol as part of the target filename, use "%%". The slot
-# number will immediately follow this value. This value can be overridden
-# using a game.cnf file.
+# number will immediately follow this value.
 
 # save_slot_name = %w.
 
 # The extension of the saved games used by the save slot system. Keep this
 # set to .sav if you wish to be able to easily load slot saves using the
-# traditional load dialog. This value can be overridden using a game.cnf
-# file.
+# traditional load dialog.
 
 # save_slot_ext = .sav
 

--- a/config.txt
+++ b/config.txt
@@ -669,6 +669,21 @@
 
 # save_slots = 0
 
+# The filename of the saved games used by the save slot system. The world
+# name can be inserted into this name by including "%w" in the value below.
+# To use a "%" symbol as part of the target filename, use "%%". The slot
+# number will immediately follow this value. This value can be overridden
+# using a game.cnf file.
+
+# save_slot_name = %w.
+
+# The extension of the saved games used by the save slot system. Keep this
+# set to .sav if you wish to be able to easily load slot saves using the
+# traditional load dialog. This value can be overridden using a game.cnf
+# file.
+
+# save_slot_ext = .sav
+
 # Set to 1 to start MZX in testing mode, exactly as if Alt+T was pressed in
 # the editor. MegaZeux will exit after gameplay ends. This is intended to be
 # used with the command line or exec(), and only works with the "megazeux"

--- a/config.txt
+++ b/config.txt
@@ -664,7 +664,8 @@
 # grab_mouse = 0
 
 # Set to 1 to use a save slot system (similar to emulator save states)
-# instead of allowing for freeform text entry.
+# instead of allowing for freeform text entry. This value can be overridden
+# using a game.cnf file.
 
 # save_slots = 0
 

--- a/config.txt
+++ b/config.txt
@@ -663,6 +663,11 @@
 
 # grab_mouse = 0
 
+# Set to 1 to use a save slot system (similar to emulator save states)
+# instead of allowing for freeform text entry.
+
+# save_slots = 0
+
 # Set to 1 to start MZX in testing mode, exactly as if Alt+T was pressed in
 # the editor. MegaZeux will exit after gameplay ends. This is intended to be
 # used with the command line or exec(), and only works with the "megazeux"

--- a/src/configure.c
+++ b/src/configure.c
@@ -208,6 +208,8 @@ static const struct config_info user_conf_default =
   false,                        // system_mouse
   false,                        // grab_mouse
   false,                        // save_slots
+  "%w.",                        // save_slots_name
+  ".sav",                       // save_slots_ext
 
   // Editor options
   false,                        // test_mode
@@ -421,6 +423,18 @@ static void config_save_slots(struct config_info *conf, char *name,
 {
   // FIXME sloppy validation
   conf->save_slots = strtol(value, NULL, 10);
+}
+
+static void config_save_slots_name(struct config_info *conf, char *name,
+ char *value, char *extended_data)
+{
+  snprintf(conf->save_slots_name, 256, "%s", value);
+}
+
+static void config_save_slots_ext(struct config_info *conf, char *name,
+ char *value, char *extended_data)
+{
+  snprintf(conf->save_slots_ext, 256, "%s", value);
 }
 
 static void config_enable_oversampling(struct config_info *conf, char *name,
@@ -905,6 +919,8 @@ static const struct config_entry config_options[] =
   { "sample_volume", config_set_sam_volume, false },
   { "save_file", config_save_file, false },
   { "save_slots", config_save_slots, true },
+  { "save_slots_ext", config_save_slots_ext, true },
+  { "save_slots_name", config_save_slots_name, true },
 #ifdef CONFIG_NETWORK
   { "socks_host", config_set_socks_host, false },
   { "socks_port", config_set_socks_port, false },

--- a/src/configure.c
+++ b/src/configure.c
@@ -904,7 +904,7 @@ static const struct config_entry config_options[] =
   { "resample_mode", config_resample_mode, false },
   { "sample_volume", config_set_sam_volume, false },
   { "save_file", config_save_file, false },
-  { "save_slots", config_save_slots, false },
+  { "save_slots", config_save_slots, true },
 #ifdef CONFIG_NETWORK
   { "socks_host", config_set_socks_host, false },
   { "socks_port", config_set_socks_port, false },

--- a/src/configure.c
+++ b/src/configure.c
@@ -207,6 +207,7 @@ static const struct config_info user_conf_default =
   false,                        // no_titlescreen
   false,                        // system_mouse
   false,                        // grab_mouse
+  false,                        // save_slots
 
   // Editor options
   false,                        // test_mode
@@ -413,6 +414,13 @@ static void config_grab_mouse(struct config_info *conf, char *name,
 {
   // FIXME sloppy validation
   conf->grab_mouse = strtol(value, NULL, 10);
+}
+
+static void config_save_slots(struct config_info *conf, char *name,
+ char *value, char *extended_data)
+{
+  // FIXME sloppy validation
+  conf->save_slots = strtol(value, NULL, 10);
 }
 
 static void config_enable_oversampling(struct config_info *conf, char *name,
@@ -896,6 +904,7 @@ static const struct config_entry config_options[] =
   { "resample_mode", config_resample_mode, false },
   { "sample_volume", config_set_sam_volume, false },
   { "save_file", config_save_file, false },
+  { "save_slots", config_save_slots, false },
 #ifdef CONFIG_NETWORK
   { "socks_host", config_set_socks_host, false },
   { "socks_port", config_set_socks_port, false },

--- a/src/configure.c
+++ b/src/configure.c
@@ -918,9 +918,9 @@ static const struct config_entry config_options[] =
   { "resample_mode", config_resample_mode, false },
   { "sample_volume", config_set_sam_volume, false },
   { "save_file", config_save_file, false },
-  { "save_slots", config_save_slots, true },
-  { "save_slots_ext", config_save_slots_ext, true },
-  { "save_slots_name", config_save_slots_name, true },
+  { "save_slots", config_save_slots, false },
+  { "save_slots_ext", config_save_slots_ext, false },
+  { "save_slots_name", config_save_slots_name, false },
 #ifdef CONFIG_NETWORK
   { "socks_host", config_set_socks_host, false },
   { "socks_port", config_set_socks_port, false },

--- a/src/configure.h
+++ b/src/configure.h
@@ -98,6 +98,7 @@ struct config_info
   boolean no_titlescreen;
   boolean system_mouse;
   boolean grab_mouse;
+  boolean save_slots;
 
   // Editor options
   boolean test_mode;

--- a/src/configure.h
+++ b/src/configure.h
@@ -99,6 +99,8 @@ struct config_info
   boolean system_mouse;
   boolean grab_mouse;
   boolean save_slots;
+  char save_slots_name[256];
+  char save_slots_ext[256];
 
   // Editor options
   boolean test_mode;

--- a/src/game.c
+++ b/src/game.c
@@ -391,9 +391,21 @@ static boolean load_savegame_selection(struct game_context *game)
 {
   struct world *mzx_world = ((context *)game)->world;
   char save_file_name[MAX_PATH] = { 0 };
+  int slot_result = SLOTSEL_FILE_MANAGER_RESULT;
 
-  if(!choose_file_ch(mzx_world, save_ext, save_file_name,
-    "Choose game to restore", true))
+  if(get_config()->save_slots)
+  {
+    slot_result = slot_manager(mzx_world, save_file_name,
+     "Choose game to restore", false);
+
+    if(slot_result == SLOTSEL_CANCEL_RESULT)
+    {
+      return false;
+    }
+  }
+
+  if(slot_result == SLOTSEL_OK_RESULT || !choose_file_ch(mzx_world, save_ext,
+   save_file_name, "Choose game to restore", true))
   {
     return load_savegame(game, save_file_name);
   }
@@ -651,9 +663,21 @@ static boolean game_key(context *ctx, int *key)
         if(allow_save_menu(mzx_world))
         {
           char save_game[MAX_PATH];
+          int slot_result = SLOTSEL_FILE_MANAGER_RESULT;
           strcpy(save_game, curr_sav);
 
-          if(!new_file(mzx_world, save_ext, ".sav", save_game, "Save game", 1))
+          if(get_config()->save_slots)
+          {
+            slot_result = slot_manager(mzx_world, save_game, "Save game", true);
+
+            if(slot_result == SLOTSEL_CANCEL_RESULT)
+            {
+              return true;
+            }
+          }
+
+          if(slot_result == SLOTSEL_OK_RESULT ||
+           !new_file(mzx_world, save_ext, ".sav", save_game, "Save game", 1))
           {
             strcpy(curr_sav, save_game);
             save_world(mzx_world, curr_sav, true, MZX_VERSION);

--- a/src/window.c
+++ b/src/window.c
@@ -2786,7 +2786,7 @@ static void update_slot_prefix(void)
   if(cur_slot_prefix != NULL)
     free(cur_slot_prefix);
 
-  cur_slot_prefix = malloc(sizeof(char) * MAX_PATH);
+  cur_slot_prefix = cmalloc(sizeof(char) * MAX_PATH);
 
   fmt = get_config()->save_slots_name;
   fmt_len = strlen(fmt);
@@ -2809,7 +2809,7 @@ static void update_slot_prefix(void)
 
   // Fetch the world name, sans extension.
   world_len = strlen(curr_file) - 4;
-  world_name = malloc(sizeof(char) * world_len);
+  world_name = cmalloc(sizeof(char) * world_len);
   memcpy(world_name, curr_file, world_len);
 
   // We already know where the first token is. Copy everything before that
@@ -2885,7 +2885,7 @@ static int slot_manager(struct world *mzx_world, char *ret,
   {
     if(save)
     {
-      highlighted_slots = malloc(sizeof(boolean) * SLOTSEL_NUM_SLOTS);
+      highlighted_slots = cmalloc(sizeof(boolean) * SLOTSEL_NUM_SLOTS);
       for(i = 0; i < SLOTSEL_NUM_SLOTS; i++)
       {
         highlighted_slots[i] = slot_save_exists(cur_slot_prefix, i);
@@ -2893,7 +2893,7 @@ static int slot_manager(struct world *mzx_world, char *ret,
     }
     else
     {
-      disabled_slots = malloc(sizeof(boolean) * SLOTSEL_NUM_SLOTS);
+      disabled_slots = cmalloc(sizeof(boolean) * SLOTSEL_NUM_SLOTS);
       for(i = 0; i < SLOTSEL_NUM_SLOTS; i++)
       {
         disabled_slots[i] = !slot_save_exists(cur_slot_prefix, i);

--- a/src/window.c
+++ b/src/window.c
@@ -70,6 +70,9 @@ static struct char_element screen_storage[NUM_SAVSCR][SET_SCREEN_SIZE];
 // Current space for save_screen and restore_screen
 static int cur_screen = 0;
 
+// The last-used saved game slot.
+static int cur_slot = 0;
+
 // Free up memory.
 
 // The following functions do NOT check to see if memory is reserved, in
@@ -2847,6 +2850,17 @@ static boolean remove_files(char *directory_name, boolean remove_recursively)
   return success;
 }
 
+static int slot_manager(struct world *mzx_world, char *ret,
+ const char *title) {
+  char ext[8];
+
+  strncpy(ret, curr_file, MAX_PATH);
+  snprintf(ext, 8, ".%i.sav", cur_slot);
+  add_ext(ret, ext);
+  debug("%s: %s\n", title, ret);
+  return 1;
+}
+
 __editor_maybe_static int file_manager(struct world *mzx_world,
  const char *const *wildcards, const char *default_ext, char *ret,
  const char *title, int dirs_okay, int allow_new, struct element **dialog_ext,
@@ -3472,15 +3486,21 @@ skip_dir:
 int choose_file_ch(struct world *mzx_world, const char *const *wildcards,
  char *ret, const char *title, int dirs_okay)
 {
-  return file_manager(mzx_world, wildcards, NULL, ret, title, dirs_okay,
-   0, NULL, 0, 0);
+  if(get_config()->save_slots && strcmp(*wildcards, ".SAV") == 0) // TODO: yuck! changeme
+    return slot_manager(mzx_world, ret, title);
+  else
+    return file_manager(mzx_world, wildcards, NULL, ret, title, dirs_okay,
+     0, NULL, 0, 0);
 }
 
 int new_file(struct world *mzx_world, const char *const *wildcards,
  const char *default_ext, char *ret, const char *title, int dirs_okay)
 {
-  return file_manager(mzx_world, wildcards, default_ext, ret, title, dirs_okay,
-   1, NULL, 0, 0);
+  if(get_config()->save_slots && strcmp(*wildcards, ".SAV") == 0) // TODO: yuck! changeme
+    return slot_manager(mzx_world, ret, title);
+  else
+    return file_manager(mzx_world, wildcards, default_ext, ret, title, dirs_okay,
+     1, NULL, 0, 0);
 }
 
 #if defined(CONFIG_UPDATER) || defined(CONFIG_LOADSAVE_METER)

--- a/src/window.c
+++ b/src/window.c
@@ -2800,6 +2800,7 @@ static void update_slot_prefix(void)
   if(token_pos < 0)
   {
     snprintf(cur_slot_prefix, MAX_PATH, "%s", fmt);
+    cur_slot_prefix[fmt_len] = 0;
     debug("update_slot_prefix: slot prefix: %s\n", cur_slot_prefix);
     return;
   }

--- a/src/window.c
+++ b/src/window.c
@@ -1432,7 +1432,7 @@ static void draw_slot_selector(struct world *mzx_world, struct dialog *di,
   int slot_x;
   int slot_y = y + SLOTSEL_BAR_Y;
   int i;
-  int slot_color;
+  int slot_color = DI_SLOTSEL_NORMAL;
 
   write_string(src->title, x, y, color, 0);
 
@@ -2881,15 +2881,13 @@ int slot_manager(struct world *mzx_world, char *ret,
 
   while(return_value > 0)
   {
-    if(save)
+    highlighted_slots = cmalloc(sizeof(boolean) * SLOTSEL_NUM_SLOTS);
+    for(i = 0; i < SLOTSEL_NUM_SLOTS; i++)
     {
-      highlighted_slots = cmalloc(sizeof(boolean) * SLOTSEL_NUM_SLOTS);
-      for(i = 0; i < SLOTSEL_NUM_SLOTS; i++)
-      {
-        highlighted_slots[i] = slot_save_exists(cur_slot_prefix, i);
-      }
+      highlighted_slots[i] = slot_save_exists(cur_slot_prefix, i);
     }
-    else
+
+    if(!save)
     {
       disabled_slots = cmalloc(sizeof(boolean) * SLOTSEL_NUM_SLOTS);
       for(i = 0; i < SLOTSEL_NUM_SLOTS; i++)

--- a/src/window.c
+++ b/src/window.c
@@ -1422,7 +1422,6 @@ static void draw_slot_selector(struct world *mzx_world, struct dialog *di,
   int y = di->y + e->y;
   int slot_x;
   int slot_y = y + SLOTSEL_BAR_Y;
-  int width = e->width;
   int i;
   int slot_color;
 
@@ -2785,11 +2784,11 @@ static int slot_manager(struct world *mzx_world, char *ret,
      construct_slot_selector(3, 2, "Choose a slot:", SLOTSEL_NUM_SLOTS,
      highlighted_slots, disabled_slots, selected_slot, save);
     elements[SLOTSEL_OKAY_BUTTON] =
-     construct_button(14, 6, "OK", 0);
+     construct_button(16, 6, "OK", 0);
     elements[SLOTSEL_CANCEL_BUTTON] =
-     construct_button(20, 6, "Cancel", -1);
+     construct_button(23, 6, "Cancel", -1);
 
-    construct_dialog(&di, title, 17, 8, 46, 8, elements,
+    construct_dialog(&di, title, 17, 8, 46, 9, elements,
      SLOTSEL_MAX_ELEMENTS, SLOTSEL_SELECTOR);
     dialog_result = run_dialog(mzx_world, &di);
 

--- a/src/window.c
+++ b/src/window.c
@@ -2568,7 +2568,7 @@ struct element *construct_slot_selector(int x, int y,
   src->save = save;
 
   construct_element(&(src->e), x, y, num_slots * 4, 3, draw_slot_selector,
-   key_slot_selector, click_slot_selector, NULL, NULL);;
+   key_slot_selector, click_slot_selector, NULL, NULL);
 
   return (struct element *)src;
 }

--- a/src/window.c
+++ b/src/window.c
@@ -1824,6 +1824,7 @@ static int key_slot_selector(struct world *mzx_world, struct dialog *di,
 {
   struct slot_selector *src = (struct slot_selector *)e;
   int this_slot = src->selected_slot;
+  int target_slot;
 
   switch(key)
   {
@@ -1852,6 +1853,32 @@ static int key_slot_selector(struct world *mzx_world, struct dialog *di,
          src->disabled_slots) != SLOT_DISABLED)
           break;
       }
+      break;
+    }
+
+    case IKEY_1:
+    case IKEY_2:
+    case IKEY_3:
+    case IKEY_4:
+    case IKEY_5:
+    case IKEY_6:
+    case IKEY_7:
+    case IKEY_8:
+    case IKEY_9:
+    {
+      target_slot = key - IKEY_1;
+      if(src->save || get_slot_state(target_slot, src->highlighted_slots,
+       src->disabled_slots) != SLOT_DISABLED)
+        src->selected_slot = target_slot;
+      break;
+    }
+
+    case IKEY_0:
+    {
+      // Special case for the 10th element.
+      if(src->save || get_slot_state(9, src->highlighted_slots,
+       src->disabled_slots) != SLOT_DISABLED)
+        src->selected_slot = 9;
       break;
     }
 

--- a/src/window.c
+++ b/src/window.c
@@ -87,9 +87,6 @@ static char *cur_slot_prefix = NULL;
 #define SLOTSEL_FILE_MANAGER_BUTTON 2
 #define SLOTSEL_SELECTOR            3
 #define SLOTSEL_NUM_SLOTS           10
-#define SLOTSEL_OK_RESULT           0
-#define SLOTSEL_CANCEL_RESULT       -1
-#define SLOTSEL_FILE_MANAGER_RESULT -2
 
 // Free up memory.
 
@@ -2867,7 +2864,7 @@ static void update_slot_prefix(void)
   free(world_name);
 }
 
-static int slot_manager(struct world *mzx_world, char *ret,
+int slot_manager(struct world *mzx_world, char *ret,
  const char *title, boolean save)
 {
   int i;
@@ -3873,14 +3870,6 @@ skip_dir:
 int choose_file_ch(struct world *mzx_world, const char *const *wildcards,
  char *ret, const char *title, int dirs_okay)
 {
-  int slot_result = SLOTSEL_FILE_MANAGER_RESULT;
-
-  if(get_config()->save_slots && strcmp(*wildcards, ".SAV") == 0)
-    slot_result = slot_manager(mzx_world, ret, title, false);
-
-  if(slot_result != SLOTSEL_FILE_MANAGER_RESULT)
-    return slot_result;
-
   return file_manager(mzx_world, wildcards, NULL, ret, title, dirs_okay,
    0, NULL, 0, 0);
 }
@@ -3888,14 +3877,6 @@ int choose_file_ch(struct world *mzx_world, const char *const *wildcards,
 int new_file(struct world *mzx_world, const char *const *wildcards,
  const char *default_ext, char *ret, const char *title, int dirs_okay)
 {
-  int slot_result = SLOTSEL_FILE_MANAGER_RESULT;
-
-  if(get_config()->save_slots && strcmp(*wildcards, ".SAV") == 0)
-    slot_result = slot_manager(mzx_world, ret, title, true);
-
-  if(slot_result != SLOTSEL_FILE_MANAGER_RESULT)
-    return slot_result;
-
   return file_manager(mzx_world, wildcards, default_ext, ret, title, dirs_okay,
    1, NULL, 0, 0);
 }

--- a/src/window.c
+++ b/src/window.c
@@ -2772,7 +2772,8 @@ static int sort_function(const void *dest_str_ptr, const void *src_str_ptr)
   return strcasecmp(dest_str, src_str);
 }
 
-static void update_slot_prefix(void) {
+static void update_slot_prefix(void)
+{
   char *world_name;
   size_t i;
   size_t pos = 0;

--- a/src/window.c
+++ b/src/window.c
@@ -2799,7 +2799,7 @@ static void update_slot_prefix(void)
   // If no tokens were found, just copy the string over as-is.
   if(token_pos < 0)
   {
-    strncpy(cur_slot_prefix, fmt, MAX_PATH);
+    snprintf(cur_slot_prefix, MAX_PATH, "%s", fmt);
     debug("update_slot_prefix: slot prefix: %s\n", cur_slot_prefix);
     return;
   }

--- a/src/window.c
+++ b/src/window.c
@@ -3874,7 +3874,7 @@ int choose_file_ch(struct world *mzx_world, const char *const *wildcards,
 {
   int slot_result = SLOTSEL_FILE_MANAGER_RESULT;
 
-  if(get_config()->save_slots && strcmp(*wildcards, ".SAV") == 0) // TODO: yuck! changeme
+  if(get_config()->save_slots && strcmp(*wildcards, ".SAV") == 0)
     slot_result = slot_manager(mzx_world, ret, title, false);
 
   if(slot_result != SLOTSEL_FILE_MANAGER_RESULT)
@@ -3889,7 +3889,7 @@ int new_file(struct world *mzx_world, const char *const *wildcards,
 {
   int slot_result = SLOTSEL_FILE_MANAGER_RESULT;
 
-  if(get_config()->save_slots && strcmp(*wildcards, ".SAV") == 0) // TODO: yuck! changeme
+  if(get_config()->save_slots && strcmp(*wildcards, ".SAV") == 0)
     slot_result = slot_manager(mzx_world, ret, title, true);
 
   if(slot_result != SLOTSEL_FILE_MANAGER_RESULT)

--- a/src/window.h
+++ b/src/window.h
@@ -203,6 +203,17 @@ struct board_list
   int *result;
 };
 
+struct slot_selector
+{
+  struct element e;
+  const char *title;
+  int num_slots;
+  boolean *highlighted_slots;
+  boolean *disabled_slots;
+  int selected_slot;
+  int save;
+};
+
 struct file_selector
 {
   struct element e;
@@ -295,6 +306,10 @@ CORE_LIBSPEC void meter_interior(unsigned int progress, unsigned int out_of);
 #define DI_DEBUG_BOX_CORNER   DI_INPUT_BOX_CORNER
 #define DI_DEBUG_LABEL        DI_INPUT_BOX_LABEL
 #define DI_DEBUG_NUMBER       79
+
+#define DI_SLOTSEL_NORMAL     7
+#define DI_SLOTSEL_HIGHLIGHT  11
+#define DI_SLOTSEL_DISABLE    128
 
 #define arrow_char '\x10'
 #define pc_top_arrow '\x1E'

--- a/src/window.h
+++ b/src/window.h
@@ -310,8 +310,8 @@ CORE_LIBSPEC void meter_interior(unsigned int progress, unsigned int out_of);
 #define DI_DEBUG_LABEL        DI_INPUT_BOX_LABEL
 #define DI_DEBUG_NUMBER       79
 
-#define DI_SLOTSEL_NORMAL     7
-#define DI_SLOTSEL_HIGHLIGHT  11
+#define DI_SLOTSEL_NORMAL     8
+#define DI_SLOTSEL_HIGHLIGHT  10
 #define DI_SLOTSEL_DISABLE    128
 
 #define SLOTSEL_OK_RESULT           0

--- a/src/window.h
+++ b/src/window.h
@@ -314,6 +314,10 @@ CORE_LIBSPEC void meter_interior(unsigned int progress, unsigned int out_of);
 #define DI_SLOTSEL_HIGHLIGHT  11
 #define DI_SLOTSEL_DISABLE    128
 
+#define SLOTSEL_OK_RESULT           0
+#define SLOTSEL_CANCEL_RESULT       -1
+#define SLOTSEL_FILE_MANAGER_RESULT -2
+
 #define arrow_char '\x10'
 #define pc_top_arrow '\x1E'
 #define pc_bottom_arrow '\x1F'
@@ -322,6 +326,8 @@ CORE_LIBSPEC void meter_interior(unsigned int progress, unsigned int out_of);
 #define pc_meter 219
 
 CORE_LIBSPEC int run_dialog(struct world *mzx_world, struct dialog *di);
+CORE_LIBSPEC int slot_manager(struct world *mzx_world, char *ret,
+ const char *title, boolean save);
 
 #ifdef CONFIG_EDITOR
 CORE_LIBSPEC void construct_element(struct element *e, int x, int y,

--- a/src/window.h
+++ b/src/window.h
@@ -240,6 +240,9 @@ CORE_LIBSPEC struct element *construct_radio_button(int x, int y,
  const char **choices, int num_choices, int max_length, int *result);
 CORE_LIBSPEC struct element *construct_button(int x, int y, const char *label,
  int return_value);
+CORE_LIBSPEC struct element *construct_slot_selector(int x, int y,
+ const char *title, int num_slots, boolean *highlighted_slots,
+ boolean *disabled_slots, int default_slot, int save);
 CORE_LIBSPEC struct element *construct_number_box(int x, int y,
  const char *question, int lower_limit, int upper_limit,
  enum number_box_type type, int *result);


### PR DESCRIPTION
* Added optional save slot support.
* Added three config.txt options to control this behavior: `save_slots`, `save_slots_name`, and `save_slots_ext`. These values can be overridden in game.cnf.