### PR TITLE
Add joystick config unit test, fix joystick ranges for NDS/3DS

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -1406,6 +1406,19 @@ static enum joystick_special_axis find_joystick_axis(const char *name)
 }
 
 /**
+ * Provide direct access to the joystick map structure. This is currently only
+ * used for config file unit tests but it might be useful later for the
+ * settings menu.
+ */
+struct joystick_map *get_joystick_map(boolean is_global)
+{
+  if(is_global)
+    return &(input.joystick_global_map);
+  else
+    return &(input.joystick_game_map);
+}
+
+/**
  * A joystick can be mapped to either an int from 0 to 32767 (a key binding),
  * a key enum string (also a key binding), or to a joystick action enum string
  * (action binding). Read either from an input value string.
@@ -1453,7 +1466,7 @@ boolean joystick_parse_map_value(const char *value, Sint16 *binding)
 void joystick_map_button(int first, int last, int button, const char *value,
  boolean is_global)
 {
-  if((first <= last) && (first >= 0) && (last < MAX_JOYSTICKS) &&
+  if((first <= last) && (first >= 0) && (first < MAX_JOYSTICKS) &&
    (button >= 0) && (button < MAX_JOYSTICK_BUTTONS))
   {
     Sint16 binding;
@@ -1461,6 +1474,7 @@ void joystick_map_button(int first, int last, int button, const char *value,
 
     if(joystick_parse_map_value(value, &binding))
     {
+      last = MIN(last, MAX_JOYSTICKS - 1);
       for(i = first; i <= last; i++)
       {
         if(is_global)
@@ -1485,7 +1499,7 @@ void joystick_map_button(int first, int last, int button, const char *value,
 void joystick_map_axis(int first, int last, int axis, const char *neg,
  const char *pos, boolean is_global)
 {
-  if((first <= last) && (first >= 0) && (last < MAX_JOYSTICKS) &&
+  if((first <= last) && (first >= 0) && (first < MAX_JOYSTICKS) &&
    (axis >= 0) && (axis < MAX_JOYSTICK_AXES))
   {
     Sint16 binding_neg, binding_pos;
@@ -1494,6 +1508,7 @@ void joystick_map_axis(int first, int last, int axis, const char *neg,
     if(joystick_parse_map_value(neg, &binding_neg) &&
      joystick_parse_map_value(pos, &binding_pos))
     {
+      last = MIN(last, MAX_JOYSTICKS - 1);
       for(i = first; i <= last; i++)
       {
         if(is_global)
@@ -1520,7 +1535,7 @@ void joystick_map_axis(int first, int last, int axis, const char *neg,
 void joystick_map_hat(int first, int last, const char *up, const char *down,
  const char *left, const char *right, boolean is_global)
 {
-  if((first <= last) && (first >= 0) && (last < MAX_JOYSTICKS))
+  if((first <= last) && (first >= 0) && (first < MAX_JOYSTICKS))
   {
     Sint16 binding_up, binding_down, binding_left, binding_right;
     int i;
@@ -1530,6 +1545,7 @@ void joystick_map_hat(int first, int last, const char *up, const char *down,
      joystick_parse_map_value(left, &binding_left) &&
      joystick_parse_map_value(right, &binding_right))
     {
+      last = MIN(last, MAX_JOYSTICKS - 1);
       for(i = first; i <= last; i++)
       {
         if(is_global)
@@ -1563,7 +1579,7 @@ void joystick_map_hat(int first, int last, const char *up, const char *down,
 void joystick_map_action(int first, int last, const char *action,
  const char *value, boolean is_global)
 {
-  if((first <= last) && (first >= 0) && (last < MAX_JOYSTICKS))
+  if((first <= last) && (first >= 0) && (first < MAX_JOYSTICKS))
   {
     enum joystick_action action_value = find_joystick_action(action);
     Sint16 binding;
@@ -1571,6 +1587,8 @@ void joystick_map_action(int first, int last, const char *action,
 
     if(!joystick_parse_map_value(value, &binding) || (binding < 0))
       return;
+
+    last = MIN(last, MAX_JOYSTICKS - 1);
 
     if(action_value != JOY_NO_ACTION)
     {

--- a/src/event.h
+++ b/src/event.h
@@ -239,6 +239,7 @@ CORE_LIBSPEC void key_release(struct buffered_status *status, enum keycode key);
 CORE_LIBSPEC boolean get_exit_status(void);
 CORE_LIBSPEC boolean set_exit_status(boolean value);
 CORE_LIBSPEC boolean peek_exit_input(void);
+CORE_LIBSPEC struct joystick_map *get_joystick_map(boolean is_global);
 CORE_LIBSPEC Uint32 get_joystick_ui_action(void);
 CORE_LIBSPEC Uint32 get_joystick_ui_key(void);
 

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -1401,7 +1401,9 @@ UNITTEST(Joystick)
     {
       // Setting              Value           [#, #]  which   expected
       { "joy1button1",        "key_space",    1,  1,  1,      { IKEY_SPACE }},
+      { "joy[1,1]button2",    "key_insert",   1,  1,  2,      { IKEY_INSERT }},
       { "joy16button256",     "key_escape",   16, 16, 256,    { IKEY_ESCAPE, }},
+      { "joy[1,16]button16",  "act_lstick",   1,  16, 16,     { -JOY_LSTICK }},
       { "joy[1,16]button256", "act_a",        1,  16, 256,    { -JOY_A }},
       { "joy[4,8]button10",   "act_start",    4,  8,  10,     { -JOY_START }},
       { "joy[9,9]button123",  "27",           9,  9,  123,    { IKEY_ESCAPE }},
@@ -1416,6 +1418,7 @@ UNITTEST(Joystick)
     {
       // Setting              Value                   [#, #]  which   expected
       { "joy1axis1",          "key_left, key_right",  1,  1,  1,      { IKEY_LEFT, IKEY_RIGHT }},
+      { "joy[1,1]axis2",      "key_a,key_d",          1,  1,  2,      { IKEY_a, IKEY_d }},
       { "joy16axis16",        "key_w,key_s",          16, 16, 16,     { IKEY_w, IKEY_s }},
       { "joy[11,16]axis16",   "key_up, key_down",     11, 16, 16,     { IKEY_UP, IKEY_DOWN }},
       { "joy[2,9]axis7",      "key_1,key_delete",     2,  9,  7,      { IKEY_1, IKEY_DELETE }},


### PR DESCRIPTION
Fixes a regression caused by [e42259b4](https://github.com/AliceLR/megazeux/commit/e42259b4d189de02e12220fabc7053f34b4f9b9a#diff-f4b1dfbfae738858a42e05ae54450e00) where joystick config ranges (example: `joy[1,16].a = key_space`) stopped working for the NDS and 3DS ports. This is a problem as game configs should be using ranges like these for portability.

The bounding check for the joystick mapping functions is now entirely based on the first joystick index (the last index is just clamped to the range of valid joysticks). This means any joystick range starting from 1 should be guaranteed to work on everything. A unit test for the joystick configuration options has also been added to `unit/configure.cpp`.

- [x] Make sure the unit tests are C++11 compilant.
- [x] More testing.