### PR TITLE
HTML5 port fixes for Emscripten >=1.39.5 and SDL 2.0.10

### DIFF
--- a/arch/emscripten/Makefile.in
+++ b/arch/emscripten/Makefile.in
@@ -28,7 +28,7 @@ ifeq (${BUILD_RENDER_GL_PROGRAM},1)
 	ARCH_LDFLAGS += -s FULL_ES2=1
 endif
 
-ARCH_LDFLAGS += -s ASYNCIFY=1 -s ASYNCIFY_STACK_SIZE=32768
+ARCH_LDFLAGS += -s ASYNCIFY=1 -s ASYNCIFY_STACK_SIZE=1048576
 # TODO: Removing the whitelist should allow the editor to work.
 ARCH_LDFLAGS += -s ASYNCIFY_WHITELIST=@arch/emscripten/whitelist.json
 ARCH_LDFLAGS += -s 'ASYNCIFY_IMPORTS=["emscripten_sleep"]'

--- a/arch/emscripten/web/res/index.html
+++ b/arch/emscripten/web/res/index.html
@@ -8,18 +8,19 @@
  * https://www.digitalmzx.com/forums/index.php?app=tracker&showissue=788
  */
 * { border: 0; margin: 0; padding: 0; }
-#mzx_canvas {
+#canvas {
 	width: 100%; height: 100%; display: block; position: absolute; top: 0; left: 0; overflow: hidden;
 	background: url('play.png') center center / contain no-repeat #000;
 }
 </style>
 </head>
 <body>
-<canvas id="mzx_canvas" width="640" height="350" oncontextmenu="event.preventDefault()" tabindex="0"></canvas>
+<canvas id="canvas" width="640" height="350" oncontextmenu="event.preventDefault()" tabindex="0"></canvas>
 <script type="text/javascript" src="./mzxrun_loader.js"></script>
 <script type="text/javascript">
 (function() {
-	var mzxCanvas = document.getElementById("mzx_canvas");
+	// NOTE: the canvas ID being "canvas" is a hardcoded requirement somewhere in Emscripten and/or SDL.
+	var mzxCanvas = document.getElementById("canvas");
 	var mzxLoadAttempted = false;
 
 	// The initialization process should be triggered by a click - audio enabling!

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -372,6 +372,11 @@ boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
   SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
   SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 0);
   SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 0);
+
+#if SDL_VERSION_ATLEAST(2,0,10)
+  // Also, a hint needs to be set to make gl_swap_buffers not crash. Brilliant.
+  SDL_SetHint(SDL_HINT_EMSCRIPTEN_ASYNCIFY, "0");
+#endif
 #endif
 
   render_data->window = SDL_CreateWindow("MegaZeux",


### PR DESCRIPTION
This branch fixes problems caused by Emscripten >=1.39.5 and Emscripten's SDL 2.0.10 fork that weren't actually fixed in 2.92d.

- [x] Fixes required due to the removal of `Module.canvas` in Emscripten 1.39.5. This wasn't caused by the callback accidentally referencing this variable but actually by Emscripten and/or SDL having hardcoded references to the canvas ID `canvas` added during the removal of `Module.canvas`. The actual fix was to just change the canvas ID.
- [x] Fixes required due to Emscripten's SDL fork [adding emscripten_sleep() calls](https://github.com/emscripten-ports/SDL2/pull/97) for asyncify builds that effectively would have required extending the asyncify whitelist deep into the GLSL renderer. There is a hint to opt out of this, which MZX now uses.
- [x] MZX builds produced by newer Emscripten releases seem to require a larger asyncify stack, so I've increased it to a value that should be good enough for the foreseeable future.
- [x] More testing :(