### PR TITLE
Fix memcasecmp alignment issues

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -48,6 +48,7 @@ DEVELOPERS
 + Fixed a bug where khash tables couldn't expand beyond 2^31,
   added hash caching, made the MZX copy of khash use MZX style,
   and better documented the changes made to it.
++ Fixed alignment issues in memcasecmp.
 + Added a config.sh flag for UndefinedBehaviorSanitizer.
 + Categorized config.sh flags list.
 

--- a/src/counter_struct.h
+++ b/src/counter_struct.h
@@ -35,6 +35,13 @@ struct counter
 #endif
   uint16_t name_length;
   uint8_t gateway_write;
+  uint8_t unused;
+
+  /**
+   * This struct will be allocated with extra space to contain the entire
+   * counter name, null-terminated. This field MUST be at least 4-aligned and
+   * it must be the last field (any extra padding after it will be used).
+   */
   char name[1];
 };
 
@@ -92,6 +99,14 @@ struct string
 #endif
 
   uint16_t name_length;
+  uint8_t unused;
+  uint8_t unused2;
+
+  /**
+   * This struct will be allocated with extra space to contain the string name
+   * and string value. This field MUST be at least 4-aligned and must be the
+   * last field in the struct (any extra padding after it will be used).
+   */
   char name[1];
 };
 

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -572,7 +572,7 @@ static inline uint32_t fnv_1a_hash_string_len(const void *_str, uint32_t len)
   fnv_1a_hash_string_len(keyptr, keylen)
 
 #define kh_mem_hash_equal(aptr, bptr, alen, blen) \
-  (((uint32_t)alen == (uint32_t)blen) && !memcasecmp(aptr, bptr, blen))
+  (((uint32_t)alen == (uint32_t)blen) && !memcasecmp32(aptr, bptr, blen))
 
 /* --- END OF HASH FUNCTIONS --- */
 

--- a/src/io/zip.h
+++ b/src/io/zip.h
@@ -153,6 +153,8 @@ struct zip_file_header
   uint8_t mzx_robot_id;
   uint16_t file_name_length;
   // This struct is allocated with an extended area for the filename.
+  // This field MUST be at least 4-aligned and it must be the last field in the
+  // struct (any extra padding after will be used).
   char file_name[1];
 };
 

--- a/src/memcasecmp.h
+++ b/src/memcasecmp.h
@@ -1,6 +1,7 @@
 /* MegaZeux
  *
  * Copyright (C) 2004 Gilead Kutnick <exophase@adelphia.net>
+ * Copyright (C) 2020 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -24,8 +25,31 @@
 
 __M_BEGIN_DECLS
 
+#include <assert.h>
 #include <inttypes.h>
 #include "platform_endian.h"
+
+/**
+ * Minimum string length before aligned comparison should be invoked.
+ */
+#define _memcasecmp32_align (sizeof(uint32_t))
+#define _memcasecmp32_threshold (_memcasecmp32_align * 2)
+
+#if ARCHITECTURE_BITS >= 64
+#define _memcasecmp64_align (sizeof(uint64_t))
+#define _memcasecmp64_threshold (_memcasecmp64_align * 2)
+#endif
+
+/**
+ * Macros to get byte b of unsigned int x.
+ */
+#if PLATFORM_BYTE_ORDER == PLATFORM_LIL_ENDIAN
+#define _memcaseget32(x,b) memtolower((x >> (b * 8)) & 0xFF)
+#define _memcaseget64(x,b) _memcaseget32(x,b)
+#else /* PLATFORM_BYTE_ORDER == PLATFORM_BIG_ENDIAN */
+#define _memcaseget32(x,b) memtolower((x >> (24 >> (b * 8))) & 0xFF)
+#define _memcaseget64(x,b) memtolower((x >> (56 >> (b * 8))) & 0xFF)
+#endif
 
 static const unsigned char memtolower_table[256] =
 {
@@ -52,97 +76,204 @@ static inline int memtolower(unsigned char c)
   return memtolower_table[c];
 }
 
