### PR TITLE
Fix khash 2^31 bug, cache hash values in key struct

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -80,7 +80,7 @@ usage() {
 	echo "  --enable-egl            Enables EGL backend (if SDL disabled)."
 	echo "  --enable-gles           Enable hacks for OpenGL ES platforms."
 	echo "  --disable-check-alloc   Disables memory allocator error handling."
-	echo "  --disable-khash         Disables using khash for counter/string lookups."
+	echo "  --disable-counter-hash  Disables hash tables for counter/string lookups."
 	echo "  --enable-debytecode     Enable experimental 'debytecode' transform."
 	echo "  --disable-libsdl2       Disable SDL 2.0 support (falls back on 1.2)."
 	echo "  --enable-stdio-redirect Redirect console output to stdout.txt/stderr.txt."
@@ -152,7 +152,7 @@ SDL="true"
 EGL="false"
 GLES="false"
 CHECK_ALLOC="true"
-KHASH="true"
+COUNTER_HASH="true"
 DEBYTECODE="false"
 LIBSDL2="true"
 STDIO_REDIRECT="false"
@@ -352,8 +352,8 @@ while [ "$1" != "" ]; do
 	[ "$1" = "--disable-check-alloc" ] && CHECK_ALLOC="false"
 	[ "$1" = "--enable-check-alloc" ]  && CHECK_ALLOC="true"
 
-	[ "$1" = "--enable-khash" ]  && KHASH="true"
-	[ "$1" = "--disable-khash" ] && KHASH="false"
+	[ "$1" = "--enable-counter-hash" ]  && COUNTER_HASH="true"
+	[ "$1" = "--disable-counter-hash" ] && COUNTER_HASH="false"
 
 	[ "$1" = "--enable-debytecode" ]  && DEBYTECODE="true"
 	[ "$1" = "--disable-debytecode" ] && DEBYTECODE="false"
@@ -679,7 +679,7 @@ if [ "$PLATFORM" = "nds" ]; then
 	SOFTWARE="false"
 
 	echo "Force-disabling hash tables on NDS."
-	KHASH="false"
+	COUNTER_HASH="false"
 fi
 
 #
@@ -1327,12 +1327,12 @@ fi
 #
 # Allow use of hash table counter/string lookups, if enabled
 #
-if [ "$KHASH" = "true" ]; then
-	echo "khash counter/string lookup enabled."
-	echo "#define CONFIG_KHASH" >> src/config.h
-	echo "BUILD_KHASH=1" >> platform.inc
+if [ "$COUNTER_HASH" = "true" ]; then
+	echo "Hash table counter/string lookups enabled."
+	echo "#define CONFIG_COUNTER_HASH_TABLES" >> src/config.h
+	echo "BUILD_COUNTER_HASH_TABLES=1" >> platform.inc
 else
-	echo "khash counter/string lookup disabled (using binary search)."
+	echo "Hash table counter/string lookups disabled (using binary search)."
 fi
 
 #

--- a/contrib/khash/khashmzx.h
+++ b/contrib/khash/khashmzx.h
@@ -25,64 +25,41 @@
 
 /**
  * NOTE: this is a significantly altered of khash specifically for MegaZeux.
- * The default key types have been replaced with a single key type expected to
- * be a struct with a key pointer field and a key length field. The names of
- * these fields can be specified. The kh_get function has also been altered to
- * optionally take a separate key pointer and key length parameters instead of
- * a key struct. Additionally, alternate macros have been added to make its
- * interface look more like uthash.
+ *
+ * Changes from the original khash:
+ * - Tab removal and style update to more closely match MZX style.
+ * - The variable scopes have been replaced with C99 "static inline".
+ * - The custom int types have been replaced by C99 stdint.h types and size_t.
+ * - The allocator macros have been replaced with MZX's check alloc functions.
+ * - The default key types have been replaced with a single struct-based key
+ *   type expected to contain a key field and a key length field. The names of
+ *   these fields can be specified.
+ * - The kh_get function has also been altered to optionally take a separate
+ *   key pointer and key length parameters instead of a key struct.
+ * - Alternate macros have been added to provide a uthash-like interface.
+ *
+ * All changes to this file for MegaZeux are also licensed under the MIT License.
+ * However, certain functions used here (check alloc, memcasecmp) are not.
  *
  * This header is not currently compatible with the standard khash header.
- * See khash.h for the original example and changelog from this file.
+ * See contrib/khash.h for the original example and changelog from this file.
  */
 
 #ifndef KHASHMZX_H
 #define KHASHMZX_H
 
-// We want to use the MZX check alloc functions.
 #include "../../src/compat.h"
-#define kcalloc(N,Z) ccalloc(N,Z)
-#define kmalloc(Z) cmalloc(Z)
-#define krealloc(P,Z) crealloc(P,Z)
 
-/*!
-  @header
+__M_BEGIN_DECLS
 
-  Generic hash table library.
- */
-
-#define AC_VERSION_KHASH_H "0.2.8"
-
+#include <stddef.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
 
-/* compiler specific configuration */
-
-#if UINT_MAX == 0xffffffffu
-typedef unsigned int khint32_t;
-#elif ULONG_MAX == 0xffffffffu
-typedef unsigned long khint32_t;
-#endif
-
-#ifndef kh_inline
-#ifdef _MSC_VER
-#define kh_inline __inline
-#else
-#define kh_inline inline
-#endif
-#endif /* kh_inline */
-
-#ifndef klib_unused
-#if (defined __clang__ && __clang_major__ >= 3) || (defined __GNUC__ && __GNUC__ >= 3)
-#define klib_unused __attribute__ ((__unused__))
-#else
-#define klib_unused
-#endif
-#endif /* klib_unused */
-
-typedef khint32_t khint_t;
-typedef khint_t khiter_t;
+#include "../../src/memcasecmp.h"
+#include "../../src/platform_endian.h"
 
 #define __ac_isempty(flag, i) ((flag[i>>4]>>((i&0xfU)<<1))&2)
 #define __ac_isdel(flag, i) ((flag[i>>4]>>((i&0xfU)<<1))&1)
@@ -98,201 +75,319 @@ typedef khint_t khiter_t;
 #define kroundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
 #endif
 
-#ifndef kcalloc
-#define kcalloc(N,Z) calloc(N,Z)
-#endif
-#ifndef kmalloc
-#define kmalloc(Z) malloc(Z)
-#endif
-#ifndef krealloc
-#define krealloc(P,Z) realloc(P,Z)
-#endif
-#ifndef kfree
-#define kfree(P) free(P)
-#endif
-
 static const double __ac_HASH_UPPER = 0.77;
 
+/**
+ * Keep table sizes in the uint32_t range since the hashes are uint32_t.
+ * In practice, tables over this size will probably never be used, since the
+ * counters and strings lists are bounded to 2^31.
+ */
+#if ARCHITECTURE_BITS >= 64
+static const uint64_t __ac_HASH_MAXIMUM = ((uint64_t)UINT32_MAX) + 1;
+#else
+static const size_t __ac_HASH_MAXIMUM = ((size_t)INT32_MAX) + 1;
+#endif
+
 #define __KHASH_TYPE(name, khkey_t, khval_t) \
-	typedef struct kh_##name##_s { \
-		khint_t n_buckets, size, n_occupied, upper_bound; \
-		khint32_t *flags; \
-		khkey_t *keys; \
-		khval_t *vals; \
-	} kh_##name##_t;
+  typedef struct kh_##name##_s \
+  { \
+    size_t n_buckets;   \
+    size_t size;        \
+    size_t n_occupied;  \
+    size_t upper_bound; \
+    uint32_t *flags;    \
+    khkey_t *keys;      \
+    khval_t *vals;      \
+  } kh_##name##_t;
 
