### PR TITLE
Add config.sh flags `--disable-getaddrinfo` and `--disable-ipv6`

### DIFF
--- a/arch/psp/Makefile.in
+++ b/arch/psp/Makefile.in
@@ -23,7 +23,8 @@ ARCH_LDFLAGS  += -L${PREFIX}/sdk/lib
 # needs to go there. Otherwise, linking fails. This issue was encountered with
 # the devkitPSP r16 build of PSPDEV.
 SDL_CFLAGS = -I${PREFIX}/include/SDL
-SDL_LDFLAGS = -lSDL -lGL -lpspirkeyb -lc -lc -lpspvfpu -lpsprtc -lpsppower -lpspaudio -lpspgu -lpspge -lpspdisplay -lpsphprm -lpspctrl -lpspnet_inet -lpspuser
+SDL_LDFLAGS = -lSDL -lGL -lpspirkeyb -lc -lc -lpspvfpu -lpsprtc -lpsppower -lpspaudio \
+  -lpspgu -lpspge -lpspdisplay -lpsphprm -lpspctrl -lpspnet_inet -lpspnet_resolver -lpspuser
 LIBPNG_CFLAGS =
 LIBPNG_LDFLAGS = -lpng
 

--- a/arch/wii/Makefile.in
+++ b/arch/wii/Makefile.in
@@ -67,6 +67,10 @@ arch/wii/%.o: arch/wii/%.c
 	$(if ${V},,@echo "  CC      " $<)
 	${CC} -MD ${core_cflags} ${core_flags} -c $< -o $@
 
+arch/wii/%.o: arch/wii/%.cpp
+	$(if ${V},,@echo "  CXX     " $<)
+	${CXX} -MD ${core_cxxflags} ${core_flags} -c $< -o $@
+
 #
 # Need to nest Wii binaries in a subdir
 #

--- a/arch/wii/network.cpp
+++ b/arch/wii/network.cpp
@@ -1,0 +1,127 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2020 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "../../src/network/Socket.hpp"
+
+#include <network.h>
+#include <fcntl.h>
+
+/**
+ * Wii essentially uses standard BSD socket functions with different names.
+ * Note while BSD socket fd functions are compatible with other operations for
+ * fds, the Wii socket functions are not. That doesn't really matter as far
+ * as MegaZeux is concerned, though.
+ */
+
+struct hostent *Socket::gethostbyname(const char *name)
+{
+  return net_gethostbyname(name);
+}
+
+void Socket::perror(const char *message)
+{
+  ::perror(message);
+}
+
+int Socket::accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
+{
+  return net_accept(sockfd, addr, addrlen);
+}
+
+int Socket::bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
+{
+  return net_bind(sockfd, (struct sockaddr *)addr, addrlen);
+}
+
+void Socket::close(int fd)
+{
+  net_close(fd);
+}
+
+int Socket::connect(int sockfd, const struct sockaddr *serv_addr,
+ socklen_t addrlen)
+{
+  return net_connect(sockfd, const_cast<struct sockaddr *>(serv_addr), addrlen);
+}
+
+uint16_t Socket::hton_short(uint16_t hostshort)
+{
+  return htons(hostshort);
+}
+
+int Socket::listen(int sockfd, int backlog)
+{
+  return net_listen(sockfd, backlog);
+}
+
+int Socket::select(int nfds, fd_set *readfds, fd_set *writefds,
+ fd_set *exceptfds, struct timeval *timeout)
+{
+  return net_select(nfds, readfds, writefds, exceptfds, timeout);
+}
+
+ssize_t Socket::send(int sockfd, const void *buf, size_t len, int flags)
+{
+  return net_send(sockfd, buf, len, flags);
+}
+
+ssize_t Socket::sendto(int sockfd, const void *buf, size_t len, int flags,
+ const struct sockaddr *to, socklen_t tolen)
+{
+  return net_sendto(sockfd, buf, len, flags, (struct sockaddr *)to, tolen);
+}
+
+int Socket::setsockopt(int sockfd, int level, int optname,
+ const void *optval, socklen_t optlen)
+{
+  return net_setsockopt(sockfd, level, optname, optval, optlen);
+}
+
+int Socket::socket(int af, int type, int protocol)
+{
+  return net_socket(af, type, protocol);
+}
+
+int Socket::recv(int sockfd, void *buf, size_t len, int flags)
+{
+  return net_recv(sockfd, buf, len, flags);
+}
+
+int Socket::recvfrom(int sockfd, void *buf, size_t len, int flags,
+ struct sockaddr *from, socklen_t *fromlen)
+{
+  return net_recvfrom(sockfd, buf, len, flags, from, fromlen);
+}
+
+boolean Socket::is_last_error_fatal()
+{
+  return is_last_errno_fatal();
+}
+
+void Socket::set_blocking(int sockfd, boolean blocking)
+{
+  int flags = net_fcntl(sockfd, F_GETFL, 0);
+
+  if(!blocking)
+    flags |= O_NONBLOCK;
+  else
+    flags &= ~O_NONBLOCK;
+
+  net_fcntl(sockfd, F_SETFL, flags);
+}