-static inline int memcasecmp(const void *A, const void *B, size_t cmp_length)
+#if ARCHITECTURE_BITS >= 64
+
+static inline int _memcasecmp64(const uint8_t *a_value, const uint8_t *b_value,
+ size_t cmp_length, size_t *position)
 {
-  // Compare 32bits at a time, should be mostly portable now
-  const char *a_value = (const char *)A;
-  const char *b_value = (const char *)B;
-  char val_a;
-  char val_b;
-  size_t length_32b = cmp_length / 4;
-  uint32_t *a_value_32b = (uint32_t *)A;
-  uint32_t *b_value_32b = (uint32_t *)B;
-  uint32_t val_a_32b;
-  uint32_t val_b_32b;
-  uint32_t difference;
+  const uint64_t *a_value_64b = (const uint64_t *)a_value;
+  const uint64_t *b_value_64b = (const uint64_t *)b_value;
+  size_t length_64b = cmp_length / _memcasecmp64_align;
+  uint64_t val_a;
+  uint64_t val_b;
   size_t i;
+  int cmp;
 
-  for(i = 0; i < length_32b; i++)
+  for(i = 0; i < length_64b; i++)
   {
-    val_a_32b = a_value_32b[i];
-    val_b_32b = b_value_32b[i];
-
-    if(val_a_32b != val_b_32b)
-    {
-#if PLATFORM_BYTE_ORDER == PLATFORM_LIL_ENDIAN
-
-      difference = memtolower(val_a_32b & 0xFF) -
-       memtolower(val_b_32b & 0xFF);
-
-      if(difference)
-        return difference;
-
-      difference = memtolower((val_a_32b >> 8) & 0xFF) -
-       memtolower((val_b_32b >> 8) & 0xFF);
-
-      if(difference)
-        return difference;
-
-      difference = memtolower((val_a_32b >> 16) & 0xFF) -
-       memtolower((val_b_32b >> 16) & 0xFF);
-
-      if(difference)
-        return difference;
-
-      difference =
-       memtolower(val_a_32b >> 24) - memtolower(val_b_32b >> 24);
-
-      if(difference)
-        return difference;
-
-#else // PLATFORM_BYTE_ORDER == PLATFORM_BIG_ENDIAN
-
-      difference =
-       memtolower(val_a_32b >> 24) - memtolower(val_b_32b >> 24);
-
-      if(difference)
-        return difference;
-
-      difference = memtolower((val_a_32b >> 16) & 0xFF) -
-       memtolower((val_b_32b >> 16) & 0xFF);
-
-      if(difference)
-        return difference;
-
-      difference = memtolower((val_a_32b >> 8) & 0xFF) -
-       memtolower((val_b_32b >> 8) & 0xFF);
-
-      if(difference)
-        return difference;
-
-      difference = memtolower(val_a_32b & 0xFF) -
-       memtolower(val_b_32b & 0xFF);
-
-      if(difference)
-        return difference;
-#endif
-    }
-  }
-
-  for(i = length_32b * 4; i < cmp_length; i++)
-  {
-    val_a = a_value[i];
-    val_b = b_value[i];
+    val_a = a_value_64b[i];
+    val_b = b_value_64b[i];
 
     if(val_a != val_b)
     {
-      difference = memtolower((int)val_a) - memtolower((int)val_b);
+      cmp = _memcaseget64(val_a, 0) - _memcaseget64(val_b, 0);
+      if(cmp)
+        return cmp;
 
-      if(difference)
-        return difference;
+      cmp = _memcaseget64(val_a, 1) - _memcaseget64(val_b, 1);
+      if(cmp)
+        return cmp;
+
+      cmp = _memcaseget64(val_a, 2) - _memcaseget64(val_b, 2);
+      if(cmp)
+        return cmp;
+
+      cmp = _memcaseget64(val_a, 3) - _memcaseget64(val_b, 3);
+      if(cmp)
+        return cmp;
+
+      cmp = _memcaseget64(val_a, 4) - _memcaseget64(val_b, 4);
+      if(cmp)
+        return cmp;
+
+      cmp = _memcaseget64(val_a, 5) - _memcaseget64(val_b, 5);
+      if(cmp)
+        return cmp;
+
+      cmp = _memcaseget64(val_a, 6) - _memcaseget64(val_b, 6);
+      if(cmp)
+        return cmp;
+
+      cmp = _memcaseget64(val_a, 7) - _memcaseget64(val_b, 7);
+      if(cmp)
+        return cmp;
     }
   }
 
+  *position = length_64b * _memcasecmp64_align;
+  return 0;
+}
+
+#endif
+
+static inline int _memcasecmp32(const uint8_t *a_value, const uint8_t *b_value,
+ size_t cmp_length, size_t *position)
+{
+  const uint32_t *a_value_32b = (const uint32_t *)a_value;
+  const uint32_t *b_value_32b = (const uint32_t *)b_value;
+  size_t length_32b = cmp_length / _memcasecmp32_align;
+  uint32_t val_a;
+  uint32_t val_b;
+  size_t i;
+  int cmp;
+
+  for(i = 0; i < length_32b; i++)
+  {
+    val_a = a_value_32b[i];
+    val_b = b_value_32b[i];
+
+    if(val_a != val_b)
+    {
+      cmp = _memcaseget32(val_a, 0) - _memcaseget32(val_b, 0);
+      if(cmp)
+        return cmp;
+
+      cmp = _memcaseget32(val_a, 1) - _memcaseget32(val_b, 1);
+      if(cmp)
+        return cmp;
+
+      cmp = _memcaseget32(val_a, 2) - _memcaseget32(val_b, 2);
+      if(cmp)
+        return cmp;
+
+      cmp = _memcaseget32(val_a, 3) - _memcaseget32(val_b, 3);
+      if(cmp)
+        return cmp;
+    }
+  }
+
+  *position = length_32b * _memcasecmp32_align;
+  return 0;
+}
+
+static inline int memcasecmp(const void *A, const void *B, size_t cmp_length)
+{
+  const uint8_t *a_value = (const uint8_t *)A;
+  const uint8_t *b_value = (const uint8_t *)B;
+  size_t i = 0;
+  size_t a_align;
+  size_t b_align;
+  int cmp;
+
+#if ARCHITECTURE_BITS >= 64
+  if(cmp_length >= _memcasecmp64_threshold)
+  {
+    a_align = (size_t)(a_value) % _memcasecmp64_align;
+    b_align = (size_t)(b_value) % _memcasecmp64_align;
+
+    if(a_align == b_align)
+    {
+      while((size_t)a_value % _memcasecmp64_align)
+      {
+        cmp = memtolower(*(a_value++)) - memtolower(*(b_value++));
+        if(cmp)
+          return cmp;
+        cmp_length--;
+      }
+
+      cmp = _memcasecmp64(a_value, b_value, cmp_length, &i);
+      if(cmp)
+        return cmp;
+    }
+    else
+      goto try_32;
+  }
+  else
+#endif
+
+  if(cmp_length >= _memcasecmp32_threshold)
+  {
+try_32:
+    a_align = (size_t)(a_value) % _memcasecmp32_align;
+    b_align = (size_t)(b_value) % _memcasecmp32_align;
+
+    if(a_align == b_align)
+    {
+      while((size_t)a_value % _memcasecmp32_align)
+      {
+        cmp = memtolower(*(a_value++)) - memtolower(*(b_value++));
+        if(cmp)
+          return cmp;
+        cmp_length--;
+      }
+
+      cmp = _memcasecmp32(a_value, b_value, cmp_length, &i);
+      if(cmp)
+        return cmp;
+    }
+  }
+
+  for(; i < cmp_length; i++)
+  {
+    cmp = memtolower(a_value[i]) - memtolower(b_value[i]);
+    if(cmp)
+      return cmp;
+  }
+
+  return 0;
+}
+
+/**
+ * Compare two strings known to be aligned to 4 bytes. This is useful
+ * primarily for counter and string name comparisons, which are always
+ * aligned to 4 bytes and are typically too short to benefit from the
+ * 64-bit compare conditionally used in the general case function.
+ *
+ * @param  A            A non-terminated string aligned to 4 bytes.
+ * @param  B            A non-terminated string aligned to 4 bytes.
+ * @param  cmp_length   The length to compare.
+ * @return              0 if A==B; >0 if A>B; <0 if A<B.
+ */
+static inline int memcasecmp32(const void *A, const void *B, size_t cmp_length)
+{
+  const uint8_t *a_value = (const uint8_t *)A;
+  const uint8_t *b_value = (const uint8_t *)B;
+  size_t i = 0;
+  int cmp;
+
+  assert((size_t)A % _memcasecmp32_align == 0);
+  assert((size_t)B % _memcasecmp32_align == 0);
+
+  cmp = _memcasecmp32(a_value, b_value, cmp_length, &i);
+  if(cmp)
+    return cmp;
+
+  for(; i < cmp_length; i++)
+  {
+    cmp = memtolower(a_value[i]) - memtolower(b_value[i]);
+    if(cmp)
+      return cmp;
+  }
   return 0;
 }
 

