### PR TITLE
Improve config file validation for most settings, fix config bugs

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -401,6 +401,7 @@
 # Color codes for various types.
 # For colors, use 255 to show a color box.
 
+# ccode_chars = 14
 # ccode_colors = 255
 # ccode_commands = 15
 # ccode_conditions = 15

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -6,10 +6,17 @@ USERS
   MinGW's non-compliant fdopen.
 + Fixed a bug where the title screen's intro message wouldn't
   cycle the scroll color while no world was loaded.
++ Added the missing "ccode_chars" config setting.
++ Fixed a bug where the "ccode_extras" config setting would
+  change the strings color code instead.
++ Fixed division-by-zero crashes and GL errors when using
+  invalid fullscreen_resolution or window_resolution values.
 
 DEVELOPERS
 
 + Fixed memcasecmp test alignment checks for the Motorola 68000.
++ Improved validation of config setting inputs and added a unit
+  test for config file and command line parsing.
 
 
 May 8th, 2020 - MZX 2.92d

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -9,6 +9,9 @@ USERS
 + Added the missing "ccode_chars" config setting.
 + Fixed a bug where the "ccode_extras" config setting would
   change the strings color code instead.
++ Fixed a bug where "macro_#" where # is 0 or between 6-9 would
+  corrupt various parts of the editor configuration. Notably,
+  "macro_6" would corrupt the extended macros and cause crashes.
 + Fixed division-by-zero crashes and GL errors when using
   invalid fullscreen_resolution or window_resolution values.
 