-#define __KHASH_PROTOTYPES(name, khkey_t, khval_t)	 					\
-	extern kh_##name##_t *kh_init_##name(void);							\
-	extern void kh_destroy_##name(kh_##name##_t *h);					\
-	extern void kh_clear_##name(kh_##name##_t *h);						\
-	extern khint_t kh_get_##name(const kh_##name##_t *h, khkey_t key); 	\
-	extern khint_t kh_get_no_obj_##name(const kh_##name##_t *h, const void *key_ptr, khint_t key_len);	\
-	extern int kh_resize_##name(kh_##name##_t *h, khint_t new_n_buckets); \
-	extern khint_t kh_put_##name(kh_##name##_t *h, khkey_t key, int *ret); \
-	extern void kh_del_##name(kh_##name##_t *h, khint_t x);
+/* FIXME cached hash field */
+#define __KHASH_IMPL(name, khkey_t, khval_t, kh_is_map, ptr_field, len_field, \
+ __hash_func, __hash_equal) \
+  \
+  static inline kh_##name##_t *kh_init_##name(void) \
+  { \
+    return (kh_##name##_t*)ccalloc(1, sizeof(kh_##name##_t));             \
+  } \
+  static inline void kh_destroy_##name(kh_##name##_t *h) \
+  { \
+    if(h)                                                                 \
+    {                                                                     \
+      free(h->flags);                                                     \
+      free((void *)h->keys);                                              \
+      free((void *)h->vals);                                              \
+      free(h);                                                            \
+    }                                                                     \
+  } \
+  \
+  static inline void kh_clear_##name(kh_##name##_t *h) \
+  { \
+    if(h && h->flags)                                                     \
+    {                                                                     \
+      size_t flags_size = __ac_fsize(h->n_buckets);                       \
+      memset(h->flags, 0xaa, flags_size * sizeof(uint32_t));              \
+      h->size = h->n_occupied = 0;                                        \
+    }                                                                     \
+  } \
+  \
+  /* FIXME cached hash as param, only hash if 0 */ \
+  static inline size_t kh_get_no_obj_##name(const kh_##name##_t *h, \
+   const void *key_ptr, uint32_t key_len) \
+  { \
+    if(h->n_buckets)                                                      \
+    {                                                                     \
+      size_t k, i, last, mask, step = 0;                                  \
+      mask = h->n_buckets - 1;                                            \
+      k = __hash_func(key_ptr, key_len);                                  \
+      i = k & mask;                                                       \
+      last = i;                                                           \
+      while(!__ac_isempty(h->flags, i) &&                                 \
+       (__ac_isdel(h->flags, i) ||                                        \
+        !__hash_equal(h->keys[i]->ptr_field, key_ptr,                     \
+         h->keys[i]->len_field, key_len)))                                \
+      {                                                                   \
+        i = (i + (++step)) & mask;                                        \
+        if(i == last)                                                     \
+          return h->n_buckets;                                            \
+      }                                                                   \
+      if(!__ac_iseither(h->flags, i))                                     \
+        return i;                                                         \
+    }                                                                     \
+    return h->n_buckets;                                                  \
+  } \
+  \
+  static inline size_t kh_get_##name(const kh_##name##_t *h, khkey_t key) \
+  { \
+    /* FIXME cached hash too */ \
+    return kh_get_no_obj_##name(h, key->ptr_field, key->len_field);       \
+  } \
+  \
+  static inline int kh_resize_##name(kh_##name##_t *h, size_t new_n_buckets) \
+  { \
+    /* This function uses 0.25*n_buckets bytes of working space instead of \
+     * [sizeof(key_t+val_t)+.25]*n_buckets. \
+     */ \
+    uint32_t *new_flags = 0;                                              \
+    size_t j = 1;                                                         \
+    size_t new_upper_bound;                                               \
+  \
+    kroundup32(new_n_buckets);                                            \
+    if(new_n_buckets > __ac_HASH_MAXIMUM)                                 \
+      return -1;                                                          \
+    if(new_n_buckets < 4)                                                 \
+      new_n_buckets = 4;                                                  \
+  \
+    new_upper_bound = (size_t)(new_n_buckets * __ac_HASH_UPPER + 0.5);    \
+    if(h->size >= new_upper_bound)                                        \
+    {                                                                     \
+      j = 0;  /* requested size is too small */                           \
+    }                                                                     \
+    else                                                                  \
+    {                                                                     \
+      /* hash table size to be changed (shrink or expand); rehash */      \
+      size_t flags_size = __ac_fsize(new_n_buckets) * sizeof(uint32_t);   \
+      new_flags = (uint32_t *)cmalloc(flags_size);                        \
+      if(!new_flags)                                                      \
+        return -1;                                                        \
+      memset(new_flags, 0xaa, flags_size);                                \
+      if(h->n_buckets < new_n_buckets)                                    \
+      {                                                                   \
+        /* expand */                                                      \
+        size_t size = new_n_buckets * sizeof(khkey_t);                    \
+        khkey_t *new_keys = (khkey_t *)crealloc((void *)h->keys, size);   \
+        if(!new_keys)                                                     \
+        {                                                                 \
+          free(new_flags);                                                \
+          return -1;                                                      \
+        }                                                                 \
+        h->keys = new_keys;                                               \
+        if(kh_is_map)                                                     \
+        {                                                                 \
+          size_t size = new_n_buckets * sizeof(khval_t);                  \
+          khval_t *new_vals = (khval_t *)crealloc((void *)h->vals, size); \
+          if(!new_vals)                                                   \
+          {                                                               \
+            free(new_flags);                                              \
+            return -1;                                                    \
+          }                                                               \
+          h->vals = new_vals;                                             \
+        }                                                                 \
+      } /* otherwise shrink */                                            \
+    } \
+  \
+    if(j) \
+    { \
+      /* rehashing is needed */                                           \
+      for(j = 0; j != h->n_buckets; ++j)                                  \
+      {                                                                   \
+        if(__ac_iseither(h->flags, j) == 0)                               \
+        {                                                                 \
+          khkey_t key = h->keys[j];                                       \
+          khval_t val;                                                    \
+          size_t new_mask;                                                \
+          new_mask = new_n_buckets - 1;                                   \
+          if(kh_is_map)                                                   \
+            val = h->vals[j];                                             \
+          __ac_set_isdel_true(h->flags, j);                               \
+          while(1)                                                        \
+          {                                                               \
+            /* kick-out process; sort of like in Cuckoo hashing */        \
+            size_t k, i, step = 0;                                        \
+            /* FIXME cache these */ \
+            k = __hash_func(key->ptr_field, key->len_field);              \
+            i = k & new_mask;                                             \
+            while(!__ac_isempty(new_flags, i))                            \
+              i = (i + (++step)) & new_mask;                              \
+            __ac_set_isempty_false(new_flags, i);                         \
+            if(i < h->n_buckets && __ac_iseither(h->flags, i) == 0)       \
+            {                                                             \
+              /* kick out the existing element */                         \
+              { khkey_t tmp = h->keys[i]; h->keys[i] = key; key = tmp; }  \
+              if(kh_is_map)                                               \
+              { khval_t tmp = h->vals[i]; h->vals[i] = val; val = tmp; }  \
+              /* mark it as deleted in the old hash table */              \
+              __ac_set_isdel_true(h->flags, i);                           \
+            }                                                             \
+            else                                                          \
+            {                                                             \
+              /* write the element and jump out of the loop */            \
+              h->keys[i] = key;                                           \
+              if(kh_is_map)                                               \
+                h->vals[i] = val;                                         \
+              break;                                                      \
+            }                                                             \
+          }                                                               \
+        }                                                                 \
+      }                                                                   \
+      if(h->n_buckets > new_n_buckets)                                    \
+      {                                                                   \
+        /* shrink the hash table */                                       \
+        size_t size = new_n_buckets * sizeof(khkey_t);                    \
+        h->keys = (khkey_t*)crealloc((void *)h->keys, size);              \
+        if(kh_is_map)                                                     \
+        {                                                                 \
+          size = new_n_buckets * sizeof(khval_t);                         \
+          h->vals = (khval_t*)crealloc((void *)h->vals, size);            \
+        }                                                                 \
+      }                                                                   \
+      free(h->flags); /* free the working space */                        \
+      h->flags = new_flags;                                               \
+      h->n_buckets = new_n_buckets;                                       \
+      h->n_occupied = h->size;                                            \
+      h->upper_bound = new_upper_bound;                                   \
+    }                                                                     \
+    return 0;                                                             \
+  } \
+  \
+  static inline size_t kh_put_##name(kh_##name##_t *h, khkey_t key, int *ret) \
+  { \
+    size_t x;                                                             \
+    if(h->n_occupied >= h->upper_bound)                                   \
+    {                                                                     \
+      /* update the hash table */                                         \
+      if(h->n_buckets > (h->size << 1))                                   \
+      {                                                                   \
+        /* clear "deleted" elements */                                    \
+        if(kh_resize_##name(h, h->n_buckets - 1) < 0)                     \
+        {                                                                 \
+          *ret = -1;                                                      \
+          return h->n_buckets;                                            \
+        }                                                                 \
+      }                                                                   \
+      else                                                                \
+  \
+      if(kh_resize_##name(h, h->n_buckets + 1) < 0)                       \
+      {                                                                   \
+        /* expand the hash table */                                       \
+        *ret = -1;                                                        \
+        return h->n_buckets;                                              \
+      }                                                                   \
+    }                                                                     \
+    /* TODO: to implement automatically shrinking;                        \
+     * resize() already support shrinking */                              \
+    {                                                                     \
+      size_t k, i, site, last, mask = h->n_buckets - 1, step = 0;         \
+      x = site = h->n_buckets;                                            \
+      /* FIXME cache this in the new key */ \
+      k = __hash_func(key->ptr_field, key->len_field);                    \
+      i = k & mask;                                                       \
+      if(__ac_isempty(h->flags, i))                                       \
+      {                                                                   \
+        /* for speed up */                                                \
+        x = i;                                                            \
+      }                                                                   \
+      else                                                                \
+      {                                                                   \
+        last = i;                                                         \
+        while(!__ac_isempty(h->flags, i) &&                               \
+         (__ac_isdel(h->flags, i) ||                                      \
+          !__hash_equal(h->keys[i]->ptr_field, key->ptr_field,            \
+           h->keys[i]->len_field, key->len_field)))                       \
+        {                                                                 \
+          if(__ac_isdel(h->flags, i))                                     \
+            site = i;                                                     \
+          i = (i + (++step)) & mask;                                      \
+          if(i == last)                                                   \
+          {                                                               \
+            x = site;                                                     \
+            break;                                                        \
+          }                                                               \
+        }                                                                 \
+        if(x == h->n_buckets)                                             \
+        {                                                                 \
+          if(__ac_isempty(h->flags, i) && site != h->n_buckets)           \
+            x = site;                                                     \
+          else                                                            \
+            x = i;                                                        \
+        }                                                                 \
+      }                                                                   \
+    }                                                                     \
+    if(__ac_isempty(h->flags, x))                                         \
+    {                                                                     \
+      /* not present at all */                                            \
+      h->keys[x] = key;                                                   \
+      __ac_set_isboth_false(h->flags, x);                                 \
+      ++h->size;                                                          \
+      ++h->n_occupied;                                                    \
+      *ret = 1;                                                           \
+    }                                                                     \
+    else                                                                  \
+  \
+    if(__ac_isdel(h->flags, x))                                           \
+    {                                                                     \
+      /* deleted */                                                       \
+      h->keys[x] = key;                                                   \
+      __ac_set_isboth_false(h->flags, x);                                 \
+      ++h->size;                                                          \
+      *ret = 2;                                                           \
+    }                                                                     \
+    /* Don't touch h->keys[x] if present and not deleted */               \
+    else                                                                  \
+      *ret = 0;                                                           \
+    return x;                                                             \
+  }                                                                       \
+  \
+  static inline void kh_del_##name(kh_##name##_t *h, uint32_t x) \
+  { \
+    if(x != h->n_buckets && !__ac_iseither(h->flags, x))                  \
+    {                                                                     \
+      __ac_set_isdel_true(h->flags, x);                                   \
+      --h->size;                                                          \
+      h->keys[x] = 0;                                                     \
+      if(kh_is_map)                                                       \
+        h->vals[x] = 0;                                                   \
+    }                                                                     \
+  }
 
-#define __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, ptr_field, len_field, __hash_func, __hash_equal) \
-	SCOPE kh_##name##_t *kh_init_##name(void) {							\
-		return (kh_##name##_t*)kcalloc(1, sizeof(kh_##name##_t));		\
-	}																	\
-	SCOPE void kh_destroy_##name(kh_##name##_t *h)						\
-	{																	\
-		if (h) {														\
-			kfree((void *)h->keys); kfree(h->flags);					\
-			kfree((void *)h->vals);										\
-			kfree(h);													\
-		}																\
-	}																	\
-	SCOPE void kh_clear_##name(kh_##name##_t *h)						\
-	{																	\
-		if (h && h->flags) {											\
-			memset(h->flags, 0xaa, __ac_fsize(h->n_buckets) * sizeof(khint32_t)); \
-			h->size = h->n_occupied = 0;								\
-		}																\
-	}																	\
-	SCOPE khint_t kh_get_no_obj_##name(const kh_##name##_t *h, const void *key_ptr, khint_t key_len) 	\
-	{																	\
-		if (h->n_buckets) {												\
-			khint_t k, i, last, mask, step = 0; \
-			mask = h->n_buckets - 1;									\
-			k = __hash_func(key_ptr, key_len); i = k & mask;							\
-			last = i; \
-			while (!__ac_isempty(h->flags, i) && (__ac_isdel(h->flags, i) || \
-				!__hash_equal(h->keys[i]->ptr_field, key_ptr, h->keys[i]->len_field, key_len))) { \
-				i = (i + (++step)) & mask; \
-				if (i == last) return h->n_buckets;						\
-			}															\
-			return __ac_iseither(h->flags, i)? h->n_buckets : i;		\
-		} else return 0;												\
-	}																	\
-	SCOPE khint_t kh_get_##name(const kh_##name##_t *h, khkey_t key) 	\
-	{																	\
-		return kh_get_no_obj_##name(h, key->ptr_field, key->len_field); \
-	}																	\
-	SCOPE int kh_resize_##name(kh_##name##_t *h, khint_t new_n_buckets) \
-	{ /* This function uses 0.25*n_buckets bytes of working space instead of [sizeof(key_t+val_t)+.25]*n_buckets. */ \
-		khint32_t *new_flags = 0;										\
-		khint_t j = 1;													\
-		{																\
-			kroundup32(new_n_buckets); 									\
-			if (new_n_buckets < 4) new_n_buckets = 4;					\
-			if (h->size >= (khint_t)(new_n_buckets * __ac_HASH_UPPER + 0.5)) j = 0;	/* requested size is too small */ \
-			else { /* hash table size to be changed (shrink or expand); rehash */ \
-				new_flags = (khint32_t*)kmalloc(__ac_fsize(new_n_buckets) * sizeof(khint32_t));	\
-				if (!new_flags) return -1;								\
-				memset(new_flags, 0xaa, __ac_fsize(new_n_buckets) * sizeof(khint32_t)); \
-				if (h->n_buckets < new_n_buckets) {	/* expand */		\
-					khkey_t *new_keys = (khkey_t*)krealloc((void *)h->keys, new_n_buckets * sizeof(khkey_t)); \
-					if (!new_keys) { kfree(new_flags); return -1; }		\
-					h->keys = new_keys;									\
-					if (kh_is_map) {									\
-						khval_t *new_vals = (khval_t*)krealloc((void *)h->vals, new_n_buckets * sizeof(khval_t)); \
-						if (!new_vals) { kfree(new_flags); return -1; }	\
-						h->vals = new_vals;								\
-					}													\
-				} /* otherwise shrink */								\
-			}															\
-		}																\
-		if (j) { /* rehashing is needed */								\
-			for (j = 0; j != h->n_buckets; ++j) {						\
-				if (__ac_iseither(h->flags, j) == 0) {					\
-					khkey_t key = h->keys[j];							\
-					khval_t val;										\
-					khint_t new_mask;									\
-					new_mask = new_n_buckets - 1; 						\
-					if (kh_is_map) val = h->vals[j];					\
-					__ac_set_isdel_true(h->flags, j);					\
-					while (1) { /* kick-out process; sort of like in Cuckoo hashing */ \
-						khint_t k, i, step = 0; \
-						k = __hash_func(key->ptr_field, key->len_field);							\
-						i = k & new_mask;								\
-						while (!__ac_isempty(new_flags, i)) i = (i + (++step)) & new_mask; \
-						__ac_set_isempty_false(new_flags, i);			\
-						if (i < h->n_buckets && __ac_iseither(h->flags, i) == 0) { /* kick out the existing element */ \
-							{ khkey_t tmp = h->keys[i]; h->keys[i] = key; key = tmp; } \
-							if (kh_is_map) { khval_t tmp = h->vals[i]; h->vals[i] = val; val = tmp; } \
-							__ac_set_isdel_true(h->flags, i); /* mark it as deleted in the old hash table */ \
-						} else { /* write the element and jump out of the loop */ \
-							h->keys[i] = key;							\
-							if (kh_is_map) h->vals[i] = val;			\
-							break;										\
-						}												\
-					}													\
-				}														\
-			}															\
-			if (h->n_buckets > new_n_buckets) { /* shrink the hash table */ \
-				h->keys = (khkey_t*)krealloc((void *)h->keys, new_n_buckets * sizeof(khkey_t)); \
-				if (kh_is_map) h->vals = (khval_t*)krealloc((void *)h->vals, new_n_buckets * sizeof(khval_t)); \
-			}															\
-			kfree(h->flags); /* free the working space */				\
-			h->flags = new_flags;										\
-			h->n_buckets = new_n_buckets;								\
-			h->n_occupied = h->size;									\
-			h->upper_bound = (khint_t)(h->n_buckets * __ac_HASH_UPPER + 0.5); \
-		}																\
-		return 0;														\
-	}																	\
-	SCOPE khint_t kh_put_##name(kh_##name##_t *h, khkey_t key, int *ret) \
-	{																	\
-		khint_t x;														\
-		if (h->n_occupied >= h->upper_bound) { /* update the hash table */ \
-			if (h->n_buckets > (h->size<<1)) {							\
-				if (kh_resize_##name(h, h->n_buckets - 1) < 0) { /* clear "deleted" elements */ \
-					*ret = -1; return h->n_buckets;						\
-				}														\
-			} else if (kh_resize_##name(h, h->n_buckets + 1) < 0) { /* expand the hash table */ \
-				*ret = -1; return h->n_buckets;							\
-			}															\
-		} /* TODO: to implement automatically shrinking; resize() already support shrinking */ \
-		{																\
-			khint_t k, i, site, last, mask = h->n_buckets - 1, step = 0; \
-			x = site = h->n_buckets; k = __hash_func(key->ptr_field, key->len_field); i = k & mask; \
-			if (__ac_isempty(h->flags, i)) x = i; /* for speed up */	\
-			else {														\
-				last = i; \
-				while (!__ac_isempty(h->flags, i) && (__ac_isdel(h->flags, i) || \
-					!__hash_equal(h->keys[i]->ptr_field, key->ptr_field, h->keys[i]->len_field, key->len_field))) { \
-					if (__ac_isdel(h->flags, i)) site = i;				\
-					i = (i + (++step)) & mask; \
-					if (i == last) { x = site; break; }					\
-				}														\
-				if (x == h->n_buckets) {								\
-					if (__ac_isempty(h->flags, i) && site != h->n_buckets) x = site; \
-					else x = i;											\
-				}														\
-			}															\
-		}																\
-		if (__ac_isempty(h->flags, x)) { /* not present at all */		\
-			h->keys[x] = key;											\
-			__ac_set_isboth_false(h->flags, x);							\
-			++h->size; ++h->n_occupied;									\
-			*ret = 1;													\
-		} else if (__ac_isdel(h->flags, x)) { /* deleted */				\
-			h->keys[x] = key;											\
-			__ac_set_isboth_false(h->flags, x);							\
-			++h->size;													\
-			*ret = 2;													\
-		} else *ret = 0; /* Don't touch h->keys[x] if present and not deleted */ \
-		return x;														\
-	}																	\
-	SCOPE void kh_del_##name(kh_##name##_t *h, khint_t x)				\
-	{																	\
-		if (x != h->n_buckets && !__ac_iseither(h->flags, x)) {			\
-			__ac_set_isdel_true(h->flags, x);							\
-			--h->size;													\
-		}																\
-	}
+#define KHASH_INIT2(name, khkey_t, khval_t, kh_is_map,    \
+ ptr_field, len_field, __hash_func, __hash_equal)         \
+  __KHASH_TYPE(name, khkey_t, khval_t)                    \
+  __KHASH_IMPL(name, khkey_t, khval_t, kh_is_map,         \
+   ptr_field, len_field, __hash_func, __hash_equal)
 
-#define KHASH_DECLARE(name, khkey_t, khval_t)		 					\
-	__KHASH_TYPE(name, khkey_t, khval_t) 								\
-	__KHASH_PROTOTYPES(name, khkey_t, khval_t)
-
-#define KHASH_INIT2(name, SCOPE, khkey_t, khval_t, kh_is_map, ptr_field, len_field, __hash_func, __hash_equal) \
-	__KHASH_TYPE(name, khkey_t, khval_t) 								\
-	__KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, ptr_field, len_field, __hash_func, __hash_equal)
-
-#define KHASH_INIT(name, khkey_t, khval_t, kh_is_map, ptr_field, len_field, __hash_func, __hash_equal) \
-	KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, ptr_field, len_field, __hash_func, __hash_equal)
+#define KHASH_INIT(name, khkey_t, khval_t, kh_is_map,     \
+ ptr_field, len_field, __hash_func, __hash_equal)         \
+  KHASH_INIT2(name, khkey_t, khval_t, kh_is_map,          \
+   ptr_field, len_field, __hash_func, __hash_equal)
 
 /* Other convenient macros... */
 
