### PR TITLE
Pulled in upstream libxmp MOD validation behavior

### DIFF
--- a/contrib/libxmp/src/loaders/mod_load.c
+++ b/contrib/libxmp/src/loaders/mod_load.c
@@ -101,6 +101,7 @@ static int validate_pattern(uint8 *buf)
 		for (j = 0; j < 4; j++) {
 			uint8 *d = buf + (i * 4 + j) * 4;
 			if ((d[0] >> 4) > 1) {
+				printf("invalid pattern data: row %d ch %d: %02x\n", i, j, d[0]);
 				return -1;
 			}
 		}
@@ -116,6 +117,7 @@ static int mod_test(HIO_HANDLE * f, char *t, const int start)
 	uint8 pat_buf[1024];
 	int smp_size, num_pat;
 	long size;
+	int count;
 
 	hio_seek(f, start + 1080, SEEK_SET);
 	if (hio_read(buf, 1, 4, f) < 4) {
@@ -206,11 +208,16 @@ static int mod_test(HIO_HANDLE * f, char *t, const int start)
 		return -1;
 
 	/* validate pattern data in an attempt to catch UNICs with MOD size */
-	for (i = 0; i < num_pat; i++) {
+	for (count = i = 0; i < num_pat; i++) {
 		hio_seek(f, start + 1084 + 1024 * i, SEEK_SET);
 		hio_read(pat_buf, 1024, 1, f);
-		if (validate_pattern(pat_buf) < 0)
-			return -1;
+		if (validate_pattern(pat_buf) < 0) {
+			/* Allow a few errors, "lexstacy" has 0x52 */
+			count++;
+		}
+	}
+	if (count > 2) {
+		return -1;
 	}
 
 found:

--- a/contrib/patches/libxmp/17-libxmp-4.4.1-reduce-mod-pattern-restrictions.patch
+++ b/contrib/patches/libxmp/17-libxmp-4.4.1-reduce-mod-pattern-restrictions.patch
@@ -1,0 +1,40 @@
+diff --git a/contrib/libxmp/src/loaders/mod_load.c b/contrib/libxmp/src/loaders/mod_load.c
+index 378eecd6..6cd7dcc9 100644
+--- a/contrib/libxmp/src/loaders/mod_load.c
++++ b/contrib/libxmp/src/loaders/mod_load.c
+@@ -101,6 +101,7 @@ static int validate_pattern(uint8 *buf)
+ 		for (j = 0; j < 4; j++) {
+ 			uint8 *d = buf + (i * 4 + j) * 4;
+ 			if ((d[0] >> 4) > 1) {
++				printf("invalid pattern data: row %d ch %d: %02x\n", i, j, d[0]);
+ 				return -1;
+ 			}
+ 		}
+@@ -116,6 +117,7 @@ static int mod_test(HIO_HANDLE * f, char *t, const int start)
+ 	uint8 pat_buf[1024];
+ 	int smp_size, num_pat;
+ 	long size;
++	int count;
+ 
+ 	hio_seek(f, start + 1080, SEEK_SET);
+ 	if (hio_read(buf, 1, 4, f) < 4) {
+@@ -206,11 +208,16 @@ static int mod_test(HIO_HANDLE * f, char *t, const int start)
+ 		return -1;
+ 
+ 	/* validate pattern data in an attempt to catch UNICs with MOD size */
+-	for (i = 0; i < num_pat; i++) {
++	for (count = i = 0; i < num_pat; i++) {
+ 		hio_seek(f, start + 1084 + 1024 * i, SEEK_SET);
+ 		hio_read(pat_buf, 1024, 1, f);
+-		if (validate_pattern(pat_buf) < 0)
+-			return -1;
++		if (validate_pattern(pat_buf) < 0) {
++			/* Allow a few errors, "lexstacy" has 0x52 */
++			count++;
++		}
++	}
++	if (count > 2) {
++		return -1;
+ 	}
+ 
+ found:

--- a/contrib/patches/libxmp/README
+++ b/contrib/patches/libxmp/README
@@ -90,6 +90,9 @@ Patch summary
     https://github.com/cmatsuoka/libxmp/pull/163
 16: Fixes GDM fine effects continue. Pending merge upstream:
     https://github.com/cmatsuoka/libxmp/pull/165
+17: Allows MODs to have a couple of errors in their patterns. This allows some
+    buggy MOD files to load. Backported from upstream:
+    cmatsuoka/libxmp@fa8ede35b76f23ea0d93f8ab22b2162469d49bc0
 
 20: Disables USE_VERSIONED_SYMBOLS. Required to get our hacked libxmp to link
     on unix platforms. This should probably be merged into patch 01.


### PR DESCRIPTION
* Makes pattern validation slightly more lenient to allow some MODs (like drwho.mod) to play.
* Source: cmatsuoka/libxmp@fa8ede35b76f23ea0d93f8ab22b2162469d49bc0