### PR TITLE
Fix warnings for GCC 10

### DIFF
--- a/src/editor/block.c
+++ b/src/editor/block.c
@@ -119,7 +119,7 @@ static void flip_layer_block(
  char *dest_char, char *dest_color, int dest_width, int dest_offset,
  int block_width, int block_height)
 {
-  char *buffer = malloc(sizeof(char) * block_width);
+  char *buffer = cmalloc(sizeof(char) * block_width);
 
   int start_offset = dest_offset;
   int end_offset = dest_offset + dest_width * (block_height - 1);
@@ -150,7 +150,7 @@ static void flip_layer_block(
 static void flip_board_block(struct board *dest_board, int dest_offset,
  int block_width, int block_height)
 {
-  char *buffer = malloc(sizeof(char) * block_width);
+  char *buffer = cmalloc(sizeof(char) * block_width);
 
   char *level_id = dest_board->level_id;
   char *level_color = dest_board->level_color;

--- a/src/error.c
+++ b/src/error.c
@@ -51,7 +51,6 @@ int error(const char *string, enum error_type type, unsigned int options,
   const char *type_name;
   int t1 = 9, ret = 0;
   int joystick_key;
-  char temp[5];
   int x;
 
   // Find the name of this error type.
@@ -149,9 +148,9 @@ int error(const char *string, enum error_type type, unsigned int options,
 
   if(code != 0)
   {
-    write_string(" Debug code:0000h ", 30, 14, 64, 0);
-    sprintf(temp, "%x", code);
-    write_string(temp, 46 - (Uint32)strlen(temp), 14, 64, 0);
+    char temp[32];
+    snprintf(temp, 32, " Debug code:%4.4xh ", code);
+    write_string(temp, 30, 14, 64, 0);
   }
 
   update_screen();

--- a/src/utils/ccv.c
+++ b/src/utils/ccv.c
@@ -288,7 +288,7 @@ Config *LoadConfig(int argc, char **argv)
         continue;
       }
       if (Option("-output", 1, argv[i], args_left)) {
-        strncpy(cfg->output, argv[i+1], MAX_PATH-4+1);
+        snprintf(cfg->output, MAX_PATH - 4, "%s", argv[i+1]);
         cfg->output[MAX_PATH-4] = '\0';
         arg_used[i+1] = 1;
         continue;
@@ -299,7 +299,7 @@ Config *LoadConfig(int argc, char **argv)
         continue;
       }
       if (Option("-dither", 1, argv[i], args_left)) {
-        strncpy(cfg->dither, argv[i+1], 256);
+        snprintf(cfg->dither, sizeof(cfg->dither), "%s", argv[i+1]);
         cfg->output[255] = '\0';
         arg_used[i+1] = 1;
         continue;
@@ -357,7 +357,7 @@ Config *LoadConfig(int argc, char **argv)
       }
     } else { // Filename
       InputFile *file = malloc(sizeof(InputFile));
-      strncpy(file->path, argv[i], MAX_PATH);
+      snprintf(file->path, MAX_PATH + 1, "%s", argv[i]);
       file->path[MAX_PATH] = 0;
       HASH_ADD_STR(cfg->files, path, file);
     }

--- a/src/utils/checkres.c
+++ b/src/utils/checkres.c
@@ -1201,7 +1201,7 @@ static struct base_path *add_base_path(const char *path_name,
       alloc = 4;
     }
 
-    *path_list = realloc(*path_list, 2 * alloc * sizeof(struct base_path *));
+    *path_list = crealloc(*path_list, 2 * alloc * sizeof(struct base_path *));
     *path_list_alloc *= 2;
   }
 
@@ -1228,7 +1228,7 @@ static struct base_file *add_base_file(const char *path_name,
       alloc = 4;
     }
 
-    *file_list = realloc(*file_list, 2 * alloc * sizeof(struct base_file *));
+    *file_list = crealloc(*file_list, 2 * alloc * sizeof(struct base_file *));
     *file_list_alloc *= 2;
   }
 

--- a/src/utils/hlp2html.c
+++ b/src/utils/hlp2html.c
@@ -146,7 +146,7 @@ static char *expand_buffer(struct html_buffer *buffer, int required_length)
   while(buffer->alloc < required_length)
     buffer->alloc *= 2;
 
-  buffer->data = realloc(buffer->data, buffer->alloc);
+  buffer->data = crealloc(buffer->data, buffer->alloc);
   return buffer->data;
 }
 
@@ -181,7 +181,7 @@ static void append_file(struct help_file *current, const char *filename)
 static struct help_file *new_help_file(const char *title)
 {
   struct help_file *check;
-  struct help_file *current = calloc(1, sizeof(struct help_file));
+  struct help_file *current = ccalloc(1, sizeof(struct help_file));
   snprintf(current->name, MAX_FILE_NAME, "%s", title);
   current->name_length = strlen(current->name);
 
@@ -222,7 +222,7 @@ static void free_help_files(void)
 static void new_anchor(struct help_file *parent, const char *name)
 {
   struct help_anchor *check;
-  struct help_anchor *anchor = calloc(1, sizeof(struct help_anchor));
+  struct help_anchor *anchor = ccalloc(1, sizeof(struct help_anchor));
   snprintf(anchor->name, MAX_ANCHOR_NAME, "%s", name);
   anchor->name_length = strlen(anchor->name);
   anchor->parent = parent;
@@ -259,7 +259,7 @@ static void free_anchors(void)
 static void new_link(struct help_file *parent, const char *name,
  const char *target_file, const char *target_anchor)
 {
-  struct help_link *link = calloc(1, sizeof(struct help_link));
+  struct help_link *link = ccalloc(1, sizeof(struct help_link));
   snprintf(link->name, MAX_ANCHOR_NAME, "%s", name);
   link->name_length = strlen(link->name);
   link->parent = parent;


### PR DESCRIPTION
This fixes some issues found by new warnings in GCC 10 as well as (an unfortunately small number of) any legitimate issues found by `-fanalyzer`. All of the legitimate issues found by `-fanalyzer` in its current state were MZX using `malloc` or `calloc` instead of the check_alloc functions.