### PR TITLE
Fix HTML5 port for Emscripten 1.39.19

### DIFF
--- a/arch/emscripten/web/src/index.js
+++ b/arch/emscripten/web/src/index.js
@@ -66,7 +66,13 @@ class LoadingScreen {
     }
 }
 
-window.MzxrunInitialize = function(options) {
+/**
+ * Initialize the MegaZeux frontend and run MegaZeux.
+ * @param {Object} options Options to configure the frontend and MegaZeux.
+ * @returns {Promise} Promise to run MegaZeux.
+ */
+window.MzxrunInitialize = function(options)
+{
     console.log("Initializing MegaZeux web frontend");
 
     if (!options.render) throw "Missing option: render!";
@@ -111,16 +117,14 @@ window.MzxrunInitialize = function(options) {
         return Promise.reject(e);
     }
 
-    // FIXME this breaks the return value of this function.
-    // Fix this when Emscripten bothers to make their Modules actual promises.
-    zip.initialize().then(_ =>
-    {
     const loadingScreen = new LoadingScreen(canvas, ctx, options);
 
     var vfsPromises = [];
     var vfsProgresses = [];
     var vfsObjects = [];
 
+  return zip.initialize().then(_ =>
+  {
     for (var s in options.files) {
         vfsProgresses.push(0);
         const file = options.files[s];
@@ -149,8 +153,8 @@ window.MzxrunInitialize = function(options) {
             );
         }
     }
-
-    return loadingScreen._drawBackground().then(_ => Promise.all(vfsPromises)).then(_ => {
+  }).then(_ => loadingScreen._drawBackground()).then(_ => Promise.all(vfsPromises)).then(_ =>
+  {
         // add MegaZeux config.txt vfs
         // Set startup_path first so user config will override it...
         var configString = "startup_path = /data/game\n";
@@ -237,13 +241,16 @@ window.MzxrunInitialize = function(options) {
         options.render.canvas = canvas;
 
         Module({
-            canvas: options.render.canvas
-        }).then((module) => {
+          canvas: options.render.canvas,
+          preRun: function(module)
+          {
             window.FS = module["FS"];
             FS.createFolder(FS.root, "data", true, true);
             FS.mount(wrapStorageForEmscripten(vfs), null, "/data");
             console.log("Filesystem initialization complete!");
-
+          }
+        }).then((module) =>
+        {
             // This event listener refocuses MZX when clicked if it's inside of
             // an iframe (e.g. embedded on itch.io). This is necessary to regain
             // keyboard control after focus is lost (though tab can be used too).
@@ -256,6 +263,5 @@ window.MzxrunInitialize = function(options) {
         });
     })).then(_ => true).catch(reason => {
         drawErrorMessage(canvas, ctx, reason);
-    });
     });
 }

--- a/arch/emscripten/web/src/zip.js
+++ b/arch/emscripten/web/src/zip.js
@@ -37,6 +37,12 @@ export var zip =
     "_emzip_free",
     "UTF8ToString"
   ],
+
+  /**
+   * Initialize the zip utility.
+   * @returns {Promise} Promise to initialize the zip utility.
+   * @throws {string} Error string if an error occurred.
+   */
   initialize: function()
   {
     if(zip.emzip === undefined)
@@ -45,19 +51,32 @@ export var zip =
       if(typeof(emzip)!=='function')
         return {then:function(cb){return cb();}};
 
-      zip.emzip = emzip();
-
-      zip.emzip_functions.forEach(function(fn)
+      var promise = emzip().then(module =>
       {
-        if(typeof(zip.emzip[fn])!=='function')
-          throw "zip.initialize: function emzip." + fn + " not found!";
+        zip.emzip = module;
+        zip.emzip_functions.forEach(function(fn)
+        {
+          if(typeof(zip.emzip[fn])!=='function')
+          {
+            console.error('zip.initialize: typeof(zip.emzip["'+fn+'"]) == ' +
+             typeof(zip.emzip[fn]));
+            throw "zip.initialize: function emzip." + fn + " not found!";
+          }
+        });
       });
-
-      return zip.emzip;
+      return promise;
     }
     else
       throw "zip.initialize: already initialized!";
   },
+
+  /**
+   * Extract files from a zip archive.
+   * @param {ArrayBuffer} bytes Zip archive to extract.
+   * @returns {Object.<string, Uint8Array>}
+   *   Object containing {filename => file data} for each file in the archive.
+   * @throws {string} Error string if an error occurred.
+   */
   extract: function(bytes)
   {
     // Attempt UZIP first since it's lighter on memory usage. If that fails,

--- a/arch/emscripten/web/src/zip.js
+++ b/arch/emscripten/web/src/zip.js
@@ -51,7 +51,7 @@ export var zip =
       if(typeof(emzip)!=='function')
         return {then:function(cb){return cb();}};
 
-      var promise = emzip().then(module =>
+      return emzip().then(module =>
       {
         zip.emzip = module;
         zip.emzip_functions.forEach(function(fn)
@@ -64,7 +64,6 @@ export var zip =
           }
         });
       });
-      return promise;
     }
     else
       throw "zip.initialize: already initialized!";

--- a/arch/emscripten/web/src/zip.js
+++ b/arch/emscripten/web/src/zip.js
@@ -49,7 +49,7 @@ export var zip =
     {
       // If emzip isn't loaded, silently fail (it might not be needed anyway).
       if(typeof(emzip)!=='function')
-        return {then:function(cb){return cb();}};
+        return Promise.resolve();
 
       return emzip().then(module =>
       {

--- a/docs/platform_matrix.html
+++ b/docs/platform_matrix.html
@@ -232,7 +232,7 @@ var archs =
     description:      "HTML5 (Emscripten)",
     architecture:     "JavaScript <br> WebAssembly",
     endian:           "Little",
-    toolchain:        "clang 11.0.0 <br> emsdk 1.39.15",
+    toolchain:        "clang 11.0.0 <br> emsdk 1.39.19",
     packaged:         ZIP,
     stack_protector:  _FAULTY(),
     layer_rendering:  yes,


### PR DESCRIPTION
This branch fixes the HTML5 port to work with newer releases of Emscripten, where `Module()` now returns a proper Promise instead of the module object. This mainly just required fixes to the way emzip is initialized and moving the FS initialization from `Module.then()` to `Module["preRun"]`. The `window.MzxrunInitialize` function now returns a Promise (like it did before emzip was added). As a bonus, I added a couple of doc comments.