### PR TITLE
Use config setting registry instead of separate set_config functions

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -14,6 +14,9 @@ USERS
   "macro_6" would corrupt the extended macros and cause crashes.
 + Fixed division-by-zero crashes and GL errors when using
   invalid fullscreen_resolution or window_resolution values.
++ Fixed a bug where files included by the config file include
+  directive would ignore editor settings. Also added a recursion
+  limit for includes.
 
 DEVELOPERS
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -16,7 +16,8 @@ USERS
   invalid fullscreen_resolution or window_resolution values.
 + Fixed a bug where files included by the config file include
   directive would ignore editor settings. Also added a recursion
-  limit for includes.
+  limit for includes and fixed a bug where the "include=file"
+  format would not work on some platforms.
 
 DEVELOPERS
 

--- a/src/configure.c
+++ b/src/configure.c
@@ -813,32 +813,26 @@ static void pause_on_unfocus(struct config_info *conf, char *name,
   config_boolean(&conf->pause_on_unfocus, value);
 }
 
-// This one's for the original include N form.
 static void include_config(struct config_info *conf, char *name,
  char *value, char *extended_data)
 {
   if(current_include_depth < MAX_INCLUDE_DEPTH)
   {
     current_include_depth++;
-    set_config_from_file(current_config_type, name + 7);
+
+    // The format "include FILENAME.EXT" is condensed into the name.
+    // The format "include=FILENAME.EXT" uses the value instead.
+    if(name[7])
+    {
+      set_config_from_file(current_config_type, name + 7);
+    }
+    else
+      set_config_from_file(current_config_type, value);
+
     current_include_depth--;
   }
   else
     warn("Failed to include '%s' (maximum recursion depth exceeded)\n", name + 7);
-}
-
-// This one's for the include = N form.
-static void include2_config(struct config_info *conf, char *name,
- char *value, char *extended_data)
-{
-  if(current_include_depth < MAX_INCLUDE_DEPTH)
-  {
-    current_include_depth++;
-    set_config_from_file(current_config_type, value);
-    current_include_depth--;
-  }
-  else
-    warn("Failed to include '%s' (maximum recursion depth exceeded)\n", value);
 }
 
 static void config_set_pcs_volume(struct config_info *conf, char *name,
@@ -1025,7 +1019,6 @@ static const struct config_entry config_options[] =
   { "gl_scaling_shader", config_set_gl_scaling_shader, true },
   { "gl_vsync", config_gl_vsync, false },
   { "grab_mouse", config_grab_mouse, false },
-  { "include", include2_config, true },
   { "include*", include_config, true },
   { "joy!.*", joy_action_set, true },
   { "joy!axis!", joy_axis_set, true },

--- a/src/configure.h
+++ b/src/configure.h
@@ -26,6 +26,14 @@ __M_BEGIN_DECLS
 
 #define OPTION_NAME_LEN 33
 
+enum config_type
+{
+  SYSTEM_CNF,
+  GAME_CNF,
+  GAME_EDITOR_CNF,
+  NUM_CONFIG_TYPES
+};
+
 enum ratio_type
 {
   RATIO_CLASSIC_4_3,
@@ -145,20 +153,18 @@ struct config_enum
 
 CORE_LIBSPEC struct config_info *get_config(void);
 CORE_LIBSPEC void default_config(void);
-CORE_LIBSPEC void set_config_from_file(const char *conf_file_name);
-CORE_LIBSPEC void set_config_from_file_startup(const char *conf_file_name);
+CORE_LIBSPEC void set_config_from_file(enum config_type type,
+ const char *conf_file_name);
 CORE_LIBSPEC void set_config_from_command_line(int *argc, char *argv[]);
 CORE_LIBSPEC void free_config(void);
 
-typedef int (*find_change_option)(void *conf, char *name, char *value,
+typedef boolean (*find_change_option)(void *conf, char *name, char *value,
  char *extended_data);
 
 #ifdef CONFIG_EDITOR
 
-CORE_LIBSPEC void __set_config_from_file(find_change_option find_change_handler,
- void *conf, const char *conf_file_name);
-CORE_LIBSPEC void __set_config_from_command_line(
- find_change_option find_change_handler, void *conf, int *argc, char *argv[]);
+CORE_LIBSPEC void register_config(enum config_type type, void *conf,
+ find_change_option handler);
 
 CORE_LIBSPEC boolean config_int(int *dest, char *value, int min, int max);
 CORE_LIBSPEC boolean _config_enum(int *dest, const char *value,

--- a/src/editor/configure.c
+++ b/src/editor/configure.c
@@ -738,7 +738,7 @@ static const struct editor_config_entry *find_editor_option(char *name,
   return NULL;
 }
 
-static int editor_config_change_option(void *conf, char *name, char *value,
+static boolean editor_config_change_option(void *conf, char *name, char *value,
  char *extended_data)
 {
   const struct editor_config_entry *current_option = find_editor_option(name,
@@ -747,9 +747,9 @@ static int editor_config_change_option(void *conf, char *name, char *value,
   if(current_option)
   {
     current_option->change_option(conf, name, value, extended_data);
-    return 1;
+    return true;
   }
-  return 0;
+  return false;
 }
 
 struct editor_config_info *get_editor_config(void)
@@ -759,19 +759,15 @@ struct editor_config_info *get_editor_config(void)
 
 void default_editor_config(void)
 {
+  static boolean registered = false;
   memcpy(&editor_conf, &editor_conf_default, sizeof(struct editor_config_info));
-}
 
-void set_editor_config_from_file(const char *conf_file_name)
-{
-  __set_config_from_file(editor_config_change_option, &editor_conf,
-   conf_file_name);
-}
-
-void set_editor_config_from_command_line(int *argc, char *argv[])
-{
-  __set_config_from_command_line(editor_config_change_option, &editor_conf,
-   argc, argv);
+  if(!registered)
+  {
+    register_config(SYSTEM_CNF, &editor_conf, editor_config_change_option);
+    register_config(GAME_EDITOR_CNF, &editor_conf, editor_config_change_option);
+    registered = true;
+  }
 }
 
 void store_editor_config_backup(void)

--- a/src/editor/configure.h
+++ b/src/editor/configure.h
@@ -128,10 +128,6 @@ struct editor_config_info
 };
 
 EDITOR_LIBSPEC void default_editor_config(void);
-EDITOR_LIBSPEC void set_editor_config_from_file(const char *conf_file_name);
-EDITOR_LIBSPEC void set_editor_config_from_command_line(int *argc,
- char *argv[]);
-
 EDITOR_LIBSPEC void store_editor_config_backup(void);
 EDITOR_LIBSPEC void free_editor_config(void);
 

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -219,7 +219,7 @@ static boolean editor_reload_world(struct editor_context *editor,
   strncpy(config_file_name + file_name_len, ".editor.cnf", 12);
 
   if(stat(config_file_name, &file_info) >= 0)
-    set_editor_config_from_file(config_file_name);
+    set_config_from_file(GAME_EDITOR_CNF, config_file_name);
 
   edit_menu_show_board_mod(editor->edit_menu);
   return true;

--- a/src/main.c
+++ b/src/main.c
@@ -221,13 +221,11 @@ __libspec int main(int argc, char *argv[])
   chdir(config_dir);
 
   default_config();
-  set_config_from_file_startup(mzx_res_get_by_id(CONFIG_TXT));
+  default_editor_config();
+  set_config_from_file(SYSTEM_CNF, mzx_res_get_by_id(CONFIG_TXT));
   set_config_from_command_line(&argc, argv);
   conf = get_config();
 
-  default_editor_config();
-  set_editor_config_from_file(mzx_res_get_by_id(CONFIG_TXT));
-  set_editor_config_from_command_line(&argc, argv);
   store_editor_config_backup();
 
   init_macros();

--- a/src/run_stubs.c
+++ b/src/run_stubs.c
@@ -25,8 +25,6 @@ void editor_init(void) { }
 void init_macros(void) { }
 
 void default_editor_config(void) {}
-void set_editor_config_from_file(const char *conf_file_name) {}
-void set_editor_config_from_command_line(int *argc, char *argv[]) {}
 void store_editor_config_backup(void) {}
 void free_editor_config(void) {}
 #endif

--- a/src/run_stubs.h
+++ b/src/run_stubs.h
@@ -30,8 +30,6 @@ void editor_init(void);
 void init_macros(void);
 
 void default_editor_config(void);
-void set_editor_config_from_file(const char *conf_file_name);
-void set_editor_config_from_command_line(int *argc, char *argv[]);
 void store_editor_config_backup(void);
 void free_editor_config(void);
 #else
@@ -40,8 +38,6 @@ static inline void editor_init(void) {}
 static inline void init_macros(void) {}
 
 static inline void default_editor_config(void) {}
-static inline void set_editor_config_from_file(const char *conf_file_name) {}
-static inline void set_editor_config_from_command_line(int *argc, char *argv[]){}
 static inline void store_editor_config_backup(void) {}
 static inline void free_editor_config(void) {}
 #endif

--- a/src/world.c
+++ b/src/world.c
@@ -2646,7 +2646,7 @@ static void load_world(struct world *mzx_world, struct zip_archive *zp,
   strncpy(config_file_name + file_name_len, ".cnf", 5);
 
   if(stat(config_file_name, &file_info) >= 0)
-    set_config_from_file(config_file_name);
+    set_config_from_file(GAME_CNF, config_file_name);
 
   // Some initial setting(s)
   mzx_world->custom_sfx_on = 0;

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -60,8 +60,10 @@ DEBUG_CFLAGS ?= -O0
 # Build without -DDEBUG to suppress debug messages,
 # build without -DNDEBUG to allow assert().
 #
-unit_cflags ?= ${DEBUG_CFLAGS} -g ${SDL_CFLAGS} \
+unit_cflags ?= ${DEBUG_CFLAGS} -g \
  -Wall -Wextra -pedantic -Wno-unused-parameter -funsigned-char -std=gnu++11
+
+unit_cflags += ${SDL_CFLAGS} -Umain
 unit_ldflags +=
 
 ifeq (${BUILD_F_ANALYZER},1)

--- a/unit/Unit.hpp
+++ b/unit/Unit.hpp
@@ -505,12 +505,23 @@ void sigabrt_handler(int signal)
     std::cerr << "Unexpected signal received\n";
 }
 
-#ifdef __WIN32__
-int WinMain(int argc, char *argv[])
-#else
 int main(int argc, char *argv[])
-#endif
 {
+  if(argc && argv && argv[0])
+  {
+    char *fpos = strrchr(argv[0], '/');
+    char *bpos = strrchr(argv[0], '\\');
+    char tmp;
+
+    if(fpos || bpos)
+    {
+      fpos = (fpos > bpos) ? fpos : bpos;
+      tmp = *fpos;
+      *fpos = '\0';
+      chdir(argv[0]);
+      *fpos = tmp;
+    }
+  }
   std::signal(SIGABRT, sigabrt_handler);
   return !(Unit::unittestrunner.run());
 }

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -88,9 +88,6 @@ static void load_arg(char *arg)
   tmp_args[argc++] = arg;
 
   set_config_from_command_line(&argc, tmp_args);
-#ifdef CONFIG_EDITOR
-  set_editor_config_from_command_line(&argc, tmp_args);
-#endif
 }
 
 static void load_arg_file(char *arg, boolean is_game_config)
@@ -106,14 +103,8 @@ static void load_arg_file(char *arg, boolean is_game_config)
     ret = fclose(fp);
     assert(!ret);
 
-    if(!is_game_config)
-      set_config_from_file_startup(CONFIG_FILENAME);
-    else
-      set_config_from_file(CONFIG_FILENAME);
-
-#ifdef CONFIG_EDITOR
-    set_editor_config_from_file(CONFIG_FILENAME);
-#endif
+    config_type type = is_game_config ? GAME_EDITOR_CNF : SYSTEM_CNF;
+    set_config_from_file(type, CONFIG_FILENAME);
   }
 }
 
@@ -135,9 +126,6 @@ static void load_args(const char * const (&args)[SIZE])
   }
 
   set_config_from_command_line(&argc, tmp_args);
-#ifdef CONFIG_EDITOR
-  set_editor_config_from_command_line(&argc, tmp_args);
-#endif
 }
 
 #define DEFAULT_V(v) static_cast<std::remove_reference<decltype(v)>::type>(DEFAULT)

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -90,19 +90,27 @@ static void load_arg(char *arg)
   set_config_from_command_line(&argc, tmp_args);
 }
 
-static void load_arg_file(char *arg, boolean is_game_config)
+static boolean write_config(const char *path, const char *config)
 {
-  static const char CONFIG_FILENAME[] = "unit/.build/_config_tmp";
-
-  FILE *fp = fopen_unsafe(CONFIG_FILENAME, "wb");
+  FILE *fp = fopen_unsafe(path, "wb");
   assert(fp);
   if(fp)
   {
-    int ret = fwrite(arg, strlen(arg), 1, fp);
+    int ret = fwrite(config, strlen(config), 1, fp);
     assert(ret == 1);
     ret = fclose(fp);
     assert(!ret);
+    return true;
+  }
+  return false;
+}
 
+static void load_arg_file(const char *arg, boolean is_game_config)
+{
+  static const char CONFIG_FILENAME[] = "_config_tmp";
+
+  if(write_config(CONFIG_FILENAME, arg))
+  {
     config_type type = is_game_config ? GAME_EDITOR_CNF : SYSTEM_CNF;
     set_config_from_file(type, CONFIG_FILENAME);
   }
@@ -1127,6 +1135,81 @@ UNITTEST(Settings)
   }
 
 #endif /* CONFIG_EDITOR */
+}
+
+UNITTEST(Include)
+{
+  struct config_info *conf = get_config();
+  default_config();
+
+#ifdef CONFIG_EDITOR
+  struct editor_config_info *econf = get_editor_config();
+  default_editor_config();
+#endif
+
+  SECTION(Include)
+  {
+    // This version only works from a config file.
+    boolean ret = write_config("a.cnf", "include b.cnf");
+    ret &= write_config("b.cnf", "mzx_speed = 4");
+    ASSERTEQ(ret, true);
+
+    conf->mzx_speed = 2;
+
+    set_config_from_file(SYSTEM_CNF, "a.cnf");
+    ASSERTEQ(conf->mzx_speed, 4);
+  }
+
+  SECTION(IncludeEquals)
+  {
+    // This version works from both the config file and the command line.
+    char include_conf[] = "include=c.cnf";
+    boolean ret = write_config("c.cnf", "mzx_speed = 6");
+    ASSERTEQ(ret, true);
+
+    conf->mzx_speed = 1;
+
+    load_arg(include_conf);
+    ASSERTEQX(conf->mzx_speed, 6, include_conf);
+
+    conf->mzx_speed = 2;
+
+    load_arg_file(include_conf, false);
+    ASSERTEQX(conf->mzx_speed, 6, include_conf);
+  }
+
+  SECTION(Recursion)
+  {
+    // Make sure a sane amount of recursive includes work.
+    // Also make sure this works for both the main and editor configuration.
+    boolean ret = write_config("a.cnf", "include b.cnf");
+    ret &= write_config("b.cnf", "include c.cnf");
+    ret &= write_config("c.cnf", "mzx_speed=5\nboard_editor_hide_help=1");
+    ASSERTEQ(ret, true);
+
+    conf->mzx_speed = 1;
+#ifdef CONFIG_EDITOR
+    econf->board_editor_hide_help = false;
+#endif
+
+    load_arg((char *)"include=a.cnf");
+    ASSERTEQ(conf->mzx_speed, 5);
+#ifdef CONFIG_EDITOR
+    ASSERTEQ(econf->board_editor_hide_help, true);
+#endif
+  }
+
+  SECTION(RecursionLimit)
+  {
+    // Make sure recursive include fails gracefully. Even before the hard limit
+    // was added this would happen due to MZX hitting the maximum allowed number
+    // of file descriptors prior to running out of stack. This is pretty much
+    // a freebie, it just needs to not crash or run out of memory.
+    boolean ret = write_config("a.cnf", "include a.cnf");
+    ASSERTEQ(ret, true);
+
+    set_config_from_file(SYSTEM_CNF, "a.cnf");
+  }
 }
 
 #ifdef CONFIG_EDITOR


### PR DESCRIPTION
This branch gets rid of the `set_editor_config_from...` functions and replaces them with a registry (similar to the `audio/ext.c` registry). This allows both config structs to be populated at the same time instead of parsing the config file twice. This also should fix a bug where the `include` directive would not work for editor settings in any version after the editor config was split from the main config (allowing things like putting extended macros in a separate config file).

- [x] Add config registry.
- [x] Get rid of `is_startup` (should check the current config type instead...).
- [x] Add `include` recursion limit.
- [x] Add configure unit test for the `include` directive.
- [x] Changelog entry.
- [x] More testing...