### PR TITLE
Properly handle SDL_TEXTINPUT, add event text buffer

### DIFF
--- a/arch/3ds/keyboard.c
+++ b/arch/3ds/keyboard.c
@@ -208,8 +208,7 @@ boolean ctr_keyboard_update(struct buffered_status *status)
         unicode = convert_internal_unicode(area->keycode);
 
         key_press(status, area->keycode);
-        if(unicode)
-          key_press_unicode(status, unicode);
+        key_press_unicode(status, unicode);
 
         keys_down[keys_down_count++] = area->keycode;
         retval = true;

--- a/arch/3ds/keyboard.c
+++ b/arch/3ds/keyboard.c
@@ -19,6 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "../../src/event.h"
 #include "../../src/graphics.h"
 #include "../../src/render.h"
 #include "../../src/renderers.h"
@@ -177,57 +178,12 @@ void ctr_keyboard_draw(struct ctr_render_data *render_data)
   }
 }
 
-static enum keycode convert_internal_unicode(enum keycode key)
-{
-  if(key >= 32 && key <= 126)
-  {
-    if(get_shift_status(keycode_internal))
-    {
-      if((key >= IKEY_a) && (key <= IKEY_z))
-        return (key - 32);
-
-      // TODO based on a US keyboard right now since that's as good as any
-      // default and possibly what most users are going to expect. It would
-      // be nice to have more locales at some point if someone requests them.
-      switch(key)
-      {
-        case IKEY_BACKQUOTE:    return '~';
-        case IKEY_1:            return '!';
-        case IKEY_2:            return '@';
-        case IKEY_3:            return '#';
-        case IKEY_4:            return '$';
-        case IKEY_5:            return '%';
-        case IKEY_6:            return '^';
-        case IKEY_7:            return '&';
-        case IKEY_8:            return '*';
-        case IKEY_9:            return '(';
-        case IKEY_0:            return ')';
-        case IKEY_MINUS:        return '_';
-        case IKEY_EQUALS:       return '+';
-        case IKEY_LEFTBRACKET:  return '{';
-        case IKEY_RIGHTBRACKET: return '}';
-        case IKEY_BACKSLASH:    return '|';
-        case IKEY_SEMICOLON:    return ':';
-        case IKEY_QUOTE:        return '"';
-        case IKEY_COMMA:        return '<';
-        case IKEY_PERIOD:       return '>';
-        case IKEY_SLASH:        return '?';
-        default:                return IKEY_UNKNOWN;
-      }
-    }
-
-    return key;
-  }
-
-  return IKEY_UNKNOWN;
-}
-
 boolean ctr_keyboard_update(struct buffered_status *status)
 {
   touchPosition pos;
   Uint32 down, up, i;
   boolean retval = false;
-  enum keycode unicode;
+  Uint32 unicode;
 
   if(get_bottom_screen_mode() != BOTTOM_SCREEN_MODE_KEYBOARD)
     return retval;
@@ -251,7 +207,10 @@ boolean ctr_keyboard_update(struct buffered_status *status)
       {
         unicode = convert_internal_unicode(area->keycode);
 
-        key_press(status, area->keycode, unicode);
+        key_press(status, area->keycode);
+        if(unicode)
+          key_press_unicode(status, unicode);
+
         keys_down[keys_down_count++] = area->keycode;
         retval = true;
         break;

--- a/arch/3ds/keyboard.c
+++ b/arch/3ds/keyboard.c
@@ -208,7 +208,7 @@ boolean ctr_keyboard_update(struct buffered_status *status)
         unicode = convert_internal_unicode(area->keycode);
 
         key_press(status, area->keycode);
-        key_press_unicode(status, unicode);
+        key_press_unicode(status, unicode, true);
 
         keys_down[keys_down_count++] = area->keycode;
         retval = true;

--- a/arch/nds/event.c
+++ b/arch/nds/event.c
@@ -98,14 +98,8 @@ static int nds_map_joystick(int nds_button, boolean *is_hat)
   return -1;
 }
 
-static void convert_nds_internal(int key, int *internal_code, int *unicode)
+static void convert_nds_internal(int key, int *internal_code)
 {
-  // Actually ASCIIish, but close enough.
-  if(key > 0)
-    *unicode = key;
-  else
-    *unicode = 0;
-
   // Uppercase letters
   if(key >= 65 && key <= 90)
     *internal_code = key + 32;
@@ -196,9 +190,15 @@ static boolean process_event(NDSEvent *event)
     // Software key down
     case NDS_EVENT_KEYBOARD_DOWN:
     {
-      int internal_code, unicode;
+      enum keycode internal_code;
+      Uint32 unicode;
+
       convert_nds_internal(event->key, &internal_code, &unicode);
-      key_press(status, internal_code, unicode);
+      unicode = convert_internal_unicode(internal_code);
+
+      key_press(status, internal_code);
+      if(unicode)
+        key_press_unicode(status, unicode);
 
       keyboard_allow_release = true;
       break;
@@ -206,8 +206,8 @@ static boolean process_event(NDSEvent *event)
 
     case NDS_EVENT_KEYBOARD_UP:
     {
-      int internal_code, unicode;
-      convert_nds_internal(event->key, &internal_code, &unicode);
+      int internal_code;
+      convert_nds_internal(event->key, &internal_code);
       key_release(status, internal_code);
       break;
     }

--- a/arch/nds/event.c
+++ b/arch/nds/event.c
@@ -199,8 +199,7 @@ static boolean process_event(NDSEvent *event)
       int internal_code, unicode;
       convert_nds_internal(event->key, &internal_code, &unicode);
       key_press(status, internal_code);
-      if(unicode)
-        key_press_unicode(status, unicode);
+      key_press_unicode(status, unicode);
 
       keyboard_allow_release = true;
       break;

--- a/arch/nds/event.c
+++ b/arch/nds/event.c
@@ -190,10 +190,10 @@ static boolean process_event(NDSEvent *event)
     // Software key down
     case NDS_EVENT_KEYBOARD_DOWN:
     {
-      enum keycode internal_code;
+      int internal_code;
       Uint32 unicode;
 
-      convert_nds_internal(event->key, &internal_code, &unicode);
+      convert_nds_internal(event->key, &internal_code);
       unicode = convert_internal_unicode(internal_code);
 
       key_press(status, internal_code);

--- a/arch/nds/event.c
+++ b/arch/nds/event.c
@@ -98,8 +98,14 @@ static int nds_map_joystick(int nds_button, boolean *is_hat)
   return -1;
 }
 
-static void convert_nds_internal(int key, int *internal_code)
+static void convert_nds_internal(int key, int *internal_code, int *unicode)
 {
+  // Actually ASCIIish, but close enough.
+  if(key > 0)
+    *unicode = key;
+  else
+    *unicode = 0;
+
   // Uppercase letters
   if(key >= 65 && key <= 90)
     *internal_code = key + 32;
@@ -190,12 +196,8 @@ static boolean process_event(NDSEvent *event)
     // Software key down
     case NDS_EVENT_KEYBOARD_DOWN:
     {
-      int internal_code;
-      Uint32 unicode;
-
-      convert_nds_internal(event->key, &internal_code);
-      unicode = convert_internal_unicode(internal_code);
-
+      int internal_code, unicode;
+      convert_nds_internal(event->key, &internal_code, &unicode);
       key_press(status, internal_code);
       if(unicode)
         key_press_unicode(status, unicode);
@@ -206,8 +208,8 @@ static boolean process_event(NDSEvent *event)
 
     case NDS_EVENT_KEYBOARD_UP:
     {
-      int internal_code;
-      convert_nds_internal(event->key, &internal_code);
+      int internal_code, unicode;
+      convert_nds_internal(event->key, &internal_code, &unicode);
       key_release(status, internal_code);
       break;
     }

--- a/arch/nds/event.c
+++ b/arch/nds/event.c
@@ -199,7 +199,7 @@ static boolean process_event(NDSEvent *event)
       int internal_code, unicode;
       convert_nds_internal(event->key, &internal_code, &unicode);
       key_press(status, internal_code);
-      key_press_unicode(status, unicode);
+      key_press_unicode(status, unicode, true);
 
       keyboard_allow_release = true;
       break;

--- a/arch/wii/event.c
+++ b/arch/wii/event.c
@@ -959,7 +959,7 @@ static boolean process_event(union event *ev)
       }
 
       key_press(status, ckey);
-      key_press_unicode(status, ev->key.unicode);
+      key_press_unicode(status, ev->key.unicode, true);
       break;
     }
 

--- a/arch/wii/event.c
+++ b/arch/wii/event.c
@@ -958,7 +958,9 @@ static boolean process_event(union event *ev)
         }
       }
 
-      key_press(status, ckey, ev->key.unicode);
+      key_press(status, ckey);
+      if(ev->key.unicode)
+        key_press_unicode(ev->key.unicode);
       break;
     }
 

