### PR TITLE
Fix glsl and opengl2 renderers for big endian machines

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,10 @@
+GIT
+
+USERS
+
++ Fixed a graphics corruption issue when using the GLSL renderer
+  on big endian platforms.
+
 July 20th, 2020 - MZX 2.92e
 
 This bugfix release includes miscellaneous audio fixes and fixes

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -2,8 +2,8 @@ GIT
 
 USERS
 
-+ Fixed a graphics corruption issue when using the GLSL renderer
-  on big endian platforms.
++ Fixed graphics corruption when using the glsl and opengl2
+  renderers on big endian platforms.
 
 July 20th, 2020 - MZX 2.92e
 

--- a/src/render_gl.h
+++ b/src/render_gl.h
@@ -28,6 +28,7 @@ __M_BEGIN_DECLS
 
 #include "configure.h"
 #include "graphics.h"
+#include "platform.h"
 #include "util.h"
 
 #ifdef CONFIG_SDL
@@ -87,6 +88,29 @@ enum gl_lib_type
   GL_LIB_FIXED,
   GL_LIB_PROGRAMMABLE,
 };
+
+#if PLATFORM_BYTE_ORDER == PLATFORM_BIG_ENDIAN
+/**
+ * The GL renderers use GL_UNSIGNED_BYTE for 32-bit texture buffers for GLES 2
+ * compatibility. This leads to some problems when packing bytes on big endian
+ * machines because each of these packings assumes GL_UNSIGNED_INT_8_8_8_8_REV
+ * (which isn't in GLES 2).
+ */
+static inline Uint32 gl_pack_u32(Uint32 x)
+{
+  return
+   ((x & 0xFF000000) >> 24) |
+   ((x & 0x00FF0000) >> 8) |
+   ((x & 0x0000FF00) << 8) |
+   ((x & 0x000000FF) << 24);
+}
+#else
+/**
+ * For little endian, GL_UNSIGNED_BYTE and GL_UNSIGNED_INT_8_8_8_8_REV are
+ * equivalent, so don't change anything.
+ */
+#define gl_pack_u32(x) (x)
+#endif
 
 __M_END_DECLS
 

--- a/src/render_gl.h
+++ b/src/render_gl.h
@@ -95,6 +95,8 @@ enum gl_lib_type
  * compatibility. This leads to some problems when packing bytes on big endian
  * machines because each of these packings assumes GL_UNSIGNED_INT_8_8_8_8_REV
  * (which isn't in GLES 2).
+ *
+ * TODO: bswap32 here if compatibility defines for it are added.
  */
 static inline Uint32 gl_pack_u32(Uint32 x)
 {

--- a/src/render_gl2.c
+++ b/src/render_gl2.c
@@ -405,8 +405,8 @@ static void gl2_update_colors(struct graphics_data *graphics,
   Uint32 i;
   for(i = 0; i < count; i++)
   {
-    graphics->flat_intensity_palette[i] = (0xFF << 24) | (palette[i].b << 16) |
-     (palette[i].g << 8) | palette[i].r;
+    graphics->flat_intensity_palette[i] = gl_pack_u32((0xFF << 24) |
+     (palette[i].b << 16) | (palette[i].g << 8) | palette[i].r);
     render_data->palette[i*3  ] = (GLubyte)palette[i].r;
     render_data->palette[i*3+1] = (GLubyte)palette[i].g;
     render_data->palette[i*3+2] = (GLubyte)palette[i].b;

--- a/src/render_glsl.c
+++ b/src/render_glsl.c
@@ -1133,7 +1133,7 @@ static void glsl_render_layer(struct graphics_data *graphics,
   dest = render_data->background_texture;
   for(i = 0; i < 4; i++)
     for(j = 0; j < SMZX_PAL_SIZE; j++, dest++)
-      *dest = graphics->smzx_indices[j * 4 + i];
+      *dest = pack_u32(graphics->smzx_indices[j * 4 + i]);
 
   glsl.glTexSubImage2D(GL_TEXTURE_2D, 0,
    TEX_DATA_IDX_X, TEX_DATA_IDX_Y, SMZX_PAL_SIZE, 4,

--- a/src/render_glsl.c
+++ b/src/render_glsl.c
@@ -117,29 +117,6 @@ enum
   ATTRIB_COLOR,
 };
 
-#if PLATFORM_BYTE_ORDER == PLATFORM_BIG_ENDIAN
-/**
- * This uses GL_UNSIGNED_BYTE for GLES 2 compatibility. This leads to some
- * problems when packing bytes on big endian machines because these packings
- * assume GL_UNSIGNED_INT_8_8_8_8_REV (which isn't in GLES 2).
- */
-static inline Uint32 pack_u32(Uint32 x)
-{
-  return
-   ((x & 0xFF000000) >> 24) |
-   ((x & 0x00FF0000) >> 8) |
-   ((x & 0x0000FF00) << 8) |
-   ((x & 0x000000FF) << 24);
-}
-#else
-/**
- * For little endian, GL_UNSIGNED_BYTE and GL_UNSIGNED_INT_8_8_8_8_REV are
- * equivalent, so don't change anything.
- */
-#define pack_u32(x) (x)
-#endif
-
-
 /**
  * Some GL drivers attempt to run GLSL in software, resulting in extremely poor
  * performance for MegaZeux. When one of the drivers in this blacklist is
@@ -984,7 +961,7 @@ static void glsl_update_colors(struct graphics_data *graphics,
   Uint32 i;
   for(i = 0; i < count; i++)
   {
-    graphics->flat_intensity_palette[i] = pack_u32((0xFF << 24) |
+    graphics->flat_intensity_palette[i] = gl_pack_u32((0xFF << 24) |
      (palette[i].b << 16) | (palette[i].g << 8) | palette[i].r);
     render_data->palette[i*3  ] = (GLubyte)palette[i].r;
     render_data->palette[i*3+1] = (GLubyte)palette[i].g;
@@ -1099,7 +1076,7 @@ static void glsl_render_layer(struct graphics_data *graphics,
       fg_color = FULL_PAL_SIZE;
     }
 
-    *dest = pack_u32(
+    *dest = gl_pack_u32(
      (char_value << LAYER_CHAR_POS) |
      (bg_color << LAYER_BG_POS) |
      (fg_color << LAYER_FG_POS));
@@ -1133,7 +1110,7 @@ static void glsl_render_layer(struct graphics_data *graphics,
   dest = render_data->background_texture;
   for(i = 0; i < 4; i++)
     for(j = 0; j < SMZX_PAL_SIZE; j++, dest++)
-      *dest = pack_u32(graphics->smzx_indices[j * 4 + i]);
+      *dest = gl_pack_u32(graphics->smzx_indices[j * 4 + i]);
 
   glsl.glTexSubImage2D(GL_TEXTURE_2D, 0,
    TEX_DATA_IDX_X, TEX_DATA_IDX_Y, SMZX_PAL_SIZE, 4,


### PR DESCRIPTION
All textures in the OpenGL renderers are currently read from buffers using the `GL_UNSIGNED_BYTE` pixel format mode for compatibility with GLES and all instances of pixel packing in these renderers (the palette for the background colors in the opengl2 renderer; the palette, indices, and layer data in the glsl renderer) assumed an ordering equivalent to `GL_UNSIGNED_INT_8_8_8_8_REV`. This branch simply adds a function that flips these bytes for big endian platforms.

The layer data bug has existed in the GLSL renderer since 2.83; the palette bugs were introduced in 2.90.

- [x] Testing (via Rosetta)
- [ ] Real hardware testing?