--- a/src/memcasecmp.h
+++ b/src/memcasecmp.h
@@ -242,7 +242,9 @@ static inline int memcasecmp(const void *A, const void *B, size_t cmp_length)
    */
   if(cmp_length >= _memcasecmp32_threshold)
   {
+#if ARCHITECTURE_BITS >= 64
 try_32:
+#endif
     a_align = (size_t)(a_value) % _memcasecmp32_align;
     b_align = (size_t)(b_value) % _memcasecmp32_align;
 

--- a/src/memcasecmp.h
+++ b/src/memcasecmp.h
@@ -295,8 +295,10 @@ static inline int memcasecmp32(const void *A, const void *B, size_t cmp_length)
   size_t i = 0;
   int cmp;
 
-  assert((size_t)A % _memcasecmp32_align == 0);
-  assert((size_t)B % _memcasecmp32_align == 0);
+  // The 4 alignment apparently can't be guaranteed 100% of the time, so just
+  // fall back to the regular compare if there's an issue.
+  if((size_t)A % _memcasecmp32_align || (size_t)B % _memcasecmp32_align)
+    return memcasecmp(A, B, cmp_length);
 
   cmp = _memcasecmp32(a_value, b_value, cmp_length, &i);
   if(cmp)


### PR DESCRIPTION
This branch fixes undefined alignment behavior in memcasecmp that could potentially cause performance issues or crashes on some platforms. Additionally, counter names and string names/values are now aligned to 4 bytes and hash tables use a special case version of memcasecmp roughly equivalent to the older memcasecmp to bypass extra checks.

- [x] Sanitizers
- [x] Big endian testing...