### PR TITLE
Fix audio.c, sfx.c threading issues and PC speaker note cancelling

### DIFF
--- a/arch/nds/audio.c
+++ b/arch/nds/audio.c
@@ -68,6 +68,9 @@ static inline void nds_pcs_tick(int duration)
   int ticks = 0;
   int ticked;
 
+  if(sfx_should_cancel_note())
+    pcs_playing = 0;
+
   while(ticks < duration)
   {
     if(pcs_playing)
@@ -102,11 +105,6 @@ static inline void nds_pcs_tick(int duration)
   {
     nds_pcs_sound(pcs_frequency, NDS_VOLUME(audio_get_pcs_volume()));
   }
-}
-
-void pcs_stream_cancel_current(void)
-{
-  pcs_playing = 0;
 }
 
 // Maxmod glue code

--- a/arch/nds/audio.c
+++ b/arch/nds/audio.c
@@ -27,7 +27,6 @@
 #include <maxmod9.h>
 #include "platform.h"
 #include "../../src/audio/audio.h"
-#include "../../src/audio/audio_pcs.h"
 #include "../../src/audio/sfx.h"
 
 #ifdef CONFIG_AUDIO

--- a/arch/nds/audio.c
+++ b/arch/nds/audio.c
@@ -103,6 +103,11 @@ static inline void nds_pcs_tick(int duration)
   }
 }
 
+void pcs_stream_cancel_current(void)
+{
+  pcs_playing = 0;
+}
+
 // Maxmod glue code
 
 #define MAX_NUM_SAMPLES 8

--- a/arch/nds/audio.c
+++ b/arch/nds/audio.c
@@ -27,6 +27,7 @@
 #include <maxmod9.h>
 #include "platform.h"
 #include "../../src/audio/audio.h"
+#include "../../src/audio/audio_pcs.h"
 #include "../../src/audio/sfx.h"
 
 #ifdef CONFIG_AUDIO

--- a/arch/nds/audio.c
+++ b/arch/nds/audio.c
@@ -67,7 +67,7 @@ static inline void nds_pcs_tick(int duration)
   int ticks = 0;
   int ticked;
 
-  if(sfx_should_cancel_note())
+  if(!audio_get_pcs_on() || sfx_should_cancel_note())
     pcs_playing = 0;
 
   while(ticks < duration)
@@ -320,6 +320,9 @@ int audio_play_module(char *filename, boolean safely, int volume)
   char *mas_ext_pos;
   u8 *mas_buffer;
 
+  if(!audio_get_music_on())
+    return 1;
+
   // we can only play pre-converted .MAS files
   strcpy(mas_filename, filename);
   mas_ext_pos = strrchr(mas_filename, '.');
@@ -391,6 +394,9 @@ void audio_play_sample(char *filename, boolean safely, int period)
   mm_sound_effect sfx;
   int freq_desired, freq_real;
   u32 sample_id, mas_fn_len;
+
+  if(!audio_get_music_on())
+    return;
 
   // we can only play pre-converted .SAM files
   strcpy(mas_filename, filename);

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -75,6 +75,9 @@ USERS
   not update the world title.
 + Fixed a crash that could be caused by selecting a block on the
   overlay/vlayer, changing boards, then pressing enter.
++ Fixed a bug where the currently playing PC speaker note would
+  play for the rest of its duration after turning off PC speaker
+  sound effects, after "end play", after exiting gameplay, etc.
 
 DEVELOPERS
 

--- a/src/audio/audio.c
+++ b/src/audio/audio.c
@@ -32,6 +32,7 @@
 #include "audio_pcs.h"
 #include "ext.h"
 #include "sampled_stream.h"
+#include "sfx.h"
 
 #include "../configure.h"
 #include "../data.h"
@@ -323,6 +324,7 @@ void init_audio(struct config_info *conf)
   init_pc_speaker(conf);
 
   audio_set_pcs_volume(conf->pc_speaker_volume);
+  sfx_init();
 
   init_audio_platform(conf);
 }