@@ -327,7 +422,7 @@ static const double __ac_HASH_UPPER = 0.77;
   @abstract     Resize a hash table.
   @param  name  Name of the hash table [symbol]
   @param  h     Pointer to the hash table [khash_t(name)*]
-  @param  s     New size [khint_t]
+  @param  s     New size [uint32_t]
  */
 #define kh_resize(name, h, s) kh_resize_##name(h, s)
 
@@ -339,8 +434,8 @@ static const double __ac_HASH_UPPER = 0.77;
   @param  r     Extra return code: -1 if the operation failed;
                 0 if the key is present in the hash table;
                 1 if the bucket is empty (never used); 2 if the element in
-				the bucket has been deleted [int*]
-  @return       Iterator to the inserted element [khint_t]
+        the bucket has been deleted [int*]
+  @return       Iterator to the inserted element [uint32_t]
  */
 #define kh_put(name, h, k, r) kh_put_##name(h, k, r)
 
@@ -349,7 +444,7 @@ static const double __ac_HASH_UPPER = 0.77;
   @param  name  Name of the hash table [symbol]
   @param  h     Pointer to the hash table [khash_t(name)*]
   @param  k     Key [type of keys]
-  @return       Iterator to the found element, or kh_end(h) if the element is absent [khint_t]
+  @return       Iterator to the found element, or kh_end(h) if the element is absent [uint32_t]
  */
 #define kh_get(name, h, k) kh_get_##name(h, k)
 #define kh_get_no_obj(name, h, kp, kl) kh_get_no_obj_##name(h, kp, kl)