--- a/arch/wii/event.c
+++ b/arch/wii/event.c
@@ -960,7 +960,7 @@ static boolean process_event(union event *ev)
 
       key_press(status, ckey);
       if(ev->key.unicode)
-        key_press_unicode(ev->key.unicode);
+        key_press_unicode(status, ev->key.unicode);
       break;
     }
 

--- a/arch/wii/event.c
+++ b/arch/wii/event.c
@@ -959,8 +959,7 @@ static boolean process_event(union event *ev)
       }
 
       key_press(status, ckey);
-      if(ev->key.unicode)
-        key_press_unicode(status, ev->key.unicode);
+      key_press_unicode(status, ev->key.unicode);
       break;
     }
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -10,8 +10,8 @@ DEVELOPERS
 + Decoupled SDL 2 text input handling from regular key handling
   and added a text input buffer. Text keys can now be requested
   multiple times and either as ASCII or unicode; the next key in
-  the buffer is returned on subsequent calls. intake can now
-  now accept multiple text chars per frame.
+  the buffer is returned on subsequent calls. intake and editor
+  text entry can now accept multiple text chars per frame.
 
 
 March 8th, 2020 - MZX 2.92c

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,19 @@
+GIT
+
+USERS
+
++ Fixed a bug where input text with no corresponding internal
+  key would be ignored by the robot editor.
+
+DEVELOPERS
+
++ Decoupled SDL 2 text input handling from regular key handling
+  and added a text input buffer. Text keys can now be requested
+  multiple times and either as ASCII or unicode; the next key in
+  the buffer is returned on subsequent calls. intake can now
+  now accept multiple text chars per frame.
+
+
 March 8th, 2020 - MZX 2.92c
 
 Here's another bugfix release, this time mostly oriented towards

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -8,6 +8,8 @@ USERS
   in the robot editor (note: SDL doesn't distinguish Alt from
   AltGr, so any Alt key combos with a special meaning in the
   robot editor will still be intercepted by MZX).
