### PR TITLE
Added Safari support to the Emscripten build.

### DIFF
--- a/arch/emscripten/web/res/mzxrun_loader.js
+++ b/arch/emscripten/web/res/mzxrun_loader.js
@@ -2,6 +2,7 @@
  * MegaZeux
  *
  * Copyright (C) 2018, 2019 Adrian Siekierka
+ * Copyright (C) 2020 Ian Burgmyer <spectere@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +22,81 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+(function() {
+	const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+	const audioUnlockEvents = [ "keydown", "mousedown", "touchstart" ];
+	let swapSdlContext = false;
+
+	window.replaceSdlAudioContext = function(sdl)
+	{
+		if(!swapSdlContext || sdl.audioContext.state !== "suspended")
+			return;
+
+		// Replace the forever-locked context that SDL2 creates in favor
+		// of the unlocked one we created earlier.
+		sdl.audioContext = audioCtx;
+
+		// Fetch some data from the original script processor node and create
+		// a new one.
+		let node = sdl.audio.scriptProcessorNode;
+		let buffer = node.bufferSize;
+		let channels = node.channelCount;
+		let audioProcessFunc = node.onaudioprocess;
+
+		sdl.audio.scriptProcessorNode =
+			sdl.audioContext.createScriptProcessor(buffer, 0, channels);
+
+		// Connect the script processor to the destination and migrate SDL's
+		// onaudioprocess event function over so that it can use the new node.
+		sdl.audio.scriptProcessorNode.onaudioprocess = audioProcessFunc;
+		sdl.audio.scriptProcessorNode.connect(sdl.audioContext.destination);
+	}
+
+	function addAudioEventListeners()
+	{
+		audioUnlockEvents.forEach(
+			ev => window.addEventListener(ev, unlockAudioContext, false)
+		);
+	}
+
+	function removeAudioEventListeners()
+	{
+		audioUnlockEvents.forEach(
+			ev => window.removeEventListener(ev, unlockAudioContext)
+		);
+	}
+
+	function unlockAudioContext()
+	{
+		// Safari requires some special handling to unlock the audio context.
+		// We start unlocking it here so that the audio will be ready when SDL
+		// initializes.
+
+		// Gecko seems to automatically start the audio context very shortly
+		// after it's created, so this helps us detect that behavior.
+		if(audioCtx.state !== "suspended")
+		{
+			removeAudioEventListeners();
+			return;
+		}
+
+		// Create a short buffer, set up the context, and play it.
+		console.log("Unlocking audio context");
+		var buffer = audioCtx.createBuffer(1, 1, 22050);
+		var source = audioCtx.createBufferSource();
+		source.buffer = buffer;
+
+		source.connect(audioCtx.destination);
+		source.start(0);
+
+		// The newly unlocked context is ready to be swapped in.
+		swapSdlContext = true;
+		removeAudioEventListeners();
+	}
+
+	document.addEventListener("DOMContentLoaded", addAudioEventListeners);
+})();
 
 MzxrunLoad = function(options, callback) {
 	if (!options.path) throw "Missing option: path!";


### PR DESCRIPTION
Safari requires audio events to occur immediately after a user interaction event in order to unlock an audio context. This PR creates and unlocks an audio context during initialization and, if necessary, replaces SDL's audio context with the unlocked one.

This works well on Safari (tested on both macOS and iOS), as well as Chrome (Linux). There is a tiny issue on Firefox where the audio unlock routine can be triggered if the user mashes left-click on the canvas while the page is loading (the DOMContentLoaded event listener largely mitigates this, but it isn't foolproof). It must be emphasized that the user has to really, _really_ be trying to break this, and even then it's not a sure thing.

I tried several workarounds for this, but the check for that delayed audio context state change seems to be the most consistent one that works consistently across those three browsers. :shrug:

Let me know what you think.