@@ -358,14 +453,14 @@ static const double __ac_HASH_UPPER = 0.77;
   @abstract     Remove a key from the hash table.
   @param  name  Name of the hash table [symbol]
   @param  h     Pointer to the hash table [khash_t(name)*]
-  @param  k     Iterator to the element to be deleted [khint_t]
+  @param  k     Iterator to the element to be deleted [uint32_t]
  */
 #define kh_del(name, h, k) kh_del_##name(h, k)
 
 /*! @function
   @abstract     Test whether a bucket contains data.
   @param  h     Pointer to the hash table [khash_t(name)*]
-  @param  x     Iterator to the bucket [khint_t]
+  @param  x     Iterator to the bucket [uint32_t]
   @return       1 if containing data; 0 otherwise [int]
  */
 #define kh_exist(h, x) (!__ac_iseither((h)->flags, (x)))
@@ -373,7 +468,7 @@ static const double __ac_HASH_UPPER = 0.77;
 /*! @function
   @abstract     Get key given an iterator
   @param  h     Pointer to the hash table [khash_t(name)*]
-  @param  x     Iterator to the bucket [khint_t]
+  @param  x     Iterator to the bucket [uint32_t]
   @return       Key [type of keys]
  */
 #define kh_key(h, x) ((h)->keys[x])