--- a/src/configure.c
+++ b/src/configure.c
@@ -1087,7 +1087,7 @@ __editor_maybe_static void __set_config_from_file(
   if(!conf_file)
     return;
 
-  extended_buffer = (char *)malloc(extended_allocate_size);
+  extended_buffer = (char *)cmalloc(extended_allocate_size);
 
   while(fsafegets(line_buffer_alternate, LINE_BUFFER_SIZE, conf_file))
   {

--- a/src/configure.c
+++ b/src/configure.c
@@ -304,6 +304,7 @@ static const struct config_enum system_mouse_values[] =
   { "1", 1 }
 };
 
+#ifdef CONFIG_UPDATER
 static const struct config_enum update_auto_check_values[] =
 {
   { "0", UPDATE_AUTO_CHECK_OFF },
@@ -312,6 +313,7 @@ static const struct config_enum update_auto_check_values[] =
   { "on", UPDATE_AUTO_CHECK_ON },
   { "silent", UPDATE_AUTO_CHECK_SILENT }
 };
+#endif
 
 static const struct config_enum video_ratio_values[] =
 {

--- a/src/configure.c
+++ b/src/configure.c
@@ -1087,7 +1087,7 @@ __editor_maybe_static void __set_config_from_file(
 
   extended_buffer = (char *)malloc(extended_allocate_size);
 
-  while(fsafegets(line_buffer_alternate, 255, conf_file))
+  while(fsafegets(line_buffer_alternate, LINE_BUFFER_SIZE, conf_file))
   {
     if(line_buffer_alternate[0] != '#')
     {

--- a/src/configure.h
+++ b/src/configure.h
@@ -41,6 +41,12 @@ enum resample_modes
   RESAMPLE_MODE_FIR
 };
 
+enum gl_filter_type
+{
+  CONFIG_GL_FILTER_NEAREST,
+  CONFIG_GL_FILTER_LINEAR
+};
+
 enum allow_cheats_type
 {
   ALLOW_CHEATS_NEVER,
@@ -68,7 +74,7 @@ struct config_info
   char video_output[16];
   int force_bpp;
   enum ratio_type video_ratio;
-  char gl_filter_method[16];
+  enum gl_filter_type gl_filter_method;
   char gl_scaling_shader[32];
   int gl_vsync;
   boolean allow_screenshots;
@@ -85,6 +91,11 @@ struct config_info
   int pc_speaker_volume;
   boolean music_on;
   boolean pc_speaker_on;
+
+  // Event options
+  boolean allow_gamecontroller;
+  boolean pause_on_unfocus;
+  int num_buffered_events;
 
   // Game options
   char startup_path[256];
@@ -123,6 +134,15 @@ struct config_info
 #endif
 };
 
+/**
+ * Used to create arrays containing all allowed values for certain options.
+ */
+struct config_enum
+{
+  const char * const key;
+  const int value;
+};
+
 CORE_LIBSPEC struct config_info *get_config(void);
 CORE_LIBSPEC void default_config(void);
 CORE_LIBSPEC void set_config_from_file(const char *conf_file_name);
@@ -139,6 +159,15 @@ CORE_LIBSPEC void __set_config_from_file(find_change_option find_change_handler,
  void *conf, const char *conf_file_name);
 CORE_LIBSPEC void __set_config_from_command_line(
  find_change_option find_change_handler, void *conf, int *argc, char *argv[]);
+
+CORE_LIBSPEC boolean config_int(int *dest, char *value, int min, int max);
+CORE_LIBSPEC boolean _config_enum(int *dest, const char *value,
+ const struct config_enum *allowed, size_t num);
+CORE_LIBSPEC boolean config_boolean(boolean *dest, const char *value);
+CORE_LIBSPEC boolean _config_string(char *dest, size_t dest_len, const char *value);
+
+#define config_enum(d, v, a) _config_enum(d, v, a, ARRAY_SIZE(a))
+#define config_string(d, v) _config_string(d, ARRAY_SIZE(d), v)
 
 #endif // CONFIG_EDITOR
 

--- a/src/editor/configure.c
+++ b/src/editor/configure.c
@@ -18,15 +18,17 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 #include "configure.h"
+#include "robo_ed.h"
 
 #include "../counter.h"
 #include "../configure.h"
 #include "../const.h"
 #include "../util.h"
 
+#include <ctype.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
 
 static struct editor_config_info editor_conf;
 static struct editor_config_info editor_conf_backup;
@@ -112,149 +114,204 @@ struct editor_config_entry
   editor_config_function change_option;
 };
 
+static const struct config_enum default_invalid_status_values[] =
+{
+#ifndef CONFIG_DEBYTECODE
+  { "ignore", invalid_uncertain },
+  { "delete", invalid_discard },
+  { "comment", invalid_comment }
+#else
+  { "", 0 }
+#endif
+};
+
+static const struct config_enum disassemble_base_values[] =
+{
+  { "10", 10 },
+  { "16", 16 }
+};
+
+static const struct config_enum explosions_leave_values[] =
+{
+  { "space", EXPL_LEAVE_SPACE },
+  { "ash", EXPL_LEAVE_ASH },
+  { "fire", EXPL_LEAVE_FIRE }
+};
+
+static const struct config_enum overlay_enabled_values[] =
+{
+  { "disabled", OVERLAY_OFF },
+  { "enabled", OVERLAY_ON },
+  { "static", OVERLAY_STATIC },
+  { "transparent", OVERLAY_TRANSPARENT },
+};
+
+static const struct config_enum saving_enabled_values[] =
+{
+  { "disabled", CANT_SAVE },
+  { "enabled", CAN_SAVE },
+  { "sensoronly", CAN_SAVE_ON_SENSOR }
+};
+
 // Default colors for color coding:
 // 0 current line - 11
-// 1 immediates - 10
-// 2 characters - 14
-// 3 colors - color box or 2
-// 4 directions - 3
-// 5 things - 11
-// 6 params - 2
-// 7 strings - 14
-// 8 equalities - 0
-// 9 conditions - 15
-// 10 items - 11
-// 11 extras - 7
-// 12 commands and command fragments - 15
+// 1 immediate  - 10
+// 2 immediates - 10 (unused?)
+// 3 characters - 14
+// 4 colors - color box (255) or 2
+// 5 directions - 3
+// 6 things - 11
+// 7 params - 2
+// 8 strings - 14
+// 9 equalities - 0
+// 10 conditions - 15
+// 11 items - 11
+// 12 extras - 7
+// 13 commands and command fragments - 15
+// 14 invalid line (ignore)
+// 15 invalid line (delete)
+// 16 invalid line (comment)
+
+static void config_ccode_chars(struct editor_config_info *conf,
+ char *name, char *value, char *extended_data)
+{
+  int result;
+  if(config_int(&result, value, 0, 15))
+    conf->color_codes[ROBO_ED_CC_CHARACTERS] = result;
+}
 
 static void config_ccode_colors(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->color_codes[4] = (char)strtol(value, NULL, 10);
+  int result;
+  if(config_int(&result, value, 0, 15))
+  {
+    conf->color_codes[ROBO_ED_CC_COLORS] = result;
+  }
+  else
+
+  // Special case- 255 instructs the robot editor to use a color box.
+  if(!strcmp(value, "255"))
+    conf->color_codes[ROBO_ED_CC_COLORS] = 255;
 }
 
 static void config_ccode_commands(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->color_codes[13] = (char)strtol(value, NULL, 10);
+  int result;
+  if(config_int(&result, value, 0, 15))
+    conf->color_codes[ROBO_ED_CC_COMMANDS] = result;
 }
 
 static void config_ccode_conditions(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->color_codes[10] = (char)strtol(value, NULL, 10);
+  int result;
+  if(config_int(&result, value, 0, 15))
+    conf->color_codes[ROBO_ED_CC_CONDITIONS] = result;
 }
 
 static void config_ccode_current_line(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->color_codes[0] = (char)strtol(value, NULL, 10);
+  int result;
+  if(config_int(&result, value, 0, 15))
+    conf->color_codes[ROBO_ED_CC_CURRENT_LINE] = result;
 }
 
 static void config_ccode_directions(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->color_codes[5] = (char)strtol(value, NULL, 10);
+  int result;
+  if(config_int(&result, value, 0, 15))
+    conf->color_codes[ROBO_ED_CC_DIRECTIONS] = result;
 }
 
 static void config_ccode_equalities(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->color_codes[9] = (char)strtol(value, NULL, 10);
+  int result;
+  if(config_int(&result, value, 0, 15))
+    conf->color_codes[ROBO_ED_CC_EQUALITIES] = result;
 }
 
 static void config_ccode_extras(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->color_codes[8] = (char)strtol(value, NULL, 10);
+  int result;
+  if(config_int(&result, value, 0, 15))
+    conf->color_codes[ROBO_ED_CC_EXTRAS] = result;
 }
 
 static void config_ccode_on(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->color_coding_on = strtol(value, NULL, 10);
+  config_boolean(&conf->color_coding_on, value);
 }
 
 static void config_ccode_immediates(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  int new_color = strtol(value, NULL, 10);
-  conf->color_codes[1] = new_color;
-  conf->color_codes[2] = new_color;
+  int result;
+  if(config_int(&result, value, 0, 15))
+  {
+    conf->color_codes[ROBO_ED_CC_IMMEDIATES] = result;
+    conf->color_codes[ROBO_ED_CC_IMMEDIATES_2] = result;
+  }
 }
 
 static void config_ccode_items(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->color_codes[11] = (char)strtol(value, NULL, 10);
+  int result;
+  if(config_int(&result, value, 0, 15))
+    conf->color_codes[ROBO_ED_CC_ITEMS] = result;
 }
 
 static void config_ccode_params(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->color_codes[7] = (char)strtol(value, NULL, 10);
+  int result;
+  if(config_int(&result, value, 0, 15))
+    conf->color_codes[ROBO_ED_CC_PARAMS] = result;
 }
 
 static void config_ccode_strings(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->color_codes[8] = (char)strtol(value, NULL, 10);
+  int result;
+  if(config_int(&result, value, 0, 15))
+    conf->color_codes[ROBO_ED_CC_STRINGS] = result;
 }
 
 static void config_ccode_things(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->color_codes[6] = (char)strtol(value, NULL, 10);
+  int result;
+  if(config_int(&result, value, 0, 15))
+    conf->color_codes[ROBO_ED_CC_THINGS] = result;
 }
 
-static void config_default_invald(struct editor_config_info *conf,
+static void config_default_invalid(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  if(!strcasecmp(value, "ignore"))
-  {
-    conf->default_invalid_status = 1;
-  }
-  else
-
-  if(!strcasecmp(value, "delete"))
-  {
-    conf->default_invalid_status = 2;
-  }
-  else
-
-  if(!strcasecmp(value, "comment"))
-  {
-    conf->default_invalid_status = 3;
-  }
+  int result;
+  if(config_enum(&result, value, default_invalid_status_values))
+    conf->default_invalid_status = result;
 }
 
 static void config_disassemble_extras(struct editor_config_info *conf,
  char *name, char *value, char *ext_data)
 {
-  // FIXME sloppy validation
-  conf->disassemble_extras = strtoul(value, NULL, 10);
+  config_boolean(&conf->disassemble_extras, value);
 }
 
 static void config_disassemble_base(struct editor_config_info *conf,
  char *name, char *value, char *ext_data)
 {
-  // FIXME slightly sloppy validation
-  unsigned long new_base = strtoul(value, NULL, 10);
-
-  if((new_base == 10) || (new_base == 16))
-    conf->disassemble_base = new_base;
+  int result;
+  if(config_enum(&result, value, disassemble_base_values))
+    conf->disassemble_base = result;
 }
 
 static void config_macro(struct editor_config_info *conf,
@@ -264,9 +321,9 @@ static void config_macro(struct editor_config_info *conf,
 
   if(isdigit((int)macro_name[0]) && !macro_name[1] && !extended_data)
   {
-    int macro_num = macro_name[0] - 0x31;
-    value[63] = 0;
-    strcpy(conf->default_macros[macro_num], value);
+    size_t macro_num = macro_name[0] - '1';
+    if(macro_num < ARRAY_SIZE(conf->default_macros))
+      config_string(conf->default_macros[macro_num], value);
   }
   else
   {
@@ -278,90 +335,85 @@ static void config_macro(struct editor_config_info *conf,
 static void board_editor_hide_help(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->board_editor_hide_help = strtol(value, NULL, 10);
+  config_boolean(&conf->board_editor_hide_help, value);
 }
 
 static void robot_editor_hide_help(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->robot_editor_hide_help = strtol(value, NULL, 10);
+  config_boolean(&conf->robot_editor_hide_help, value);
 }
 
 static void palette_editor_hide_help(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->palette_editor_hide_help = strtol(value, NULL, 10);
+  config_boolean(&conf->palette_editor_hide_help, value);
 }
 
 static void backup_count(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->backup_count = strtol(value, NULL, 10);
+  int result;
+  if(config_int(&result, value, 0, INT_MAX))
+    conf->backup_count = result;
 }
 
 static void backup_interval(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->backup_interval = strtol(value, NULL, 10);
+  int result;
+  if(config_int(&result, value, 0, INT_MAX))
+    conf->backup_interval = result;
 }
 
 static void backup_name(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  snprintf(conf->backup_name, 256, "%s", value);
+  config_string(conf->backup_name, value);
 }
 
 static void backup_ext(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  snprintf(conf->backup_ext, 256, "%s", value);
+  config_string(conf->backup_ext, value);
 }
 
 static void config_editor_space_toggles(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->editor_space_toggles = strtol(value, NULL, 10);
+  config_boolean(&conf->editor_space_toggles, value);
 }
 
 static void config_editor_enter_splits(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->editor_enter_splits = strtol(value, NULL, 10);
+  config_boolean(&conf->editor_enter_splits, value);
 }
 
 static void config_editor_load_board_assets(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->editor_load_board_assets = strtol(value, NULL, 10);
+  config_boolean(&conf->editor_load_board_assets, value);
 }
 
 static void config_editor_tab_focus(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->editor_tab_focuses_view = CLAMP(strtol(value, NULL, 10), 0, 1);
+  config_boolean(&conf->editor_tab_focuses_view, value);
 }
 
 static void config_editor_thing_menu_places(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->editor_thing_menu_places = CLAMP(strtol(value, NULL, 10), 0, 1);
+  config_boolean(&conf->editor_thing_menu_places, value);
 }
 
 static void config_undo_history_size(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  // FIXME sloppy validation
-  conf->undo_history_size = CLAMP(strtol(value, NULL, 10), 0, 1000);
+  int result;
+  if(config_int(&result, value, 0, 1000))
+    conf->undo_history_size = result;
 }
 
 static void config_saved_positions(struct editor_config_info *conf,
@@ -397,197 +449,197 @@ static void config_saved_positions(struct editor_config_info *conf,
 static void config_board_width(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->board_width = CLAMP(strtol(value, NULL, 10), 1, 32767);
-  if(conf->viewport_w > conf->board_width)
-    conf->viewport_w = conf->board_width;
-  if(conf->board_width * conf->board_height > MAX_BOARD_SIZE)
-    conf->board_height = MAX_BOARD_SIZE / conf->board_width;
+  int result;
+  if(config_int(&result, value, 1, 32767))
+  {
+    conf->board_width = result;
+    if(conf->viewport_w > conf->board_width)
+      conf->viewport_w = conf->board_width;
+    if(conf->board_width * conf->board_height > MAX_BOARD_SIZE)
+      conf->board_height = MAX_BOARD_SIZE / conf->board_width;
+  }
 }
 
 static void config_board_height(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->board_height = CLAMP(strtol(value, NULL, 10), 1, 32767);
-  if(conf->viewport_h > conf->board_height)
-    conf->viewport_h = conf->board_height;
-  if(conf->board_width * conf->board_height > MAX_BOARD_SIZE)
-    conf->board_width = MAX_BOARD_SIZE / conf->board_height;
+  int result;
+  if(config_int(&result, value, 1, 32767))
+  {
+    conf->board_height = result;
+    if(conf->viewport_h > conf->board_height)
+      conf->viewport_h = conf->board_height;
+    if(conf->board_width * conf->board_height > MAX_BOARD_SIZE)
+      conf->board_width = MAX_BOARD_SIZE / conf->board_height;
+  }
 }
 
 static void config_board_viewport_w(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->viewport_w = CLAMP(strtol(value, NULL, 10), 1, MIN(conf->board_width, 80));
-  if(conf->viewport_x + conf->viewport_w > 80)
-    conf->viewport_x = 80 - conf->viewport_w;
+  int result;
+  if(config_int(&result, value, 1, 80))
+  {
+    conf->viewport_w = MIN(result, conf->board_width);
+    if(conf->viewport_x + conf->viewport_w > 80)
+      conf->viewport_x = 80 - conf->viewport_w;
+  }
 }
 
 static void config_board_viewport_h(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->viewport_h = CLAMP(strtol(value, NULL, 10), 1, MIN(conf->board_height, 25));
-  if(conf->viewport_y + conf->viewport_h > 25)
-    conf->viewport_y = 25 - conf->viewport_h;
+  int result;
+  if(config_int(&result, value, 1, 25))
+  {
+    conf->viewport_h = MIN(result, conf->board_height);
+    if(conf->viewport_y + conf->viewport_h > 25)
+      conf->viewport_y = 25 - conf->viewport_h;
+  }
 }
 
 static void config_board_viewport_x(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->viewport_x = CLAMP(strtol(value, NULL, 10), 0, 80 - conf->viewport_w);
+  int result;
+  if(config_int(&result, value, 0, 79))
+    conf->viewport_x = MIN(result, 80 - conf->viewport_w);
 }
 
 static void config_board_viewport_y(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->viewport_y = CLAMP(strtol(value, NULL, 10), 0, (25 - conf->viewport_h));
+  int result;
+  if(config_int(&result, value, 0, 24))
+    conf->viewport_y = MIN(result, 25 - conf->viewport_h);
 }
 
 static void config_board_can_shoot(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->can_shoot = CLAMP(strtol(value, NULL, 10), 0, 1);
+  config_boolean(&conf->can_shoot, value);
 }
 
 static void config_board_can_bomb(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->can_bomb = CLAMP(strtol(value, NULL, 10), 0, 1);
+  config_boolean(&conf->can_bomb, value);
 }
 
 static void config_board_fire_spaces(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->fire_burns_spaces = CLAMP(strtol(value, NULL, 10), 0, 1);
+  config_boolean(&conf->fire_burns_spaces, value);
 }
 
 static void config_board_fire_fakes(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->fire_burns_fakes = CLAMP(strtol(value, NULL, 10), 0, 1);
+  config_boolean(&conf->fire_burns_fakes, value);
 }
 
 static void config_board_fire_trees(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->fire_burns_trees = CLAMP(strtol(value, NULL, 10), 0, 1);
+  config_boolean(&conf->fire_burns_trees, value);
 }
 
 static void config_board_fire_brown(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->fire_burns_brown = CLAMP(strtol(value, NULL, 10), 0, 1);
+  config_boolean(&conf->fire_burns_brown, value);
 }
 
 static void config_board_fire_forever(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->fire_burns_forever = CLAMP(strtol(value, NULL, 10), 0, 1);
+  config_boolean(&conf->fire_burns_forever, value);
 }
 
 static void config_board_forest(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->forest_to_floor = CLAMP(strtol(value, NULL, 10), 0, 1);
+  config_boolean(&conf->forest_to_floor, value);
 }
 
 static void config_board_collect_bombs(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->collect_bombs = CLAMP(strtol(value, NULL, 10), 0, 1);
+  config_boolean(&conf->collect_bombs, value);
 }
 
 static void config_board_restart(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->restart_if_hurt = CLAMP(strtol(value, NULL, 10), 0, 1);
+  config_boolean(&conf->restart_if_hurt, value);
 }
 
 static void config_board_reset_on_entry(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->reset_on_entry = CLAMP(strtol(value, NULL, 10), 0, 1);
+  config_boolean(&conf->reset_on_entry, value);
 }
 
 static void config_board_locked_ns(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->player_locked_ns = CLAMP(strtol(value, NULL, 10), 0, 1);
+  config_boolean(&conf->player_locked_ns, value);
 }
 
 static void config_board_locked_ew(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->player_locked_ew = CLAMP(strtol(value, NULL, 10), 0, 1);
+  config_boolean(&conf->player_locked_ew, value);
 }
 
 static void config_board_locked_att(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->player_locked_att = CLAMP(strtol(value, NULL, 10), 0, 1);
+  config_boolean(&conf->player_locked_att, value);
 }
 
 static void config_board_time_limit(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  conf->time_limit = CLAMP(strtol(value, NULL, 10), 0, 32767);
+  int result;
+  if(config_int(&result, value, 0, 32767))
+    conf->time_limit = result;
 }
 
 static void config_board_charset(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  int size = MIN(strlen(value), MAX_PATH - 1);
-  memcpy(conf->charset_path, value, size);
-  conf->charset_path[size] = 0;
+  config_string(conf->charset_path, value);
 }
 
 static void config_board_palette(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  int size = MIN(strlen(value), MAX_PATH - 1);
-  strncpy(conf->palette_path, value, size);
-  conf->palette_path[size] = 0;
+  config_string(conf->palette_path, value);
 }
 
 static void config_board_explosions(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  if(!strcasecmp(value, "space"))
-    conf->explosions_leave = EXPL_LEAVE_SPACE;
-
-  if(!strcasecmp(value, "ash"))
-    conf->explosions_leave = EXPL_LEAVE_ASH;
-
-  if(!strcasecmp(value, "fire"))
-    conf->explosions_leave = EXPL_LEAVE_FIRE;
+  int result;
+  if(config_enum(&result, value, explosions_leave_values))
+    conf->explosions_leave = result;
 }
 
 static void config_board_saving(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  if(!strcasecmp(value, "disabled"))
-    conf->saving_enabled = CANT_SAVE;
-
-  if(!strcasecmp(value, "enabled"))
-    conf->saving_enabled = CAN_SAVE;
-
-  if(!strcasecmp(value, "sensoronly"))
-    conf->saving_enabled = CAN_SAVE_ON_SENSOR;
+  int result;
+  if(config_enum(&result, value, saving_enabled_values))
+    conf->saving_enabled = result;
 }
 
 static void config_board_overlay(struct editor_config_info *conf,
  char *name, char *value, char *extended_data)
 {
-  if(!strcasecmp(value, "disabled"))
-    conf->overlay_enabled = OVERLAY_OFF;
-
-  if(!strcasecmp(value, "enabled"))
-    conf->overlay_enabled = OVERLAY_ON;
-
-  if(!strcasecmp(value, "static"))
-    conf->overlay_enabled = OVERLAY_STATIC;
-
-  if(!strcasecmp(value, "transparent"))
-    conf->overlay_enabled = OVERLAY_TRANSPARENT;
+  int result;
+  if(config_enum(&result, value, overlay_enabled_values))
+    conf->overlay_enabled = result;
 }
 
 /**********************/
@@ -630,6 +682,7 @@ static const struct editor_config_entry editor_config_options[] =
   { "board_default_viewport_y", config_board_viewport_y },
   { "board_default_width", config_board_width },
   { "board_editor_hide_help", board_editor_hide_help },
+  { "ccode_chars", config_ccode_chars },
   { "ccode_colors", config_ccode_colors },
   { "ccode_commands", config_ccode_commands },
   { "ccode_conditions", config_ccode_conditions },
@@ -643,7 +696,7 @@ static const struct editor_config_entry editor_config_options[] =
   { "ccode_strings", config_ccode_strings },
   { "ccode_things", config_ccode_things },
   { "color_coding_on", config_ccode_on },
-  { "default_invalid_status", config_default_invald },
+  { "default_invalid_status", config_default_invalid },
   { "disassemble_base", config_disassemble_base },
   { "disassemble_extras", config_disassemble_extras },
   { "editor_enter_splits", config_editor_enter_splits },

--- a/src/editor/configure.h
+++ b/src/editor/configure.h
@@ -30,6 +30,27 @@ __M_BEGIN_DECLS
 
 #define NUM_SAVED_POSITIONS 10
 
+enum robo_ed_color_codes
+{
+  ROBO_ED_CC_CURRENT_LINE,
+  ROBO_ED_CC_IMMEDIATES,
+  ROBO_ED_CC_IMMEDIATES_2,
+  ROBO_ED_CC_CHARACTERS,
+  ROBO_ED_CC_COLORS,
+  ROBO_ED_CC_DIRECTIONS,
+  ROBO_ED_CC_THINGS,
+  ROBO_ED_CC_PARAMS,
+  ROBO_ED_CC_STRINGS,
+  ROBO_ED_CC_EQUALITIES,
+  ROBO_ED_CC_CONDITIONS,
+  ROBO_ED_CC_ITEMS,
+  ROBO_ED_CC_EXTRAS,
+  ROBO_ED_CC_COMMANDS,
+  ROBO_ED_CC_INVALID_IGNORE,
+  ROBO_ED_CC_INVALID_DELETE,
+  ROBO_ED_CC_INVALID_COMMENT
+};
+
 struct editor_config_info
 {
   // Board editor options
@@ -47,20 +68,20 @@ struct editor_config_info
   int viewport_h;
   int board_width;
   int board_height;
-  int can_shoot;
-  int can_bomb;
-  int fire_burns_spaces;
-  int fire_burns_fakes;
-  int fire_burns_trees;
-  int fire_burns_brown;
-  int fire_burns_forever;
-  int forest_to_floor;
-  int collect_bombs;
-  int restart_if_hurt;
-  int reset_on_entry;
-  int player_locked_ns;
-  int player_locked_ew;
-  int player_locked_att;
+  boolean can_shoot;
+  boolean can_bomb;
+  boolean fire_burns_spaces;
+  boolean fire_burns_fakes;
+  boolean fire_burns_trees;
+  boolean fire_burns_brown;
+  boolean fire_burns_forever;
+  boolean forest_to_floor;
+  boolean collect_bombs;
+  boolean restart_if_hurt;
+  boolean reset_on_entry;
+  boolean player_locked_ns;
+  boolean player_locked_ew;
+  boolean player_locked_att;
   int time_limit;
   int explosions_leave;
   int saving_enabled;
@@ -109,7 +130,7 @@ EDITOR_LIBSPEC void set_editor_config_from_command_line(int *argc,
 EDITOR_LIBSPEC void store_editor_config_backup(void);
 EDITOR_LIBSPEC void free_editor_config(void);
 
-struct editor_config_info *get_editor_config(void);
+EDITOR_LIBSPEC struct editor_config_info *get_editor_config(void);
 void load_editor_config_backup(void);
 
 void save_local_editor_config(struct editor_config_info *conf,

--- a/src/editor/configure.h
+++ b/src/editor/configure.h
@@ -51,6 +51,16 @@ enum robo_ed_color_codes
   ROBO_ED_CC_INVALID_COMMENT
 };
 
+struct saved_position
+{
+  int board_id;
+  int cursor_x;
+  int cursor_y;
+  int scroll_x;
+  int scroll_y;
+  int debug_x;
+};
+
 struct editor_config_info
 {
   // Board editor options
@@ -114,12 +124,7 @@ struct editor_config_info
   struct ext_macro **extended_macros;
 
   // Saved positions
-  int saved_board[NUM_SAVED_POSITIONS];
-  int saved_cursor_x[NUM_SAVED_POSITIONS];
-  int saved_cursor_y[NUM_SAVED_POSITIONS];
-  int saved_scroll_x[NUM_SAVED_POSITIONS];
-  int saved_scroll_y[NUM_SAVED_POSITIONS];
-  int saved_debug_x[NUM_SAVED_POSITIONS];
+  struct saved_position saved_positions[NUM_SAVED_POSITIONS];
 };
 
 EDITOR_LIBSPEC void default_editor_config(void);

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -1571,6 +1571,7 @@ static boolean editor_key(context *ctx, int *key)
     char mesg[80];
 
     int s_num = *key - IKEY_0;
+    struct saved_position *s = &(editor_conf->saved_positions[s_num]);
 
     if(get_ctrl_status(keycode_internal))
     {
@@ -1580,12 +1581,12 @@ static boolean editor_key(context *ctx, int *key)
 
       if(!confirm(mzx_world, mesg))
       {
-        editor_conf->saved_board[s_num] = mzx_world->current_board_id;
-        editor_conf->saved_cursor_x[s_num] = editor->cursor_x;
-        editor_conf->saved_cursor_y[s_num] = editor->cursor_y;
-        editor_conf->saved_scroll_x[s_num] = editor->scroll_x;
-        editor_conf->saved_scroll_y[s_num] = editor->scroll_y;
-        editor_conf->saved_debug_x[s_num] = editor->debug_x;
+        s->board_id = mzx_world->current_board_id;
+        s->cursor_x = editor->cursor_x;
+        s->cursor_y = editor->cursor_y;
+        s->scroll_x = editor->scroll_x;
+        s->scroll_y = editor->scroll_y;
+        s->debug_x = editor->debug_x;
         save_local_editor_config(editor_conf, curr_file);
       }
       return true;
@@ -1594,30 +1595,27 @@ static boolean editor_key(context *ctx, int *key)
 
     if(get_alt_status(keycode_internal))
     {
-      int s_board = editor_conf->saved_board[s_num];
+      int s_board = s->board_id;
 
       if(s_board < mzx_world->num_boards &&
        mzx_world->board_list[s_board])
       {
         sprintf(mesg, "Go to '%s' @ %d,%d (pos %d)?",
          mzx_world->board_list[s_board]->board_name,
-         editor_conf->saved_cursor_x[s_num],
-         editor_conf->saved_cursor_y[s_num],
-         s_num);
+         s->cursor_x, s->cursor_y, s_num);
 
         if(!confirm(mzx_world, mesg))
         {
-          editor->cursor_x = editor_conf->saved_cursor_x[s_num];
-          editor->cursor_y = editor_conf->saved_cursor_y[s_num];
-          editor->scroll_x = editor_conf->saved_scroll_x[s_num];
-          editor->scroll_y = editor_conf->saved_scroll_y[s_num];
-          editor->debug_x = editor_conf->saved_debug_x[s_num];
+          editor->cursor_x = s->cursor_x;
+          editor->cursor_y = s->cursor_y;
+          editor->scroll_x = s->scroll_x;
+          editor->scroll_y = s->scroll_y;
+          editor->debug_x = s->debug_x;
 
           if(mzx_world->current_board_id != s_board)
           {
             editor_set_current_board(editor, s_board, true);
           }
-
           else
           {
             // The saved position might be out of bounds. Board changing

--- a/src/event.c
+++ b/src/event.c
@@ -18,6 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "configure.h"
 #include "event.h"
 #include "graphics.h"
 #include "platform.h"
@@ -133,9 +134,14 @@ static void bump_status(void)
          sizeof(struct buffered_status));
 }
 
-void init_event(void)
+void init_event(struct config_info *conf)
 {
   int i, i2;
+
+  // Get defaults from config.
+  num_buffered_events = MAX(1, conf->num_buffered_events);
+  input.unfocus_pause = conf->pause_on_unfocus;
+
   input.buffer = ccalloc(num_buffered_events, sizeof(struct buffered_status));
   input.load_offset = num_buffered_events - 1;
   input.store_offset = 0;
@@ -1106,11 +1112,14 @@ boolean get_ctrl_status(enum keycode_type type)
    get_key_status(type, IKEY_RCTRL);
 }
 
+// Nothing uses this right now, but it needs to be settable for networking.
 void set_unfocus_pause(boolean value)
 {
   input.unfocus_pause = value;
 }
 
+// Nothing uses this right now, but it needs to be settable for networking.
+// TODO: when set this ought to actually reallocate the buffered events.
 void set_num_buffered_events(Uint8 value)
 {
   num_buffered_events = MAX(1, value);

--- a/src/event.h
+++ b/src/event.h
@@ -24,6 +24,7 @@
 
 __M_BEGIN_DECLS
 
+#include "configure.h"
 #include "platform.h"
 #include "keysym.h"
 
@@ -198,7 +199,7 @@ enum keycode_type
 
 #define KEYCODE_IS_ASCII(key) ((key) >= 32 && (key) < 127)
 
-CORE_LIBSPEC void init_event(void);
+CORE_LIBSPEC void init_event(struct config_info *conf);
 
 struct buffered_status *store_status(void);
 
@@ -248,7 +249,6 @@ boolean __peek_exit_input(void);
 
 #if SDL_VERSION_ATLEAST(2,0,0)
 void gamecontroller_map_sym(const char *sym, const char *value);
-void gamecontroller_set_enabled(boolean enable);
 void gamecontroller_add_mapping(const char *mapping);
 #endif
 #endif

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1631,7 +1631,7 @@ boolean init_video(struct config_info *conf, const char *caption)
   if(!set_graphics_output(conf))
     return false;
 
-  if(conf->resolution_width == -1 && conf->resolution_height == -1)
+  if(conf->resolution_width <= 0 || conf->resolution_height <= 0)
   {
 #ifdef CONFIG_SDL
     // TODO maybe be able to communicate with the renderer instead of this hack
@@ -1654,6 +1654,12 @@ boolean init_video(struct config_info *conf, const char *caption)
       graphics.resolution_width = 640;
       graphics.resolution_height = 480;
     }
+  }
+
+  if(conf->window_width <= 0 || conf->window_height <= 0)
+  {
+    graphics.window_width = 640;
+    graphics.window_height = 350;
   }
 
   snprintf(graphics.default_caption, 32, "%s", caption);

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -196,7 +196,7 @@ struct graphics_data
   Uint32 cursor_flipflop;
   Uint32 default_smzx_loaded;
   enum ratio_type ratio;
-  char *gl_filter_method;
+  enum gl_filter_type gl_filter_method;
   char *gl_scaling_shader;
   int gl_vsync;
 

--- a/src/main.c
+++ b/src/main.c
@@ -262,7 +262,7 @@ __libspec int main(int argc, char *argv[])
 
   set_mouse_mul(8, 14);
 
-  init_event();
+  init_event(conf);
 
   if(!init_video(conf, CAPTION))
     goto err_free_config;

--- a/src/render.c
+++ b/src/render.c
@@ -728,8 +728,8 @@ void fix_viewport_ratio(int width, int height, int *v_width, int *v_height,
 {
   int numerator = 0, denominator = 0;
 
-  *v_width = width;
-  *v_height = height;
+  *v_width = MAX(width, 1);
+  *v_height = MAX(height, 1);
 
   if(ratio == RATIO_STRETCH)
     return;
@@ -746,9 +746,15 @@ void fix_viewport_ratio(int width, int height, int *v_width, int *v_height,
   }
 
   if(((float)width / (float)height) < ((float)numerator / (float)denominator))
-    *v_height = (width * denominator) / numerator;
+  {
+    height = (width * denominator) / numerator;
+    *v_height = MAX(height, 1);
+  }
   else
-    *v_width = (height * numerator) / denominator;
+  {
+    width = (height * numerator) / denominator;
+    *v_width = MAX(width, 1);
+  }
 }
 
 #endif /* CONFIG_RENDER_GL_FIXED || CONFIG_RENDER_GL_PROGRAM ||

--- a/src/render_gl.c
+++ b/src/render_gl.c
@@ -100,13 +100,13 @@ boolean gl_load_syms(const struct dso_syms_map *map)
   return true;
 }
 
-void gl_set_filter_method(const char *method,
+void gl_set_filter_method(enum gl_filter_type method,
  void (GL_APIENTRY *glTexParameterf_p)(GLenum target, GLenum pname,
   GLfloat param))
 {
   GLfloat gl_filter_method = GL_LINEAR;
 
-  if(!strcasecmp(method, CONFIG_GL_FILTER_NEAREST))
+  if(method == CONFIG_GL_FILTER_NEAREST)
     gl_filter_method = GL_NEAREST;
 
   glTexParameterf_p(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, gl_filter_method);

--- a/src/render_gl.h
+++ b/src/render_gl.h
@@ -26,6 +26,7 @@
 
 __M_BEGIN_DECLS
 
+#include "configure.h"
 #include "graphics.h"
 #include "util.h"
 
@@ -55,9 +56,6 @@ __M_BEGIN_DECLS
 // Next power of 2 over SCREEN_PIX_H
 #define GL_POWER_2_HEIGHT         512
 
-#define CONFIG_GL_FILTER_LINEAR   "linear"
-#define CONFIG_GL_FILTER_NEAREST  "nearest"
-
 extern const float vertex_array_single[2 * 4];
 
 #ifdef DEBUG
@@ -69,7 +67,7 @@ static inline void gl_error(const char *file, int line,
 #endif
 
 boolean gl_load_syms(const struct dso_syms_map *map);
-void gl_set_filter_method(const char *method,
+void gl_set_filter_method(enum gl_filter_type method,
  void (GL_APIENTRY *glTexParameterf_p)(GLenum target, GLenum pname,
   GLfloat param));
 void get_context_width_height(struct graphics_data *graphics,

--- a/src/render_gl2.c
+++ b/src/render_gl2.c
@@ -528,7 +528,7 @@ static int gl2_linear_filter_method(struct graphics_data *graphics)
 
   if(render_data->ignore_linear)
     return false;
-  return strcasecmp(graphics->gl_filter_method, CONFIG_GL_FILTER_LINEAR) == 0;
+  return graphics->gl_filter_method == CONFIG_GL_FILTER_LINEAR;
 }
 
 static inline Uint32 translate_layer_color(struct graphics_data *graphics,

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -100,7 +100,7 @@ ${unit_objs}: | $(filter-out $(wildcard ${unit_obj_io}), ${unit_obj_io})
 unittest: mzx ${unit_objs}
 	@failcount=0; \
 	for t in ${unit_objs}; do \
-		./$$t ; \
+		LD_LIBRARY_PATH="." ./$$t ; \
 		if [ "$$?" != "0" ] ; then \
 			failcount=$$(($$failcount + 1)); \
 		fi; \

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -81,15 +81,15 @@ else
 
 ${unit_obj}/%${unit_ext}: ${unit_src}/%.cpp
 	$(if ${V},,@echo "  CXX     " $<)
-	${CXX} -MD ${unit_cflags} ${unit_ldflags} $< -o $@
+	${CXX} -MD ${unit_cflags} $< -o $@ ${unit_ldflags}
 
 ${unit_obj_editor}/%${unit_ext}: ${unit_src_editor}/%.cpp
 	$(if ${V},,@echo "  CXX     " $<)
-	${CXX} -MD ${unit_cflags} ${unit_ldflags} $< -o $@
+	${CXX} -MD ${unit_cflags} $< -o $@ ${unit_ldflags}
 
 ${unit_obj_io}/%${unit_ext}: ${unit_src_io}/%.cpp
 	$(if ${V},,@echo "  CXX     " $<)
-	${CXX} -MD ${unit_cflags} ${unit_ldflags} $< -o $@
+	${CXX} -MD ${unit_cflags} $< -o $@ ${unit_ldflags}
 
 -include ${unit_objs:${unit_ext}=.d}
 

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -35,6 +35,23 @@ unit_objs += \
 endif
 
 #
+# Some unit tests only work with modular builds. The reason is usually
+# that the component(s) being tested are far too dependent on other
+# components of MegaZeux to work alone.
+#
+ifneq (${BUILD_MODULAR},)
+
+unit_objs += \
+  ${unit_obj}/configure${unit_ext}
+
+unit_ldflags += -L. -lcore
+
+ifneq (${BUILD_EDITOR},)
+unit_ldflags += -L. -leditor
+endif
+endif
+
+#
 # This may already be set with sanitizer flags.
 #
 DEBUG_CFLAGS ?= -O0
@@ -43,8 +60,9 @@ DEBUG_CFLAGS ?= -O0
 # Build without -DDEBUG to suppress debug messages,
 # build without -DNDEBUG to allow assert().
 #
-unit_cflags ?= ${DEBUG_CFLAGS} -g \
- -Wall -Wextra -pedantic -Wno-unused-parameter -std=gnu++11
+unit_cflags ?= ${DEBUG_CFLAGS} -g ${SDL_CFLAGS} \
+ -Wall -Wextra -pedantic -Wno-unused-parameter -funsigned-char -std=gnu++11
+unit_ldflags +=
 
 ifeq (${BUILD_F_ANALYZER},1)
 ifeq (${HAS_F_ANALYZER},1)
@@ -63,15 +81,15 @@ else
 
 ${unit_obj}/%${unit_ext}: ${unit_src}/%.cpp
 	$(if ${V},,@echo "  CXX     " $<)
-	${CXX} -MD ${unit_cflags} $< -o $@
+	${CXX} -MD ${unit_cflags} ${unit_ldflags} $< -o $@
 
 ${unit_obj_editor}/%${unit_ext}: ${unit_src_editor}/%.cpp
 	$(if ${V},,@echo "  CXX     " $<)
-	${CXX} -MD ${unit_cflags} $< -o $@
+	${CXX} -MD ${unit_cflags} ${unit_ldflags} $< -o $@
 
 ${unit_obj_io}/%${unit_ext}: ${unit_src_io}/%.cpp
 	$(if ${V},,@echo "  CXX     " $<)
-	${CXX} -MD ${unit_cflags} $< -o $@
+	${CXX} -MD ${unit_cflags} ${unit_ldflags} $< -o $@
 
 -include ${unit_objs:${unit_ext}=.d}
 
@@ -79,7 +97,7 @@ ${unit_objs}: | $(filter-out $(wildcard ${unit_obj}), ${unit_obj})
 ${unit_objs}: | $(filter-out $(wildcard ${unit_obj_editor}), ${unit_obj_editor})
 ${unit_objs}: | $(filter-out $(wildcard ${unit_obj_io}), ${unit_obj_io})
 
-unittest: ${unit_objs}
+unittest: mzx ${unit_objs}
 	@failcount=0; \
 	for t in ${unit_objs}; do \
 		./$$t ; \

--- a/unit/Unit.hpp
+++ b/unit/Unit.hpp
@@ -224,6 +224,16 @@ public:
     }\
   } while(0)
 
+#define ASSERTXNCMP(a, b, n, reason) \
+  do\
+  {\
+    if(strncmp(a,b,n)) \
+    {\
+      this->assert_fail(__LINE__, "strncmp(" #a ", " #b ", " #n ")", (a), (b), reason); \
+      return; \
+    }\
+  } while(0)
+
 #define SECTION(sectionname) \
   this->section_name = #sectionname; \
   if((++this->count_sections) == this->expected_section)
@@ -345,7 +355,10 @@ namespace Unit
       }
 
       if(this->last_failed_section)
+      {
+        std::cerr << "  Failed " << this->failed_sections << " section(s).\n";
         return false;
+      }
 
       print_test_success();
       return true;
@@ -421,6 +434,7 @@ namespace Unit
       {
         if(this->last_failed_section < this->expected_section)
         {
+          this->failed_sections++;
           std::cerr << "  In section '" << _section_name << "': \n";
           this->last_failed_section = this->expected_section;
         }
@@ -491,7 +505,11 @@ void sigabrt_handler(int signal)
     std::cerr << "Unexpected signal received\n";
 }
 
+#ifdef __WIN32__
+int WinMain(int argc, char *argv[])
+#else
 int main(int argc, char *argv[])
+#endif
 {
   std::signal(SIGABRT, sigabrt_handler);
   return !(Unit::unittestrunner.run());

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -70,14 +70,9 @@ struct config_test_board_size_viewport
 
 struct config_test_saved_position
 {
-  const char * const value;
   int which;
-  int board;
-  int cursor_x;
-  int cursor_y;
-  int scroll_x;
-  int scroll_y;
-  int debug_x;
+  const char * const value;
+  struct saved_position expected;
 };
 
 static void load_arg(char *arg)
@@ -610,6 +605,7 @@ UNITTEST(Settings)
 #ifdef CONFIG_EDITOR
 
   struct editor_config_info *econf = get_editor_config();
+  default_editor_config();
 
   // Board editor options.
 
@@ -995,8 +991,67 @@ UNITTEST(Settings)
 
   SECTION(saved_position)
   {
-    // FIXME
-    UNIMPLEMENTED();
+    static const config_test_saved_position data[] =
+    {
+      { 0, "1,2,3,4,5,0",       { 1, 2, 3, 4, 5, 0 } },
+      { 0, "",                  { 1, 2, 3, 4, 5, 0 } },
+      { 1, "9,8,7,6,5,60",      { 9, 8, 7, 6, 5, 60 } },
+      { 2, "249,32767,32767,32767,32767,60", { 249, 32767, 32767, 32767, 32767, 60 } },
+      { 3, "3,3,3,3,3,0",       { 3, 3, 3, 3, 3, 0 } },
+      { 4, "4,4,4,4,4,0",       { 4, 4, 4, 4, 4, 0 } },
+      { 5, "5,5,5,5,5,0",       { 5, 5, 5, 5, 5, 0 } },
+      { 6, "6,6,6,6,6,0",       { 6, 6, 6, 6, 6, 0 } },
+      { 7, "7,7,7,7,7,0",       { 7, 7, 7, 7, 7, 0 } },
+      { 8, "8,8,8,8,8,0",       { 8, 8, 8, 8, 8, 0 } },
+      { 9, "9,9,9,9,9,0",       { 9, 9, 9, 9, 9, 0 } },
+      { 8, "",                  { 8, 8, 8, 8, 8, 0 } },
+      { 7, "",                  { 7, 7, 7, 7, 7, 0 } },
+      { 6, "",                  { 6, 6, 6, 6, 6, 0 } },
+      { 5, "",                  { 5, 5, 5, 5, 5, 0 } },
+      { 4, "",                  { 4, 4, 4, 4, 4, 0 } },
+      { 3, "",                  { 3, 3, 3, 3, 3, 0 } },
+      // Make sure this at least has rudimentary bounding for invalid things...
+      { 0, "0,0,0,0,0,0",       { 0, 0, 0, 0, 0, 0 } },
+      { 0, "250,0,0,0,0,0",     { 0, IGNORE, IGNORE, IGNORE, IGNORE, IGNORE } },
+      { 0, "-1,0,0,0,0,0",      { 0, IGNORE, IGNORE, IGNORE, IGNORE, IGNORE } },
+      { 0, "9,32768,0,0,0,0,0", { 0, 0,      IGNORE, IGNORE, IGNORE, IGNORE } },
+      { 0, "9,-1,0,0,0,0",      { 0, 0,      IGNORE, IGNORE, IGNORE, IGNORE } },
+      { 0, "9,0,32768,0,0,0",   { 0, IGNORE, 0,      IGNORE, IGNORE, IGNORE } },
+      { 0, "9,0,-1,0,0,0",      { 0, IGNORE, 0,      IGNORE, IGNORE, IGNORE } },
+      { 0, "9,0,0,32768,0,0",   { 0, IGNORE, IGNORE, 0,      IGNORE, IGNORE } },
+      { 0, "9,0,0,-1,0,0",      { 0, IGNORE, IGNORE, 0,      IGNORE, IGNORE } },
+      { 0, "9,0,0,0,32768,0",   { 0, IGNORE, IGNORE, IGNORE, 0,      IGNORE } },
+      { 0, "9,0,0,0,-1,0",      { 0, IGNORE, IGNORE, IGNORE, 0,      IGNORE } },
+      { 0, "9,0,0,0,0,80",      { 0, IGNORE, IGNORE, IGNORE, IGNORE, 0 } },
+      { 0, "9,0,0,0,0,-1",      { 0, IGNORE, IGNORE, IGNORE, IGNORE, 0 } },
+    };
+    const struct saved_position *dest;
+    const struct saved_position *expected;
+    char buffer[256];
+
+    for(int i = 0; i < arraysize(data); i++)
+    {
+      snprintf(buffer, sizeof(buffer), "saved_position%d=%s",
+       data[i].which, data[i].value);
+
+      load_arg(buffer);
+
+      dest = &(econf->saved_positions[data[i].which]);
+      expected = &(data[i].expected);
+
+      if(expected->board_id != IGNORE)
+        ASSERTEQX(dest->board_id, expected->board_id, buffer);
+      if(expected->cursor_x != IGNORE)
+        ASSERTEQX(dest->cursor_x, expected->cursor_x, buffer);
+      if(expected->cursor_y != IGNORE)
+        ASSERTEQX(dest->cursor_y, expected->cursor_y, buffer);
+      if(expected->scroll_x != IGNORE)
+        ASSERTEQX(dest->scroll_x, expected->scroll_x, buffer);
+      if(expected->scroll_y != IGNORE)
+        ASSERTEQX(dest->scroll_y, expected->scroll_y, buffer);
+      if(expected->debug_x != IGNORE)
+        ASSERTEQX(dest->debug_x, expected->debug_x, buffer);
+    }
   }
 
 #endif

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -17,6 +17,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <climits>
+#include <cstdio>
+
 #include "Unit.hpp"
 
 #include "../src/configure.h"

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -23,6 +23,7 @@
 #include "Unit.hpp"
 
 #include "../src/configure.h"
+#include "../src/const.h"
 #include "../src/util.h"
 
 #ifdef CONFIG_SDL
@@ -57,6 +58,7 @@ struct config_test_string
   const char * const expected;
 };
 
+#ifdef CONFIG_EDITOR
 struct config_test_board_size_viewport
 {
   const char * const setting;
@@ -75,6 +77,7 @@ struct config_test_saved_position
   const char * const value;
   struct saved_position expected;
 };
+#endif /* CONFIG_EDITOR */
 
 static void load_arg(char *arg)
 {
@@ -625,7 +628,7 @@ UNITTEST(Settings)
     TEST_INT("socks_port", conf->socks_port, 0, 65535);
   }
 
-#endif
+#endif /* CONFIG_NETWORK */
 
 #ifdef CONFIG_UPDATER
 
@@ -680,7 +683,7 @@ UNITTEST(Settings)
     TEST_ENUM("update_auto_check", conf->update_auto_check, data);
   }
 
-#endif
+#endif /* CONFIG_UPDATER */
 
 #ifdef CONFIG_EDITOR
 
@@ -1135,7 +1138,7 @@ UNITTEST(Settings)
     }
   }
 
-#endif
+#endif /* CONFIG_EDITOR */
 }
 
 #ifdef CONFIG_EDITOR
@@ -1150,4 +1153,4 @@ UNITTEST(ExtendedMacros)
 }
 */
 
-#endif
+#endif /* CONFIG_EDITOR */

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -1,0 +1,912 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2020 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "Unit.hpp"
+
+#include "../src/configure.h"
+#include "../src/util.h"
+
+#ifdef CONFIG_SDL
+#include <SDL_version.h>
+#endif
+
+#ifdef CONFIG_EDITOR
+#include "../src/editor/configure.h"
+#include "../src/editor/robo_ed.h"
+#endif
+
+static const int MAX_ARGS = 16;
+static const int DEFAULT = 255;
+
+struct config_test_single
+{
+  const char * const value;
+  int expected;
+};
+
+struct config_test_pair
+{
+  const char * const value;
+  int expected_a;
+  int expected_b;
+};
+
+struct config_test_string
+{
+  const char * const value;
+};
+
+static void load_arg(char *arg)
+{
+  char *tmp_args[2];
+  int argc = 0;
+
+  tmp_args[argc++] = nullptr;
+  tmp_args[argc++] = arg;
+
+  set_config_from_command_line(&argc, tmp_args);
+#ifdef CONFIG_EDITOR
+  set_editor_config_from_command_line(&argc, tmp_args);
+#endif
+}
+
+template<int SIZE>
+static void load_args(const char * const (&args)[SIZE])
+{
+  char *tmp_args[SIZE + 1];
+  int argc = 0;
+  int i;
+
+  tmp_args[argc++] = nullptr;
+
+  for(i = 0; i < SIZE; i++)
+  {
+    if(!args[i])
+      break;
+
+    tmp_args[argc++] = (char *)args[i];
+  }
+
+  set_config_from_command_line(&argc, tmp_args);
+#ifdef CONFIG_EDITOR
+  set_editor_config_from_command_line(&argc, tmp_args);
+#endif
+}
+
+#define DEFAULT_V(v) static_cast<std::remove_reference<decltype(v)>::type>(DEFAULT)
+//static_cast<decltype(setting)>(DEFAULT);
+
+#define TEST_INT(setting_name, setting, min, max) \
+do { \
+  char arg[512]; \
+  for(int _i = -16; _i < 32; _i++) \
+  { \
+    int _tmp = ((unsigned)max - min) * _i / 16 + min; \
+    snprintf(arg, 512, "%s=%d", setting_name, _tmp); \
+    setting = DEFAULT_V(setting); \
+    load_arg(arg); \
+    if(_tmp >= min && _tmp <= max) \
+      ASSERTEQX((int)(setting), _tmp, arg); \
+    else \
+      ASSERTEQX((int)(setting), DEFAULT, arg); \
+  } \
+} while(0)
+
+#define TEST_ENUM(setting_name, setting, data) \
+do { \
+  for(int _i = 0; _i < arraysize(data); _i++) \
+  { \
+    char arg[512]; \
+    snprintf(arg, 512, "%s=%s", setting_name, data[_i].value); \
+    setting = DEFAULT_V(setting); \
+    load_arg(arg); \
+    ASSERTEQX((int)(setting), (int)data[_i].expected, arg); \
+  } \
+} while(0)
+
+#define TEST_PAIR(setting_name, setting_a, setting_b, data) \
+do { \
+  for(int _i = 0; _i < arraysize(data); _i++) \
+  { \
+    char arg[512]; \
+    snprintf(arg, 512, "%s=%s", setting_name, data[_i].value); \
+    setting_a = DEFAULT_V(setting_a); \
+    setting_b = DEFAULT_V(setting_b); \
+    load_arg(arg); \
+    ASSERTEQX((int)(setting_a), (int)data[_i].expected_a, arg); \
+    ASSERTEQX((int)(setting_b), (int)data[_i].expected_b, arg); \
+  } \
+} while(0)
+
+#define TEST_STRING(setting_name, setting, data) \
+do { \
+  for(int _i = 0; _i < arraysize(data); _i++) \
+  { \
+    char arg[512]; \
+    size_t len = MIN(strlen(data[_i].value), sizeof(setting) - 1); \
+    snprintf(arg, 512, "%s=%s", setting_name, data[_i].value); \
+    setting[0] = '\0'; \
+    load_arg(arg); \
+    ASSERTXNCMP(setting, data[_i].value, len, arg); \
+    ASSERTEQX(setting[len], '\0', arg); \
+  } \
+} while(0)
+
+/**
+ * FIXME should make sure settings are enforced when loading as an arg vs.
+ * when loading as a game config file!
+ */
+UNITTEST(Settings)
+{
+  struct config_info *conf = get_config();
+
+  static const config_test_single boolean_data[] =
+  {
+    { "0", false },
+    { "1", true },
+    { "2", DEFAULT },
+    { "23", DEFAULT },
+    { "-12", DEFAULT },
+    { "-1", DEFAULT },
+    { "yes", DEFAULT },
+    { "ABCD", DEFAULT },
+  };
+
+  static const config_test_pair pair_data[] =
+  {
+    { "-1,-1", -1, -1 },
+    { "-1,0", -1, 0 },
+    { "0,-1", 0, -1 },
+    { "640,350", 640, 350 },
+    { "640,480", 640, 480 },
+    { "1280,700", 1280, 700 },
+    { "1920,1080", 1920, 1080 },
+    { "2560,1440", 2560, 1440 },
+    { "3840,2160", 3840, 2160 },
+    { "640, 350", 640, 350 },
+    { "1600,  1200", 1600, 1200 },
+    { "640,a", DEFAULT, DEFAULT },
+    { "a,480", DEFAULT, DEFAULT },
+    { "a,b", DEFAULT, DEFAULT },
+    { "640px,350px", DEFAULT, DEFAULT },
+    { "-2,4154", DEFAULT, DEFAULT },
+    { "1233,-13513", DEFAULT, DEFAULT },
+  };
+
+  static const config_test_string string_data[] =
+  {
+    { "" },
+    { "software" },
+    { "glsl" },
+    { "crt" },
+    { "greyscale" },
+    { "really long setting string wtf don't do this" },
+    {
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+  };
+
+  default_config();
+
+  // Video options.
+
+  SECTION(fullscreen)
+  {
+    TEST_ENUM("fullscreen", conf->fullscreen, boolean_data);
+  }
+
+  SECTION(fullscreen_windowed)
+  {
+    TEST_ENUM("fullscreen_windowed", conf->fullscreen_windowed, boolean_data);
+  }
+
+  SECTION(fullscreen_resolution)
+  {
+    TEST_PAIR("fullscreen_resolution", conf->resolution_width,
+     conf->resolution_height, pair_data);
+  }
+
+  SECTION(window_resolution)
+  {
+    TEST_PAIR("window_resolution", conf->window_width,
+     conf->window_height, pair_data);
+  }
+
+  SECTION(allow_resize)
+  {
+    TEST_ENUM("enable_resizing", conf->allow_resize, boolean_data);
+  }
+
+  SECTION(video_output)
+  {
+    TEST_STRING("video_output", conf->video_output, string_data);
+  }
+
+  SECTION(force_bpp)
+  {
+    static const config_test_single data[] =
+    {
+      { "8", 8 },
+      { "16", 16 },
+      { "32", 32 },
+      { "-1", DEFAULT },
+      { "231", DEFAULT },
+      { "0", DEFAULT },
+      { "asdfsdf", DEFAULT },
+    };
+    TEST_ENUM("force_bpp", conf->force_bpp, data);
+  }
+
+  SECTION(video_ratio)
+  {
+    static const config_test_single data[] =
+    {
+      { "classic", RATIO_CLASSIC_4_3 },
+      { "modern", RATIO_MODERN_64_35 },
+      { "stretch", RATIO_STRETCH },
+      { "-1", DEFAULT },
+      { "12312342", DEFAULT },
+      { "classiccc", DEFAULT },
+    };
+    TEST_ENUM("video_ratio", conf->video_ratio, data);
+  }
+
+  SECTION(gl_filter_method)
+  {
+    static const config_test_single data[] =
+    {
+      { "nearest", CONFIG_GL_FILTER_NEAREST },
+      { "linear", CONFIG_GL_FILTER_LINEAR },
+      { "213123", DEFAULT },
+      { "nearets", DEFAULT },
+    };
+    TEST_ENUM("gl_filter_method", conf->gl_filter_method, data);
+  }
+
+  SECTION(gl_scaling_shader)
+  {
+    TEST_STRING("gl_scaling_shader", conf->gl_scaling_shader, string_data);
+  }
+
+  SECTION(gl_vsync)
+  {
+    static const config_test_single data[] =
+    {
+      { "-1", -1 },
+      { "0", 0 },
+      { "1", 1 },
+      { "default", -1 },
+      { "-2", DEFAULT },
+      { "-12312", DEFAULT },
+      { "2", DEFAULT },
+      { "6456", DEFAULT },
+      { "1a", DEFAULT },
+    };
+    TEST_ENUM("gl_vsync", conf->gl_vsync, data);
+  }
+
+  SECTION(allow_screenshots)
+  {
+    TEST_ENUM("allow_screenshots", conf->allow_screenshots, boolean_data);
+  }
+
+  // Audio options.
+
+  SECTION(audio_sample_rate)
+  {
+    TEST_INT("audio_sample_rate", conf->output_frequency, 1, INT_MAX);
+  }
+
+  SECTION(audio_buffer_samples)
+  {
+    TEST_INT("audio_buffer_samples", conf->audio_buffer_samples, 1, INT_MAX);
+  }
+
+  SECTION(enable_oversampling)
+  {
+    TEST_ENUM("enable_oversampling", conf->oversampling_on, boolean_data);
+  }
+
+  SECTION(resample_mode)
+  {
+    static const config_test_single data[] =
+    {
+      { "none", RESAMPLE_MODE_NONE },
+      { "linear", RESAMPLE_MODE_LINEAR },
+      { "cubic", RESAMPLE_MODE_CUBIC },
+      { "fir", DEFAULT },
+      { "sdfsedfsd", DEFAULT },
+      { "0", DEFAULT },
+      { "", DEFAULT },
+    };
+    TEST_ENUM("resample_mode", conf->resample_mode, data);
+  }
+
+  SECTION(module_resample_mode)
+  {
+    static const config_test_single data[] =
+    {
+      { "none", RESAMPLE_MODE_NONE },
+      { "linear", RESAMPLE_MODE_LINEAR },
+      { "cubic", RESAMPLE_MODE_CUBIC },
+      { "fir", RESAMPLE_MODE_FIR },
+      { "sdfsedfsd", DEFAULT },
+      { "0", DEFAULT },
+      { "", DEFAULT },
+    };
+    TEST_ENUM("module_resample_mode", conf->module_resample_mode, data);
+  }
+
+  SECTION(max_simultaneous_samples)
+  {
+    TEST_INT("max_simultaneous_samples", conf->max_simultaneous_samples, -1, INT_MAX);
+  }
+
+  SECTION(music_volume)
+  {
+    TEST_INT("music_volume", conf->music_volume, 0, 10);
+  }
+
+  SECTION(sam_volume)
+  {
+    TEST_INT("sample_volume", conf->sam_volume, 0, 10);
+  }
+
+  SECTION(pc_speaker_volume)
+  {
+    TEST_INT("pc_speaker_volume", conf->pc_speaker_volume, 0, 10);
+  }
+
+  SECTION(music_on)
+  {
+    TEST_ENUM("music_on", conf->music_on, boolean_data);
+  }
+
+  SECTION(pc_speaker_on)
+  {
+    TEST_ENUM("pc_speaker_on", conf->pc_speaker_on, boolean_data);
+  }
+
+  // Event options.
+
+  // TODO Most joystick and gamecontroller options are stored elsewhere and
+  // too hard to test right now.
+
+#ifdef CONFIG_SDL
+#if SDL_VERSION_ATLEAST(2,0,0)
+  SECTION(allow_gamecontroller)
+  {
+    TEST_ENUM("gamecontroller_enable", conf->allow_gamecontroller, boolean_data);
+  }
+#endif
+#endif
+
+  SECTION(pause_on_unfocus)
+  {
+    TEST_ENUM("pause_on_unfocus", conf->pause_on_unfocus, boolean_data);
+  }
+
+  SECTION(num_buffered_events)
+  {
+    TEST_INT("num_buffered_events", conf->num_buffered_events, 1, 256);
+  }
+
+  // Game options.
+
+  // TODO startup_path relies on stat.
+  // TODO startup_file relies on stat.
+
+  SECTION(save_file)
+  {
+    TEST_STRING("save_file", conf->default_save_name, string_data);
+  }
+
+  SECTION(mzx_speed)
+  {
+    TEST_INT("mzx_speed", conf->mzx_speed, 1, 16);
+  }
+
+  SECTION(allow_cheats)
+  {
+    static const config_test_single data[] =
+    {
+      { "0", ALLOW_CHEATS_NEVER },
+      { "1", ALLOW_CHEATS_ALWAYS },
+      { "never", ALLOW_CHEATS_NEVER },
+      { "always", ALLOW_CHEATS_ALWAYS },
+      { "mzxrun", ALLOW_CHEATS_MZXRUN },
+      { "asdbfnsd", DEFAULT },
+      { "", DEFAULT },
+    };
+    TEST_ENUM("allow_cheats", conf->allow_cheats, data);
+  }
+
+  SECTION(auto_decrypt_worlds)
+  {
+    TEST_ENUM("auto_decrypt_worlds", conf->auto_decrypt_worlds, boolean_data);
+  }
+
+  SECTION(startup_editor)
+  {
+    TEST_ENUM("startup_editor", conf->startup_editor, boolean_data);
+  }
+
+  SECTION(standalone_mode)
+  {
+    TEST_ENUM("standalone_mode", conf->standalone_mode, boolean_data);
+  }
+
+  SECTION(no_titlescreen)
+  {
+    TEST_ENUM("no_titlescreen", conf->no_titlescreen, boolean_data);
+  }
+
+  SECTION(system_mouse)
+  {
+    TEST_ENUM("system_mouse", conf->system_mouse, boolean_data);
+  }
+
+  SECTION(grab_mouse)
+  {
+    TEST_ENUM("grab_mouse", conf->grab_mouse, boolean_data);
+  }
+
+  SECTION(save_slots)
+  {
+    TEST_ENUM("save_slots", conf->save_slots, boolean_data);
+  }
+
+  SECTION(save_slots_name)
+  {
+    TEST_STRING("save_slots_name", conf->save_slots_name, string_data);
+  }
+
+  SECTION(save_slots_ext)
+  {
+    TEST_STRING("save_slots_ext", conf->save_slots_ext, string_data);
+  }
+
+  // Editor options used by core.
+
+  SECTION(test_mode)
+  {
+    TEST_ENUM("test_mode", conf->test_mode, boolean_data);
+  }
+
+  SECTION(test_mode_start_board)
+  {
+    TEST_INT("test_mode_start_board", conf->test_mode_start_board, 0, MAX_BOARDS - 1);
+  }
+
+  SECTION(mask_midchars)
+  {
+    TEST_ENUM("mask_midchars", conf->mask_midchars, boolean_data);
+  }
+
+#ifdef CONFIG_NETWORK
+
+  // Network options.
+
+  SECTION(network_enabled)
+  {
+    TEST_ENUM("network_enabled", conf->network_enabled, boolean_data);
+  }
+
+  SECTION(socks_host)
+  {
+    TEST_STRING("socks_host", conf->socks_host, string_data);
+  }
+
+  SECTION(socks_port)
+  {
+    TEST_INT("socks_port", conf->socks_port, 0, 65535);
+  }
+
+#endif
+
+#ifdef CONFIG_UPDATER
+
+  // Updater options.
+
+  SECTION(update_host)
+  {
+    static const char * const option = "update_host";
+    static const char * const hosts[] =
+    {
+      "updates.doot.rip",
+      "updates.digitalmzx.com",
+      "updates.megazuex.org",
+      "looooo,.l",
+      "a website",
+      "sdjfjklsdfsdsdfsd",
+      "",
+      "PADDING"
+    };
+    char buffer[512];
+
+    for(int i = 0; i < arraysize(hosts); i++)
+    {
+      snprintf(buffer, sizeof(buffer), "%s=%s", option, hosts[i]);
+      load_arg(buffer);
+
+      ASSERTEQ(conf->update_host_count, i+1);
+      for(int j = 0; j <= i; j++)
+        ASSERTCMP(conf->update_hosts[j], hosts[j]);
+    }
+    free_config();
+  }
+
+  SECTION(update_branch_pin)
+  {
+    TEST_STRING("update_branch_pin", conf->update_branch_pin, string_data);
+  }
+
+  SECTION(update_auto_check)
+  {
+    static const config_test_single data[] =
+    {
+      { "0", UPDATE_AUTO_CHECK_OFF },
+      { "1", UPDATE_AUTO_CHECK_ON },
+      { "off", UPDATE_AUTO_CHECK_OFF },
+      { "on", UPDATE_AUTO_CHECK_ON },
+      { "silent", UPDATE_AUTO_CHECK_SILENT },
+      { "2", DEFAULT },
+      { "asdfasdfasdf", DEFAULT },
+      { "", DEFAULT },
+    };
+    TEST_ENUM("update_auto_check", conf->update_auto_check, data);
+  }
+
+#endif
+
+#ifdef CONFIG_EDITOR
+
+  struct editor_config_info *econf = get_editor_config();
+
+  // Board editor options.
+
+  SECTION(board_editor_hide_help)
+  {
+    TEST_ENUM("board_editor_hide_help", econf->board_editor_hide_help, boolean_data);
+  }
+
+  SECTION(editor_space_toggles)
+  {
+    TEST_ENUM("editor_space_toggles", econf->editor_space_toggles, boolean_data);
+  }
+
+  SECTION(editor_tab_focuses_view)
+  {
+    TEST_ENUM("editor_tab_focuses_view", econf->editor_tab_focuses_view, boolean_data);
+  }
+
+  SECTION(editor_load_board_assets)
+  {
+    TEST_ENUM("editor_load_board_assets", econf->editor_load_board_assets, boolean_data);
+  }
+
+  SECTION(editor_thing_menu_places)
+  {
+    TEST_ENUM("editor_thing_menu_places", econf->editor_thing_menu_places, boolean_data);
+  }
+
+  // Board defaults.
+
+  SECTION(viewport_and_size)
+  {
+    // FIXME
+    UNIMPLEMENTED();
+  }
+
+  SECTION(can_shoot)
+  {
+    TEST_ENUM("board_default_can_shoot", econf->can_shoot, boolean_data);
+  }
+
+  SECTION(can_bomb)
+  {
+    TEST_ENUM("board_default_can_bomb", econf->can_bomb, boolean_data);
+  }
+
+  SECTION(fire_burns_spaces)
+  {
+    TEST_ENUM("board_default_fire_burns_spaces", econf->fire_burns_spaces, boolean_data);
+  }
+
+  SECTION(fire_burns_fakes)
+  {
+    TEST_ENUM("board_default_fire_burns_fakes", econf->fire_burns_fakes, boolean_data);
+  }
+
+  SECTION(fire_burns_trees)
+  {
+    TEST_ENUM("board_default_fire_burns_trees", econf->fire_burns_trees, boolean_data);
+  }
+
+  SECTION(fire_burns_brown)
+  {
+    TEST_ENUM("board_default_fire_burns_brown", econf->fire_burns_brown, boolean_data);
+  }
+
+  SECTION(fire_burns_forever)
+  {
+    TEST_ENUM("board_default_fire_burns_forever", econf->fire_burns_forever, boolean_data);
+  }
+
+  SECTION(forest_to_floor)
+  {
+    TEST_ENUM("board_default_forest_to_floor", econf->forest_to_floor, boolean_data);
+  }
+
+  SECTION(collect_bombs)
+  {
+    TEST_ENUM("board_default_collect_bombs", econf->collect_bombs, boolean_data);
+  }
+
+  SECTION(restart_if_hurt)
+  {
+    TEST_ENUM("board_default_restart_if_hurt", econf->restart_if_hurt, boolean_data);
+  }
+
+  SECTION(reset_on_entry)
+  {
+    TEST_ENUM("board_default_reset_on_entry", econf->reset_on_entry, boolean_data);
+  }
+
+  SECTION(player_locked_ns)
+  {
+    TEST_ENUM("board_default_player_locked_ns", econf->player_locked_ns, boolean_data);
+  }
+
+  SECTION(player_locked_ew)
+  {
+    TEST_ENUM("board_default_player_locked_ew", econf->player_locked_ew, boolean_data);
+  }
+
+  SECTION(player_locked_att)
+  {
+    TEST_ENUM("board_default_player_locked_att", econf->player_locked_att, boolean_data);
+  }
+
+  SECTION(time_limit)
+  {
+    TEST_INT("board_default_time_limit", econf->time_limit, 0, 32767);
+  }
+
+  SECTION(explosions_leave)
+  {
+    static const config_test_single data[] =
+    {
+      { "space", EXPL_LEAVE_SPACE },
+      { "ash", EXPL_LEAVE_ASH },
+      { "fire", EXPL_LEAVE_FIRE },
+      { "0", DEFAULT },
+      { "1", DEFAULT },
+      { "2", DEFAULT },
+      { "1a", DEFAULT },
+      { "", DEFAULT },
+    };
+    TEST_ENUM("board_default_explosions_leave", econf->explosions_leave, data);
+  }
+
+  SECTION(saving_enabled)
+  {
+    static const config_test_single data[] =
+    {
+      { "disabled", CANT_SAVE },
+      { "enabled", CAN_SAVE },
+      { "sensoronly", CAN_SAVE_ON_SENSOR },
+      { "0", DEFAULT },
+      { "1", DEFAULT },
+      { "2", DEFAULT },
+      { "sdfbv", DEFAULT },
+      { "", DEFAULT },
+    };
+    TEST_ENUM("board_default_saving", econf->saving_enabled, data);
+  }
+
+  SECTION(overlay_enabled)
+  {
+    static const config_test_single data[] =
+    {
+      { "disabled", OVERLAY_OFF },
+      { "enabled", OVERLAY_ON },
+      { "static", OVERLAY_STATIC },
+      { "transparent", OVERLAY_TRANSPARENT },
+      { "-1", DEFAULT },
+      { "1", DEFAULT },
+      { "2", DEFAULT },
+      { "disabledb", DEFAULT },
+      { "", DEFAULT },
+    };
+    TEST_ENUM("board_default_overlay", econf->overlay_enabled, data);
+  }
+
+  SECTION(charset_path)
+  {
+    TEST_STRING("board_default_charset_path", econf->charset_path, string_data);
+  }
+
+  SECTION(palette_path)
+  {
+    TEST_STRING("board_default_palette_path", econf->palette_path, string_data);
+  }
+
+  // Palette editor options.
+
+  SECTION(palette_editor_hide_help)
+  {
+    TEST_ENUM("palette_editor_hide_help", econf->palette_editor_hide_help, boolean_data);
+  }
+
+  // Robot editor options.
+
+  SECTION(editor_enter_splits)
+  {
+    TEST_ENUM("editor_enter_splits", econf->editor_enter_splits, boolean_data);
+  }
+
+  SECTION(color_codes)
+  {
+    static const struct
+    {
+      const char * const opt;
+      unsigned int idx;
+    } color_code_opts[] =
+    {
+      { "ccode_chars", ROBO_ED_CC_CHARACTERS },
+      { "ccode_colors", ROBO_ED_CC_COLORS },
+      { "ccode_commands", ROBO_ED_CC_COMMANDS },
+      { "ccode_conditions", ROBO_ED_CC_CONDITIONS },
+      { "ccode_current_line", ROBO_ED_CC_CURRENT_LINE },
+      { "ccode_directions", ROBO_ED_CC_DIRECTIONS },
+      { "ccode_equalities", ROBO_ED_CC_EQUALITIES },
+      { "ccode_extras", ROBO_ED_CC_EXTRAS },
+      { "ccode_immediates", ROBO_ED_CC_IMMEDIATES },
+      { "ccode_items", ROBO_ED_CC_ITEMS },
+      { "ccode_params", ROBO_ED_CC_PARAMS },
+      { "ccode_strings", ROBO_ED_CC_STRINGS },
+      { "ccode_things", ROBO_ED_CC_THINGS },
+    };
+    static const config_test_single color_data[] =
+    {
+      { "255", 255 },
+    };
+
+    for(int i = 0; i < arraysize(color_code_opts); i++)
+    {
+      auto opt = color_code_opts[i];
+      TEST_INT(opt.opt, econf->color_codes[opt.idx], 0, 15);
+    }
+
+    // Test the colors special case...
+    TEST_ENUM("ccode_colors", econf->color_codes[ROBO_ED_CC_COLORS], color_data);
+  }
+
+  SECTION(color_coding_on)
+  {
+    TEST_ENUM("color_coding_on", econf->color_coding_on, boolean_data);
+  }
+
+  SECTION(default_invalid_status)
+  {
+    static const config_test_single data[] =
+    {
+      { "ignore", invalid_uncertain },
+      { "delete", invalid_discard },
+      { "comment", invalid_comment },
+      { "-1", DEFAULT },
+      { "1", DEFAULT },
+      { "2", DEFAULT },
+      { "disabledb", DEFAULT },
+      { "", DEFAULT },
+    };
+    TEST_ENUM("default_invalid_status", econf->default_invalid_status, data);
+  }
+
+  SECTION(disassemble_extras)
+  {
+    TEST_ENUM("disassemble_extras", econf->disassemble_extras, boolean_data);
+  }
+
+  SECTION(disassemble_base)
+  {
+    static const config_test_single data[] =
+    {
+      { "10", 10 },
+      { "16", 16 },
+      { "2", DEFAULT },
+      { "4", DEFAULT },
+      { "8", DEFAULT },
+      { "10bfd", DEFAULT },
+      { "11", DEFAULT },
+      { "", DEFAULT },
+    };
+    TEST_ENUM("disassemble_base", econf->disassemble_base, data);
+  }
+
+  SECTION(robot_editor_hide_help)
+  {
+    TEST_ENUM("robot_editor_hide_help", econf->robot_editor_hide_help, boolean_data);
+  }
+
+  // Backup options.
+
+  SECTION(backup_count)
+  {
+    TEST_INT("backup_count", econf->backup_count, 0, INT_MAX);
+  }
+
+  SECTION(backup_interval)
+  {
+    TEST_INT("backup_interval", econf->backup_interval, 0, INT_MAX);
+  }
+
+  SECTION(backup_name)
+  {
+    TEST_STRING("backup_name", econf->backup_name, string_data);
+  }
+
+  SECTION(backup_ext)
+  {
+    TEST_STRING("backup_ext", econf->backup_ext, string_data);
+  }
+
+  // Macro options.
+
+  // TODO extended macros should be a separate test.
+
+  SECTION(default_macros)
+  {
+    char buffer[16];
+    for(int i = 0; i < arraysize(econf->default_macros); i++)
+    {
+      snprintf(buffer, sizeof(buffer), "macro_%d", i+1);
+      TEST_STRING(buffer, econf->default_macros[i], string_data);
+    }
+  }
+
+  // Saved positions.
+
+  SECTION(saved_position)
+  {
+    // FIXME
+    UNIMPLEMENTED();
+  }
+
+#endif
+}
+
+#ifdef CONFIG_EDITOR
+
+/*
+UNITTEST(ExtendedMacros)
+{
+  // FIXME
+  UNIMPLEMENTED();
+
+  free_editor_config();
+}
+*/
+
+#endif

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -95,7 +95,7 @@ static void load_arg(char *arg)
 
 static void load_arg_file(char *arg, boolean is_game_config)
 {
-  static const char CONFIG_FILENAME[] = "_config_tmp";
+  static const char CONFIG_FILENAME[] = "unit/.build/_config_tmp";
 
   FILE *fp = fopen_unsafe(CONFIG_FILENAME, "wb");
   assert(fp);


### PR DESCRIPTION
This implements the config file validation improvements from #170 without so much of the disgusting macro/offsetof hackery. Unfortunately, this means there's still a lot of boilerplate (but really, I'll take that over what the previous attempt at this ended up like).

Things carried over from the original PR:
- [x] Improved validation for setting values. Integer values will be ignored if they are outside of the allowed range, there are new "enum" arrays for settings where only a small handful of exact values made sense (including but not limited to boolean settings), and more consistent string bounding.
- [x] Make `gl_filter_method` an enum instead of a string.
- [x] Store several startup event settings in the config struct instead of having the config handler call a function to set them.
- [x] `ccheck_extras` bugfix.

New things:
- [x] Added `ccheck_chars` which seems to have been omitted as an oversight. Also added an enum for the `color_codes` indices (though it's currently only used by the config code and not by the robot editor).
- [x] Fixed a bug where `macro_#` for numbers 0 and 6-9 would not be ignored. Fortunately due to the saved positions 7-9 could only corrupt other values in the config struct, but `macro_6` corrupts the extended macro fields and causes various crashes.
- [x] Fixed bugs when providing `window_resolution` and `fullscreen_resolution` with negative or zero coordinates, including a division-by-zero crash.
- [x] Config setting testing.
- [x] Config setting testing for `saved_position` and the default board width/height/viewport settings.
- [x] ~~Config setting testing for extended macros.~~ don't wanna right now :-(
- [x] ~~Config argv syntax testing.~~ fix whitespace handling first (do later) :-(
- [x] ~~Config file syntax testing.~~ fix whitespace handling first (do later) :-(
- [x] Testing to make sure options allowed/not allowed in game config files have the expected behavior.

Other tasks:
- [x] `make test` on various things to make sure both the changes work and the test linking the core/editor libraries works.
- [x] `--disable-editor` testing too.

Things missing from the original PR:
* Editor `include`. I don't like the original idea of having two separate include handlers and changing the way the argv parser handles options. I think a better approach is to register `find_change_option`/config struct pairs at startup and keep one set of functions for loading configuration instead of two. This should be a separate commit.