### PR TITLE
Decrease counter/string allocation sizes, fix signedness in lists

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -22,6 +22,11 @@ USERS
 + Fixed potential null termination issues in both world loaders
   that could be triggered with invalid board name, robot name,
   scroll, sensor, sfx, and status counter strings.
++ Decreased the sizes of the counter and string structs and
+  fixed a crash that would occur when attempting to expand the
+  counters or strings lists beyond 1 billion. Checks have been
+  added to prevent them from expanding beyond 2^31 (please don't
+  actually use this many counters/strings).
 
 DEVELOPERS
 

--- a/src/counter.c
+++ b/src/counter.c
@@ -25,6 +25,7 @@
 #include <assert.h>
 #include <math.h>
 #include <ctype.h>
+#include <limits.h>
 #include <time.h>
 #include <sys/stat.h>
 
@@ -3670,7 +3671,11 @@ void initialize_gateway_functions(struct world *mzx_world)
 static struct counter *allocate_new_counter(const char *name, int name_length,
  int value)
 {
-  struct counter *dest = cmalloc(sizeof(struct counter) + name_length);
+  // Attempt to reclaim any padding bytes at the end of the struct...
+  size_t size = MAX(sizeof(struct counter),
+   offsetof(struct counter, name) + name_length + 1);
+
+  struct counter *dest = cmalloc(size);
 
   memcpy(dest->name, name, name_length);
   dest->name[name_length] = 0;
@@ -3682,19 +3687,25 @@ static struct counter *allocate_new_counter(const char *name, int name_length,
 }
 
 static void add_counter(struct counter_list *counter_list, const char *name,
- int value, int position)
+ int value, unsigned int position)
 {
-  int count = counter_list->num_counters;
-  int allocated = counter_list->num_counters_allocated;
+  unsigned int count = counter_list->num_counters;
+  unsigned int allocated = counter_list->num_counters_allocated;
   struct counter **base = counter_list->counters;
   struct counter *dest;
-  int name_length = strlen(name);
+  unsigned int name_length = strlen(name);
 
   // Need a reallocation?
   if(count == allocated)
   {
     if(allocated)
+    {
+      // Gracefully fail if this tries to go over 2b...
+      if(allocated >= (size_t)(INT32_MAX))
+        return;
+
       allocated *= 2;
+    }
     else
       allocated = MIN_COUNTER_ALLOCATE;
 
@@ -4036,7 +4047,7 @@ void sort_counter_list(struct counter_list *counter_list)
 
 void clear_counter_list(struct counter_list *counter_list)
 {
-  int i;
+  size_t i;
 
 #ifdef CONFIG_KHASH
   KHASH_CLEAR(COUNTER, counter_list->hash_table);

--- a/src/counter_struct.h
+++ b/src/counter_struct.h
@@ -28,15 +28,15 @@ __M_BEGIN_DECLS
 struct counter
 {
   int value;
-  int name_length;
+  unsigned short name_length;
   unsigned char gateway_write;
   char name[1];
 };
 
 struct counter_list
 {
-  int num_counters;
-  int num_counters_allocated;
+  unsigned int num_counters;
+  unsigned int num_counters_allocated;
   struct counter **counters;
 #ifdef CONFIG_KHASH
   void *hash_table;
@@ -78,11 +78,11 @@ struct string
   // because we're not using a search to find it with the hash table. We'll
   // add it for both though so there doesn't have to be a hash table ifdef
   // in world.c
-  int list_ind;
+  unsigned int list_ind;
 
-  int name_length;
-  size_t length;
-  size_t allocated_length;
+  unsigned int name_length;
+  unsigned int length;
+  unsigned int allocated_length;
   char *value;
 
   char name[1];
@@ -90,8 +90,8 @@ struct string
 
 struct string_list
 {
-  int num_strings;
-  int num_strings_allocated;
+  unsigned int num_strings;
+  unsigned int num_strings_allocated;
   struct string **strings;
 #ifdef CONFIG_KHASH
   void *hash_table;

--- a/src/counter_struct.h
+++ b/src/counter_struct.h
@@ -25,11 +25,13 @@
 
 __M_BEGIN_DECLS
 
+#include <inttypes.h>
+
 struct counter
 {
-  int value;
-  unsigned short name_length;
-  unsigned char gateway_write;
+  int32_t value;
+  uint16_t name_length;
+  uint8_t gateway_write;
   char name[1];
 };
 
@@ -74,17 +76,15 @@ struct counter_list
 
 struct string
 {
-  // Back reference to the string's position in the list, mandatory
-  // because we're not using a search to find it with the hash table. We'll
-  // add it for both though so there doesn't have to be a hash table ifdef
-  // in world.c
-  unsigned int list_ind;
-
-  unsigned int name_length;
-  unsigned int length;
-  unsigned int allocated_length;
   char *value;
+  uint32_t length;
+  uint32_t allocated_length;
 
+  // Back reference to the string's position in the main list, mandatory as
+  // a hash table search needs to be able to determine this value.
+  uint32_t list_ind;
+
+  uint16_t name_length;
   char name[1];
 };
 

--- a/src/editor/debug.c
+++ b/src/editor/debug.c
@@ -1529,7 +1529,7 @@ static int get_rolodex_position(struct world *mzx_world, int first)
 }
 
 static struct debug_node *create_rolodex_nodes(struct debug_node *parent,
- int counts[NUM_ROLODEX], const char *name_prefix)
+ size_t counts[NUM_ROLODEX], const char *name_prefix)
 {
   struct debug_node *nodes = ccalloc(NUM_ROLODEX, sizeof(struct debug_node));
   int i;
@@ -1558,12 +1558,12 @@ static void init_counters_node(struct world *mzx_world, struct debug_node *dest)
   struct debug_node *nodes;
   struct debug_node *current_node = NULL;
   struct debug_var *current_var;
-  int var_counts[NUM_ROLODEX] = { 0 };
-  int num_counters = counter_list->num_counters;
+  size_t var_counts[NUM_ROLODEX] = { 0 };
+  size_t num_counters = counter_list->num_counters;
   int first_prev = -1;
   int first;
   int n = 0;
-  int i;
+  size_t i;
 
   // The counter list may not be in the order we want to display it in.
   sort_counter_list(counter_list);
@@ -1607,12 +1607,12 @@ static void init_strings_node(struct world *mzx_world, struct debug_node *dest)
   struct debug_node *nodes;
   struct debug_node *current_node = NULL;
   struct debug_var *current_var;
-  int var_counts[NUM_ROLODEX] = { 0 };
-  int num_strings = string_list->num_strings;
+  size_t var_counts[NUM_ROLODEX] = { 0 };
+  size_t num_strings = string_list->num_strings;
   int first_prev = -1;
   int first;
   int n = 0;
-  int i;
+  size_t i;
 
   // Don't create any child nodes if there are no strings.
   if(!num_strings)
@@ -2780,6 +2780,7 @@ void __debug_counters(context *ctx)
           struct counter_list *counter_list = &(mzx_world->counter_list);
           struct string_list *string_list = &(mzx_world->string_list);
           FILE *fp;
+          size_t i;
 
           fp = fopen_unsafe(export_name, "wb");
 

--- a/src/memfile.h
+++ b/src/memfile.h
@@ -153,6 +153,11 @@ static inline int mfgetd(struct memfile *mf)
   return v;
 }
 
+static inline unsigned int mfgetud(struct memfile *mf)
+{
+  return (unsigned int)mfgetd(mf);
+}
+
 static inline int mfputc(int ch, struct memfile *mf)
 {
   mf->current[0] = ch & 0xFF;
@@ -174,6 +179,11 @@ static inline void mfputd(int ch, struct memfile *mf)
   mf->current[2] = (ch >> 16) & 0xFF;
   mf->current[3] = (ch >> 24) & 0xFF;
   mf->current += 4;
+}
+
+static inline void mfputud(size_t ch, struct memfile *mf)
+{
+  mfputd((unsigned int)ch, mf);
 }
 
 static inline size_t mfread(void *dest, size_t len, size_t count,

--- a/src/mzm.c
+++ b/src/mzm.c
@@ -104,6 +104,9 @@ static void save_mzm_common(struct world *mzx_world, int start_x, int start_y,
   }
 
   buffer = alloc(mzm_size, storage);
+  if(!buffer)
+    return;
+
   bufferPtr = buffer;
   memcpy(bufferPtr, "MZM3", 4);
   bufferPtr += 4;
@@ -304,7 +307,7 @@ static void save_mzm_common(struct world *mzx_world, int start_x, int start_y,
 static void *mem_allocate(size_t length, void **dest)
 {
   size_t *dataPtr;
-  *dest = malloc(length + sizeof(size_t));
+  *dest = cmalloc(length + sizeof(size_t));
   dataPtr = *dest;
   dataPtr[0] = length;
   return &dataPtr[1];
@@ -342,7 +345,7 @@ static void *str_allocate(size_t length, void **dest)
 
   data->str = new_string(data->mzx_world, data->name, length, data->id);
 
-  return data->str->value;
+  return data->str ? data->str->value : NULL;
 }
 
 void save_mzm_string(struct world *mzx_world, const char *name, int start_x,

--- a/src/str.c
+++ b/src/str.c
@@ -135,6 +135,11 @@ static size_t get_string_alloc_size(unsigned int name_length,
    offsetof(struct string, name) + name_length + value_length + 1);
 }
 
+/**
+ * Allocate a new string and initialize its name, length, and pointer fields.
+ * This function does not add the new string to the string list or initialize
+ * its value.
+ */
 static struct string *allocate_new_string(const char *name, int name_length,
  size_t length)
 {
@@ -152,6 +157,10 @@ static struct string *allocate_new_string(const char *name, int name_length,
   return dest;
 }
 
+/**
+ * Create a named string in the string list and preallocate it to the given
+ * length. Returns NULL if the strings list is full.
+ */
 static struct string *add_string_preallocate(struct string_list *string_list,
  const char *name, size_t length, unsigned int position)
 {
@@ -167,11 +176,8 @@ static struct string *add_string_preallocate(struct string_list *string_list,
     if(allocated)
     {
       // Gracefully fail if this tries to go over 2b...
-      // TODO: The string code is pretty complicated and it looks like a bit
-      // of work to make it safely fail, so show a helpful error instead.
       if(allocated >= (size_t)(INT32_MAX))
-        error("Congrats, you have a lot of RAM!",
-         ERROR_T_FATAL, ERROR_OPT_EXIT,  0x8008);
+        return NULL;
 
       allocated *= 2;
     }
@@ -209,6 +215,9 @@ static struct string *add_string_preallocate(struct string_list *string_list,
   return dest;
 }
 
+/**
+ * Reallocate an existing string.
+ */
 static struct string *reallocate_string(struct string_list *string_list,
  struct string *src, int pos, size_t length)
 {
@@ -242,28 +251,46 @@ static struct string *reallocate_string(struct string_list *string_list,
   return src;
 }
 
-static void force_string_length(struct string_list *string_list,
+/**
+ * Set a string's length and reallocate it if necessary.
+ * If the string does not exist, it will be created.
+ * Returns false if a string could not be created, otherwise true.
+ */
+static boolean force_string_length(struct string_list *string_list,
  const char *name, int next, struct string **str, size_t *length)
 {
   if(*length > MAX_STRING_LEN)
     *length = MAX_STRING_LEN;
 
   if(!*str)
+  {
     *str = add_string_preallocate(string_list, name, *length, next);
+    if(!*str)
+      return false;
+  }
+  else
 
-  else if(*length > (*str)->allocated_length)
+  if(*length > (*str)->allocated_length)
     *str = reallocate_string(string_list, *str, next, *length);
 
   /* Wipe string if the length has increased but not the allocated memory */
   if(*length > (*str)->length)
     memset(&((*str)->value[(*str)->length]), ' ', (*length) - (*str)->length);
+
+  return true;
 }
 
-static void force_string_splice(struct string_list *string_list,
+/**
+ * Bound a splice of a string and/or truncate a string.
+ * If the string does not exist, it will be created.
+ * Returns false if a string could not be created, otherwise true.
+ */
+static boolean force_string_splice(struct string_list *string_list,
  const char *name, int next, struct string **str, size_t s_length,
  size_t offset, boolean offset_specified, size_t *size, boolean size_specified)
 {
-  force_string_length(string_list, name, next, str, &s_length);
+  if(!force_string_length(string_list, name, next, str, &s_length))
+    return false;
 
   if((*size == 0 && !size_specified) || *size > s_length)
     *size = s_length;
@@ -279,21 +306,39 @@ static void force_string_splice(struct string_list *string_list,
     else
       (*str)->length = offset + *size;
   }
+  return true;
 }
 
-static void force_string_copy(struct string_list *string_list,
+/**
+ * Copy an external char buffer over a string or string splice (memcpy).
+ * If the source of the copy is another string, use force_string_move instead.
+ * If the string does not exist, it will be created.
+ * Returns false if a string could not be created, otherwise true.
+ */
+static boolean force_string_copy(struct string_list *string_list,
  const char *name, int next, struct string **str, size_t s_length,
  size_t offset, boolean offset_specified, size_t *size, boolean size_specified,
  char *src)
 {
-  force_string_splice(string_list, name, next, str, s_length,
-   offset, offset_specified, size, size_specified);
+  if(!force_string_splice(string_list, name, next, str, s_length,
+   offset, offset_specified, size, size_specified))
+    return false;
 
   if(offset <= (*str)->length - *size)
     memcpy((*str)->value + offset, src, *size);
+
+  return true;
 }
 
-static void force_string_move(struct string_list *string_list,
+/**
+ * Copy a char buffer over a string or string splice safely (memmove). This
+ * function is guaranteed to work if the source is a substring of or overlaps
+ * the destination. Otherwise, it is equivalent to force_string_copy.
+ *
+ * If the string does not exist, it will be created.
+ * Returns false if a string could not be created, otherwise true.
+ */
+static boolean force_string_move(struct string_list *string_list,
  const char *name, int next, struct string **str, size_t s_length,
  size_t offset, boolean offset_specified, size_t *size, boolean size_specified,
  char *src)
@@ -308,14 +353,17 @@ static void force_string_move(struct string_list *string_list,
       src_dest_match = true;
   }
 
-  force_string_splice(string_list, name, next, str, s_length,
-   offset, offset_specified, size, size_specified);
+  if(!force_string_splice(string_list, name, next, str, s_length,
+   offset, offset_specified, size, size_specified))
+    return false;
 
   if(src_dest_match)
     src = (*str)->value + off;
 
   if(offset <= (*str)->length - *size)
     memmove((*str)->value + offset, src, *size);
+
+  return true;
 }
 
 static void get_string_dot_value(char *dot_ptr, int *index,
@@ -600,7 +648,8 @@ void string_write_as_counter(struct world *mzx_world,
       }
     }
 
-    force_string_length(string_list, name, next, &src, &alloc_length);
+    if(!force_string_length(string_list, name, next, &src, &alloc_length))
+      return;
 
     if(index_specified)
     {
@@ -818,8 +867,9 @@ int set_string(struct world *mzx_world, const char *name, struct string *src,
       if(current_pos + read_count > (unsigned int)file_size)
         read_count = file_size - current_pos;
 
-      force_string_splice(string_list, name, next, &dest,
-       read_count, offset, offset_specified, &size, size_specified);
+      if(!force_string_splice(string_list, name, next, &dest,
+       read_count, offset, offset_specified, &size, size_specified))
+        return 0;
 
       actual_read = fread(dest->value + offset, 1, read_count, input_file);
       if(offset == 0 && !offset_specified)
@@ -835,8 +885,10 @@ int set_string(struct world *mzx_world, const char *name, struct string *src,
       unsigned int allocated = 32;
       unsigned int new_allocated = allocated;
 
-      force_string_splice(string_list, name, next, &dest,
-       allocated, offset, offset_specified, &size, size_specified);
+      if(!force_string_splice(string_list, name, next, &dest,
+       allocated, offset, offset_specified, &size, size_specified))
+        return 0;
+
       dest_value = dest->value;
 
       while(1)
@@ -942,7 +994,8 @@ int set_string(struct world *mzx_world, const char *name, struct string *src,
     board_size = board_width * src_board->board_height;
     board_pos = get_board_x_board_y_offset(mzx_world, id);
 
-    force_string_length(string_list, name, next, &dest, &read_length);
+    if(!force_string_length(string_list, name, next, &dest, &read_length))
+      return 0;
 
     if(board_pos < board_size)
     {
@@ -1192,8 +1245,11 @@ int set_string(struct world *mzx_world, const char *name, struct string *src,
   return 0;
 }
 
-// Creates a new string if it doesn't already exist; otherwise, resizes
-// the string to the provided length
+/**
+ * Creates a new string and adds it to the strings list if it doesn't already
+ * exist; otherwise, resizes the string to exactly the provided length. Returns
+ * NULL if the new string could not be added to the string list.
+ */
 struct string *new_string(struct world *mzx_world, const char *name,
  size_t length, int id)
 {
@@ -1202,7 +1258,9 @@ struct string *new_string(struct world *mzx_world, const char *name,
   int next = 0;
 
   str = find_string(string_list, name, &next);
-  force_string_length(string_list, name, next, &str, &length);
+  if(!force_string_length(string_list, name, next, &str, &length))
+    return NULL;
+
   str->length = length;
   return str;
 }

--- a/src/world.c
+++ b/src/world.c
@@ -1463,15 +1463,15 @@ static inline int save_world_counters(struct world *mzx_world,
   struct counter_list *counter_list = &(mzx_world->counter_list);
   struct counter *src_counter;
   size_t name_length;
+  size_t i;
   int result;
-  int i;
 
   result = zip_write_open_file_stream(zp, name, ZIP_M_NONE);
   if(result != ZIP_SUCCESS)
     return result;
 
   mfopen(buffer, 8, &mf);
-  mfputd(counter_list->num_counters, &mf);
+  mfputud(counter_list->num_counters, &mf);
   zwrite(buffer, 4, zp);
 
   for(i = 0; i < counter_list->num_counters; i++)
@@ -1481,7 +1481,7 @@ static inline int save_world_counters(struct world *mzx_world,
 
     mf.current = buffer;
     mfputd(src_counter->value, &mf);
-    mfputd(name_length, &mf);
+    mfputud(name_length, &mf);
     zwrite(buffer, 8, zp);
     zwrite(src_counter->name, name_length, zp);
   }
@@ -1500,9 +1500,9 @@ static inline int load_world_counters(struct world *mzx_world,
   int value;
 
   struct counter_list *counter_list = &(mzx_world->counter_list);
-  int num_prev_allocated;
-  int num_counters;
-  int i;
+  size_t num_prev_allocated;
+  size_t num_counters;
+  size_t i;
 
   enum zip_error result;
   unsigned int method;
@@ -1530,7 +1530,7 @@ static inline int load_world_counters(struct world *mzx_world,
     mfopen(buffer, actual_size, &mf);
   }
 
-  num_counters = mfgetd(&mf);
+  num_counters = mfgetud(&mf);
 
   num_prev_allocated = counter_list->num_counters_allocated;
 
@@ -1545,7 +1545,7 @@ static inline int load_world_counters(struct world *mzx_world,
   for(i = 0; i < num_counters; i++)
   {
     value = mfgetd(&mf);
-    name_length = mfgetd(&mf);
+    name_length = mfgetud(&mf);
 
     if(name_length >= ROBOT_MAX_TR)
       break;
@@ -1596,15 +1596,15 @@ static inline int save_world_strings(struct world *mzx_world,
   struct string *src_string;
   size_t name_length;
   size_t str_length;
+  size_t i;
   int result;
-  int i;
 
   result = zip_write_open_file_stream(zp, name, ZIP_M_NONE);
   if(result != ZIP_SUCCESS)
     return result;
 
   mfopen(buffer, 8, &mf);
-  mfputd(string_list->num_strings, &mf);
+  mfputud(string_list->num_strings, &mf);
   zwrite(buffer, 4, zp);
 
   for(i = 0; i < string_list->num_strings; i++)
@@ -1614,8 +1614,8 @@ static inline int save_world_strings(struct world *mzx_world,
     str_length = src_string->length;
 
     mf.current = buffer;
-    mfputd(name_length, &mf);
-    mfputd(str_length, &mf);
+    mfputud(name_length, &mf);
+    mfputud(str_length, &mf);
     zwrite(buffer, 8, zp);
     zwrite(src_string->name, name_length, zp);
     zwrite(src_string->value, str_length, zp);
@@ -1639,9 +1639,9 @@ static inline int load_world_strings_mem(struct world *mzx_world,
   size_t name_length;
   size_t str_length;
 
-  int num_prev_allocated;
-  int num_strings;
-  int i;
+  size_t num_prev_allocated;
+  size_t num_strings;
+  size_t i;
 
   // If this is an uncompressed memory zip, we can read the memory directly.
   if(zp->is_memory && method == ZIP_M_NONE)
@@ -1661,7 +1661,7 @@ static inline int load_world_strings_mem(struct world *mzx_world,
     mfopen(buffer, actual_size, &mf);
   }
 
-  num_strings = mfgetd(&mf);
+  num_strings = mfgetud(&mf);
 
   num_prev_allocated = string_list->num_strings_allocated;
 
@@ -1675,8 +1675,8 @@ static inline int load_world_strings_mem(struct world *mzx_world,
 
   for(i = 0; i < num_strings; i++)
   {
-    name_length = mfgetd(&mf);
-    str_length = mfgetd(&mf);
+    name_length = mfgetud(&mf);
+    str_length = mfgetud(&mf);
 
     if(name_length >= ROBOT_MAX_TR || str_length > MAX_STRING_LEN)
       break;
@@ -1731,9 +1731,9 @@ static inline int load_world_strings(struct world *mzx_world,
   size_t name_length;
   size_t str_length;
 
-  int num_prev_allocated;
-  int num_strings;
-  int i;
+  size_t num_prev_allocated;
+  size_t num_strings;
+  size_t i;
 
   enum zip_error result;
   unsigned int method;
@@ -1751,7 +1751,7 @@ static inline int load_world_strings(struct world *mzx_world,
   mfopen(buffer, 8, &mf);
   zread(buffer, 4, zp);
 
-  num_strings = mfgetd(&mf);
+  num_strings = mfgetud(&mf);
   num_prev_allocated = string_list->num_strings_allocated;
 
   // If there aren't already any strings, allocate manually.
@@ -1766,8 +1766,8 @@ static inline int load_world_strings(struct world *mzx_world,
   {
     zread(buffer, 8, zp);
     mf.current = buffer;
-    name_length = mfgetd(&mf);
-    str_length = mfgetd(&mf);
+    name_length = mfgetud(&mf);
+    str_length = mfgetud(&mf);
 
     if(name_length >= ROBOT_MAX_TR || str_length > MAX_STRING_LEN)
       break;

--- a/src/world.c
+++ b/src/world.c
@@ -1690,6 +1690,8 @@ static inline int load_world_strings_mem(struct world *mzx_world,
     {
       name_buffer[name_length] = 0;
       src_string = new_string(mzx_world, name_buffer, str_length, -1);
+      if(!src_string)
+        break;
     }
 
     // Otherwise, put them in the list manually.
@@ -1781,6 +1783,8 @@ static inline int load_world_strings(struct world *mzx_world,
     {
       name_buffer[name_length] = 0;
       src_string = new_string(mzx_world, name_buffer, str_length, -1);
+      if(!src_string)
+        break;
     }
 
     // Otherwise, put them in the list manually.


### PR DESCRIPTION
This further reduces some of the bloat the counter/string structs have acquired over time, makes counter/string allocation account for the extra padding bytes in the structs, and fixes the signedness of the counter/string list counts and allocation sizes so MZX (hopefully) won't crash at 1 billion counters anymore. It also adds checks to prevent these from going over 2 billion (though the string check currently triggers a fatal error ☹️).

- [x] (Lots of) testing.
- [x] Maybe don't make the string check cause a fatal error. ☹️

World for testing counter creation: [new_ctrs_per_second.zip](https://github.com/AliceLR/megazeux/files/4383818/new_ctrs_per_second.zip)