@@ -381,7 +476,7 @@ static const double __ac_HASH_UPPER = 0.77;
 /*! @function
   @abstract     Get value given an iterator
   @param  h     Pointer to the hash table [khash_t(name)*]
-  @param  x     Iterator to the bucket [khint_t]
+  @param  x     Iterator to the bucket [uint32_t]
   @return       Value [type of values]
   @discussion   For hash sets, calling this results in segfault.
  */
@@ -395,28 +490,28 @@ static const double __ac_HASH_UPPER = 0.77;
 /*! @function
   @abstract     Get the start iterator
   @param  h     Pointer to the hash table [khash_t(name)*]
-  @return       The start iterator [khint_t]
+  @return       The start iterator [uint32_t]
  */
-#define kh_begin(h) (khint_t)(0)
+#define kh_begin(h) (uint32_t)(0)
 
 /*! @function
   @abstract     Get the end iterator
   @param  h     Pointer to the hash table [khash_t(name)*]
-  @return       The end iterator [khint_t]
+  @return       The end iterator [uint32_t]
  */
 #define kh_end(h) ((h)->n_buckets)
 
 /*! @function
   @abstract     Get the number of elements in the hash table
   @param  h     Pointer to the hash table [khash_t(name)*]
-  @return       Number of elements in the hash table [khint_t]
+  @return       Number of elements in the hash table [uint32_t]
  */
 #define kh_size(h) ((h)->size)
 
 /*! @function
   @abstract     Get the number of buckets in the hash table
   @param  h     Pointer to the hash table [khash_t(name)*]
-  @return       Number of buckets in the hash table [khint_t]
+  @return       Number of buckets in the hash table [uint32_t]
  */
 #define kh_n_buckets(h) ((h)->n_buckets)
 
@@ -427,13 +522,13 @@ static const double __ac_HASH_UPPER = 0.77;
   @param  vvar  Variable to which value will be assigned
   @param  code  Block of code to execute
  */
-#define kh_foreach(h, kvar, vvar, code) { khint_t __i;		\
-	for (__i = kh_begin(h); __i != kh_end(h); ++__i) {		\
-		if (!kh_exist(h,__i)) continue;						\
-		(kvar) = kh_key(h,__i);								\
-		(vvar) = kh_val(h,__i);								\
-		code;												\
-	} }
+#define kh_foreach(h, kvar, vvar, code) { uint32_t __i;    \
+  for (__i = kh_begin(h); __i != kh_end(h); ++__i) {    \
+    if (!kh_exist(h,__i)) continue;            \
+    (kvar) = kh_key(h,__i);                \
+    (vvar) = kh_val(h,__i);                \
+    code;                        \
+  } }
 
 /*! @function
   @abstract     Iterate over the values in the hash table
@@ -441,16 +536,14 @@ static const double __ac_HASH_UPPER = 0.77;
   @param  vvar  Variable to which value will be assigned
   @param  code  Block of code to execute
  */
-#define kh_foreach_value(h, vvar, code) { khint_t __i;		\
-	for (__i = kh_begin(h); __i != kh_end(h); ++__i) {		\
-		if (!kh_exist(h,__i)) continue;						\
-		(vvar) = kh_val(h,__i);								\
-		code;												\
-	} }
+#define kh_foreach_value(h, vvar, code) { uint32_t __i;    \
+  for (__i = kh_begin(h); __i != kh_end(h); ++__i) {    \
+    if (!kh_exist(h,__i)) continue;            \
+    (vvar) = kh_val(h,__i);                \
+    code;                        \
+  } }
 
 /* --- BEGIN OF HASH FUNCTIONS --- */
