### PR TITLE
Implement Wii network support.

### DIFF
--- a/arch/wii/network.cpp
+++ b/arch/wii/network.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "../../src/network/Socket.hpp"
+#include "../../src/util.h"
 
 #include <network.h>
 #include <fcntl.h>
@@ -29,35 +30,113 @@
  * as MegaZeux is concerned, though.
  */
 
+/**
+ * Track whether or not the internal Wii network layer is initialized.
+ */
+static boolean net_is_initialized = false;
+
+/**
+ * Since it seems like libogc won't set errno for anything but gethostbyname,
+ * it has to be manually handled by the wrapper functions here. This is set to
+ * whatever the return value of the previous socket function was. When >= 0,
+ * there is no error. When negative, there was an error, which should be
+ * converted to an error message using strerror_r(-net_errno).
+ *
+ * TODO thread safety.
+ */
+static int net_errno = 0;
+
+boolean platform_socket_init()
+{
+  return true;
+}
+
+boolean platform_socket_init_late()
+{
+  if(!net_is_initialized)
+  {
+    net_errno = net_init();
+    if(net_errno != 0)
+    {
+      Socket::perror("platform_socket_init_late() -> net_init()");
+      return false;
+    }
+  }
+  net_is_initialized = true;
+  return true;
+}
+
+void platform_socket_exit()
+{
+  if(net_is_initialized)
+  {
+    net_is_initialized = false;
+    net_deinit();
+  }
+}
+
 struct hostent *Socket::gethostbyname(const char *name)
 {
-  return net_gethostbyname(name);
+  // This one actually does set errno...
+  struct hostent *ret = net_gethostbyname(name);
+  net_errno = errno;
+  return ret;
+}
+
+int Socket::get_errno()
+{
+  return net_errno < 0 ? -net_errno : 0;
 }
 
 void Socket::perror(const char *message)
 {
-  ::perror(message);
+  char buf[256];
+  buf[0] = '\0';
+
+  // NOTE: return value not portable.
+  strerror_r(MAX(0, -net_errno), buf, ARRAY_SIZE(buf));
+  warn("--SOCKET-- %s: %s\n", message, buf);
 }
 
 int Socket::accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 {
-  return net_accept(sockfd, addr, addrlen);
+  net_errno = net_accept(sockfd, addr, addrlen);
+  return net_errno;
 }
 
 int Socket::bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 {
-  return net_bind(sockfd, (struct sockaddr *)addr, addrlen);
+  net_errno = net_bind(sockfd, (struct sockaddr *)addr, addrlen);
+  return net_errno;
 }
 
 void Socket::close(int fd)
 {
-  net_close(fd);
+  net_errno = net_close(fd);
 }
 
 int Socket::connect(int sockfd, const struct sockaddr *serv_addr,
  socklen_t addrlen)
 {
-  return net_connect(sockfd, const_cast<struct sockaddr *>(serv_addr), addrlen);
+  net_errno = net_connect(sockfd, const_cast<struct sockaddr *>(serv_addr), addrlen);
+  return net_errno;
+}
+
+int Socket::getsockopt(int sockfd, int level, int optname, void *optval,
+ socklen_t *optlen)
+{
+  warn("--SOCKET-- getsockopt() is not implemented by libogc.\n");
+  if(level == SOL_SOCKET && optname == SO_ERROR && optval && optlen &&
+   *optlen == sizeof(int))
+  {
+    // Just pretend everything is ok since there's no way to get the error ;-(
+    int *optval_i = reinterpret_cast<int *>(optval);
+    *optval_i = 0;
+    net_errno = 0;
+    return 0;
+  }
+  net_errno = -EINVAL;
+  return net_errno;
 }
 
 uint16_t Socket::hton_short(uint16_t hostshort)