@@ -331,6 +333,7 @@ void quit_audio(void)
 {
   // Signal the audio thread to stop and wait for it to release the lock.
   quit_audio_platform();
+  sfx_quit();
 
   LOCK();
 

--- a/src/audio/audio.c
+++ b/src/audio/audio.c
@@ -75,65 +75,21 @@
 // May be used by audio plugins
 struct audio audio;
 
-#define __lock()      platform_mutex_lock(&audio.audio_mutex)
-#define __unlock()    platform_mutex_unlock(&audio.audio_mutex)
+#ifndef DEBUG
 
-#ifdef DEBUG
+#define LOCK()   platform_mutex_lock(&audio.audio_mutex)
+#define UNLOCK() platform_mutex_unlock(&audio.audio_mutex)
 
-#define LOCK()   lock(__FILE__, __LINE__)
-#define UNLOCK() unlock(__FILE__, __LINE__)
+#else /* DEBUG */
 
-static volatile int locked = 0;
-static volatile char last_lock[32];
+#include "../thread_debug.h"
 
-#ifdef CONFIG_SDL
-static volatile platform_thread_id last_thread = 0;
-#endif
+static platform_mutex_debug mutex_debug;
 
-static void lock(const char *file, int line)
-{
-#ifdef CONFIG_SDL
-  // lock may be held here, but it shouldn't be held by the current thread.
-  // If this is SDL, we can determine if the current thread is holding it.
-  // Otherwise, print nothing because this debug message is annoying and is
-  // almost always spurious.
-  platform_thread_id cur_thread = platform_get_thread_id();
-
-  if(locked && (last_thread == cur_thread))
-  {
-    debug("%s:%d (thread %zu): locked at %s (thread %zu) already!\n",
-     file, line, (size_t)cur_thread, last_lock, (size_t)last_thread);
-  }
-#endif
-
-  // acquire the mutex
-  __lock();
-
-  // store information on this lock
-  snprintf((char *)last_lock, 32, "%s:%d", file, line);
-  last_lock[31] = '\0';
-#ifdef CONFIG_SDL
-  last_thread = platform_get_thread_id();
-#endif
-
-  locked = 1;
-}
-
-static void unlock(const char *file, int line)
-{
-  // lock should be held here
-  if(!locked)
-    debug("%s:%d: tried to unlock when not locked!\n", file, line);
-
-  // all ok, unlock this mutex
-  locked = 0;
-  __unlock();
-}
-
-#else // !DEBUG
-
-#define LOCK()     __lock()
-#define UNLOCK()   __unlock()
+#define LOCK()   platform_mutex_lock_debug(&audio.audio_mutex, \
+                  &audio.audio_debug_mutex, &mutex_debug, __FILE__, __LINE__)
+#define UNLOCK() platform_mutex_unlock_debug(&audio.audio_mutex, \
+                  &audio.audio_debug_mutex, &mutex_debug, __FILE__, __LINE__)
 
 #endif // DEBUG
 
@@ -283,6 +239,10 @@ void audio_callback(Sint16 *stream, int len)
 void init_audio(struct config_info *conf)
 {
   platform_mutex_init(&audio.audio_mutex);
+  platform_mutex_init(&audio.audio_sfx_mutex);
+#ifdef DEBUG
+  platform_mutex_init(&audio.audio_debug_mutex);
+#endif
 
   audio.output_frequency = conf->output_frequency;
   audio.master_resample_mode = conf->resample_mode;
@@ -324,7 +284,6 @@ void init_audio(struct config_info *conf)
   init_pc_speaker(conf);
 
   audio_set_pcs_volume(conf->pc_speaker_volume);
-  sfx_init();
 
   init_audio_platform(conf);
 }