-
-#include "../../src/memcasecmp.h"
 
 /**
  * This hash function results in far better distribution than the default X31
@@ -460,12 +553,12 @@ static const double __ac_HASH_UPPER = 0.77;
  */
 
 // TODO make case sensitive version?
-static kh_inline khint_t fnv_1a_hash_string_len(const void *_str, khint_t len)
+static inline uint32_t fnv_1a_hash_string_len(const void *_str, uint32_t len)
 {
   const char *str = _str;
-  khint_t h = 0;
+  uint32_t h = 0;
   for(; len; len--)
-    h = (h ^ (khint_t)memtolower((int)*(str++))) * 16777619;
+    h = (h ^ (uint32_t)memtolower((int)*(str++))) * 16777619;
   return h;
 }
 
@@ -474,50 +567,53 @@ static kh_inline khint_t fnv_1a_hash_string_len(const void *_str, khint_t len)
 
 // TODO make case sensitive version?
 #define kh_mem_hash_equal(aptr, bptr, alen, blen) \
-  (((khint_t)alen == (khint_t)blen) && !memcasecmp(aptr, bptr, blen))
+  (((uint32_t)alen == (uint32_t)blen) && !memcasecmp(aptr, bptr, blen))
 
 /* --- END OF HASH FUNCTIONS --- */
 
-#define KHASH_SET_INIT(name, khkey_t, key_ptr_field, key_len_field) \
+#define HASH_SET_INIT(name, khkey_t, key_ptr_field, key_len_field) \
   KHASH_INIT(name, khkey_t, char, 0, \
    key_ptr_field, key_len_field, kh_mem_hash_func, kh_mem_hash_equal)
 
-#define KHASH_MAP_INIT(name, khkey_t, khval_t, key_ptr_field, key_len_field) \
+#define HASH_MAP_INIT(name, khkey_t, khval_t, key_ptr_field, key_len_field) \
   KHASH_INIT(name, khkey_t, khval_t, 1, \
    key_ptr_field, key_len_field, kh_mem_hash_func, kh_mem_hash_equal)
 
+// khash_t(n) abstraction for the unlikely event this library gets replaced.
+#define hash_t(n) khash_t(n)
+
 // uthash-like macros.
-#define KHASH_ADD(n, h, keyobj) do                                \
+#define HASH_ADD(n, h, keyobj) do                                 \
 {                                                                 \
   int _res;                                                       \
   if(!h) h = kh_init(n);                                          \
   kh_put(n, (khash_t(n) *)h, keyobj, &_res);                      \
 } while(0)
 
-#define KHASH_FIND(n, _h, keyptr, keylen, destobj) do             \
+#define HASH_FIND(n, _h, keyptr, keylen, destobj) do              \
 {                                                                 \
   destobj = NULL;                                                 \
   if(_h)                                                          \
   {                                                               \
     khash_t(n) *h = _h;                                           \
-    khint_t iter = kh_get_no_obj(n, h, keyptr, (khint_t)keylen);  \
+    uint32_t iter = kh_get_no_obj(n, h, keyptr, (uint32_t)keylen);\
                                                                   \
     if(iter < kh_end(h)) destobj = h->keys[iter];                 \
   }                                                               \
 } while(0)
 
-#define KHASH_DELETE(n, _h, keyobj) do                            \
+#define HASH_DELETE(n, _h, keyobj) do                             \
 {                                                                 \
   if(_h)                                                          \
   {                                                               \
     khash_t(n) *h = _h;                                           \
-    khint_t iter = kh_get(n, h, keyobj);                          \
+    uint32_t iter = kh_get(n, h, keyobj);                         \
                                                                   \
     if(iter < kh_end(h)) kh_del(n, h, iter);                      \
   }                                                               \
 } while(0)
 
-#define KHASH_CLEAR(n, _h) do                                     \
+#define HASH_CLEAR(n, _h) do                                      \
 {                                                                 \
   if(_h)                                                          \
   {                                                               \
@@ -527,10 +623,10 @@ static kh_inline khint_t fnv_1a_hash_string_len(const void *_str, khint_t len)
   }                                                               \
 } while(0)
 
-#define KHASH_ITER(n, _h, element, code) do                       \
+#define HASH_ITER(n, _h, element, code) do                        \
 {                                                                 \
   khash_t(n) *__h = _h;                                           \
-  khint_t __i;                                                    \
+  uint32_t __i;                                                   \
   if(_h) for(__i = kh_begin(__h); __i != kh_end(__h); __i++)      \
   {                                                               \
     if(!kh_exist(__h, __i)) continue;                             \
@@ -538,5 +634,7 @@ static kh_inline khint_t fnv_1a_hash_string_len(const void *_str, khint_t len)
     code;                                                         \
   }                                                               \
 } while(0)
+
+__M_END_DECLS
 
 #endif // KHASHMZX_H

--- a/contrib/khash/khashmzx.h
+++ b/contrib/khash/khashmzx.h
@@ -1,6 +1,7 @@
 /* The MIT License
 
    Copyright (c) 2008, 2009, 2011 by Attractive Chaos <attractor@live.co.uk>
+   Copyright (C) 2020 Alice Rowan <petrifiedrowan@gmail.com>
 
    Permission is hereby granted, free of charge, to any person obtaining
    a copy of this software and associated documentation files (the

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -39,6 +39,9 @@ DEVELOPERS
 + Added SDL 1.2 implementation for __peek_exit_input.
 + Contributed sound engines (libxmp, libmodplug) should now
   properly rebuild after config.sh is run.
++ Fixed a bug where khash tables couldn't expand beyond 2^31,
+  added hash caching, made the MZX copy of khash use MZX style,
+  and better documented the changes made to it.
 
 
 March 8th, 2020 - MZX 2.92c

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -289,7 +289,7 @@ core_ldflags := $(LIBPNG_LDFLAGS) ${core_ldflags}
 core_cobjs += ${core_obj}/pngops.o
 endif
 
-ifeq (${BUILD_KHASH},1)
+ifeq (${BUILD_COUNTER_HASH_TABLES},1)
 core_flags += -Icontrib/khash/
 endif
 

--- a/src/counter.c
+++ b/src/counter.c
@@ -61,9 +61,9 @@
  * all counter names.
  */
 
-#ifdef CONFIG_KHASH
+#ifdef CONFIG_COUNTER_HASH_TABLES
 #include <khashmzx.h>
-KHASH_SET_INIT(COUNTER, struct counter *, name, name_length)
+HASH_SET_INIT(COUNTER, struct counter *, name, name_length)
 #endif
 
 #ifndef M_PI