++ Windows Alt+numpad sequences corresponding to ASCII characters
+  32-126 should now be recognized.
 
 DEVELOPERS
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -4,6 +4,10 @@ USERS
 
 + Fixed a bug where input text with no corresponding internal
   key would be ignored by the robot editor.
++ Fixed a bug where some AltGr key combinations would not work
+  in the robot editor (note: SDL doesn't distinguish Alt from
+  AltGr, so any Alt key combos with a special meaning in the
+  robot editor will still be intercepted by MZX).
 
 DEVELOPERS
 

--- a/src/core.c
+++ b/src/core.c
@@ -844,6 +844,11 @@ static void core_update(core_context *root)
 
   get_mouse_position(&mouse_x, &mouse_y);
 
+  // The key handler needs to be called when there is text input but no
+  // regular key input. In this situation, use the IKEY_UNICODE keycode.
+  if(!key && has_unicode_input())
+    key = IKEY_UNICODE;
+
   ctx_data->stack.pos = ctx_data->stack.size - 1;
 
   do

--- a/src/core.h
+++ b/src/core.h
@@ -29,12 +29,11 @@ __M_BEGIN_DECLS
 
 /**
  * The type of a given context. Used to identify particular contexts and to open
- * help files contextually. Do not sort is enum by value.
+ * help files contextually. Do not sort this enum by value.
  *
  * Numbers >0 correspond directly to a hyperlink in the help system.
  * Numbers <=0 are used by contexts with no unique link in the help system.
  */