@@ -67,46 +146,121 @@ uint16_t Socket::hton_short(uint16_t hostshort)
 
 int Socket::listen(int sockfd, int backlog)
 {
-  return net_listen(sockfd, backlog);
+  net_errno = net_listen(sockfd, backlog);
+  return net_errno;
 }
 
 int Socket::select(int nfds, fd_set *readfds, fd_set *writefds,
  fd_set *exceptfds, struct timeval *timeout)
 {
-  return net_select(nfds, readfds, writefds, exceptfds, timeout);
+  /**
+   * Try actual select first. Most likely, this isn't actually implemented and
+   * poll needs to be substituted for it instead. Actual select can technically
+   * return -EINVAL, but this only happens if nfds or the timeout are invalid
+   * (i.e. it should happen instantly).
+   */
+  net_errno = net_select(nfds, readfds, writefds, exceptfds, timeout);
+  if(net_errno != -EINVAL)
+    return net_errno;
+
+  struct pollsd ps[FD_SETSIZE];
+  int num_ps = 0;
+
+  for(int i = 0; i < nfds; i++)
+  {
+    int rf = readfds ? FD_ISSET(i, readfds) : 0;
+    int wf = writefds ? FD_ISSET(i, writefds) : 0;
+    int ef = exceptfds ? FD_ISSET(i, exceptfds) : 0;
+    if(rf || wf || ef)
+    {
+      if(num_ps >= FD_SETSIZE)
+        return -EINVAL;
+
+      struct pollsd &p = ps[num_ps++];
+
+      p.socket = i;
+      p.events = 0;
+      p.revents = 0;
+
+      if(rf)
+        p.events |= POLLIN;
+      if(wf)
+        p.events |= POLLOUT;
+      if(ef)
+        p.events |= POLLPRI;
+    }
+  }
+
+  if(readfds)
+    FD_ZERO(readfds);
+  if(writefds)
+    FD_ZERO(writefds);
+  if(exceptfds)
+    FD_ZERO(exceptfds);
+
+  int timeout_ms = (timeout->tv_sec * 1000 + timeout->tv_usec / 1000);
+  net_errno = net_poll(ps, num_ps, timeout_ms);
+  if(net_errno > 0)
+  {
+    for(int i = 0; i < num_ps; i++)
+    {
+      struct pollsd &p = ps[i];
+      if(readfds && (p.revents & POLLIN))
+        FD_SET(p.socket, readfds);
+      if(writefds && (p.revents & POLLOUT))
+        FD_SET(p.socket, writefds);
+      if(exceptfds && (p.revents & POLLPRI))
+        FD_SET(p.socket, exceptfds);
+    }
+  }
+  return net_errno;
 }
 
 ssize_t Socket::send(int sockfd, const void *buf, size_t len, int flags)
 {
-  return net_send(sockfd, buf, len, flags);
+  net_errno = net_send(sockfd, buf, len, flags);
+  return net_errno;
 }
 
 ssize_t Socket::sendto(int sockfd, const void *buf, size_t len, int flags,
  const struct sockaddr *to, socklen_t tolen)
 {
-  return net_sendto(sockfd, buf, len, flags, (struct sockaddr *)to, tolen);
+  net_errno = net_sendto(sockfd, buf, len, flags, (struct sockaddr *)to, tolen);
+  return net_errno;
 }
 
 int Socket::setsockopt(int sockfd, int level, int optname,
  const void *optval, socklen_t optlen)
 {
-  return net_setsockopt(sockfd, level, optname, optval, optlen);
+  net_errno = net_setsockopt(sockfd, level, optname, optval, optlen);
+  return net_errno;
 }
 
 int Socket::socket(int af, int type, int protocol)
 {
-  return net_socket(af, type, protocol);
+  /**
+   * Doesn't recognize IPPROTO_TCP, but IPPROTO_IP is fine... :/
+   * https://github.com/devkitPro/wii-examples/blob/master/devices/network/sockettest/source/sockettest.c
+   */
+  if((type == SOCK_STREAM && protocol == IPPROTO_TCP) ||
+   (type == SOCK_DGRAM && protocol == IPPROTO_UDP))
+    protocol = IPPROTO_IP;
+
+  net_errno = net_socket(af, type, protocol);
+  return net_errno;
 }
 
 int Socket::recv(int sockfd, void *buf, size_t len, int flags)
 {
-  return net_recv(sockfd, buf, len, flags);
+  net_errno = net_recv(sockfd, buf, len, flags);
+  return net_errno;
 }
 
 int Socket::recvfrom(int sockfd, void *buf, size_t len, int flags,
  struct sockaddr *from, socklen_t *fromlen)
 {
-  return net_recvfrom(sockfd, buf, len, flags, from, fromlen);
+  net_errno = net_recvfrom(sockfd, buf, len, flags, from, fromlen);
+  return net_errno;
 }
 
 boolean Socket::is_last_error_fatal()

