### PR TITLE
Refactor path functions out of util.c

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -6,6 +6,10 @@ USERS
   the start and the end of the current program.
 + Added docs/fileform.html, a document describing all currently
   supported MZX file formats in excessive detail.
++ When startup_file is provided with both a directory and a
+  filename and no startup_path has been set, the directory will
+  now be used as startup_path. If startup_path is set, the
+  directory portion of startup_file will still be ignored.
 + Fixed a bug where input text with no corresponding internal
   key would be ignored by the robot editor.
 + Fixed a bug where some AltGr key combinations would not work
@@ -58,6 +62,7 @@ DEVELOPERS
   changed most dns.c, fsafeopen.c, and checkres.c debug logging
   to use it. Use the --enable-trace config.sh flag to enable
   trace logging for debug builds.
++ Refactored path functions out of util.c.
 
 
 March 8th, 2020 - MZX 2.92c

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -117,6 +117,7 @@ core_cobjs := \
   ${core_obj}/world.o             \
   ${io_obj}/dir.o                 \
   ${io_obj}/fsafeopen.o           \
+  ${io_obj}/path.o                \
   ${io_obj}/vfile.o               \
   ${io_obj}/zip.o                 \
   ${io_obj}/zip_stream.o

--- a/src/audio/ext.c
+++ b/src/audio/ext.c
@@ -26,7 +26,7 @@
 #include "audio.h"
 #include "ext.h"
 