@@ -333,7 +292,6 @@ void quit_audio(void)
 {
   // Signal the audio thread to stop and wait for it to release the lock.
   quit_audio_platform();
-  sfx_quit();
 
   LOCK();
 
@@ -341,6 +299,12 @@ void quit_audio(void)
   free(audio.pcs_stream);
 
   UNLOCK();
+
+#ifdef DEBUG
+  platform_mutex_destroy(&audio.audio_debug_mutex);
+#endif
+  platform_mutex_destroy(&audio.audio_sfx_mutex);
+  platform_mutex_destroy(&audio.audio_mutex);
 }
 
 /* If the mod was successfully changed, return 1.  This value is used

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -120,6 +120,10 @@ struct audio
   struct audio_stream *stream_list_end;
 
   platform_mutex audio_mutex;
+  platform_mutex audio_sfx_mutex;
+#ifdef DEBUG
+  platform_mutex audio_debug_mutex;
+#endif
 
   Uint32 music_on;
   Uint32 pcs_on;

--- a/src/audio/audio_pcs.c
+++ b/src/audio/audio_pcs.c
@@ -28,8 +28,6 @@
 
 #include <string.h>
 
-static boolean pcs_cancel_current = false;
-
 struct pc_speaker_stream
 {
   struct audio_stream a;
@@ -43,11 +41,6 @@ struct pc_speaker_stream
   Uint32 sample_cutoff;
   Uint32 last_increment_buffer;
 };
-
-void pcs_stream_cancel_current(void)
-{
-  pcs_cancel_current = true;
-}
 
 static Uint32 pcs_mix_data(struct audio_stream *a_src, Sint32 *buffer,
  Uint32 len)
@@ -66,9 +59,8 @@ static Uint32 pcs_mix_data(struct audio_stream *a_src, Sint32 *buffer,
    * Cancel the current playing note if PC speaker effects were turned off or
    * if the sfx queue was cleared.
    */
-  if(!audio_get_pcs_on() || pcs_cancel_current)
+  if(!audio_get_pcs_on() || sfx_should_cancel_note())
   {
-    pcs_cancel_current = false;
     pcs_stream->last_playing = 0;
     pcs_stream->last_duration = 0;
     sample_duration = 0;

--- a/src/audio/audio_pcs.h
+++ b/src/audio/audio_pcs.h
@@ -27,6 +27,7 @@
 __M_BEGIN_DECLS
 
 void init_pc_speaker(struct config_info *conf);
+void pcs_stream_cancel_current(void);
 
 __M_END_DECLS
 

--- a/src/audio/audio_pcs.h
+++ b/src/audio/audio_pcs.h
@@ -27,7 +27,6 @@
 __M_BEGIN_DECLS
 
 void init_pc_speaker(struct config_info *conf);
-void pcs_stream_cancel_current(void);
 
 __M_END_DECLS
 

--- a/src/audio/sfx.c
+++ b/src/audio/sfx.c
@@ -127,7 +127,7 @@ static int backindex = 0; // Marks bottom of queue
  * up through 2.92e. It is highly unlikely anything ever relied on a duration
  * over 65535 (~131 seconds at 500 Hz).
  *
- * The frequency is guaranteed to never actually need aynthing higher than the
+ * The frequency is guaranteed to never actually need anything higher than the
  * table below, so there's no reason for it to be 32-bit.
  */
 struct noise

--- a/src/audio/sfx.c
+++ b/src/audio/sfx.c
@@ -511,7 +511,7 @@ int sfx_length_left(void)
   int left = topindex - backindex;
 
   if(left < 0)
-    left = topindex + (NOISEMAX - backindex);
+    left += NOISEMAX;
 
   return left;
 }

--- a/src/audio/sfx.h
+++ b/src/audio/sfx.h
@@ -96,6 +96,7 @@ CORE_LIBSPEC extern char sfx_strs[NUM_SFX][SFX_SIZE];
 
 // Called by audio_pcs.c under lock.
 void sfx_next_note(int *is_playing, int *freq, int *duration);
+boolean sfx_should_cancel_note(void);
 
 void play_sfx(struct world *mzx_world, enum sfx_id sfx);
 void play_string(char *str, int sfx_play);

--- a/src/audio/sfx.h
+++ b/src/audio/sfx.h
@@ -97,8 +97,6 @@ CORE_LIBSPEC extern char sfx_strs[NUM_SFX][SFX_SIZE];
 // Called by audio_pcs.c under lock.
 void sfx_next_note(int *is_playing, int *freq, int *duration);
 