--- a/arch/wii/network.cpp
+++ b/arch/wii/network.cpp
@@ -255,9 +255,6 @@ int Socket::poll(struct pollfd *fds, unsigned int nfds, int timeout_ms)
   static_assert(offsetof(pollfd, revents) == offsetof(pollsd, revents), "");
 #endif
 
-  if(!fds || !nfds)
-    return set_net_errno(-EINVAL);
-
   int res = net_poll(reinterpret_cast<struct pollsd *>(fds), nfds, timeout_ms);
   return set_net_errno(res);
 }

--- a/arch/wii/network.cpp
+++ b/arch/wii/network.cpp
@@ -88,10 +88,7 @@ void platform_socket_exit()
 struct hostent *Socket::gethostbyname(const char *name)
 {
   // This one actually does set errno...
-  struct hostent *ret = net_gethostbyname(name);
-  if(!ret)
-    set_net_errno(errno);
-  return ret;
+  return net_gethostbyname(name);
 }
 
 int Socket::get_errno()

--- a/arch/wii/network.cpp
+++ b/arch/wii/network.cpp
@@ -158,7 +158,8 @@ struct hostent *Socket::gethostbyname(const char *name)
 {
   // This one actually does set errno...
   struct hostent *ret = net_gethostbyname(name);
-  set_net_errno(errno);
+  if(!ret)
+    set_net_errno(errno);
   return ret;
 }
 
@@ -170,11 +171,11 @@ int Socket::get_errno()
 
 void Socket::perror(const char *message)
 {
+  int net_errno = get_net_errno();
   char buf[256];
   buf[0] = '\0';
 
   // NOTE: return value not portable.
-  int net_errno = get_net_errno();
   strerror_r(MAX(0, -net_errno), buf, ARRAY_SIZE(buf));
   warn("--SOCKET-- %s: %s\n", message, buf);
 }

--- a/config.sh
+++ b/config.sh
@@ -918,7 +918,7 @@ fi
 #
 # Force disable updater (unsupported platform)
 #
-if [ "$PLATFORM" != "mingw" -a "$PLATFORM" != "wii" ]; then
+if [ "$PLATFORM" != "mingw" ]; then
 	echo "Force-disabling updater (unsupported platform)."
 	UPDATER="false"
 fi

--- a/config.sh
+++ b/config.sh
@@ -913,7 +913,7 @@ fi
 #
 # Force disable updater (unsupported platform)
 #
-if [ "$PLATFORM" != "mingw" ]; then
+if [ "$PLATFORM" != "mingw" -a "$PLATFORM" != "wii" ]; then
 	echo "Force-disabling updater (unsupported platform)."
 	UPDATER="false"
 fi

--- a/src/network/Host.cpp
+++ b/src/network/Host.cpp
@@ -177,6 +177,14 @@ boolean Host::host_layer_init(struct config_info *in_conf)
   return true;
 }
 