--- a/config.sh
+++ b/config.sh
@@ -99,7 +99,7 @@ usage() {
 	echo "Network options:"
 	echo "  --disable-network       Disable networking abilities."
 	echo "  --disable-updater       Disable built-in updater."
-	echo "  --disable-getaddrinfo   Disable getaddrinfo() for name resolution."
+	echo "  --disable-getaddrinfo   Disable getaddrinfo for name resolution."
 	echo "  --disable-ipv6          Disable IPv6 support."
 	echo
 	echo "e.g.: ./config.sh --platform unix --prefix /usr"
@@ -939,7 +939,7 @@ fi
 #
 if [ "$NETWORK" = "true" ] && \
  [ "$PLATFORM" = "amiga" -o "$PLATFORM" = "wii" -o "$PLATFORM" = "psp" ]; then
-	echo "Force-disabling getaddrinfo() name resolution and IPv6 support (unsupported platform)."
+	echo "Force-disabling getaddrinfo name resolution and IPv6 support (unsupported platform)."
 	GETADDRINFO="false"
 	IPV6="false"
 fi
@@ -1377,10 +1377,10 @@ if [ "$NETWORK" = "true" ]; then
 	# Handle networking options.
 	#
 	if [ "$GETADDRINFO" = "true" ]; then
-		echo "getaddrinfo() name resolution enabled."
+		echo "getaddrinfo name resolution enabled."
 		echo "#define CONFIG_GETADDRINFO" >> src/config.h
 	else
-		echo "getaddrinfo() name resolution disabled."
+		echo "getaddrinfo name resolution disabled."
 	fi
 
 	if [ "$IPV6" = "true" ]; then

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -90,6 +90,9 @@ DEVELOPERS
   support disabled.
 + Added const and restrict to the software render_graph and
   render_layer implementations for a small performance boost.
++ Added --disable-getaddrinfo and --disable-ipv6 config.sh flags
+  to allow disabling these for old platforms and consoles SDKs.
+  Amiga, Wii, and PSP network builds force-disable these.
 
 
 July 20th, 2020 - MZX 2.92e

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -189,6 +189,10 @@ ifeq (${BUILD_AUDIO},1)
 core_cobjs += arch/wii/audio.o
 endif
 endif
+# Required regardless of whether SDL is enabled or not...
+ifeq (${BUILD_NETWORK},1)
+core_cxxobjs += arch/wii/network.o
+endif
 endif
 
 ifeq (${BUILD_PSP},1)

--- a/src/network/DNS.cpp
+++ b/src/network/DNS.cpp
@@ -21,6 +21,7 @@
 // trying to work with platform-dependent solutions.
 
 #include <assert.h>
+#include <stdlib.h>
 
 #include "DNS.hpp"
 #include "Socket.hpp"

--- a/src/network/Host.cpp
+++ b/src/network/Host.cpp
@@ -38,10 +38,6 @@
 #include <algorithm>
 #include <utility>
 
-#ifndef __amigaos__
-#define CONFIG_IPV6
-#endif
-
 static struct config_info *conf;
 
 static const char *get_proxy_error(enum proxy_status s)

--- a/src/network/Host.cpp
+++ b/src/network/Host.cpp
@@ -40,7 +40,7 @@
 
 static struct config_info *conf;
 
-static const char *get_proxy_error(enum proxy_status s)
+static inline const char *get_proxy_error(enum proxy_status s)
 {
   switch(s)
   {

--- a/src/network/Socket.cpp
+++ b/src/network/Socket.cpp
@@ -25,6 +25,7 @@
 
 #include <assert.h>
 #include <inttypes.h>
+#include <stdlib.h>
 
 #if defined(__WIN32__) || !defined(CONFIG_GETADDRINFO)
 

--- a/src/network/Socket.cpp
+++ b/src/network/Socket.cpp
@@ -139,6 +139,7 @@ boolean Socket::init(struct config_info *conf)
   if(!init_ref_count)
     platform_mutex_init(&gai_lock);
   init_ref_count++;
+  return true;
 }
 
 void Socket::exit()

--- a/src/network/Socket.cpp
+++ b/src/network/Socket.cpp
@@ -26,7 +26,7 @@
 #include <assert.h>
 #include <inttypes.h>
 
-#if defined(__WIN32__) || defined(__amigaos__)
+#if defined(__WIN32__) || !defined(CONFIG_GETADDRINFO)
 
 /**
  * gethostbyname may use a static struct that is shared across threads
@@ -129,9 +129,9 @@ const char *Socket::gai_strerror_alt(int errcode)
       return "Unknown error.";
   }
 }
-#endif // __WIN32__ || __amigaos__
+#endif // __WIN32__ || !CONFIG_GETADDRINFO
 
-#ifdef __amigaos__
+#if !defined(__WIN32__) && !defined(CONFIG_GETADDRINFO)
 static int init_ref_count;
 
 boolean Socket::init(struct config_info *conf)

--- a/src/network/Socket.hpp
+++ b/src/network/Socket.hpp
@@ -58,10 +58,21 @@
 //#include <net/if.h>
 #endif // __WIN32__
 
-#if defined(__amigaos__)
+#if defined(CONFIG_GETADDRINFO) && !defined(EAI_AGAIN)
+#error "Missing getaddrinfo() support; configure with --disable-getaddrinfo."
+#endif
+
+#if defined(CONFIG_IPV6) && !defined(AF_INET6)
+#error "Missing IPv6 support; configure with --disable-ipv6."
+#endif
+
+#if !defined(CONFIG_GETADDRINFO)
 
 // Amiga doesn't have getaddrinfo and needs to use a fallback implementation.
+// This affects various other legacy platforms and some console SDKs as well.
 #define GETADDRINFO_MAYBE_INLINE(x)
+
+#if !defined(EAI_AGAIN)
 #define EAI_NONAME -2
 #define EAI_AGAIN  -3
 #define EAI_FAIL   -4
@@ -78,6 +89,7 @@ struct addrinfo
   char *ai_canonname;
   struct addrinfo *ai_next;
 };
+#endif
 #endif
 
 #ifndef AI_V4MAPPED

--- a/src/network/Socket.hpp
+++ b/src/network/Socket.hpp
@@ -44,7 +44,12 @@
 #endif // !__WIN64__
 #include <winsock2.h>
 #include <ws2tcpip.h>
-#else // !__WIN32__
+#elif defined(CONFIG_WII)
+// See arch/wii/network.cpp.
+#include <network.h>
+#include <fcntl.h>
+#define UNIX_INLINE(x)
+#else // !__WIN32__ && !CONFIG_WII
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/select.h>


### PR DESCRIPTION
This allows these features to be disabled for platforms that don't support them, whether they're old platforms (e.g. AmigaOS 4) or their console SDKs don't support them (PSP, Wii, Wii U #246). I also added patches to get PSP and Wii to build with network support since I'm tired of manually patching them in for testing (network support shouldn't actually work on either right now, though...). If a platform that doesn't support these tries to build with them enabled it should trigger a compile time error, but this needs more testing.

- [x] Testing.
- [x] ~~Maybe actually get Wii network support working.~~ out of scope :-(