-void sfx_init(void);
-void sfx_quit(void);
 void play_sfx(struct world *mzx_world, enum sfx_id sfx);
 void play_string(char *str, int sfx_play);
 void sfx_clear_queue(void);
@@ -107,8 +105,6 @@ int sfx_length_left(void);
 
 #else // !CONFIG_AUDIO
 
-void sfx_init(void) {}
-void sfx_quit(void) {}
 static inline void play_sfx(struct world *mzx_world, int sfxn) {}
 static inline void play_string(char *str, int sfx_play) {}
 static inline void sfx_clear_queue(void) {}

--- a/src/audio/sfx.h
+++ b/src/audio/sfx.h
@@ -88,9 +88,6 @@ enum sfx_id
 // Requires NUM_SFX/SFX_SIZE, so don't include.
 struct world;
 
-// Size of sound queue
-#define NOISEMAX        4096
-
 #ifdef CONFIG_EDITOR
 CORE_LIBSPEC extern char sfx_strs[NUM_SFX][SFX_SIZE];
 #endif // CONFIG_EDITOR
@@ -100,18 +97,22 @@ CORE_LIBSPEC extern char sfx_strs[NUM_SFX][SFX_SIZE];
 // Called by audio_pcs.c under lock.
 void sfx_next_note(int *is_playing, int *freq, int *duration);
 
+void sfx_init(void);
+void sfx_quit(void);
 void play_sfx(struct world *mzx_world, enum sfx_id sfx);
 void play_string(char *str, int sfx_play);
 void sfx_clear_queue(void);
-char sfx_is_playing(void);
+boolean sfx_is_playing(void);
 int sfx_length_left(void);
 
 #else // !CONFIG_AUDIO
 
+void sfx_init(void) {}
+void sfx_quit(void) {}
 static inline void play_sfx(struct world *mzx_world, int sfxn) {}
 static inline void play_string(char *str, int sfx_play) {}
 static inline void sfx_clear_queue(void) {}
-static inline char sfx_is_playing(void) { return 0; }
+static inline boolean sfx_is_playing(void) { return false; }
 static inline int sfx_length_left(void) { return 0; }
 
 #endif // CONFIG_AUDIO

--- a/src/thread_debug.h
+++ b/src/thread_debug.h
@@ -29,8 +29,6 @@
 
 __M_BEGIN_DECLS
 
-//#ifdef DEBUG
-
 #include "platform.h"
 #include "util.h"
 
@@ -106,8 +104,6 @@ static inline void platform_mutex_unlock_debug(platform_mutex *mutex,
 
   platform_mutex_unlock(mutex);
 }
-
-//#endif /* DEBUG */
 
 __M_END_DECLS
 