+boolean Host::host_layer_init_check()
+{
+  if(!conf)
+    return false;
+
+  return Socket::init_late();
+}
+
 void Host::host_layer_exit(void)
 {
   DNS::exit();

--- a/src/network/Host.hpp
+++ b/src/network/Host.hpp
@@ -132,6 +132,16 @@ public:
   static boolean host_layer_init(struct config_info *conf);
 
   /**
+   * Check the host layer initialization status. If the current platform needs
+   * to perform any late initialization (e.g. when initializing the network
+   * would take too long for it to be worth performing on startup), this
+   * function will handle that.
+   *
+   * @return `true` if the host layer is ready, otherwise `false`.
+   */
+  static boolean host_layer_init_check();
+
+  /**
    * Shuts down the host layer.
    * Frees any associated operating system resources.
    */

--- a/src/network/Socket.cpp
+++ b/src/network/Socket.cpp
@@ -138,7 +138,12 @@ static int init_ref_count;
 boolean Socket::init(struct config_info *conf)
 {
   if(!init_ref_count)
+  {
+    if(!platform_socket_init())
+      return false;
+
     platform_mutex_init(&gai_lock);
+  }
   init_ref_count++;
   return true;
 }
@@ -148,7 +153,10 @@ void Socket::exit()
   assert(init_ref_count);
   init_ref_count--;
   if(!init_ref_count)
+  {
+    platform_socket_exit();
     platform_mutex_destroy(&gai_lock);
+  }
 }
 
 int Socket::getaddrinfo(const char *node, const char *service,
@@ -383,6 +391,11 @@ void winsock_perror(const char *message, int code)
 
   warn("%s (code %d): %s", message, code, err_message);
   LocalFree(err_message);
+}
+
+void Socket::get_errno()
+{
+  return socksyms.WSAGetLastError();
 }
 
 void Socket::perror(const char *message)

--- a/src/network/Socket.hpp
+++ b/src/network/Socket.hpp
@@ -53,11 +53,13 @@
 #include <fcntl.h>
 #define UNIX_INLINE(x)
 
+// libogc uses a structure different from the regular structure and does not
+// declare pollfd. Declare this to be identical to the libogc version...
 struct pollfd
 {
-  int fd;
-  short events;
-  short revents;
+  s32 fd;
+  u32 events;
+  u32 revents;
 };
 
 #else // !__WIN32__ && !CONFIG_WII

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -417,6 +417,19 @@ static void display_clear(void)
 }
 
 /**
+ * Indicate that the network is currently being initialized.
+ */
+static void display_initializing()
+{
+  static const char str[] = "Initializing network...";
+  m_hide();
+  draw_window_box(3, 11, 76, 13, DI_MAIN, DI_DARK, DI_CORNER, 1, 1);
+  write_string(str, (WIDGET_BUF_LEN - strlen(str)) / 2, 12, DI_TEXT, 0);
+  update_screen();
+  m_show();
+}
+
+/**
  * Indicate that the client is currently connecting to a remote host.
  */
 static void display_connecting(const char *host_name)
@@ -827,6 +840,15 @@ static boolean __check_for_updates(context *ctx, boolean is_automatic)
     error_message(E_UPDATE, 14, "No updater hosts defined! Aborting.");
     return false;
   }
+
+  display_initializing();
+  if(!Host::host_layer_init_check())
+  {
+    error_message(E_UPDATE, 15, "Failed to initialize network layer.");
+    display_clear();
+    return false;
+  }
+  display_clear();
 
   set_context(CTX_UPDATER);
 


### PR DESCRIPTION
This branch gets network support for the Nintendo Wii port fully working via adding some new `extern "C"` `platform_*` functions to Socket.hpp, which should also make it possible to get networking going on the [Nintendo Switch](https://switchbrew.github.io/libnx/socket_8h_source.html) and the [Nintendo](https://github.com/devkitPro/libctru/blob/master/libctru/include/3ds/services/soc.h) [3DS](https://github.com/devkitPro/3ds-examples/blob/master/network/sockets/source/sockets.c) with (hopefully) little issue. There's also an implementation of `Socket::poll` for the Wii, manual setting of `errno` for the Wii (since the Wii network functions do not set `errno`), and some bugfixes for misc. socket functions that have sketchy/broken/nonexistent Wii implementations.

- [x] ~~Investigate libctru socket `errno`~~ Sets `errno`, devkitARM `errno` is reentrant.
- [x] ~~Investigate libnx socket `errno`~~ Sets `errno`, devkitA64 `errno` is reentrant.
- [x] Replace convoluted net_errno threading junk with just setting `errno`, since it's reentrant in devkitPPC too.
- [x] Probably revert the config.sh change for now.