### PR TITLE
Implement 3DS and Switch network support.

### DIFF
--- a/arch/wii/network.cpp
+++ b/arch/wii/network.cpp
@@ -55,12 +55,12 @@ static int set_net_errno(int value)
   return value;
 }
 
-boolean platform_socket_init()
+boolean Socket::platform_init(struct config_info *conf)
 {
   return true;
 }
 
-boolean platform_socket_init_late()
+boolean Socket::platform_init_late()
 {
   if(!net_is_initialized)
   {
@@ -76,7 +76,7 @@ boolean platform_socket_init_late()
   return true;
 }
 
-void platform_socket_exit()
+void Socket::platform_exit()
 {
   if(net_is_initialized)
   {

--- a/config.sh
+++ b/config.sh
@@ -762,6 +762,9 @@ if [ "$PLATFORM" = "3ds" ]; then
 
 	echo "Disabling utils on 3DS (silly)."
 	UTILS="false"
+
+	echo "Force-disabling IPv6 on 3DS (not implemented)."
+	IPV6="false"
 fi
 
 #
@@ -778,6 +781,9 @@ if [ "$PLATFORM" = "switch" ]; then
 
 	echo "Force-enabling OpenGL ES support (Switch)."
 	GLES="true"
+
+	echo "Force-disabling IPv6 on Switch (FIXME getaddrinfo seems to not support it)."
+	IPV6="false"
 
 	# This may or may not be totally useless for the Switch, disable it for now.
 	GAMECONTROLLERDB="false"

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -114,7 +114,9 @@ DEVELOPERS
   render_layer implementations for a small performance boost.
 + Added --disable-getaddrinfo and --disable-ipv6 config.sh flags
   to allow disabling these for old platforms and consoles SDKs.
-  Amiga, Wii, and PSP network builds force-disable these.
+  Amiga, Wii, and PSP network builds force-disable these. Switch
+  and 3DS builds currently force-disable IPv6.
++ Added experimental network support for Wii, Switch, and 3DS.
 
 
 July 20th, 2020 - MZX 2.92e


### PR DESCRIPTION
This branch gets network support working for the 3DS and Switch ports and makes some changes to how platform network initialization occurs (gets rid of duplicate `init_ref_counts`, the init implementation used relying on `getaddrinfo`...). For now their platform-specific hooks have just been appended to `Socket.cpp`.

- [x] More testing.
- [x] libctru `getsockopt(SOL_SOCKET, SO_ERROR)` seems broken and returns a junk error code. There's a workaround hack with `connect()` to detect `EISCONN` for now.
- [x] Make sure the `poll()` splitting patch actually does make networking more responsive on the 3DS.