-#include "../util.h"
+#include "../io/path.h"
 
 struct registry_entry
 {
@@ -69,13 +69,13 @@ struct audio_stream *audio_ext_construct_stream(char *filename,
  Uint32 frequency, Uint32 volume, Uint32 repeat)
 {
   struct audio_stream *a_return = NULL;
-  int ext_pos;
+  ssize_t ext_pos;
   int i;
 
   if(!audio.music_on)
     return NULL;
 
-  ext_pos = get_ext_pos(filename);
+  ext_pos = path_get_ext_offset(filename);
 
   // Must contain a valid ext
   if(ext_pos < 0 || ext_pos >= (int)strlen(filename))

--- a/src/editor/char_ed.c
+++ b/src/editor/char_ed.c
@@ -29,6 +29,7 @@
 #include "../util.h"
 #include "../window.h"
 #include "../world.h"
+#include "../io/path.h"
 
 #include "configure.h"
 #include "graphics.h"
@@ -967,7 +968,7 @@ static void char_import(struct world *mzx_world, int char_offset, int charset,
       replace_filenum(import_string, import_name,
        current_file);
 
-      add_ext(import_name, ".chr");
+      path_force_ext(import_name, sizeof(import_name), ".chr");
 
       if(import_mode)
       {
@@ -1060,7 +1061,7 @@ static void char_export(struct world *mzx_world, int char_offset, int charset,
       replace_filenum(export_string, export_name,
        current_file);
 
-      add_ext(export_name, ".chr");
+      path_force_ext(export_name, sizeof(export_name), ".chr");
 
       if(export_mode)
       {

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -40,6 +40,7 @@
 #include "../util.h"
 #include "../window.h"
 #include "../world.h"
+#include "../io/path.h"
 
 #include "../audio/audio.h"
 #include "../audio/sfx.h"
@@ -2884,7 +2885,8 @@ static boolean editor_key(context *ctx, int *key)
             {
               audio_play_module(new_mod, false, 255);
               strcpy(editor->current_listening_mod, new_mod);
-              get_path(new_mod, editor->current_listening_dir, MAX_PATH);
+              path_get_directory(editor->current_listening_dir, MAX_PATH,
+               new_mod);
               editor->listening_mod_active = true;
             }
 
@@ -3087,8 +3089,7 @@ static boolean editor_key(context *ctx, int *key)
             strcpy(curr_file, world_name);
             save_world(mzx_world, world_name, false, MZX_VERSION);
 
-            get_path(world_name, new_path, MAX_PATH);
-            if(new_path[0])
+            if(path_get_directory(new_path, MAX_PATH, world_name) > 0)
               chdir(new_path);
 
             editor->modified = false;
@@ -3234,7 +3235,7 @@ static boolean editor_key(context *ctx, int *key)
               if(!file_manager(mzx_world, chr_ext, NULL, export_name,
                "Export character set", 1, 1, elements, ARRAY_SIZE(elements), 2))
               {
-                add_ext(export_name, ".chr");
+                path_force_ext(export_name, MAX_PATH, ".chr");
                 ec_save_set_var(export_name, char_offset, char_size);
                 strcpy(editor->chr_name_buffer, export_name);
               }

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -43,6 +43,7 @@
 #include "../window.h"
 #include "../world.h"
 #include "../io/fsafeopen.h"
+#include "../io/path.h"
 
 #include "char_ed.h"
 #include "clipboard.h"
@@ -1530,7 +1531,7 @@ static void export_block(struct robot_editor_context *rstate,
 #ifndef CONFIG_DEBYTECODE
     if(export_type)
     {
-      add_ext(export_name, ".bc");
+      path_force_ext(export_name, MAX_PATH, ".bc");
       export_file = fopen_unsafe(export_name, "wb");
 
       fputc(0xFF, export_file);
@@ -1547,7 +1548,7 @@ static void export_block(struct robot_editor_context *rstate,
     else
 #endif
     {
-      add_ext(export_name, ".txt");
+      path_force_ext(export_name, MAX_PATH, ".txt");
       export_file = fopen_unsafe(export_name, "w");
 
       while(current_rline != end_rline)

--- a/src/io/fsafeopen.c
+++ b/src/io/fsafeopen.c
@@ -271,7 +271,7 @@ static int fsafetest(const char *path, char *newpath)
   // FIXME assuming buffer size!
   pathlen = path_clean_slashes_copy(newpath, strlen(path) + 1, path);
 
-#ifdef __WIN32__
+#if (DIR_SEPARATOR_CHAR == '\\')
   // The slash cleaning function made these Windows slashes but fsafetranslate
   // should always return Unix slashes!
   for(i = 0; i < pathlen; i++)

--- a/src/io/fsafeopen.c
+++ b/src/io/fsafeopen.c
@@ -25,6 +25,7 @@
 
 #include "fsafeopen.h"
 #include "dir.h"
+#include "path.h"
 
 #include "../util.h"
 
@@ -267,15 +268,18 @@ static int fsafetest(const char *path, char *newpath)
   if((path == NULL) || (path[0] == 0))
     return -FSAFE_INVALID_ARGUMENT;
 
-  pathlen = strlen (path);
-  clean_path_slashes(path, newpath, pathlen + 1);
+  // FIXME assuming buffer size!
+  pathlen = path_clean_slashes_copy(newpath, strlen(path) + 1, path);
 
-  // convert the slashes
+#ifdef __WIN32__
+  // The slash cleaning function made these Windows slashes but fsafetranslate
+  // should always return Unix slashes!
   for(i = 0; i < pathlen; i++)
   {
     if(newpath[i] == '\\')
       newpath[i] = '/';
   }
+#endif
 
   // check root specifiers
   if(newpath[0] == '/')

--- a/src/io/path.c
+++ b/src/io/path.c
@@ -1,0 +1,544 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2004 Gilead Kutnick <exophase@adelphia.net>
+ * Copyright (C) 2008 Alistair John Strachan <alistair@devzero.co.uk>
+ * Copyright (C) 2012, 2020 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <sys/stat.h>
+
+#include "path.h"
+#include "vfile.h"
+
+/**
+ * Force a given filename path to use the provided file extension. If the
+ * filename already has the given extension, the string will not be modified.
+ *
+ * @param  path         Path to force the extension of.
+ * @param  buffer_len   Size of the buffer of the path.
+ * @param  ext          Extension to add to the path.
+ * @return              true on success, otherwise false.
+ */
+boolean path_force_ext(char *path, size_t buffer_len, const char *ext)
+{
+  size_t path_len = strlen(path);
+  size_t ext_len = strlen(ext);
+
+  if((path_len < ext_len) || (path[path_len - ext_len] != '.') ||
+   strcasecmp(path + path_len - ext_len, ext))
+  {
+    if(path_len + ext_len >= buffer_len)
+      return false;
+
+    snprintf(path + path_len, MAX_PATH - path_len, "%s", ext);
+    path[buffer_len - 1] = '\0';
+  }
+  return true;
+}
+
+/**
+ * Get the position of the extension in a filename path.
+ *
+ * @param  path   Path to get the extension position of.
+ * @return        The index of the start of the extension or -1 if not found.
+ */
+ssize_t path_get_ext_offset(const char *path)
+{
+  ssize_t path_len = strlen(path);
+  ssize_t ext_pos;
+
+  for(ext_pos = path_len - 1; ext_pos >= 0; ext_pos--)
+  {
+    // Don't let this detect an "extension" of a directory!
+    if(isslash(path[ext_pos]))
+      break;
+
+    if(path[ext_pos] == '.')
+      return ext_pos;
+  }
+  return -1;
+}
+
+/**
+ * Get the location of the first char of the filename in a filename path.
+ * If there is no filename, the returned index will be the location of the
+ * null terminator. If the string is empty, -1 will be returned.
+ */
+static ssize_t path_get_filename_offset(const char *path)
+{
+  struct stat stat_info;
+  ssize_t pos;
+  if(!path || !path[0])
+    return -1;
+
+  // If this path stats and happens to be a directory without a terminating
+  // slash, the filename offset is the end of the string...
+  if(vstat(path, &stat_info) >= 0 && S_ISDIR(stat_info.st_mode))
+    return strlen(path);
+
+  // Otherwise, find the last directory separator (if any).
+  pos = (ssize_t)strlen(path) - 1;
+  while(pos >= 0)
+  {
+    if(isslash(path[pos]))
+      return pos + 1;
+
+    pos--;
+  }
+  return 0;
+}
+
+/**
+ * Truncate a path to its directory portion, if any.
+ *
+ * @param  path         Path to truncate.
+ * @param  buffer_len   Size of the path buffer.
+ * @return              The length of the directory string, or -1 on error.
+ */
+ssize_t path_to_directory(char *path, size_t buffer_len)
+{
+  ssize_t filename_pos = path_get_filename_offset(path);
+
+  // Invalid path.
+  if(filename_pos < 0 || (size_t)filename_pos >= buffer_len)
+  {
+    if(buffer_len > 0)
+      path[0] = '\0';
+
+    return -1;
+  }
+
+  path[filename_pos] = '\0';
+  if(filename_pos > 0)
+    filename_pos = path_clean_slashes(path, buffer_len);
+
+  return filename_pos;
+}
+
+/**
+ * Remove the directory portion of a filename path, if any.
+ *
+ * @param  path         Filename path to remove the directory portion of.
+ * @param  buffer_len   Size of the path buffer.
+ * @return              The length of the filename string, or -1 on error.
+ */
+ssize_t path_to_filename(char *path, size_t buffer_len)
+{
+  ssize_t filename_pos = path_get_filename_offset(path);
+  size_t path_len = strlen(path);
+  size_t filename_len;
+
+  // Invalid path.
+  if(filename_pos < 0 || path_len - (size_t)filename_pos >= buffer_len)
+  {
+    if(buffer_len > 0)
+      path[0] = '\0';
+
+    return -1;
+  }
+
+  // If there isn't a directory prefix, don't modify the buffer...
+  if(filename_pos == 0)
+    return path_len;
+
+  filename_len = path_len - filename_pos;
+  if(filename_len > 0)
+    memmove(path, path + filename_pos, filename_len);
+  path[filename_len] = '\0';
+
+  return filename_len;
+}
+
+/**
+ * Copy the directory portion of a filename or directory path to the
+ * destination buffer.
+ *
+ * @param  dest       Destination buffer for the directory.
+ * @param  dest_len   Size of the destination buffer.
+ * @param  path       Path to get the directory of.
+ * @return            The length of the directory string, or -1 on error.
+ */
+ssize_t path_get_directory(char *dest, size_t dest_len, const char *path)
+{
+  ssize_t filename_pos = path_get_filename_offset(path);
+
+  // Invalid path, or it's too long to store.
+  if(filename_pos < 0 || (size_t)filename_pos >= dest_len)
+  {
+    if(dest_len > 0)
+      dest[0] = '\0';
+
+    return -1;
+  }
+
+  dest[filename_pos] = '\0';
+  if(filename_pos > 0)
+  {
+    memcpy(dest, path, filename_pos);
+    filename_pos = path_clean_slashes(dest, dest_len);
+  }
+  return filename_pos;
+}
+
+/**
+ * Copy the filename portion of a filename path to the destination buffer.
+ *
+ * @param  dest       Destination buffer for the filename.
+ * @param  dest_len   Size of the destination buffer.
+ * @param  path       Path to get the filename of.
+ * @return            The length of the filename string, or -1 on error.
+ */
+ssize_t path_get_filename(char *dest, size_t dest_len, const char *path)
+{
+  ssize_t filename_pos = path_get_filename_offset(path);
+  size_t path_len = strlen(path);
+  size_t filename_len;
+
+  // Invalid path, or it's too long to store.
+  if(filename_pos < 0 || path_len - (size_t)filename_pos >= dest_len)
+  {
+    if(dest_len > 0)
+      dest[0] = '\0';
+
+    return -1;
+  }
+
+  filename_len = path_len - filename_pos;
+  dest[filename_len] = '\0';
+  if(filename_len > 0)
+    memcpy(dest, path + filename_pos, filename_len);
+
+  return filename_len;
+}
+
+/**
+ * Copy both the directory and the filename portions of a filename path to
+ * individual destination buffers.
+ *
+ * @param  d_dest   Destination buffer for the directory.
+ * @param  d_len    Size of the directory destination buffer.
+ * @param  f_dest   Destination buffer for the filename.
+ * @param  f_len    Size of the filename destination buffer.
+ * @param  path     Path to get the directory and filename of.
+ * @return          true on success, otherwise false.
+ */
+boolean path_get_directory_and_filename(char *d_dest, size_t d_len,
+ char *f_dest, size_t f_len, const char *path)
+{
+  ssize_t filename_pos = path_get_filename_offset(path);
+  size_t path_len = strlen(path);
+  size_t filename_len;
+
+  // Invalid path, or one of the components is too long to store.
+  if(filename_pos < 0 || (size_t)filename_pos >= d_len ||
+   path_len - (size_t)filename_pos >= f_len)
+  {
+    if(d_len > 0)
+      d_dest[0] = '\0';
+    if(f_len > 0)
+      f_dest[0] = '\0';
+
+    return false;
+  }
+
+  d_dest[filename_pos] = '\0';
+  if(filename_pos > 0)
+  {
+    memcpy(d_dest, path, filename_pos);
+    path_clean_slashes(d_dest, d_len);
+  }
+
+  filename_len = path_len - filename_pos;
+  f_dest[filename_len] = '\0';
+  if(filename_len > 0)
+    memcpy(f_dest, path + filename_pos, filename_len);
+
+  return true;
+}
+
+/**
+ * Clean duplicate directory separators out of a path and normalize them to
+ * the correct slash for the current platform.
+ *
+ * @param  path       Path to clean slashes of.
+ * @param  path_len   Size of the path buffer.
+ * @return            The length of the destination path.
+ */
+size_t path_clean_slashes(char *path, size_t path_len)
+{
+  boolean need_copy = false;
+  size_t i = 0;
+  size_t j = 0;
+
+  while((i < path_len) && path[i])
+  {
+    if(isslash(path[i]))
+    {
+      while(isslash(path[i]))
+        i++;
+
+      if(i > j + 1)
+        need_copy = true;
+
+      path[j++] = DIR_SEPARATOR_CHAR;
+    }
+    else
+    {
+      if(need_copy)
+        path[j] = path[i];
+
+      i++;
+      j++;
+    }
+  }
+  path[j] = '\0';
+
+  if((j >= 2) && (path[j - 1] == DIR_SEPARATOR_CHAR) && (path[j - 2] != ':'))
+    path[--j] = '\0';
+
+  return j;
+}
+
+/**
+ * Create a duplicate of a path with duplicate directory separators removed
+ * and with the directory separators normalized to the correct slash for the
+ * current platform.
+ *
+ * @param  dest       Destination buffer for the cleaned path.
+ * @param  dest_len   Size of the destination buffer.
+ * @param  path       Path to clean slashes of.
+ * @return            The length of the destination path.
+ */
+size_t path_clean_slashes_copy(char *dest, size_t dest_len, const char *path)
+{
+  size_t path_len = strlen(path);
+  size_t i = 0;
+  size_t j = 0;
+
+  while((i < path_len) && (j < dest_len - 1))
+  {
+    if(isslash(path[i]))
+    {
+      while(isslash(path[i]))
+        i++;
+
+      dest[j++] = DIR_SEPARATOR_CHAR;
+    }
+    else
+      dest[j++] = path[i++];
+  }
+  dest[j] = '\0';
+
+  if((j >= 2) && (dest[j - 1] == DIR_SEPARATOR_CHAR) && (dest[j - 2] != ':'))
+    dest[--j] = '\0';
+
+  return j;
+}
+
+/**
+ * Append a relative directory or filename path to an existing base path.
+ * This function does not handle ./, ../, etc; to resolve relative paths
+ * containing those, use path_navigate() instead. On succes, the destination
+ * is guaranteed to have cleaned slashes (see path_clean_slashes).
+ *
+ * @param  path         Existing base path.
+ * @param  buffer_len   Size of the base path buffer.
+ * @param  rel          Relative path to be joined to the end of the base path.
+ * @return              The new length of the base path, or -1 on error.
+ */
+ssize_t path_append(char *path, size_t buffer_len, const char *rel)
+{
+  size_t path_len = strlen(path);
+  size_t rel_len = strlen(rel);
+
+  if(path_len && rel_len && path_len + rel_len + 2 < buffer_len)
+  {
+    path_len = path_clean_slashes(path, buffer_len);
+    path[path_len++] = DIR_SEPARATOR_CHAR;
+
+    rel_len = path_clean_slashes_copy(path + path_len, buffer_len - path_len, rel);
+    return path_len + rel_len;
+  }
+  return -1;
+}
+
+/**
+ * Join a base directory path to a relative directory or filename path.
+ * This function does not handle ./, ../, etc; to resolve relative paths
+ * containing those, use path_navigate() instead. On success, the destination
+ * is guaranteed to have cleaned slashes (see path_clean_slashes)
+ *
+ * @param  dest       Destination buffer for the joined path.
+ * @param  dest_len   Size of the destination buffer.
+ * @param  base       Base directory path.
+ * @param  rel        Relative path to be joined to the end of the base path.
+ * @return            The length of the resulting path, or -1 on error.
+ */
+ssize_t path_join(char *dest, size_t dest_len, const char *base, const char *rel)
+{
+  size_t base_len = strlen(base);
+  size_t rel_len = strlen(rel);
+
+  if(base_len && rel_len && base_len + rel_len + 2 < dest_len)
+  {
+    base_len = path_clean_slashes_copy(dest, dest_len, base);
+    dest[base_len++] = DIR_SEPARATOR_CHAR;
+
+    rel_len = path_clean_slashes_copy(dest + base_len, dest_len - base_len, rel);
+    return base_len + rel_len;
+  }
+  return -1;
+}
+
+/**
+ * Navigate a directory path to a target like chdir. The provided directory
+ * path must be a valid directory. The target may be a relative path or an
+ * absolute path in either Unix or Windows style. If "." or ".." is found in
+ * the target, it will be handled appropriately. If the final resulting path
+ * successfully stats, the provided path will be overwritten with the
+ * destination. If the final path is not valid or if an error occurs, the
+ * provided path will not be modified.
+ *
+ * @param  path       Directory path to navigate from.
+ * @param  path_len   Size of path buffer.
+ * @param  target     Target to navigate to.
+ * @return            The new length of the path, or -1 on error.
+ */
+ssize_t path_navigate(char *path, size_t path_len, const char *target)
+{
+  struct stat stat_info;
+  char buffer[MAX_PATH];
+  const char *current;
+  const char *next;
+  const char *end;
+  char current_char;
+  size_t len;
+
+  if(!path || !target || !target[0])
+    return -1;
+
+  current = target;
+  end = target + strlen(target);
+
+  next = strchr(target, ':');
+  if(next)
+  {
+    /**
+     * Destination starts with a Windows-style root directory.
+     * Aside from Windows, these are often used by console SDKs (albeit with /
+     * instead of \) to distinguish SD cards and the like.
+     */
+    if(!isslash(next[1]) && next[1] != '\0')
+      return -1;
+
+    snprintf(buffer, MAX_PATH, "%.*s" DIR_SEPARATOR, (int)(next - target + 1),
+     target);
+    buffer[MAX_PATH - 1] = '\0';
+
+    if(vstat(buffer, &stat_info) < 0)
+      return -1;
+
+    current = next + 1;
+    if(isslash(current[0]))
+      current++;
+  }
+  else
+
+  if(isslash(target[0]))
+  {
+    /**
+     * Destination starts with a Unix-style root directory.
+     * Aside from Unix-likes, these are also supported by console platforms.
+     * Even Windows (back through XP at least) doesn't seem to mind them.
+     */
+    snprintf(buffer, MAX_PATH, DIR_SEPARATOR);
+    buffer[MAX_PATH - 1] = '\0';
+    current = target + 1;
+  }
+
+  else
+  {
+    /**
+     * Destination is relative--start from the current path. Make sure there's
+     * a trailing separator.
+     */
+    len = path_clean_slashes_copy(buffer, MAX_PATH, path);
+    if(!len)
+      return -1;
+
+    if(!isslash(buffer[len - 1]) && len + 1 < MAX_PATH)
+    {
+      buffer[len++] = DIR_SEPARATOR_CHAR;
+      buffer[len] = '\0';
+    }
+  }
+
+  current_char = current[0];
+  len = strlen(buffer);
+
+  // Apply directory fragments to the path.
+  while(current_char != '\0')
+  {
+    // Increment next to skip the separator so it will be copied over.
+    next = strpbrk(current, "/\\");
+    if(!next) next = end;
+    else      next++;
+
+    // . does nothing, .. goes back one level
+    if(current_char == '.')
+    {
+      if(current[1] == '.')
+      {
+        // Skip the rightmost separator (current level) and look for the
+        // previous separator. If found, truncate the path to it.
+        char *pos = buffer + len - 1;
+        do
+        {
+          pos--;
+        }
+        while(pos >= buffer && !isslash(*pos));
+
+        if(pos >= buffer)
+        {
+          pos[1] = '\0';
+          len = strlen(buffer);
+        }
+      }
+    }
+    else
+    {
+      snprintf(buffer + len, MAX_PATH - len, "%.*s", (int)(next - current),
+       current);
+      buffer[MAX_PATH - 1] = '\0';
+      len = strlen(buffer);
+    }
+
+    current = next;
+    current_char = current[0];
+  }
+
+  // This needs to be done before the stat for some platforms (e.g. 3DS)
+  len = path_clean_slashes(buffer, MAX_PATH);
+  if(len < path_len && vstat(buffer, &stat_info) >= 0)
+  {
+    memcpy(path, buffer, len + 1);
+    path[path_len - 1] = '\0';
+    return len;
+  }
+
+  return -1;
+}

--- a/src/io/path.h
+++ b/src/io/path.h
@@ -26,6 +26,8 @@
 
 __M_BEGIN_DECLS
 
+#include <stddef.h>
+
 #ifndef DIR_SEPARATOR
 #ifdef __WIN32__
 #define DIR_SEPARATOR "\\"

--- a/src/io/path.h
+++ b/src/io/path.h
@@ -51,6 +51,7 @@ static inline boolean isslash(const char chr)
 CORE_LIBSPEC boolean path_force_ext(char *path, size_t buffer_len, const char *ext);
 CORE_LIBSPEC ssize_t path_get_ext_offset(const char *path);
 
+CORE_LIBSPEC boolean path_has_directory(const char *path);
 CORE_LIBSPEC ssize_t path_to_directory(char *path, size_t buffer_len);
 CORE_LIBSPEC ssize_t path_to_filename(char *path, size_t buffer_len);
 CORE_LIBSPEC ssize_t path_get_directory(char *dest, size_t dest_len,
@@ -66,6 +67,8 @@ CORE_LIBSPEC size_t path_clean_slashes_copy(char *dest, size_t dest_len,
 CORE_LIBSPEC ssize_t path_append(char *path, size_t buffer_len, const char *rel);
 CORE_LIBSPEC ssize_t path_join(char *dest, size_t dest_len, const char *base,
  const char *rel);
+CORE_LIBSPEC ssize_t path_remove_prefix(char *path, size_t buffer_len,
+ const char *prefix, size_t prefix_len);
 
 CORE_LIBSPEC ssize_t path_navigate(char *path, size_t path_len,
  const char *target);

--- a/src/io/path.h
+++ b/src/io/path.h
@@ -1,0 +1,73 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2008 Alistair John Strachan <alistair@devzero.co.uk>
+ * Copyright (C) 2004 Gilead Kutnick <exophase@adelphia.net>
+ * Copyright (C) 2012, 2020 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef __IO_PATH_H
+#define __IO_PATH_H
+
+#include "../compat.h"
+
+__M_BEGIN_DECLS
+
+#ifndef DIR_SEPARATOR
+#ifdef __WIN32__
+#define DIR_SEPARATOR "\\"
+#define DIR_SEPARATOR_CHAR '\\'
+#else /* !__WIN32__ */
+#define DIR_SEPARATOR "/"
+#define DIR_SEPARATOR_CHAR '/'
+#endif
+#endif /* DIR_SEPARATOR */
+
+/**
+ * Determine if a character is a path separating slash.
+ * @param  chr  Character to check.
+ * @return      True if the character is a slash, otherwise false.
+ */
+static inline boolean isslash(const char chr)
+{
+  return (chr == '\\') || (chr == '/');
+}
+
+CORE_LIBSPEC boolean path_force_ext(char *path, size_t buffer_len, const char *ext);
+CORE_LIBSPEC ssize_t path_get_ext_offset(const char *path);
+
+CORE_LIBSPEC ssize_t path_to_directory(char *path, size_t buffer_len);
+CORE_LIBSPEC ssize_t path_to_filename(char *path, size_t buffer_len);
+CORE_LIBSPEC ssize_t path_get_directory(char *dest, size_t dest_len,
+ const char *path);
+CORE_LIBSPEC ssize_t path_get_filename(char *dest, size_t dest_len,
+ const char *path);
+CORE_LIBSPEC boolean path_get_directory_and_filename(char *d_dest, size_t d_len,
+ char *f_dest, size_t f_len, const char *path);
+
+CORE_LIBSPEC size_t path_clean_slashes(char *path, size_t path_len);
+CORE_LIBSPEC size_t path_clean_slashes_copy(char *dest, size_t dest_len,
+ const char *path);
+CORE_LIBSPEC ssize_t path_append(char *path, size_t buffer_len, const char *rel);
+CORE_LIBSPEC ssize_t path_join(char *dest, size_t dest_len, const char *base,
+ const char *rel);
+
+CORE_LIBSPEC ssize_t path_navigate(char *path, size_t path_len,
+ const char *target);
+
+__M_END_DECLS
+
+#endif /* __IO_PATH_H */

--- a/src/main.c
+++ b/src/main.c
@@ -47,6 +47,7 @@
 #include "world.h"
 #include "counter.h"
 #include "run_stubs.h"
+#include "io/path.h"
 
 #include "audio/audio.h"
 #include "audio/sfx.h"
@@ -206,7 +207,7 @@ __libspec int main(int argc, char *argv[])
   // Figure out where all configuration files should be loaded
   // form. For game.cnf, et al this should eventually be wrt
   // the game directory, not the config.txt's path.
-  get_path(mzx_res_get_by_id(CONFIG_TXT), config_dir, MAX_PATH);
+  path_get_directory(config_dir, MAX_PATH, mzx_res_get_by_id(CONFIG_TXT));
 
   // Move into the configuration file's directory so that any
   // "include" statements are done wrt this path. Move back
@@ -233,8 +234,13 @@ __libspec int main(int argc, char *argv[])
   // parameters. Interpret the first unparsed parameter
   // as a file to load (overriding startup_file etc.)
   if(argc > 1)
-    split_path_filename(argv[1], conf->startup_path, 256,
-     conf->startup_file, 256);
+  {
+    path_get_directory_and_filename(
+      conf->startup_path, sizeof(conf->startup_path),
+      conf->startup_file, sizeof(conf->startup_file),
+      argv[1]
+    );
+  }
 
   if(strlen(conf->startup_path))
   {

--- a/src/render_glsl.c
+++ b/src/render_glsl.c
@@ -31,6 +31,7 @@
 #include "render_layer.h"
 #include "renderers.h"
 #include "util.h"
+#include "io/path.h"
 
 #ifdef CONFIG_SDL
 #include "render_sdl.h"
@@ -350,24 +351,25 @@ static GLuint glsl_load_shader(struct graphics_data *graphics,
       // Try to load these from config before loading the default.
 
       char *path = cmalloc(MAX_PATH);
-
-      strcpy(path, mzx_res_get_by_id(GLSL_SHADER_SCALER_DIRECTORY));
+      size_t path_len = path_clean_slashes_copy(path, MAX_PATH,
+       mzx_res_get_by_id(GLSL_SHADER_SCALER_DIRECTORY));
 
       switch(res)
       {
         case GLSL_SHADER_SCALER_VERT:
-          sprintf(path + strlen(path), "%s%s.vert",
-           DIR_SEPARATOR, graphics->gl_scaling_shader);
+          snprintf(path + path_len, MAX_PATH - path_len,
+           DIR_SEPARATOR "%s.vert", graphics->gl_scaling_shader);
           break;
 
         case GLSL_SHADER_SCALER_FRAG:
-          sprintf(path + strlen(path), "%s%s.frag",
-           DIR_SEPARATOR, graphics->gl_scaling_shader);
+          snprintf(path + path_len, MAX_PATH - path_len,
+           DIR_SEPARATOR "%s.frag", graphics->gl_scaling_shader);
           break;
 
         default:
           break;
       }
+      path[MAX_PATH - 1] = '\0';
 
       source_cache[index] = glsl_load_string(path);
 

--- a/src/updater.c
+++ b/src/updater.c
@@ -27,6 +27,7 @@
 #include "updater.h"
 #include "util.h"
 #include "window.h"
+#include "io/path.h"
 
 #include "editor/window.h"
 
@@ -307,7 +308,7 @@ static boolean check_prune_basedir(const char *file)
   static char path[MAX_PATH];
   ssize_t ret;
 
-  ret = get_path(file, path, MAX_PATH);
+  ret = path_get_directory(path, MAX_PATH, file);
   if(ret < 0)
   {
     error_message(E_UPDATE, 0, "Failed to prune directories (path too long)");
@@ -334,7 +335,7 @@ static boolean check_create_basedir(const char *file)
   char path[MAX_PATH];
   ssize_t ret;
 
-  ret = get_path(file, path, MAX_PATH);
+  ret = path_get_directory(path, MAX_PATH, file);
   if(ret < 0)
   {
     error_message(E_UPDATE, 1, "Failed to create directories (path too long)");
@@ -461,8 +462,10 @@ static boolean find_executable_dir(int argc, char **argv)
     DWORD ret = GetModuleFileNameA(module, filename, MAX_PATH);
 
     if(ret > 0 && ret < MAX_PATH)
-      if(get_path(filename, executable_dir, MAX_PATH) > 0)
+    {
+      if(path_get_directory(executable_dir, MAX_PATH, filename) > 0)
         return true;
+    }
 
     warn("--MAIN-- Failed to get executable from Win32: %s\n", filename);
   }
@@ -470,7 +473,7 @@ static boolean find_executable_dir(int argc, char **argv)
 
   if(argc >= 1 && argv)
   {
-    if(get_path(argv[0], executable_dir, MAX_PATH) > 0)
+    if(path_get_directory(executable_dir, MAX_PATH, argv[0]) > 0)
       return true;
 
     else

--- a/src/util.h
+++ b/src/util.h
@@ -110,24 +110,7 @@ uint64_t rng_get_seed(void);
 void rng_set_seed(uint64_t seed);
 unsigned int Random(uint64_t range);
 
-CORE_LIBSPEC void add_ext(char *src, const char *ext);
-CORE_LIBSPEC int get_ext_pos(const char *filename);
-CORE_LIBSPEC ssize_t get_path(const char *file_name, char *dest, unsigned int buf_len);
-#ifdef CONFIG_UTILS
-ssize_t __get_path(const char *file_name, char *dest, unsigned int buf_len);
-#endif
-
-CORE_LIBSPEC void split_path_filename(const char *source,
- char *destpath, unsigned int path_buffer_len,
- char *destfile, unsigned int file_buffer_len);
-
 CORE_LIBSPEC int create_path_if_not_exists(const char *filename);
-
-CORE_LIBSPEC int change_dir_name(char *path_name, const char *dest);
-
-CORE_LIBSPEC void join_path_names(char* target, int max_len, const char* path1, const char* path2);
-
-CORE_LIBSPEC void clean_path_slashes(const char *source, char *dest, size_t buf_size);
 
 typedef void (*fn_ptr)(void);
 

--- a/src/util.h
+++ b/src/util.h
@@ -43,16 +43,6 @@ __M_BEGIN_DECLS
 
 #define SGN(x) ((x > 0) - (x < 0))
 
-#ifndef DIR_SEPARATOR
-#ifdef __WIN32__
-#define DIR_SEPARATOR "\\"
-#define DIR_SEPARATOR_CHAR '\\'
-#else //!__WIN32__
-#define DIR_SEPARATOR "/"
-#define DIR_SEPARATOR_CHAR '/'
-#endif
-#endif //DIR_SEPARATOR
-
 enum resource_id
 {
   CONFIG_TXT = 0,

--- a/src/utils/Makefile.in
+++ b/src/utils/Makefile.in
@@ -21,15 +21,15 @@ zip_objs  := ${io_obj}/vfile.o ${io_obj}/zip.o ${io_obj}/zip_stream.o
 checkres := ${utils_src}/checkres${BINEXT}
 checkres_objs := ${utils_obj}/checkres.o \
                  ${io_obj}/dir.o ${io_obj}/fsafeopen.o \
-                 ${core_obj}/util.o ${zip_objs}
+                 ${io_obj}/path.o ${zip_objs}
 checkres_ldflags := ${ZLIB_LDFLAGS}
 
 downver := ${utils_src}/downver${BINEXT}
-downver_objs := ${utils_obj}/downver.o ${core_obj}/util.o ${zip_objs}
+downver_objs := ${utils_obj}/downver.o ${zip_objs}
 downver_ldflags := ${ZLIB_LDFLAGS}
 
 hlp2html := ${utils_src}/hlp2html${BINEXT}
-hlp2html_objs := ${utils_obj}/hlp2html.o ${core_obj}/util.o
+hlp2html_objs := ${utils_obj}/hlp2html.o
 
 hlp2txt := ${utils_src}/hlp2txt${BINEXT}
 hlp2txt_objs := ${utils_obj}/hlp2txt.o
@@ -40,6 +40,7 @@ txt2hlp_objs := ${utils_obj}/txt2hlp.o
 png2smzx := ${utils_src}/png2smzx${BINEXT}
 png2smzx_objs := ${utils_obj}/png2smzx.o ${utils_obj}/smzxconv.o
 png2smzx_objs += ${core_obj}/util.o ${core_obj}/pngops.o
+png2smzx_objs += ${io_obj}/path.o ${io_obj}/vfile.o
 png2smzx_ldflags := ${LIBPNG_LDFLAGS} ${ZLIB_LDFLAGS}
 
 ccv := ${utils_src}/ccv${BINEXT}

--- a/src/utils/checkres.c
+++ b/src/utils/checkres.c
@@ -103,6 +103,8 @@
 #include "../util.h"
 #include "../world.h"
 
+#include "utils_alloc.h"
+
 #ifdef CONFIG_PLEDGE_UTILS
 #include <unistd.h>
 #define PROMISES "stdio rpath"
@@ -179,17 +181,6 @@ enum status
 #define warnhere(...) \
  do{ fprintf(stderr, "At " __FILE__ ":%d: ", __LINE__); \
   fprintf(stderr, "" __VA_ARGS__); fflush(stderr); }while(0)
-
-// MegaZeux's obtuse architecture requires this for the time being.
-// This function is used in out_of_memory_check (util.c), and check alloc
-// is required by zip.c (as it should be). util.c is also required by the
-// directory reading functions in fsafeopen.c on non-Win32 platforms.
-
-int error(const char *message, unsigned int a, unsigned int b, unsigned int c)
-{
-  fprintf(stderr, "%s\n", message);
-  exit(-1);
-}
 
 static const char *decode_status(enum status status)
 {

--- a/src/utils/downver.c
+++ b/src/utils/downver.c
@@ -44,7 +44,9 @@
 #include <strings.h>
 #endif
 
+#define CORE_LIBSPEC
 #include "../compat.h"
+#include "utils_alloc.h"
 
 #ifdef CONFIG_PLEDGE_UTILS
 #include <unistd.h>
@@ -75,16 +77,6 @@ enum status
   WRITE_ERROR,
   SEEK_ERROR,
 };
-
-// MegaZeux's obtuse architecture requires this for the time being.
-// This function is used in out_of_memory_check (util.c), and check alloc
-// is required by zip.c (as it should be).
-
-int error(const char *message, unsigned int a, unsigned int b, unsigned int c)
-{
-  fprintf(stderr, "%s\n", message);
-  exit(-1);
-}
 
 #define error(...) \
   { \

--- a/src/utils/hlp2html.c
+++ b/src/utils/hlp2html.c
@@ -30,6 +30,8 @@
 #include "../util.h"
 #include "../io/memfile.h"
 
+#include "utils_alloc.h"
+
 #ifdef CONFIG_PLEDGE_UTILS
 #include <unistd.h>
 #define PROMISES "stdio rpath wpath cpath"
@@ -54,12 +56,6 @@ static const char * const style_extras_file = RESOURCES "style_color.css";
 #define MAX_LINE 256
 #define MAX_FILE_NAME 16
 #define MAX_ANCHOR_NAME 32
-
-int error(const char *message, unsigned int a, unsigned int b, unsigned int c)
-{
-  fprintf(stderr, "%s\n", message);
-  exit(-1);
-}
 
 struct html_buffer
 {

--- a/src/utils/utils_alloc.h
+++ b/src/utils/utils_alloc.h
@@ -1,0 +1,72 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2007 Alistair John Strachan <alistair@devzero.co.uk>
+ * Copyright (C) 2020 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * Standalone copy of the check_alloc functions so the utils can link fewer
+ * core objects from MZX.
+ */
+
+#ifndef __UTILS_ALLOC_H
+#define __UTILS_ALLOC_H
+
+#include "../compat.h"
+
+__M_BEGIN_DECLS
+
+#ifdef CONFIG_CHECK_ALLOC
+
+#include <stdlib.h>
+
+static void out_of_memory_check(void *p, const char *file, int line)
+{
+  if(!p)
+  {
+    fprintf(stderr, "Out of memory in %s:%d\n", file, line);
+    fflush(stderr);
+    exit(-1);
+  }
+}
+
+void *check_calloc(size_t nmemb, size_t size, const char *file, int line)
+{
+  void *result = calloc(nmemb, size);
+  out_of_memory_check(result, file, line);
+  return result;
+}
+
+void *check_malloc(size_t size, const char *file, int line)
+{
+  void *result = malloc(size);
+  out_of_memory_check(result, file, line);
+  return result;
+}
+
+void *check_realloc(void *ptr, size_t size, const char *file, int line)
+{
+  void *result = realloc(ptr, size);
+  out_of_memory_check(result, file, line);
+  return result;
+}
+
+#endif
+
+__M_END_DECLS
+
+#endif /* __UTILS_ALLOC_H */

--- a/src/window.c
+++ b/src/window.c
@@ -3828,7 +3828,7 @@ skip_dir:
        strstr(current_dir_name, "..") ||
 
       // or if there's an unallowed subdirectory
-       (!dirs_okay && strstr(current_dir_name + base_dir_len, DIR_SEPARATOR)))
+       (!dirs_okay && path_has_directory(current_dir_name + base_dir_len)))
       {
         memcpy(current_dir_name, base_dir_name, base_dir_len + 1);
         return_value = 1;
@@ -3836,15 +3836,14 @@ skip_dir:
       }
       else
 
-      if(!strcmp(base_dir_name, return_dir_name) &&
-       !strncmp(base_dir_name, ret, base_dir_len))
+      // If the base dir and return dir are the same and the selected path is
+      // prefixed with the base dir, make it a relative path. This is necessary
+      // for files selected for use in a game from the editor.
+      // TODO should maybe do this regardless of the return path. The only
+      // thing that would be affected is probably GLSL shader selection.
+      if(!strcmp(base_dir_name, return_dir_name))
       {
-        // The base dir might not have a trailing slash, so skip any of those
-        // found in the selected file before copying the result.
-        while(isslash(ret[base_dir_len]))
-          base_dir_len++;
-
-        memmove(ret, ret + base_dir_len, strlen(ret + base_dir_len) + 1);
+        path_remove_prefix(ret, MAX_PATH, base_dir_name, base_dir_len);
       }
     }
 

--- a/src/window.c
+++ b/src/window.c
@@ -3325,13 +3325,10 @@ __editor_maybe_static int file_manager(struct world *mzx_world,
   snprintf(current_dir_name, MAX_PATH, "%s", return_dir_name);
   current_dir_name[MAX_PATH - 1] = '\0';
 
-  // Split the input path (it may be a directory)
-  path_get_directory_and_filename(ret_path, MAX_PATH, ret_file, MAX_PATH, ret);
-
-  // If there was a directory component to the input, the base directory is
-  // not the same as the return directory.
+  // Check the input path for a directory. If there is a directory component
+  // to the input, that should be used as the base directory.
   // TODO: this is a bad way to do this. The base dir should be a param instead.
-  if(ret_path[0])
+  if(path_get_directory(ret_path, MAX_PATH, ret) > 0)
     path_navigate(current_dir_name, MAX_PATH, ret_path);
 
   snprintf(base_dir_name, MAX_PATH, "%s", current_dir_name);
@@ -3520,8 +3517,7 @@ skip_dir:
     }
 
     // Make ret relative for the display.
-    path_get_directory_and_filename(ret_path, MAX_PATH, ret_file, MAX_PATH, ret);
-    strcpy(ret, ret_file);
+    path_to_filename(ret, MAX_PATH);
     ret[55] = '\0'; // Just in case
 
     elements[FILESEL_FILE_LIST] =

--- a/src/world.c
+++ b/src/world.c
@@ -50,8 +50,9 @@
 #include "str.h"
 #include "util.h"
 #include "window.h"
-#include "io/memfile.h"
 #include "io/fsafeopen.h"
+#include "io/memfile.h"
+#include "io/path.h"
 #include "io/zip.h"
 
 #include "audio/audio.h"
@@ -2631,10 +2632,8 @@ static void load_world(struct world *mzx_world, struct zip_archive *zp,
   char file_path[MAX_PATH];
   struct stat file_info;
 
-  get_path(file, file_path, MAX_PATH);
-
   // chdir to game directory
-  if(file_path[0])
+  if(path_get_directory(file_path, MAX_PATH, file) > 0)
   {
     getcwd(current_dir, MAX_PATH);
 
@@ -3190,11 +3189,10 @@ boolean reload_world(struct world *mzx_world, const char *file, boolean *faded)
   // Now that the world's loaded, fix the save path.
   {
     char save_name[MAX_PATH];
-    char current_dir[MAX_PATH];
-    getcwd(current_dir, MAX_PATH);
+    path_get_filename(save_name, MAX_PATH, curr_sav);
 
-    split_path_filename(curr_sav, NULL, 0, save_name, MAX_PATH);
-    join_path_names(curr_sav, MAX_PATH, current_dir, save_name);
+    getcwd(curr_sav, MAX_PATH);
+    path_append(curr_sav, MAX_PATH, save_name);
   }
 
   return true;
@@ -3232,7 +3230,6 @@ boolean reload_savegame(struct world *mzx_world, const char *file,
 boolean reload_swap(struct world *mzx_world, const char *file, boolean *faded)
 {
   char name[BOARD_NAME_SIZE];
-  char full_path[MAX_PATH];
   char file_name[MAX_PATH];
   int version;
 
@@ -3255,9 +3252,9 @@ boolean reload_swap(struct world *mzx_world, const char *file, boolean *faded)
   change_board_load_assets(mzx_world);
 
   // Give curr_file a full path
-  getcwd(full_path, MAX_PATH);
-  split_path_filename(file, NULL, 0, file_name, MAX_PATH);
-  join_path_names(curr_file, MAX_PATH, full_path, file_name);
+  path_get_filename(file_name, MAX_PATH, file);
+  getcwd(curr_file, MAX_PATH);
+  path_append(curr_file, MAX_PATH, file_name);
 
   return true;
 }


### PR DESCRIPTION
This branch moves a set of functions for manipulating paths out of util.c to `src/io/path.{c,h}` and refactors them to be safer and more consistent. A utils-specific check_alloc header has also been added so fewer utils need to link util.o now (avoiding a dependency chain caused by various util.c functions requiring the path functions).

- [x] Move path functions out of util.c and refactor them.
- [x] Add check_alloc header for utils.
- [x] Unit tests (will be merged to #223).
- [x] Unit tests need to be able to cover the special case of the splitting functions where any input path that successfully stats as a directory is treated as having no filename component.
- [x] asan.
- [x] ubsan.
- [x] Testing on non-Windows.
- [x] Testing specifically with Debian PowerPC virtual machine.
- [x] Testing specifically with the 3DS.