-
 enum context_type
 {
   // Core contexts.

--- a/src/core.h
+++ b/src/core.h
@@ -128,6 +128,7 @@ struct context
  * drag             Update function called to handle a mouse drag (mouse).
  * destroy          Optional function to be called on destruction.
  * framerate_mode   Framerate mode this context should use (context only).
+ * priority         Alters the update order. higher => updates earlier.
  */
 struct context_spec
 {
@@ -140,6 +141,7 @@ struct context_spec
   boolean (*drag)(context *, int *key, int button, int x, int y);
   void (*destroy)(context *);
   enum framerate_type framerate_mode;
+  int priority;
 };
 
 /**
@@ -152,7 +154,6 @@ struct context_spec
  * @param ctx_spec          Specification for context functions/variables.
  * @param context_type      Used to identify contexts (also, by the help system)
  */
-
 CORE_LIBSPEC void create_context(context *ctx, context *parent,
  struct context_spec *ctx_spec, enum context_type context_type);
 
@@ -164,7 +165,7 @@ CORE_LIBSPEC void create_context(context *ctx, context *parent,
  *
  * Resume:  parent, oldest subcontext -> newest subcontext
  * Draw:    parent, oldest subcontext -> newest subcontext
- * Update:  newest subcontext -> oldest subcontext, parent
+ * Update:  parent, oldest subcontext -> newest subcontext (see priority above)
  * Destroy: newest subcontext -> oldest subcontext, parent
  *
  * If "parent" is a subcontext, this function will use the parent of that
@@ -174,7 +175,6 @@ CORE_LIBSPEC void create_context(context *ctx, context *parent,
  * @param parent            The context which created this context.
  * @param sub_spec          Specification for subcontext functions/variables.
  */
-
 CORE_LIBSPEC void create_subcontext(subcontext *sub, context *parent,
  struct context_spec *sub_spec);
 
@@ -186,7 +186,6 @@ CORE_LIBSPEC void create_subcontext(subcontext *sub, context *parent,
  *
  * @param ctx           The context or subcontext to destroy.
  */
-
 CORE_LIBSPEC void destroy_context(context *ctx);
 
 /**
@@ -196,7 +195,6 @@ CORE_LIBSPEC void destroy_context(context *ctx);
  * @param ctx           Current context
  * @return              true if a context change has occurred.
  */
-
 CORE_LIBSPEC boolean has_context_changed(context *ctx);
 
 /**
@@ -206,7 +204,6 @@ CORE_LIBSPEC boolean has_context_changed(context *ctx);
  * @param context_type  A context type
  * @return              true if the context has the given context type.
  */
-
 CORE_LIBSPEC boolean is_context(context *ctx, enum context_type context_type);
 
 /**
@@ -224,7 +221,6 @@ CORE_LIBSPEC boolean is_context(context *ctx, enum context_type context_type);
  * @param param         A parameter to be provided to the callback.
  * @param func          The callback to be executed.
  */
-
 CORE_LIBSPEC void context_callback(context *ctx, context_callback_param *param,
  context_callback_function func);
 
@@ -235,7 +231,6 @@ CORE_LIBSPEC void context_callback(context *ctx, context_callback_param *param,
  * @param ctx           The current context.
  * @param framerate     The new framerate mode.
  */
-
 void set_context_framerate_mode(context *ctx, enum framerate_type framerate);
 
 /**
@@ -245,7 +240,6 @@ void set_context_framerate_mode(context *ctx, enum framerate_type framerate);
  * @param data          Global information struct.
  * @return              A core context struct.
  */
-
 CORE_LIBSPEC core_context *core_init(struct world *mzx_world);
 
 /**
@@ -253,7 +247,6 @@ CORE_LIBSPEC core_context *core_init(struct world *mzx_world);
  *
  * @param root          The core context to run.
  */
-
 CORE_LIBSPEC void core_run(core_context *root);
 
 /**
@@ -261,7 +254,6 @@ CORE_LIBSPEC void core_run(core_context *root);
  *
  * @param ctx           The current context.
  */
-
 CORE_LIBSPEC void core_full_exit(context *ctx);
 
 /**
@@ -269,7 +261,6 @@ CORE_LIBSPEC void core_full_exit(context *ctx);
  *
  * @param ctx           The current context.
  */
-
 CORE_LIBSPEC void core_full_restart(context *ctx);
 
 /**
@@ -278,7 +269,6 @@ CORE_LIBSPEC void core_full_restart(context *ctx);
  * @param root          The core context.
  * @return              True if a restart was requested.
  */
-
 CORE_LIBSPEC boolean core_restart_requested(core_context *root);
 
 /**
@@ -286,7 +276,6 @@ CORE_LIBSPEC boolean core_restart_requested(core_context *root);
  *
  * @param root          The core context to free.
  */
-
 CORE_LIBSPEC void core_free(core_context *root);
 
 // Deprecated functions.

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -690,6 +690,7 @@ static void place_text(struct editor_context *editor)
       if(editor->cursor_x < (editor->board_width - 1))
         editor->cursor_x++;
 
+      num_placed++;
       editor->modified = true;
     }
     else

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -675,7 +675,7 @@ static void place_text(struct editor_context *editor)
   struct world *mzx_world = ((context *)editor)->world;
   struct buffer_info temp_buffer;
 
-  int key = get_key(keycode_unicode);
+  int key = get_key(keycode_text_ascii);
 
   if(key != 0)
   {

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -674,24 +674,28 @@ static void place_text(struct editor_context *editor)
 {
   struct world *mzx_world = ((context *)editor)->world;
   struct buffer_info temp_buffer;
+  int num_placed = 0;
 
-  int key = get_key(keycode_text_ascii);
+  temp_buffer.id = __TEXT;
+  temp_buffer.color = editor->buffer.color;
 
-  if(key != 0)
+  while(num_placed < KEY_UNICODE_MAX)
   {
-    temp_buffer.id = __TEXT;
-    temp_buffer.param = key;
-    temp_buffer.color = editor->buffer.color;
-    place_current_at_xy(mzx_world, &temp_buffer,
-     editor->cursor_x, editor->cursor_y, editor->mode, editor->cur_history);
+    temp_buffer.param = get_key(keycode_text_ascii);
+    if(temp_buffer.param)
+    {
+      place_current_at_xy(mzx_world, &temp_buffer,
+       editor->cursor_x, editor->cursor_y, editor->mode, editor->cur_history);
 
-    if(editor->cursor_x < (editor->board_width - 1))
-      editor->cursor_x++;
+      if(editor->cursor_x < (editor->board_width - 1))
+        editor->cursor_x++;
 
-    fix_scroll(editor);
-
-    editor->modified = true;
+      editor->modified = true;
+    }
+    else
+      break;
   }
+  fix_scroll(editor);
 }
 
 /**

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -3424,8 +3424,9 @@ static boolean robot_editor_mouse(context *ctx, int *key, int button,
 
   if(button && (button <= MOUSE_BUTTON_RIGHT))
   {
+    // NOTE: let intake handle clicks on scr_line_middle.
     if((y >= rstate->scr_line_start) && (y <= rstate->scr_line_end) &&
-     (x >= 2) && (x <= 78))
+     (y != rstate->scr_line_middle) && (x >= 2) && (x <= 78))
     {
       move_and_update(rstate, y - rstate->scr_line_middle);
       rstate->current_x = x - 2;

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -4121,7 +4121,6 @@ void robot_editor(context *parent, struct robot *cur_robot)
   spec.click          = robot_editor_mouse;
   spec.key            = robot_editor_key;
   spec.destroy        = robot_editor_destroy;
-  spec.framerate_mode = FRAMERATE_UI_INTERRUPT;
   create_context((context *)rstate, parent, &spec, CTX_ROBO_ED);
 
   rstate->intk =

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -3490,19 +3490,27 @@ static boolean robot_editor_key(context *ctx, int *key)
 
     case IKEY_BACKSPACE:
     {
-      if(rstate->current_x == 0 && rstate->current_line > 1)
-        combine_current_line(rstate, -1);
+      // Let intake handle Alt+Backspace and Ctrl+Backspace.
+      if(get_alt_status(keycode_internal) || get_ctrl_status(keycode_internal))
+        break;
 
-      return true;
+      if(rstate->current_x == 0 && rstate->current_line > 1)
+      {
+        combine_current_line(rstate, -1);
+        return true;
+      }
+      break;
     }
 
     case IKEY_DELETE:
     {
       if(rstate->command_buffer[rstate->current_x] == 0 &&
        rstate->current_rline->next)
+      {
         combine_current_line(rstate, 1);
-
-      return true;
+        return true;
+      }
+      break;
     }
 
     case IKEY_RETURN:
@@ -3707,12 +3715,16 @@ static boolean robot_editor_key(context *ctx, int *key)
           rstate->command_buffer[1] = '/';
         }
         update_current_line(rstate);
+        return true;
       }
-      return true;
+      break;
     }
 #else /* !CONFIG_DEBYTECODE */
     case IKEY_c:
     {
+      if(!get_ctrl_status(keycode_internal))
+        break;
+
       if(rstate->current_rline->validity_status != valid)
       {
         rstate->current_rline->validity_status = invalid_comment;
@@ -3752,8 +3764,7 @@ static boolean robot_editor_key(context *ctx, int *key)
       }
       else
 
-      if(get_ctrl_status(keycode_internal) &&
-       (rstate->command_buffer[0] == '.') &&
+      if((rstate->command_buffer[0] == '.') &&
        (rstate->command_buffer[1] == ' ') &&
        (rstate->command_buffer[2] == '"') &&
        (rstate->command_buffer[strlen(rstate->command_buffer) - 1] == '"'))
@@ -3788,7 +3799,6 @@ static boolean robot_editor_key(context *ctx, int *key)
 
         strcpy(rstate->command_buffer, uncomment_buffer);
       }
-
       return true;
     }
 
@@ -3798,9 +3808,9 @@ static boolean robot_editor_key(context *ctx, int *key)
       {
         rstate->current_rline->validity_status = invalid_discard;
         update_current_line(rstate);
+        return true;
       }
-
-      return true;
+      break;
     }
 #endif /* !CONFIG_DEBYTECODE */
 
@@ -3873,8 +3883,9 @@ static boolean robot_editor_key(context *ctx, int *key)
           rstate->mark_start_rline = rstate->mark_end_rline;
           rstate->mark_end_rline = mark_swap_rline;
         }
+        return true;
       }
-      return true;
+      break;
     }
 
     // Block action menu

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -4092,7 +4092,6 @@ static void robot_editor_destroy(context *ctx)
   delete_robot_lines(rstate->cur_robot, rstate);
 
   restore_screen();
-  pop_context();
 }
 
 void robot_editor(context *parent, struct robot *cur_robot)

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -3804,11 +3804,14 @@ static boolean robot_editor_key(context *ctx, int *key)
 
     case IKEY_d:
     {
-      if(rstate->current_rline->validity_status != valid)
+      if(get_ctrl_status(keycode_internal))
       {
-        rstate->current_rline->validity_status = invalid_discard;
-        update_current_line(rstate);
-        return true;
+        if(rstate->current_rline->validity_status != valid)
+        {
+          rstate->current_rline->validity_status = invalid_discard;
+          update_current_line(rstate);
+          return true;
+        }
       }
       break;
     }

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -3688,8 +3688,9 @@ static boolean robot_editor_key(context *ctx, int *key)
       {
         update_current_line(rstate);
         validate_lines(rstate, 1);
+        return true;
       }
