### PR TITLE
Make active UI elements use cursor_hint

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -169,6 +169,13 @@
 
 # fullscreen = 1
 
+# MZX can optionally display the text cursor to hint at the currently selected
+# UI element when applicable. Valid settings are 0 or "off" (doesn't display),
+# 1 or "underline" (displays the underline text cursor), and "solid" (displays
+# the filled text cursor). The default value is 0.
+
+# dialog_cursor_hints = 0
+
 # Whether MZX should allow a screenshot to be taken when F12 is pressed.
 # Defaults to enabled.
 

--- a/config.txt
+++ b/config.txt
@@ -170,11 +170,13 @@
 # fullscreen = 1
 
 # MZX can optionally display the text cursor to hint at the currently selected
-# UI element when applicable. Valid settings are 0 or "off" (doesn't display),
-# 1 or "underline" (displays the underline text cursor), and "solid" (displays
-# the filled text cursor). The default value is 0.
+# UI element when applicable. Valid settings are 0 or "off" (doesn't display
+# or update the cursor position), 1 or "hidden" (doesn't display, but updates
+# the cursor position for platforms with hardware cursors), "underline"
+# (displays the underline cursor), and "solid" (displays the filled cursor).
+# The default value is 1.
 
-# dialog_cursor_hints = 0
+# dialog_cursor_hints = 1
 
 # Whether MZX should allow a screenshot to be taken when F12 is pressed.
 # Defaults to enabled.

--- a/src/configure.c
+++ b/src/configure.c
@@ -187,7 +187,7 @@ static const struct config_info user_conf_default =
   CONFIG_GL_FILTER_LINEAR,      // opengl filter method
   "",                           // opengl default scaling shader
   GL_VSYNC_DEFAULT,             // opengl vsync mode
-  CURSOR_MODE_UNDERLINE,        // cursor_hint_mode
+  CURSOR_MODE_HINT,             // cursor_hint_mode
   true,                         // allow screenshots
 
   // Audio options
@@ -306,8 +306,9 @@ static const struct config_enum resample_mode_values[] =
 static const struct config_enum cursor_hint_type_values[] =
 {
   { "0", CURSOR_MODE_INVISIBLE },
-  { "1", CURSOR_MODE_UNDERLINE },
+  { "1", CURSOR_MODE_HINT },
   { "off", CURSOR_MODE_INVISIBLE },
+  { "hidden", CURSOR_MODE_HINT },
   { "underline", CURSOR_MODE_UNDERLINE },
   { "solid", CURSOR_MODE_SOLID },
 };

--- a/src/configure.c
+++ b/src/configure.c
@@ -187,6 +187,7 @@ static const struct config_info user_conf_default =
   CONFIG_GL_FILTER_LINEAR,      // opengl filter method
   "",                           // opengl default scaling shader
   GL_VSYNC_DEFAULT,             // opengl vsync mode
+  CURSOR_MODE_UNDERLINE,        // cursor_hint_mode
   true,                         // allow screenshots
 
   // Audio options
@@ -300,6 +301,15 @@ static const struct config_enum resample_mode_values[] =
   { "none", RESAMPLE_MODE_NONE },
   { "linear", RESAMPLE_MODE_LINEAR },
   { "cubic", RESAMPLE_MODE_CUBIC }
+};
+
+static const struct config_enum cursor_hint_type_values[] =
+{
+  { "0", CURSOR_MODE_INVISIBLE },
+  { "1", CURSOR_MODE_UNDERLINE },
+  { "off", CURSOR_MODE_INVISIBLE },
+  { "underline", CURSOR_MODE_UNDERLINE },
+  { "solid", CURSOR_MODE_SOLID },
 };
 
 static const struct config_enum system_mouse_values[] =
@@ -492,6 +502,14 @@ static void config_set_resolution(struct config_info *conf, char *name,
 
   conf->resolution_width = width;
   conf->resolution_height = height;
+}
+
+static void config_set_dialog_cursor_hints(struct config_info *conf, char *name,
+ char *value, char *extended_data)
+{
+  int result;
+  if(config_enum(&result, value, cursor_hint_type_values))
+    conf->cursor_hint_mode = result;
 }
 
 static void config_set_fullscreen(struct config_info *conf, char *name,
@@ -1002,6 +1020,7 @@ static const struct config_entry config_options[] =
   { "audio_buffer_samples", config_set_audio_buffer, false },
   { "audio_sample_rate", config_set_audio_freq, false },
   { "auto_decrypt_worlds", config_set_auto_decrypt_worlds, false },
+  { "dialog_cursor_hints", config_set_dialog_cursor_hints, false },
   { "enable_oversampling", config_enable_oversampling, false },
   { "enable_resizing", config_enable_resizing, false },
   { "force_bpp", config_force_bpp, false },

--- a/src/configure.h
+++ b/src/configure.h
@@ -55,6 +55,14 @@ enum gl_filter_type
   CONFIG_GL_FILTER_LINEAR
 };
 
