### PR TITLE
Remove util.h mem_* functions

### DIFF
--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -2228,10 +2228,26 @@ static boolean editor_key(context *ctx, int *key)
             if(!new_file(mzx_world, mzm_ext, ".mzm", export_name,
              "Export MZM", 1))
             {
+              enum mzm_save_mode save_mode;
+
+              switch(editor->mode)
+              {
+                default:
+                case EDIT_BOARD:
+                  save_mode = MZM_BOARD_TO_BOARD_STORAGE;
+                  break;
+
+                case EDIT_OVERLAY:
+                  save_mode = MZM_OVERLAY_TO_LAYER_STORAGE;
+                  break;
+
+                case EDIT_VLAYER:
+                  save_mode = MZM_VLAYER_TO_LAYER_STORAGE;
+                  break;
+              }
               strcpy(editor->mzm_name_buffer, export_name);
               save_mzm(mzx_world, editor->mzm_name_buffer, block->src_x,
-               block->src_y, block->width, block->height, editor->mode,
-               false);
+               block->src_y, block->width, block->height, save_mode, false);
             }
             block->selected = false;
             editor->cursor_mode = CURSOR_PLACE;

--- a/src/legacy_robot.h
+++ b/src/legacy_robot.h
@@ -27,12 +27,13 @@ __M_BEGIN_DECLS
 
 #include "const.h"
 #include "world_struct.h"
+#include "io/memfile.h"
 
 struct robot *legacy_load_robot_allocate(struct world *mzx_world, FILE *fp,
  int savegame, int file_version, boolean *truncated);
 
 void legacy_load_robot_from_memory(struct world *mzx_world,
- struct robot *cur_robot, const void *buffer, int savegame, int version,
+ struct robot *cur_robot, struct memfile *mf, int savegame, int version,
  int robot_location);
 
 size_t legacy_calculate_partial_robot_size(int savegame, int version);

--- a/src/mzm.h
+++ b/src/mzm.h
@@ -26,6 +26,21 @@ __M_BEGIN_DECLS
 
 #include "world_struct.h"
 
+enum mzm_save_mode
+{
+  MZM_BOARD_TO_BOARD_STORAGE    = 0,
+  MZM_OVERLAY_TO_LAYER_STORAGE  = 1,
+  MZM_VLAYER_TO_LAYER_STORAGE   = 2,
+  MZM_BOARD_TO_LAYER_STORAGE    = 3,
+};
+
+enum mzm_load_mode
+{
+  MZM_LOAD_TO_BOARD   = 0,
+  MZM_LOAD_TO_OVERLAY = 1,
+  MZM_LOAD_TO_VLAYER  = 2,
+};
+
 CORE_LIBSPEC void save_mzm(struct world *mzx_world, char *name,
  int start_x, int start_y, int width, int height, int mode, int savegame);
 CORE_LIBSPEC void save_mzm_string(struct world *mzx_world, const char *name,

--- a/src/old/legacy_save.h
+++ b/src/old/legacy_save.h
@@ -27,11 +27,12 @@ __M_BEGIN_DECLS
 
 #include "const.h"
 #include "world_struct.h"
+#include "io/memfile.h"
 
 size_t legacy_save_robot_calculate_size(struct world *mzx_world,
  struct robot *cur_robot, int savegame, int version);
 
-void legacy_save_robot_to_memory(struct robot *cur_robot, void *buffer,
+void legacy_save_robot_to_memory(struct robot *cur_robot, struct memfile *mf,
  int savegame, int version);
 
 void legacy_save_robot(struct world *mzx_world, struct robot *cur_robot,

--- a/src/run_robot.c
+++ b/src/run_robot.c
@@ -651,8 +651,23 @@ static void copy_block(struct world *mzx_world, int id, int x, int y,
       char *translated_name = cmalloc(MAX_PATH);
       int err;
 
-      if(dest_param && !src_type)
-        src_type = 3;
+      switch(src_type)
+      {
+        case 0:
+          if(dest_param)
+            src_type = MZM_BOARD_TO_LAYER_STORAGE;
+          else
+            src_type = MZM_BOARD_TO_BOARD_STORAGE;
+          break;
+
+        case 1:
+          src_type = MZM_OVERLAY_TO_LAYER_STORAGE;
+          break;
+
+        case 2:
+          src_type = MZM_VLAYER_TO_LAYER_STORAGE;
+          break;
+      }
 
       // Save MZM to string (2.90+)
       if(mzx_world->version >= V290 && is_string(dest_name_buffer))

--- a/src/util.c
+++ b/src/util.c
@@ -470,51 +470,6 @@ int create_path_if_not_exists(const char *filename)
   return 0;
 }
 
-
-int mem_getc(const unsigned char **ptr)
-{
-  int val = (*ptr)[0];
-  *ptr += 1;
-  return val;
-}
-
-int mem_getw(const unsigned char **ptr)
-{
-  int val = (*ptr)[0] | ((*ptr)[1] << 8);
-  *ptr += 2;
-  return val;
-}
-
-int mem_getd(const unsigned char **ptr)
-{
-  int val = (*ptr)[0] | ((*ptr)[1] << 8) | ((*ptr)[2] << 16) | ((int)((*ptr)[3]) << 24);
-  *ptr += 4;
-  return val;
-}
-
-void mem_putc(int src, unsigned char **ptr)
-{
-  (*ptr)[0] = src;
-  *ptr += 1;
-}
-
-void mem_putw(int src, unsigned char **ptr)
-{
-  (*ptr)[0] = src & 0xFF;
-  (*ptr)[1] = (src >> 8) & 0xFF;
-  *ptr += 2;
-}
-
-void mem_putd(int src, unsigned char **ptr)
-{
-  (*ptr)[0] = src & 0xFF;
-  (*ptr)[1] = (src >> 8) & 0xFF;
-  (*ptr)[2] = (src >> 16) & 0xFF;
-  (*ptr)[3] = (src >> 24) & 0xFF;
-  *ptr += 4;
-}
-
-
 #if defined(__WIN32__) && defined(__STRICT_ANSI__)
 
 /* On WIN32 with C99 defining __STRICT_ANSI__ these POSIX.1-2001 functions

--- a/src/util.h
+++ b/src/util.h
@@ -112,14 +112,6 @@ struct dso_syms_map
 
 #include <sys/types.h>
 
-// Code to load/save multi-byte ints to/from little endian memory
-int mem_getc(const unsigned char **ptr);
-int mem_getd(const unsigned char **ptr);
-int mem_getw(const unsigned char **ptr);
-void mem_putc(int src, unsigned char **ptr);
-void mem_putd(int src, unsigned char **ptr);
-void mem_putw(int src, unsigned char **ptr);
-
 #if defined(__WIN32__) && defined(__STRICT_ANSI__)
 CORE_LIBSPEC int strcasecmp(const char *s1, const char *s2);
 CORE_LIBSPEC int strncasecmp(const char *s1, const char *s2, size_t n);


### PR DESCRIPTION
This branch removes some memory reading functions from util.c that were added before memfile.h and replaces them with the equivalents from memfile.h.