--- a/src/thread_debug.h
+++ b/src/thread_debug.h
@@ -1,0 +1,114 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2007 Alistair John Strachan <alistair@devzero.co.uk>
+ * Copyright (C) 2020 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * Functions for debugging mutexes.
+ */
+
+#ifndef __THREAD_DEBUG_H
+#define __THREAD_DEBUG_H
+
+#include "compat.h"
+
+__M_BEGIN_DECLS
+
+//#ifdef DEBUG
+
+#include "platform.h"
+#include "util.h"
+
+struct platform_mutex_debug
+{
+  char message[32];
+  platform_thread_id lock_thread;
+  boolean locked;
+};
+
+typedef struct platform_mutex_debug platform_mutex_debug;
+
+static inline void platform_mutex_lock_debug(platform_mutex *mutex,
+ platform_mutex *debug_mutex, platform_mutex_debug *info,
+ const char *file, int line)
+{
+  // lock may be held here, but it shouldn't be held by the current thread.
+  platform_thread_id cur_thread = platform_get_thread_id();
+
+  platform_mutex_lock(debug_mutex);
+
+  if(info->locked)
+  {
+    if(info->lock_thread == cur_thread)
+      warn("%s:%d (TID %zu): locked at %s (TID %zu) already!\n",
+       file, line, (size_t)cur_thread, info->message, (size_t)info->lock_thread);
+    else
+      trace("%s:%d (TID %zu): waiting on mutex locked by %s (TID %zu)\n",
+       file, line, (size_t)cur_thread, info->message, (size_t)info->lock_thread);
+  }
+
+  platform_mutex_unlock(debug_mutex);
+
+  // acquire the mutex
+  platform_mutex_lock(mutex);
+
+  platform_mutex_lock(debug_mutex);
+
+  // store information on this lock
+  snprintf((char *)info->message, 32, "%s:%d", file, line);
+  info->message[31] = '\0';
+
+  info->lock_thread = cur_thread;
+  info->locked = true;
+
+  platform_mutex_unlock(debug_mutex);
+}
+
+static inline void platform_mutex_unlock_debug(platform_mutex *mutex,
+ platform_mutex *debug_mutex, platform_mutex_debug *info,
+ const char *file, int line)
+{
+  platform_thread_id cur_thread = platform_get_thread_id();
+
+  platform_mutex_lock(debug_mutex);
+
+  // lock should be held here
+  if(!info->locked)
+  {
+    warn("%s:%d (TID %zu): tried to unlock when not locked!\n",
+     file, line, (size_t)cur_thread);
+  }
+  else
+
+  // ...but not by another thread.
+  if(info->lock_thread != cur_thread)
+    warn("%s:%d (TID %zu): tried to unlock mutex held by %s (TID %zu)!\n",
+     file, line, (size_t)cur_thread, info->message, (size_t)info->lock_thread);
+
+  info->locked = false;
+
+  platform_mutex_unlock(debug_mutex);
+
+  platform_mutex_unlock(mutex);
+}
+
+//#endif /* DEBUG */
+
+__M_END_DECLS
+
+#endif /* __THREAD_DEBUG_H */


### PR DESCRIPTION
Fixes a couple of fairly significant regressions in MZX's audio threading and PC speaker behavior introduced in the transition to SDL:

- The circular buffer used by sfx.c was fine in DOS but is prone to concurrency issues in parallel environments. This is made worse by the fact that either thread was capable of cancelling the entire queue, which made it vulnerable to (very rare) desynchronization issues. A mutex has been added to fix this. ThreadSanitizer still reports some "data races" but these are reads that don't directly affect the state of the queue, so I don't see any point in wrapping them with the lock [(issue)](https://www.digitalmzx.com/forums/index.php?app=tracker&showissue=494&st=0#entry4518).
- The annoying audio mutex locking debug messages that were introduced in 2.81f also needed to be synchronized and the "fix" I added before to check the thread ID didn't really do anything about this. Now there's an audio debug mutex too, and the mutex debug checks have been generalized in `thread_debug.h` since they could be useful elsewhere. This shouldn't affect release builds at all [(issue)](https://www.digitalmzx.com/forums/index.php?app=tracker&showissue=494&st=0#entry4518).
- In DOS versions, `end play` would cancel the current playing note. Due to the way the PCS stream works, prior port versions would continue playing the current note. This should be fixed. There's also a bug in both DOS and port versions where disabling PC speaker effects from the F2 menu wouldn't cancel the current playing note, which has also been fixed.
- The use of 32-bit ints in the SFX queue appears to be an oversight introduced by the transition out of DOS, where the values in the queue were 16-bit signed ints. Since the frequencies never rely on 32-bit values and I highly doubt anything needs to play a note longer than 131 seconds(!), I went ahead just made the NDS hack added in #251 the general handling for this, and cleaned up some issues that might have arisen due to the bizarre spaghetti nature of how the SFX durations were implemented (see `extra_duration` in `sfx.c:play_string`).

- [x] ~~`sfx_clear_queue` should lock the main audio mutex too to prevent issues with cancelling the current note.~~ I just moved the cancel flag to `sfx.c` so it can be used exclusively under the SFX lock; `audio_pcs.c` and `nds/audio.c` now call into `sfx.c` instead of the other way around.
- [x] More testing maybe :(