+enum cursor_mode_types
+{
+  CURSOR_MODE_UNDERLINE,  // Underline for text entry (insert).
+  CURSOR_MODE_SOLID,      // Solid for text entry (overwrite) and editing.
+  CURSOR_MODE_HINT,       // Hidden cursor for active UI element hints.
+  CURSOR_MODE_INVISIBLE   // Cursor disabled.
+};
+
 enum allow_cheats_type
 {
   ALLOW_CHEATS_NEVER,
@@ -85,6 +93,7 @@ struct config_info
   enum gl_filter_type gl_filter_method;
   char gl_scaling_shader[32];
   int gl_vsync;
+  enum cursor_mode_types cursor_hint_mode;
   boolean allow_screenshots;
 
   // Audio options

--- a/src/editor/window.c
+++ b/src/editor/window.c
@@ -113,6 +113,7 @@ int list_menu(const char *const *choices, int choice_size, const char *title,
 
     // Draw current
     color_string(choices[current], xpos + 4, (ypos >> 1) + 12, DI_ACTIVE);
+    cursor_hint(xpos + 4, ypos / 2 + 12);
 
     // Draw above current
     for(i = 1; i < 9 - (ypos >> 1); i++)
@@ -358,6 +359,7 @@ int list_menu(const char *const *choices, int choice_size, const char *title,
     if(exit)
     {
       restore_screen();
+      cursor_off();
       if(current == 0)
         return -32767;
       else
@@ -481,6 +483,7 @@ int color_selection(int current, int allow_wild)
     // Add selection box
     draw_window_box(currx + 14, curry + 3, currx + 16,
      curry + 5, DI_MAIN, DI_MAIN, DI_MAIN, 0, 0);
+    cursor_hint(currx + 15, curry + 4);
 
     // Write number of color
     if((allow_wild) && ((currx == 16) || (curry == 16)))
@@ -548,6 +551,7 @@ int color_selection(int current, int allow_wild)
         pop_context();
         // Selected
         restore_screen();
+        cursor_off();
         if((allow_wild) && ((currx == 16) || (curry == 16)))
         {
           // Convert wild
@@ -788,6 +792,7 @@ static void draw_check_box(struct world *mzx_world, struct dialog *di,
   {
     color_line(src->max_length + 4, x, y + src->current_choice,
      DI_ACTIVE);
+    cursor_hint(x + 1, y + src->current_choice);
   }
 }
 
@@ -801,6 +806,8 @@ static void draw_char_box(struct world *mzx_world, struct dialog *di,
   int question_len = (int)strlen(src->question) + di->pad_space;
 
   write_string(src->question, x, y, color, 0);
+  if(active)
+    cursor_hint(x, y);
 
   // Special case: display for char ID value 255 custom behavior
   if((result == 255) && !(src->allow_char_255))
@@ -830,6 +837,9 @@ static void draw_color_box_element(struct world *mzx_world, struct dialog *di,
   write_string(src->question, x, y, color, 0);
   draw_color_box(current_color & 0xFF, current_color >> 8,
    x + (int)strlen(src->question) + di->pad_space, y, 80);
+
+  if(active)
+    cursor_hint(x, y);
 }
 
 static void draw_board_list(struct world *mzx_world, struct dialog *di,
@@ -859,6 +869,8 @@ static void draw_board_list(struct world *mzx_world, struct dialog *di,
 
   write_string(src->title, x, y, color, 0);
   fill_line(BOARD_NAME_SIZE + 1, x, y + 1, 32, DI_LIST);
+  if(active)
+    cursor_hint(x, y);
 
   color_string(board_name, x + 1, y + 1, DI_LIST);
 

--- a/src/error.c
+++ b/src/error.c
@@ -104,9 +104,7 @@ int error(const char *string, enum error_type type, unsigned int options,
   x = 40 - (int)strlen(type_name)/2;
   write_string(type_name, x, 10, 78, 0);
 
-  x = 40 - (int)strlen(string)/2;
-  write_string(string, x, 11, 79, 0);
-  cursor_hint(x, 11);
+  write_string(string, 40 - ((Uint32)strlen(string) / 2), 11, 79, 0);
 
   // Add options
   write_string("Press", 4, 13, 78, 0);
@@ -226,7 +224,6 @@ int error(const char *string, enum error_type type, unsigned int options,
   dialog_fadeout();
 
   restore_screen();
-  cursor_off();
   m_show();
   if(ret == ERROR_OPT_EXIT) // Exit the program
   {

--- a/src/error.c
+++ b/src/error.c
@@ -104,7 +104,9 @@ int error(const char *string, enum error_type type, unsigned int options,
   x = 40 - (int)strlen(type_name)/2;
   write_string(type_name, x, 10, 78, 0);
 
-  write_string(string, 40 - ((Uint32)strlen(string) / 2), 11, 79, 0);
+  x = 40 - (int)strlen(string)/2;
+  write_string(string, x, 11, 79, 0);
+  cursor_hint(x, 11);
 
   // Add options
   write_string("Press", 4, 13, 78, 0);
@@ -224,6 +226,7 @@ int error(const char *string, enum error_type type, unsigned int options,
   dialog_fadeout();
 
   restore_screen();
+  cursor_off();
   m_show();
   if(ret == ERROR_OPT_EXIT) // Exit the program
   {

--- a/src/game_menu.c
+++ b/src/game_menu.c
@@ -667,6 +667,7 @@ static boolean menu_draw(context *ctx)
     x = game_menu->x + 1;
     y = + game_menu->y + 1 + i;
     color_line(game_menu->width - 2, x, y, MENU_COL_SELECTED);
+    cursor_hint(x + 1, y);
     //write_string(game_menu->options[i].label, x, y, MENU_COL_SELECTED, false);
 
     x = game_menu->x + 1;
@@ -1150,6 +1151,7 @@ static void menu_destroy(context *ctx)
     else
       main_menu_last_selected = (enum main_menu_opts)which;
   }
+  cursor_off();
   restore_screen();
 }
 

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1118,6 +1118,7 @@ void update_screen(void)
         offset = 0;
         break;
       case CURSOR_MODE_HINT:
+        break;
       case CURSOR_MODE_INVISIBLE:
         enabled = false;
         break;

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1099,14 +1099,17 @@ void update_screen(void)
   if(graphics.cursor_flipflop &&
    (graphics.cursor_mode != CURSOR_MODE_INVISIBLE))
   {
+    enum cursor_mode_types cursor_mode = graphics.cursor_mode;
     Uint16 cursor_color = get_cursor_color();
     Uint32 lines = 0;
     Uint32 offset = 0;
 
-    switch(graphics.cursor_mode)
+    if(cursor_mode == CURSOR_MODE_HINT)
+      cursor_mode = graphics.cursor_hint_mode;
+
+    switch(cursor_mode)
     {
       case CURSOR_MODE_UNDERLINE:
-      case CURSOR_MODE_HINT:
         lines = 2;
         offset = 12;
         break;
@@ -1114,6 +1117,7 @@ void update_screen(void)
         lines = 14;
         offset = 0;
         break;
+      case CURSOR_MODE_HINT:
       case CURSOR_MODE_INVISIBLE:
         break;
     }
@@ -1617,6 +1621,7 @@ boolean init_video(struct config_info *conf, const char *caption)
   graphics.window_width = conf->window_width;
   graphics.window_height = conf->window_height;
   graphics.mouse_status = false;
+  graphics.cursor_hint_mode = conf->cursor_hint_mode;
   graphics.cursor_timestamp = get_ticks();
   graphics.cursor_flipflop = 1;
   graphics.system_mouse = conf->system_mouse;

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1106,6 +1106,7 @@ void update_screen(void)
     switch(graphics.cursor_mode)
     {
       case CURSOR_MODE_UNDERLINE:
+      case CURSOR_MODE_HINT:
         lines = 2;
         offset = 12;
         break;
@@ -1113,7 +1114,6 @@ void update_screen(void)
         lines = 14;
         offset = 0;
         break;
-      case CURSOR_MODE_HINT:
       case CURSOR_MODE_INVISIBLE:
         break;
     }

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1098,16 +1098,12 @@ void update_screen(void)
 
   if(graphics.renderer.render_cursor || graphics.renderer.hardware_cursor)
   {
-    enum cursor_mode_types cursor_mode = graphics.cursor_mode;
     Uint16 cursor_color = get_cursor_color();
     boolean enabled = true;
     Uint32 lines = 0;
     Uint32 offset = 0;
 
-    if(cursor_mode == CURSOR_MODE_HINT)
-      cursor_mode = graphics.cursor_hint_mode;
-
-    switch(cursor_mode)
+    switch(graphics.cursor_mode)
     {
       case CURSOR_MODE_UNDERLINE:
         lines = 2;
@@ -2518,7 +2514,7 @@ void cursor_solid(Uint32 x, Uint32 y)
 
 void cursor_hint(Uint32 x, Uint32 y)
 {
-  graphics.cursor_mode = CURSOR_MODE_HINT;
+  graphics.cursor_mode = graphics.cursor_hint_mode;
   graphics.cursor_x = x;
   graphics.cursor_y = y;
 }

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -2513,20 +2513,6 @@ void cursor_off(void)
   graphics.cursor_mode = CURSOR_MODE_INVISIBLE;
 }
 
-#ifdef CONFIG_HELPSYS
-
-void set_cursor_mode(enum cursor_mode_types mode)
-{
-  graphics.cursor_mode = mode;
-}
-
-enum cursor_mode_types get_cursor_mode(void)
-{
-  return graphics.cursor_mode;
-}
-
-#endif // CONFIG_HELPSYS
-
 void m_hide(void)
 {
   if(!graphics.system_mouse)

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -27,14 +27,6 @@ __M_BEGIN_DECLS
 #include "platform.h"
 #include "configure.h"
 
-enum cursor_mode_types
-{
-  CURSOR_MODE_UNDERLINE,  // Underline for text entry (insert).
-  CURSOR_MODE_SOLID,      // Solid for text entry (overwrite) and editing.
-  CURSOR_MODE_HINT,       // Hidden cursor for active UI element hints.
-  CURSOR_MODE_INVISIBLE   // Cursor disabled.
-};
-
 struct rgb_color
 {
   Uint8 r;
@@ -176,6 +168,7 @@ struct graphics_data
   boolean requires_extended;
 
   enum cursor_mode_types cursor_mode;
+  enum cursor_mode_types cursor_hint_mode;
   boolean fade_status;
   boolean dialog_fade_status;
   Uint32 cursor_x;

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -356,11 +356,6 @@ CORE_LIBSPEC void ec_load_mzx(void);
 CORE_LIBSPEC void ec_load_set_secondary(const char *name, Uint8 *dest);
 #endif // CONFIG_EDITOR
 
-#ifdef CONFIG_HELPSYS
-void set_cursor_mode(enum cursor_mode_types mode);
-enum cursor_mode_types get_cursor_mode(void);
-#endif // CONFIG_HELPSYS
-
 #ifdef CONFIG_ENABLE_SCREENSHOTS
 void dump_screen(void);
 #endif

--- a/src/helpsys.c
+++ b/src/helpsys.c
@@ -64,14 +64,11 @@ void help_system(context *ctx, struct world *mzx_world)
 {
   char file[13], file2[13], label[13];
   int where, offs, size, t1, t2;
-  enum cursor_mode_types old_cmode;
   FILE *fp;
 
   fp = mzx_world->help_file;
   if(!fp)
     return;
-
-  old_cmode = get_cursor_mode();
 
   rewind(fp);
   t1 = fgetw(fp);
@@ -133,6 +130,4 @@ labelled:
       }
     }
   }
-
-  set_cursor_mode(old_cmode);
 }

--- a/src/robot.c
+++ b/src/robot.c
@@ -2696,6 +2696,7 @@ void robot_box_display(struct world *mzx_world, char *program,
   {
     // Display scroll
     robot_frame(mzx_world, program + pos, id);
+    cursor_hint(8, 12);
     update_screen();
 
     update_event_status_delay();
@@ -2837,6 +2838,7 @@ void robot_box_display(struct world *mzx_world, char *program,
 
   // Restore screen and exit
   m_hide();
+  cursor_off();
   restore_screen();
   update_event_status();
 }

--- a/src/scrdisp.c
+++ b/src/scrdisp.c
@@ -151,6 +151,7 @@ void scroll_edit(struct world *mzx_world, struct scroll *scroll, int type)
     // Display scroll. If editing, the colors of the frame need to be masked.
     // Otherwise, they should display using game colors.
     scroll_frame(mzx_world, scroll, pos, mask_chars, editing);
+    cursor_hint(8, 12);
     update_screen();
 
     if(editing)
@@ -403,6 +404,7 @@ void scroll_edit(struct world *mzx_world, struct scroll *scroll, int type)
     // Continue?
   } while(key != IKEY_ESCAPE);
   // Restore screen and exit
+  cursor_off();
   restore_screen();
   // Due to a faulty check, 2.83 through 2.91f always stay faded in here.
   // If something is found that relies on that, make this conditional.
@@ -620,6 +622,7 @@ void help_display(struct world *mzx_world, char *help, int offs, char *file,
     help_frame(mzx_world, help, pos);
     mclick = 0;
 
+    cursor_hint(8, 12);
     update_screen();
 
     update_event_status_delay();
@@ -828,6 +831,7 @@ void help_display(struct world *mzx_world, char *help, int offs, char *file,
 ex:
   dialog_fadeout();
 
+  cursor_off();
   restore_screen();
 }
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -226,10 +226,10 @@ void game_settings(struct world *mzx_world)
      radio_strings_2, 2, 18, &pcs);
     elements[2] = construct_label(2, 8 + y_offset,
      "Audio volumes-");
-    elements[3] = construct_number_box(2, 9 + y_offset,
-     "     Music- ", 0, 10, NUMBER_SLIDER, &music_volume);
-    elements[4] = construct_number_box(2, 10 + y_offset,
-     "   Samples- ", 0, 10, NUMBER_SLIDER, &sound_volume);
+    elements[3] = construct_number_box(7, 9 + y_offset,
+     "Music- ", 0, 10, NUMBER_SLIDER, &music_volume);
+    elements[4] = construct_number_box(5, 10 + y_offset,
+     "Samples- ", 0, 10, NUMBER_SLIDER, &sound_volume);
     elements[5] = construct_number_box(2, 11 + y_offset,
      "PC Speaker- ", 0, 10, NUMBER_SLIDER, &pcs_volume);
 

--- a/src/window.c
+++ b/src/window.c
@@ -388,8 +388,6 @@ __editor_maybe_static int char_selection_ext(int current, int allow_char_255,
   force_release_all_keys();
   save_screen();
 
-  cursor_off();
-
   do
   {
     // Draw box and inner box
@@ -442,6 +440,7 @@ __editor_maybe_static int char_selection_ext(int current, int allow_char_255,
 
     x = (current & 31);
     y = (current >> 5);
+    cursor_hint(x + 23, y + 7);
 
     if(get_shift_status(keycode_internal) && allow_multichar)
     {
@@ -791,6 +790,7 @@ __editor_maybe_static int char_selection_ext(int current, int allow_char_255,
   // Prevent UI keys from carrying through.
   force_release_all_keys();
   restore_screen();
+  cursor_off();
 
   return current;
 }
@@ -1004,7 +1004,6 @@ int run_dialog(struct world *mzx_world, struct dialog *di)
   else
     set_context(get_context(NULL));
 
-  cursor_off();
   m_show();
 
   save_screen();
@@ -1031,6 +1030,7 @@ int run_dialog(struct world *mzx_world, struct dialog *di)
 
   do
   {
+    cursor_off();
     highlight_element(mzx_world, di, current_element_num);
     update_screen();
 
@@ -1094,7 +1094,7 @@ int run_dialog(struct world *mzx_world, struct dialog *di)
 
         if((element_under != -1) &&
          (element_under != current_element_num) &&
-         ((di->elements[element_under])->key_function))
+         ((di->elements[element_under])->click_function))
         {
           unhighlight_element(mzx_world, di, current_element_num);
           current_element_num = element_under;
@@ -1246,12 +1246,14 @@ int run_dialog(struct world *mzx_world, struct dialog *di)
     {
       force_release_all_keys();
       pop_context();
+      cursor_off();
       return -1;
     }
 
   } while(di->done != 1);
 
   pop_context();
+  cursor_off();
 
   return di->return_value;
 }
@@ -1356,6 +1358,7 @@ static void draw_radio_button(struct world *mzx_world, struct dialog *di,
   {
     color_line(src->max_length + 4, x, y + *(src->result),
      DI_ACTIVE);
+    cursor_hint(x + 1, y + *(src->result));
   }
 }
 
@@ -1374,6 +1377,9 @@ static void draw_button(struct world *mzx_world, struct dialog *di,
   write_string(src->label, x + 1, y, color, 0);
   draw_char(' ', color, x, y);
   draw_char(' ', color, x + (Uint32)strlen(src->label) + 1, y);
+
+  if(active)
+    cursor_hint(x + 1, y);
 }
 
 static void draw_number_box(struct world *mzx_world, struct dialog *di,
@@ -1389,6 +1395,8 @@ static void draw_number_box(struct world *mzx_world, struct dialog *di,
     increment = 5;
 
   write_string(src->question, x, y, color, 0);
+  if(active)
+    cursor_hint(x, y);
 
   x += (int)strlen(src->question) + di->pad_space;
 
@@ -1493,6 +1501,9 @@ static void draw_slot_selector(struct world *mzx_world, struct dialog *di,
 
     fill_line(4, slot_x, slot_y, 0, slot_color);
     write_number(i + 1, slot_color, slot_x + 2, slot_y, 1, true, 10);
+
+    if(active && i == src->selected_slot)
+      cursor_hint(slot_x + 1, slot_y);
   }
 }
 
@@ -1508,6 +1519,8 @@ static void draw_file_selector(struct world *mzx_world, struct dialog *di,
 
   write_string(src->title, x, y, color, 0);
   fill_line(width, x, y + 1, 32, DI_LIST);
+  if(active)
+    cursor_hint(x, y);
 
   if(path[0])
   {
@@ -1579,6 +1592,8 @@ static void draw_list_box(struct world *mzx_world, struct dialog *di,
 
     fill_line(choice_length, x, y + current_in_window,
      32, color);
+    if(active)
+      cursor_hint(x, y + current_in_window);
 
     snprintf(name_buffer, draw_width, "%s", choices[current_choice]);
     name_buffer[draw_width - 1] = '\0';

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -437,8 +437,9 @@ UNITTEST(Settings)
     static const config_test_single data[] =
     {
       { "0", CURSOR_MODE_INVISIBLE },
-      { "1", CURSOR_MODE_UNDERLINE },
+      { "1", CURSOR_MODE_HINT },
       { "off", CURSOR_MODE_INVISIBLE },
+      { "hidden", CURSOR_MODE_HINT },
       { "underline", CURSOR_MODE_UNDERLINE },
       { "solid",  CURSOR_MODE_SOLID },
       { "-1", DEFAULT },

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -432,6 +432,25 @@ UNITTEST(Settings)
     TEST_ENUM("gl_vsync", conf->gl_vsync, data);
   }
 
+  SECTION(cursor_hint_mode)
+  {
+    static const config_test_single data[] =
+    {
+      { "0", CURSOR_MODE_INVISIBLE },
+      { "1", CURSOR_MODE_UNDERLINE },
+      { "off", CURSOR_MODE_INVISIBLE },
+      { "underline", CURSOR_MODE_UNDERLINE },
+      { "solid",  CURSOR_MODE_SOLID },
+      { "-1", DEFAULT },
+      { "-24124124", DEFAULT },
+      { "2", DEFAULT },
+      { "938019831", DEFAULT },
+      { "1a", DEFAULT },
+      { "umderl1ne", DEFAULT },
+    };
+    TEST_ENUM("dialog_cursor_hints", conf->cursor_hint_mode, data);
+  }
+
   SECTION(allow_screenshots)
   {
     TEST_ENUM("allow_screenshots", conf->allow_screenshots, boolean_data);


### PR DESCRIPTION
This branch makes all active dialog elements and a few other UIs (char selection, color selection, list menu, main/game menus) use the `cursor_hint` function to place the text cursor next to the highlighted element's current selection or label. This functionality was requested for a screen reader but may be useful to others.

- [x] Feedback/tweaks.
- [x] More testing.
- [x] Currently the UI hint cursor is identical to the underline cursor for testing purposes. There should be a config file option to select between "hidden" (default), "underline", and "solid".
- [x] Actually make the default for `dialog_cursor_hints` be `CURSOR_MODE_HINT` instead of `CURSOR_MODE_UNDERLINE` (was using this value to make testing easier).
- [x] ~~Maybe get rid of `CURSOR_MODE_HINT` and have `cursor_hint` just set the cursor mode to `graphics.cursor_hint_mode` directly.~~ This turned out to be actually useful since it can distinguish between enabling and disabling the cursor for the DJGPP port, meaning the hint cursor will still update with the screen reader even though it's not visible.