-      return true;
+      break;
     }
 
 #ifdef CONFIG_DEBYTECODE

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -3811,8 +3811,8 @@ static boolean robot_editor_key(context *ctx, int *key)
         {
           rstate->current_rline->validity_status = invalid_discard;
           update_current_line(rstate);
-          return true;
         }
+        return true;
       }
       break;
     }

--- a/src/editor/window.c
+++ b/src/editor/window.c
@@ -294,7 +294,7 @@ int list_menu(const char *const *choices, int choice_size, const char *title,
 
       default:
       {
-        int key_char = get_key(keycode_unicode);
+        int key_char = get_key(keycode_text_ascii);
 
         if(!get_alt_status(keycode_internal) &&
          !get_ctrl_status(keycode_internal) && (key_char >= 32))
@@ -949,7 +949,7 @@ static int key_char_box(struct world *mzx_world, struct dialog *di,
 
     default:
     {
-      int key_char = get_key(keycode_unicode);
+      int key_char = get_key(keycode_text_ascii);
 
       if(key_char >= 32)
       {

--- a/src/event.c
+++ b/src/event.c
@@ -1165,7 +1165,7 @@ void key_release(struct buffered_status *status, enum keycode key)
 boolean has_unicode_input(void)
 {
   const struct buffered_status *status = load_status();
-  return !!status->unicode_length;
+  return status->unicode_length > status->unicode_pos;
 }
 
 boolean get_exit_status(void)

--- a/src/event.c
+++ b/src/event.c
@@ -1138,13 +1138,15 @@ void key_press(struct buffered_status *status, enum keycode key)
 
 void key_press_unicode(struct buffered_status *status, Uint32 unicode)
 {
-  if(status->unicode_length < KEY_UNICODE_MAX)
+  if(unicode)
   {
-    status->unicode[status->unicode_length++] = unicode;
+    if(status->unicode_length < KEY_UNICODE_MAX)
+    {
+      status->unicode[status->unicode_length++] = unicode;
+    }
+    else
+      status->unicode[KEY_UNICODE_MAX - 1] = unicode;
   }
-  else
-    status->unicode[KEY_UNICODE_MAX - 1] = unicode;
-
   status->unicode_repeat = unicode;
 }
 

--- a/src/event.h
+++ b/src/event.h
@@ -225,7 +225,8 @@ CORE_LIBSPEC boolean get_alt_status(enum keycode_type type);
 CORE_LIBSPEC boolean get_shift_status(enum keycode_type type);
 CORE_LIBSPEC boolean get_ctrl_status(enum keycode_type type);
 CORE_LIBSPEC void key_press(struct buffered_status *status, enum keycode key);
-CORE_LIBSPEC void key_press_unicode(struct buffered_status *status, Uint32 unicode);
+CORE_LIBSPEC void key_press_unicode(struct buffered_status *status,
+ Uint32 unicode, boolean repeating);
 CORE_LIBSPEC void key_release(struct buffered_status *status, enum keycode key);
 CORE_LIBSPEC boolean get_exit_status(void);
 CORE_LIBSPEC boolean set_exit_status(boolean value);

--- a/src/event_sdl.c
+++ b/src/event_sdl.c
@@ -861,9 +861,61 @@ static void close_joystick(int joystick_index)
 }
 #endif
 
+static inline Uint32 utf8_next_char(Uint8 **_src)
+{
+  Uint8 *src = *_src;
+  Uint32 unicode;
+
+  if(!*src)
+    return 0;
+
+  unicode = *(src++);
+
+  if(unicode & 0x80)
+  {
+    Uint32 extra = 1;
+    Uint32 next;
+    Uint32 i;
+
+    if(!(unicode & 0x40))
+      goto err_invalid;
+
+    unicode = unicode & ~0xC0;
+    if(unicode & 0x20)
+    {
+      unicode = unicode & ~0x20;
+      extra++;
+      if(unicode & 0x10)
+      {
+        unicode = unicode & ~0x10;
+        extra++;
+      }
+    }
+
+    for(i = 0; i < extra; i++)
+    {
+      if(!*src)
+        goto err_invalid;
+
+      next = *src++;
+      if((next & 0xC0) != 0x80)
+        goto err_invalid;
+
+      unicode = (unicode << 6) | (next & 0x3F);
+    }
+  }
+  *_src = src;
+  return unicode;
+
+err_invalid:
+  *_src = src;
+  return 0;
+}
+
 static boolean process_event(SDL_Event *event)
 {
   struct buffered_status *status = store_status();
+  static boolean unicode_fallback = true;
   enum keycode ckey;
 
   /* SDL's numlock keyboard modifier handling seems to be broken on X11,
@@ -1051,7 +1103,7 @@ static boolean process_event(SDL_Event *event)
 
     case SDL_KEYDOWN:
     {
-      Uint16 unicode = 0;
+      Uint32 unicode = 0;
 
 #if SDL_VERSION_ATLEAST(2,0,0)
       // SDL 2.0 uses proper key repeat, but derives its timing from the OS.
@@ -1087,19 +1139,21 @@ static boolean process_event(SDL_Event *event)
         ckey = IKEY_UNICODE;
       }
 
-#if SDL_VERSION_ATLEAST(2,0,0)
-      // SDL 2.0 sends the raw key and translated 'text' as separate events.
-      // There is no longer a UNICODE mode that sends both at once.
-      // Because of the way the SDL 1.2 assumption is embedded deeply in
-      // the MZX event queue processor, emulate the 1.2 behaviour by waiting
-      // for a TEXTINPUT event after a KEYDOWN.
-      SDL_PumpEvents();
-
-      if(SDL_PeepEvents(event, 1, SDL_GETEVENT, SDL_TEXTINPUT, SDL_TEXTINPUT))
-        unicode = event->text.text[0] | event->text.text[1] << 8;
-#else
+#if !SDL_VERSION_ATLEAST(2,0,0)
       unicode = event->key.keysym.unicode;
+      if(unicode && unicode_fallback)
+      {
+        // Clear any unicode keys on the buffer generated from the fallback...
+        status->unicode_length = 0;
+        unicode_fallback = false;
+      }
 #endif
+
+      // Some platforms don't implement SDL_TEXTINPUT (SDL 2.0) or the unicode
+      // field (SDL 1.2); until usage of those is detected, fake the text key
+      // using the internal keycode.
+      if(unicode_fallback && KEYCODE_IS_ASCII(ckey))
+        unicode = convert_internal_unicode(ckey);
 
       if((ckey == IKEY_RETURN) &&
        get_alt_status(keycode_internal) &&
@@ -1157,7 +1211,9 @@ static boolean process_event(SDL_Event *event)
         }
       }
 
-      key_press(status, ckey, unicode);
+      key_press(status, ckey);
+      if(unicode)
+        key_press_unicode(status, unicode);
       break;
     }
 
@@ -1204,6 +1260,31 @@ static boolean process_event(SDL_Event *event)
     }
 
 #if SDL_VERSION_ATLEAST(2,0,0)
+    case SDL_TEXTINPUT:
+    {
+      // TODO: would be nice if they added a way to disable or ignore repeats
+      // here. If this ever happens, text repeat control can be given back
+      // to MZX (see event.c).
+      Uint8 *text = (Uint8 *)event->text.text;
+
+      if(unicode_fallback)
+      {
+        // Clear any unicode keys on the buffer generated from the fallback...
+        status->unicode_length = 0;
+        unicode_fallback = false;
+      }
+
+      // Decode the input UTF-8 string into UTF-32 for the event buffer.
+      while(*text)
+      {
+        Uint32 unicode = utf8_next_char(&text);
+
+        if(unicode)
+          key_press_unicode(status, unicode);
+      }
+      break;
+    }
+
     case SDL_JOYDEVICEADDED:
     {
       // Add a new joystick.

--- a/src/event_sdl.c
+++ b/src/event_sdl.c
@@ -1212,8 +1212,7 @@ static boolean process_event(SDL_Event *event)
       }
 
       key_press(status, ckey);
-      if(unicode)
-        key_press_unicode(status, unicode);
+      key_press_unicode(status, unicode);
       break;
     }
 

--- a/src/event_sdl.c
+++ b/src/event_sdl.c
@@ -1427,7 +1427,8 @@ boolean __update_event_status(void)
     {
       status->key = IKEY_UNKNOWN;
       status->key_repeat = IKEY_UNKNOWN;
-      status->unicode = 0;
+      status->unicode_repeat = 0;
+      status->unicode_length = 0;
       status->exit_status = true;
       return true;
     }

--- a/src/event_sdl.c
+++ b/src/event_sdl.c
@@ -1212,7 +1212,7 @@ static boolean process_event(SDL_Event *event)
       }
 
       key_press(status, ckey);
-      key_press_unicode(status, unicode);
+      key_press_unicode(status, unicode, true);
       break;
     }
 
@@ -1259,11 +1259,13 @@ static boolean process_event(SDL_Event *event)
     }
 
 #if SDL_VERSION_ATLEAST(2,0,0)
+    /**
+     * SDL 2 sends repeat key press events. In the case of SDL_TEXTINPUT, these
+     * can't be distinguished from regular key presses, so key_press_unicode
+     * needs to be called without repeating enabled.
+     */
     case SDL_TEXTINPUT:
     {
-      // TODO: would be nice if they added a way to disable or ignore repeats
-      // here. If this ever happens, text repeat control can be given back
-      // to MZX (see event.c).
       Uint8 *text = (Uint8 *)event->text.text;
 
       if(unicode_fallback)
@@ -1279,7 +1281,7 @@ static boolean process_event(SDL_Event *event)
         Uint32 unicode = utf8_next_char(&text);
 
         if(unicode)
-          key_press_unicode(status, unicode);
+          key_press_unicode(status, unicode, false);
       }
       break;
     }

--- a/src/game.c
+++ b/src/game.c
@@ -624,7 +624,7 @@ static boolean game_key(context *ctx, int *key)
   {
     // Get the char for the KEY? labels. If there is no relevant unicode
     // keypress, we want to use the regular code instead.
-    int key_unicode = get_key(keycode_unicode);
+    int key_unicode = get_key(keycode_text_ascii);
     int key_char = *key;
 
     if(key_unicode > 0 && key_unicode < 256)

--- a/src/intake.c
+++ b/src/intake.c
@@ -955,9 +955,7 @@ static boolean intake_key(subcontext *sub, int *key)
 
     default:
     {
-      if(!alt_status && !ctrl_status)
-        place = true;
-
+      place = true;
       break;
     }
   }

--- a/src/window.c
+++ b/src/window.c
@@ -747,7 +747,7 @@ __editor_maybe_static int char_selection_ext(int current, int allow_char_255,
         if(!current_charset)
         {
           // If this is from 32 to 255, jump there.
-          int key_char = get_key(keycode_unicode);
+          int key_char = get_key(keycode_text_ascii);
 
           if(key_char >= 32 && key_char <= 255)
             current = key_char;
@@ -1773,7 +1773,7 @@ static int key_number_box(struct world *mzx_world, struct dialog *di,
 
     default:
     {
-      int key_char = get_key(keycode_unicode);
+      int key_char = get_key(keycode_text_ascii);
 
       if((key >= '0') && (key <= '9'))
       {
@@ -2060,7 +2060,7 @@ static int key_list_box(struct world *mzx_world, struct dialog *di,
 
     default:
     {
-      int key_char = get_key(keycode_unicode);
+      int key_char = get_key(keycode_text_ascii);
       if(!get_alt_status(keycode_internal) &&
        !get_ctrl_status(keycode_internal) && (key_char >= 32))
       {


### PR DESCRIPTION
This branch implements an event text buffer and SDL_TEXTINPUT handler. Both intake implementations have been modified to read all input text characters instead of a single char, making typing to them more responsive than before and allowing them to use the normal MZX UI framerate. Additionally, this adds a fallback for SDL implementations that don't generate SDL_TEXTINPUT events (SDL 2+, example: PS Vita?) or return unicode values as part of the key press event (SDL 1.2, example: Pandora).

A side effect of the way SDL_TEXTINPUT is implemented is repeats can't be distinguished from initial presses, so unicode key repeat is currently disabled for SDL 2 builds.

- [x] Add event text buffer, keycode type value to get ASCII instead of Unicode.
- [x] Add SDL_TEXTINPUT handler to replace the horrible hack that was used before.
- [x] Update intake to use the text buffer.
- [x] Update editor text entry to use the text buffer.
- [x] Update intake_num to use the text buffer.
- [x] SDL Unicode fallback.
- [x] Fix bugs where text events not attached to an internal keycode are ignored.
- [x] Fix bugs in the robot editor where Alt combos without a special function would not be allowed to produce text (fixes e.g. AltGr+2 `@` when using a Denmark keyboard locale).
- [x] ~~SDL can't distinguish Alt from AltGr in locales with the latter.~~ Posted an [issue](https://www.digitalmzx.com/forums/index.php?app=tracker&showissue=798) to the tracker for this. Should probably be reported to SDL too.
- [x] More testing: SDL 2
- [x] More testing: SDL 1.2
- [x] More testing: NDS, 3DS, Wii
- [x] More testing: Palette Editor
- [x] More testing: Robot Editor
- [x] More testing: joysticks :(
- [x] Spectere's Vita Seal of Approval™

Windows x64 test build: [mzxgit-x64.zip](https://github.com/AliceLR/megazeux/files/4332082/mzxgit-x64.zip)
