### PR TITLE
3ds/nds/switch: consistently enable link-time function garbage collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,6 +301,20 @@ CXXFLAGS += -fstack-protector-all
 endif
 endif
 
+#
+# For non-modular builds, using linker garbage collection will enable
+# further dead code elimination on non-debug builds.
+#
+ifneq (${BUILD_MODULAR},1)
+ifneq (${DEBUG},1)
+ifeq (${LINK_GC_FUNCTION_SECTIONS},1)
+CFLAGS += -ffunction-sections
+CXXFLAGS += -ffunction-sections
+LDFLAGS += -Wl,--gc-sections
+endif
+endif
+endif
+
 endif
 
 #

--- a/arch/3ds/Makefile.in
+++ b/arch/3ds/Makefile.in
@@ -23,6 +23,7 @@ APP_ICON = arch/3ds/banner/megazeux-icon.png
 # 3DS target rules
 #
 STRIP  = /bin/true
+LINK_GC_FUNCTION_SECTIONS = 1
 
 #
 # Override library paths.
@@ -40,8 +41,7 @@ ifeq (${DEBUG},1)
   ARCH_CFLAGS += -Og
   EXTRA_LIBS += -lcitro3dd -lctrud -lpng16 -lz
 else
-  OPTIMIZE_CFLAGS = -O3 -fomit-frame-pointer -ffunction-sections
-# OPTIMIZE_CFLAGS += -flto
+  OPTIMIZE_CFLAGS = -O3 -fomit-frame-pointer
   EXTRA_LIBS += -lcitro3d -lctru -lpng16 -lz
 endif
 

--- a/arch/nds/Makefile.in
+++ b/arch/nds/Makefile.in
@@ -18,6 +18,7 @@ include ${DEVKITARM}/ds_rules
 # NDS target rules
 #
 STRIP  = /bin/true
+LINK_GC_FUNCTION_SECTIONS = 1
 
 #
 # Override library paths.

--- a/arch/switch/Makefile.in
+++ b/arch/switch/Makefile.in
@@ -23,6 +23,7 @@ APP_AUTHOR := \"MegaZeux Developers\"
 APP_ICON   := arch/switch/icon.jpg
 
 STRIP      := /bin/true
+LINK_GC_FUNCTION_SECTIONS := 1
 
 #
 # Override library paths.
@@ -34,7 +35,7 @@ ifeq (${DEBUG},1)
   #DRM_NOUVEAU := drm_nouveaud
   NX := nxd
 else
-  OPTIMIZE_CFLAGS := -O3 -ffunction-sections
+  OPTIMIZE_CFLAGS := -O3
   #DRM_NOUVEAU := drm_nouveau
   NX := nx
 endif


### PR DESCRIPTION
This saves about 50KB off the 3DS port's filesize, and about 10-15KB off the NDS port's filesize.

It should be possible to safely enable it on other platforms, but it may be a good idea to test them before doing so.