@@ -3457,9 +3457,9 @@ static struct counter *find_counter(struct counter_list *counter_list,
 {
   struct counter *current = NULL;
 
-#if defined(CONFIG_KHASH)
+#ifdef CONFIG_COUNTER_HASH_TABLES
   size_t name_length = strlen(name);
-  KHASH_FIND(COUNTER, counter_list->hash_table, name, name_length, current);
+  HASH_FIND(COUNTER, counter_list->hash_table, name, name_length, current);
   *next = counter_list->num_counters;
   return current;
 
@@ -3728,8 +3728,8 @@ static void add_counter(struct counter_list *counter_list, const char *name,
   counter_list->counters[position] = dest;
   counter_list->num_counters = count + 1;
 
-#ifdef CONFIG_KHASH
-  KHASH_ADD(COUNTER, counter_list->hash_table, dest);
+#ifdef CONFIG_COUNTER_HASH_TABLES
+  HASH_ADD(COUNTER, counter_list->hash_table, dest);
 #endif
 }
 
@@ -4027,8 +4027,8 @@ void load_new_counter(struct counter_list *counter_list, int index,
 
   counter_list->counters[index] = dest;
 
-#ifdef CONFIG_KHASH
-  KHASH_ADD(COUNTER, counter_list->hash_table, dest);
+#ifdef CONFIG_COUNTER_HASH_TABLES
+  HASH_ADD(COUNTER, counter_list->hash_table, dest);
 #endif
 }
 
@@ -4049,8 +4049,8 @@ void clear_counter_list(struct counter_list *counter_list)
 {
   size_t i;
 
-#ifdef CONFIG_KHASH
-  KHASH_CLEAR(COUNTER, counter_list->hash_table);
+#ifdef CONFIG_COUNTER_HASH_TABLES
+  HASH_CLEAR(COUNTER, counter_list->hash_table);
   counter_list->hash_table = NULL;
 #endif
 

--- a/src/counter_struct.h
+++ b/src/counter_struct.h
@@ -30,6 +30,9 @@ __M_BEGIN_DECLS
 struct counter
 {
   int32_t value;
+#ifdef CONFIG_COUNTER_HASH_TABLES
+  //uint32_t hash;
+#endif
   uint16_t name_length;
   uint8_t gateway_write;
   char name[1];
@@ -40,7 +43,7 @@ struct counter_list
   unsigned int num_counters;
   unsigned int num_counters_allocated;
   struct counter **counters;
-#ifdef CONFIG_KHASH
+#ifdef CONFIG_COUNTER_HASH_TABLES
   void *hash_table;
 #endif
 };
@@ -84,6 +87,10 @@ struct string
   // a hash table search needs to be able to determine this value.
   uint32_t list_ind;
 
+#ifdef CONFIG_COUNTER_HASH_TABLES
+  //uint32_t hash;
+#endif
+
   uint16_t name_length;
   char name[1];
 };
@@ -93,7 +100,7 @@ struct string_list
   unsigned int num_strings;
   unsigned int num_strings_allocated;
   struct string **strings;
-#ifdef CONFIG_KHASH
+#ifdef CONFIG_COUNTER_HASH_TABLES
   void *hash_table;
 #endif
 };

--- a/src/counter_struct.h
+++ b/src/counter_struct.h
@@ -31,7 +31,7 @@ struct counter
 {
   int32_t value;
 #ifdef CONFIG_COUNTER_HASH_TABLES
-  //uint32_t hash;
+  uint32_t hash;
 #endif
   uint16_t name_length;
   uint8_t gateway_write;
@@ -88,7 +88,7 @@ struct string
   uint32_t list_ind;
 
 #ifdef CONFIG_COUNTER_HASH_TABLES
-  //uint32_t hash;
+  uint32_t hash;
 #endif
 
   uint16_t name_length;

--- a/src/legacy_world.c
+++ b/src/legacy_world.c
@@ -816,7 +816,7 @@ void legacy_load_world(struct world *mzx_world, FILE *fp, const char *file,
       legacy_load_string(fp, string_list, i);
     }
 
-#ifndef CONFIG_KHASH
+#ifndef CONFIG_COUNTER_HASH_TABLES
     // Versions without the hash table require these to be sorted at all times
     sort_counter_list(counter_list);
     sort_string_list(string_list);

--- a/src/str.c
+++ b/src/str.c
@@ -41,9 +41,9 @@
  * all string names.
  */
 
-#ifdef CONFIG_KHASH
+#ifdef CONFIG_COUNTER_HASH_TABLES
 #include <khashmzx.h>
-KHASH_SET_INIT(STRING, struct string *, name, name_length)
+HASH_SET_INIT(STRING, struct string *, name, name_length)
 #endif
 
 // Please only use string literals with this, thanks.
@@ -81,9 +81,9 @@ static struct string *find_string(struct string_list *string_list,
 {
   struct string *current = NULL;
 
-#if defined(CONFIG_KHASH)
+#if defined(CONFIG_COUNTER_HASH_TABLES)
   size_t name_length = strlen(name);
-  KHASH_FIND(STRING, string_list->hash_table, name, name_length, current);
+  HASH_FIND(STRING, string_list->hash_table, name, name_length, current);
 
   // When reallocing we need to replace the old pointer at
   // its original list index.
@@ -208,8 +208,8 @@ static struct string *add_string_preallocate(struct string_list *string_list,
   string_list->strings[position] = dest;
   string_list->num_strings = count + 1;
 
-#ifdef CONFIG_KHASH
-  KHASH_ADD(STRING, string_list->hash_table, dest);
+#ifdef CONFIG_COUNTER_HASH_TABLES
+  HASH_ADD(STRING, string_list->hash_table, dest);
 #endif
 
   return dest;
@@ -224,9 +224,9 @@ static struct string *reallocate_string(struct string_list *string_list,
   // Find the base length (take out the current length)
   int base_length = (int)(src->value - (char *)src);
 
-#ifdef CONFIG_KHASH
+#ifdef CONFIG_COUNTER_HASH_TABLES
   // Delete the string with the same name as src if it exists in the table.
-  KHASH_DELETE(STRING, string_list->hash_table, src);
+  HASH_DELETE(STRING, string_list->hash_table, src);
 #endif
 
   src = crealloc(src, MAX(sizeof(struct string), base_length + length));
@@ -244,8 +244,8 @@ static struct string *reallocate_string(struct string_list *string_list,
 
   string_list->strings[pos] = src;
 
-#ifdef CONFIG_KHASH
-  KHASH_ADD(STRING, string_list->hash_table, src);
+#ifdef CONFIG_COUNTER_HASH_TABLES
+  HASH_ADD(STRING, string_list->hash_table, src);
 #endif
 
   return src;
@@ -1755,8 +1755,8 @@ struct string *load_new_string(struct string_list *string_list, int index,
   dest->list_ind = index;
   string_list->strings[index] = dest;
 
-#ifdef CONFIG_KHASH
-  KHASH_ADD(STRING, string_list->hash_table, dest);
+#ifdef CONFIG_COUNTER_HASH_TABLES
+  HASH_ADD(STRING, string_list->hash_table, dest);
 #endif
 
   return dest;
@@ -1786,8 +1786,8 @@ void clear_string_list(struct string_list *string_list)
 {
   unsigned int i;
 
-#ifdef CONFIG_KHASH
-  KHASH_CLEAR(STRING, string_list->hash_table);
+#ifdef CONFIG_COUNTER_HASH_TABLES
+  HASH_CLEAR(STRING, string_list->hash_table);
   string_list->hash_table = NULL;
 #endif
 

--- a/src/utils/checkres.c
+++ b/src/utils/checkres.c
@@ -903,6 +903,7 @@ struct base_path_file
 {
   char file_path[MAX_PATH];
   int file_path_len;
+  uint32_t hash;
   uint32_t crc32;
   boolean has_crc32;
   boolean used;
@@ -934,6 +935,7 @@ struct resource
   int board_num;
   int robot_num;
   int line_num;
+  uint32_t hash;
   boolean is_wildcard;
   struct base_file *parent;
 };

--- a/src/utils/hlp2html.c
+++ b/src/utils/hlp2html.c
@@ -72,6 +72,7 @@ struct help_file
   // HTML ID- needs to be unique. Use the real internal file name.
   char name[MAX_FILE_NAME];
   int name_length;
+  uint32_t hash;
 
   struct html_buffer html;
 };
@@ -83,6 +84,7 @@ struct help_anchor
   // HTML ID- needs to be unique. Use the real link name.
   char name[MAX_ANCHOR_NAME];
   int name_length;
+  uint32_t hash;
 };
 
 struct help_link
@@ -97,6 +99,7 @@ struct help_link
   // used for anything right now.
   char name[MAX_ANCHOR_NAME];
   int name_length;
+  uint32_t hash;
 };
 
 HASH_SET_INIT(FILES, struct help_file *, name, name_length)

--- a/src/utils/hlp2html.c
+++ b/src/utils/hlp2html.c
@@ -99,13 +99,13 @@ struct help_link
   int name_length;
 };
 
-KHASH_SET_INIT(FILES, struct help_file *, name, name_length)
-KHASH_SET_INIT(ANCHORS, struct help_anchor *, name, name_length)
-KHASH_SET_INIT(LINKS, struct help_link *, name, name_length)
+HASH_SET_INIT(FILES, struct help_file *, name, name_length)
+HASH_SET_INIT(ANCHORS, struct help_anchor *, name, name_length)
+HASH_SET_INIT(LINKS, struct help_link *, name, name_length)
 
-static khash_t(FILES) *files_table = NULL;
-static khash_t(ANCHORS) *anchors_table = NULL;
-static khash_t(LINKS) *links_table = NULL;
+static hash_t(FILES) *files_table = NULL;
+static hash_t(ANCHORS) *anchors_table = NULL;
+static hash_t(LINKS) *links_table = NULL;
 
 static struct help_file *help_file_list[MAX_FILES];
 static int num_help_files = 0;
@@ -185,7 +185,7 @@ static struct help_file *new_help_file(const char *title)
   snprintf(current->name, MAX_FILE_NAME, "%s", title);
   current->name_length = strlen(current->name);
 
-  KHASH_FIND(FILES, files_table, current->name, current->name_length, check);
+  HASH_FIND(FILES, files_table, current->name, current->name_length, check);
   if(check)
   {
     fprintf(stderr, "WARNING: Duplicate file '%s' found. Please debug with "
@@ -196,7 +196,7 @@ static struct help_file *new_help_file(const char *title)
   }
   else
   {
-    KHASH_ADD(FILES, files_table, current);
+    HASH_ADD(FILES, files_table, current);
     help_file_list[num_help_files] = current;
     num_help_files++;
     return current;
@@ -207,12 +207,12 @@ static void free_help_files(void)
 {
   struct help_file *current;
 
-  KHASH_ITER(FILES, files_table, current, {
+  HASH_ITER(FILES, files_table, current, {
     free(current->html.data);
     free(current);
   });
 
-  KHASH_CLEAR(FILES, files_table);
+  HASH_CLEAR(FILES, files_table);
 }
 
 /**
@@ -227,7 +227,7 @@ static void new_anchor(struct help_file *parent, const char *name)
   anchor->name_length = strlen(anchor->name);
   anchor->parent = parent;
 
-  KHASH_FIND(ANCHORS, anchors_table, anchor->name, anchor->name_length, check);
+  HASH_FIND(ANCHORS, anchors_table, anchor->name, anchor->name_length, check);
   if(check)
   {
     fprintf(stderr, "WARNING: Duplicate anchor '%s' found. Please debug with "
@@ -237,7 +237,7 @@ static void new_anchor(struct help_file *parent, const char *name)
   }
   else
   {
-    KHASH_ADD(ANCHORS, anchors_table, anchor);
+    HASH_ADD(ANCHORS, anchors_table, anchor);
   }
 }
 
@@ -245,11 +245,11 @@ static void free_anchors(void)
 {
   struct help_anchor *current;
 
-  KHASH_ITER(ANCHORS, anchors_table, current, {
+  HASH_ITER(ANCHORS, anchors_table, current, {
     free(current);
   });
 
-  KHASH_CLEAR(ANCHORS, anchors_table);
+  HASH_CLEAR(ANCHORS, anchors_table);
 }
 
 /**
@@ -268,7 +268,7 @@ static void new_link(struct help_file *parent, const char *name,
   snprintf(link->target_anchor, MAX_ANCHOR_NAME, "%s", target_anchor);
 
   // The name is generated with a unique number; don't bother checking.
-  KHASH_ADD(LINKS, links_table, link);
+  HASH_ADD(LINKS, links_table, link);
 }
 
 static void validate_links(void)
@@ -280,11 +280,11 @@ static void free_links(void)
 {
   struct help_link *current;
 
-  KHASH_ITER(LINKS, links_table, current, {
+  HASH_ITER(LINKS, links_table, current, {
     free(current);
   });
 
-  KHASH_CLEAR(LINKS, links_table);
+  HASH_CLEAR(LINKS, links_table);
 }
 
 /**

--- a/src/world.c
+++ b/src/world.c
@@ -1573,7 +1573,7 @@ static inline int load_world_counters(struct world *mzx_world,
   if(!num_prev_allocated)
     counter_list->num_counters = i;
 
-#ifndef CONFIG_KHASH
+#ifndef CONFIG_COUNTER_HASH_TABLES
   // Versions without the hash table require this to be sorted at all times
   sort_counter_list(counter_list);
 #endif
@@ -1710,7 +1710,7 @@ static inline int load_world_strings_mem(struct world *mzx_world,
   if(!num_prev_allocated)
     string_list->num_strings = i;
 
-#ifndef CONFIG_KHASH
+#ifndef CONFIG_COUNTER_HASH_TABLES
   // Versions without the hash table require this to be sorted at all times
   sort_string_list(string_list);
 #endif
@@ -1803,7 +1803,7 @@ static inline int load_world_strings(struct world *mzx_world,
   if(!num_prev_allocated)
     string_list->num_strings = i;
 
-#ifndef CONFIG_KHASH
+#ifndef CONFIG_COUNTER_HASH_TABLES
   // Versions without the hash table require this to be sorted at all times
   sort_string_list(string_list);
 #endif


### PR DESCRIPTION
- [x] Reformat khash code to better match MZX style since this copy is pretty much an integral part of MZX now. Clean up some unused parts of khash too, and better document the changes to it.
- [x] Make custom khash macros names and config.sh setting more neutral.
- [x] Fix khash 2^31 bug
- [x] Test fix for khash 2^31 bug (Lancer-X)
- [x] Cache hash values in key struct for counters, strings, checkres, hlp2html
- [x] Test hash value caching speed and memory usage vs. prior ([2020_03_28.csv.zip](https://github.com/AliceLR/megazeux/files/4398267/2020_03_28.csv.zip))


