### PR TITLE
Fix `restrict` define for MSVC 

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -408,6 +408,9 @@ exceptions are:
   as C++ (as C++ does not support them).
 * As a general rule, mixed declarations and code should be avoided as well.
   The primary exception to this is when using declarations for RAII in C++.
+* The `restrict` keyword should be used only through the macro `RESTRICT`.
+  This is for intercompatibility with C++. See GNU extensions for more info
+  and restrictions on usage.
 
 ### C standard library functions
 
@@ -437,6 +440,11 @@ compatibility. The following GNU extensions are allowed:
 * `long long` (should usually use inttypes.h and/or `size_t`/`ssize_t` instead).
 * Pragmas to locally disable warnings are acceptable in rare cases.
 * `__PRETTY_FUNCTION__` (C++ only; an MSVC compatibility define is included).
+* The `__restrict` keyword provided for C and C++ by GCC, Clang, ICC, and MSVC
+  may be used via the macro `RESTRICT` defined in compat.h. Since this is an
+  extension in C++, it's probably best to use it only on pointers. `RESTRICT`
+  should generally only be used in places where it's verified to produce a
+  significant performance increase (example: the software renderers).
 
 ### POSIX features
 

--- a/src/compat.h
+++ b/src/compat.h
@@ -29,8 +29,13 @@
 #define __M_BEGIN_DECLS extern "C" {
 #define __M_END_DECLS   }
 
-#ifndef restrict
-#define restrict __restrict
+/**
+ * Compatibility define for restrict in C++, where it is a (commonly supported)
+ * compiler extension. This has to be defined as 'RESTRICT' because defining
+ * 'restrict' conflicts with MSVC's __declspec(restrict) attribute.
+ */
+#ifndef RESTRICT
+#define RESTRICT __restrict
 #endif
 
 #if __cplusplus >= 201103
@@ -112,8 +117,8 @@ typedef unsigned char boolean;
 
 #ifdef _MSC_VER
 #include "msvc.h"
-#ifndef restrict
-#define restrict __restrict
+#ifndef RESTRICT
+#define RESTRICT __restrict
 #endif
 #endif
 
@@ -155,6 +160,10 @@ typedef unsigned char boolean;
 
 #ifndef MAX_PATH
 #define MAX_PATH 512
+#endif
+
+#ifndef RESTRICT
+#define RESTRICT restrict
 #endif
 
 #if defined(CONFIG_MODULAR) && defined(__WIN32__)

--- a/src/render.c
+++ b/src/render.c
@@ -29,7 +29,7 @@
 #include "yuv.h"
 
 static void set_colors8_mzx(const struct graphics_data *graphics,
- Uint32 * restrict char_colors, Uint8 bg, Uint8 fg)
+ Uint32 * RESTRICT char_colors, Uint8 bg, Uint8 fg)
 {
 #if PLATFORM_BYTE_ORDER == PLATFORM_BIG_ENDIAN
   char_colors[0] = (bg << 24) | (bg << 16) | (bg << 8) | bg;
@@ -69,7 +69,7 @@ static void set_colors8_mzx(const struct graphics_data *graphics,
 }
 
 static void set_colors8_smzx(const struct graphics_data *graphics,
- Uint32 * restrict char_colors, Uint8 bg, Uint8 fg)
+ Uint32 * RESTRICT char_colors, Uint8 bg, Uint8 fg)
 {
   Uint32 bb, bf, fb, ff;
   bg &= 0x0F;
@@ -121,7 +121,7 @@ static void set_colors8_smzx(const struct graphics_data *graphics,
 }
 
 static void set_colors8_smzx3(const struct graphics_data *graphics,
- Uint32 * restrict char_colors, Uint8 bg, Uint8 fg)
+ Uint32 * RESTRICT char_colors, Uint8 bg, Uint8 fg)
 {
   Uint32 c0, c1, c2, c3;
   c0 = ((bg << 4) | (fg & 0x0F)) & 0xFF;
@@ -172,7 +172,7 @@ static void set_colors8_smzx3(const struct graphics_data *graphics,
 }
 
 static void set_colors16_mzx(const struct graphics_data *graphics,
- Uint32 * restrict char_colors, Uint8 bg, Uint8 fg)
+ Uint32 * RESTRICT char_colors, Uint8 bg, Uint8 fg)
 {
   Uint32 cb_bg, cb_fg;
 
@@ -193,7 +193,7 @@ static void set_colors16_mzx(const struct graphics_data *graphics,
 }
 
 static void set_colors16_smzx(const struct graphics_data *graphics,
- Uint32 * restrict char_colors, Uint8 bg, Uint8 fg)
+ Uint32 * RESTRICT char_colors, Uint8 bg, Uint8 fg)
 {
   bg &= 0x0F;
   fg &= 0x0F;
@@ -210,7 +210,7 @@ static void set_colors16_smzx(const struct graphics_data *graphics,
 }
 
 static void set_colors16_smzx3(const struct graphics_data *graphics,
- Uint32 * restrict char_colors, Uint8 bg, Uint8 fg)
+ Uint32 * RESTRICT char_colors, Uint8 bg, Uint8 fg)
 {
   Uint8 base;
 
@@ -228,14 +228,14 @@ static void set_colors16_smzx3(const struct graphics_data *graphics,
 }
 
 static void set_colors32_mzx(const struct graphics_data *graphics,
- Uint32 * restrict char_colors, Uint8 bg, Uint8 fg)
+ Uint32 * RESTRICT char_colors, Uint8 bg, Uint8 fg)
 {
   char_colors[0] = graphics->flat_intensity_palette[bg];
   char_colors[1] = graphics->flat_intensity_palette[fg];
 }
 
 static void set_colors32_smzx(const struct graphics_data *graphics,
- Uint32 * restrict char_colors, Uint8 bg, Uint8 fg)
+ Uint32 * RESTRICT char_colors, Uint8 bg, Uint8 fg)
 {
   bg &= 0x0F;
   fg &= 0x0F;
@@ -247,7 +247,7 @@ static void set_colors32_smzx(const struct graphics_data *graphics,
 }
 
 static void set_colors32_smzx3(const struct graphics_data *graphics,
- Uint32 * restrict char_colors, Uint8 bg, Uint8 fg)
+ Uint32 * RESTRICT char_colors, Uint8 bg, Uint8 fg)
 {
   Uint8 base;
 
@@ -260,13 +260,13 @@ static void set_colors32_smzx3(const struct graphics_data *graphics,
 }
 
 static void set_indices_mzx(const struct graphics_data *graphics,
- int * restrict indices, Uint8 bg, Uint8 fg)
+ int * RESTRICT indices, Uint8 bg, Uint8 fg)
 {
   indices[0] = bg;
   indices[1] = fg;
 }
 static void set_indices_smzx(const struct graphics_data *graphics,
- int * restrict indices, Uint8 bg, Uint8 fg)
+ int * RESTRICT indices, Uint8 bg, Uint8 fg)
 {
   indices[0] = bg;
   indices[1] = -2;
@@ -274,7 +274,7 @@ static void set_indices_smzx(const struct graphics_data *graphics,
   indices[3] = fg;
 }
 static void set_indices_smzx2(const struct graphics_data *graphics,
- int * restrict indices, Uint8 bg, Uint8 fg)
+ int * RESTRICT indices, Uint8 bg, Uint8 fg)
 {
   bg &= 0x0F;
   fg &= 0x0F;
@@ -284,7 +284,7 @@ static void set_indices_smzx2(const struct graphics_data *graphics,
   indices[3] = (fg << 4) | fg;
 }
 static void set_indices_smzx3(const struct graphics_data *graphics,
- int * restrict indices, Uint8 bg, Uint8 fg)
+ int * RESTRICT indices, Uint8 bg, Uint8 fg)
 {
   Uint8 base;
 
@@ -296,7 +296,7 @@ static void set_indices_smzx3(const struct graphics_data *graphics,
 }
 
 void (*const set_colors8[4])
- (const struct graphics_data *, Uint32 * restrict, Uint8, Uint8) =
+ (const struct graphics_data *, Uint32 * RESTRICT, Uint8, Uint8) =
 {
   set_colors8_mzx,
   set_colors8_smzx,
@@ -305,7 +305,7 @@ void (*const set_colors8[4])
 };
 
 void (*const set_colors16[4])
- (const struct graphics_data *, Uint32 * restrict, Uint8, Uint8) =
+ (const struct graphics_data *, Uint32 * RESTRICT, Uint8, Uint8) =
 {
   set_colors16_mzx,
   set_colors16_smzx,
@@ -314,7 +314,7 @@ void (*const set_colors16[4])
 };
 
 void (*const set_colors32[4])
- (const struct graphics_data *, Uint32 * restrict, Uint8, Uint8) =
+ (const struct graphics_data *, Uint32 * RESTRICT, Uint8, Uint8) =
 {
   set_colors32_mzx,
   set_colors32_smzx,
@@ -323,7 +323,7 @@ void (*const set_colors32[4])
 };
 
 void (*const set_indices[4])
- (const struct graphics_data *, int * restrict, Uint8, Uint8) =
+ (const struct graphics_data *, int * RESTRICT, Uint8, Uint8) =
 {
   set_indices_mzx,
   set_indices_smzx,
@@ -332,7 +332,7 @@ void (*const set_indices[4])
 };
 
 void yuy2_subsample_set_colors_mzx(const struct graphics_data *graphics,
- Uint32 * restrict char_colors, Uint8 bg, Uint8 fg)
+ Uint32 * RESTRICT char_colors, Uint8 bg, Uint8 fg)
 {
   Uint32 yuv_bg = graphics->flat_intensity_palette[bg];
   Uint32 yuv_fg = graphics->flat_intensity_palette[fg];
@@ -344,7 +344,7 @@ void yuy2_subsample_set_colors_mzx(const struct graphics_data *graphics,
 }
 
 void uyvy_subsample_set_colors_mzx(const struct graphics_data *graphics,
- Uint32 * restrict char_colors, Uint8 bg, Uint8 fg)
+ Uint32 * RESTRICT char_colors, Uint8 bg, Uint8 fg)
 {
   Uint32 yuv_bg = graphics->flat_intensity_palette[bg];
   Uint32 yuv_fg = graphics->flat_intensity_palette[fg];
@@ -356,7 +356,7 @@ void uyvy_subsample_set_colors_mzx(const struct graphics_data *graphics,
 }
 
 void yvyu_subsample_set_colors_mzx(const struct graphics_data *graphics,
- Uint32 * restrict char_colors, Uint8 bg, Uint8 fg)
+ Uint32 * RESTRICT char_colors, Uint8 bg, Uint8 fg)
 {
   Uint32 yuv_bg = graphics->flat_intensity_palette[bg];
   Uint32 yuv_fg = graphics->flat_intensity_palette[fg];
@@ -368,9 +368,9 @@ void yvyu_subsample_set_colors_mzx(const struct graphics_data *graphics,
 }
 
 // Nominally 8-bit (Character graphics 8 bytes wide)
-void render_graph8(Uint8 * restrict pixels, Uint32 pitch,
+void render_graph8(Uint8 * RESTRICT pixels, Uint32 pitch,
  const struct graphics_data *graphics,
- void (*set_colors)(const struct graphics_data *, Uint32 * restrict, Uint8, Uint8))
+ void (*set_colors)(const struct graphics_data *, Uint32 * RESTRICT, Uint8, Uint8))
 {
   Uint32 *dest;
   Uint32 *ldest, *ldest2;
@@ -417,9 +417,9 @@ void render_graph8(Uint8 * restrict pixels, Uint32 pitch,
 }
 
 // Nominally 16-bit (Character graphics 16 bytes wide)
-void render_graph16(Uint16 * restrict pixels, Uint32 pitch,
+void render_graph16(Uint16 * RESTRICT pixels, Uint32 pitch,
  const struct graphics_data *graphics,
- void (*set_colors)(const struct graphics_data *, Uint32 * restrict, Uint8, Uint8))
+ void (*set_colors)(const struct graphics_data *, Uint32 * RESTRICT, Uint8, Uint8))
 {
   Uint32 *dest;
   Uint32 *ldest, *ldest2;
@@ -468,9 +468,9 @@ void render_graph16(Uint16 * restrict pixels, Uint32 pitch,
 }
 
 // Nominally 32-bit (Character graphics 32 bytes wide)
-void render_graph32(Uint32 * restrict pixels, Uint32 pitch,
+void render_graph32(Uint32 * RESTRICT pixels, Uint32 pitch,
  const struct graphics_data *graphics,
- void (*set_colors)(const struct graphics_data *, Uint32 * restrict, Uint8, Uint8))
+ void (*set_colors)(const struct graphics_data *, Uint32 * RESTRICT, Uint8, Uint8))
 {
   Uint32 *dest;
   Uint32 *ldest, *ldest2;
@@ -520,9 +520,9 @@ void render_graph32(Uint32 * restrict pixels, Uint32 pitch,
   }
 }
 
-void render_graph32s(Uint32 * restrict pixels, Uint32 pitch,
+void render_graph32s(Uint32 * RESTRICT pixels, Uint32 pitch,
  const struct graphics_data *graphics,
- void (*set_colors)(const struct graphics_data *, Uint32 * restrict, Uint8, Uint8))
+ void (*set_colors)(const struct graphics_data *, Uint32 * RESTRICT, Uint8, Uint8))
 {
   Uint32 *dest;
   Uint32 *ldest, *ldest2;

--- a/src/render.h
+++ b/src/render.h
@@ -27,33 +27,33 @@ __M_BEGIN_DECLS
 #include "graphics.h"
 
 extern void (*const set_colors8[4])(const struct graphics_data *graphics,
- Uint32 * restrict char_colors, Uint8 bg, Uint8 fg);
+ Uint32 * RESTRICT char_colors, Uint8 bg, Uint8 fg);
 extern void (*const set_colors16[4])(const struct graphics_data *graphics,
- Uint32 * restrict char_colors, Uint8 bg, Uint8 fg);
+ Uint32 * RESTRICT char_colors, Uint8 bg, Uint8 fg);
 extern void (*const set_colors32[4])(const struct graphics_data *graphics,
- Uint32 * restrict char_colors, Uint8 bg, Uint8 fg);
+ Uint32 * RESTRICT char_colors, Uint8 bg, Uint8 fg);
 extern void (*const set_indices[4])(const struct graphics_data *graphics,
- int * restrict indices, Uint8 bg, Uint8 fg);
+ int * RESTRICT indices, Uint8 bg, Uint8 fg);
 
 void yuy2_subsample_set_colors_mzx(const struct graphics_data *graphics,
- Uint32 * restrict char_colors, Uint8 bg, Uint8 fg);
+ Uint32 * RESTRICT char_colors, Uint8 bg, Uint8 fg);
 void uyvy_subsample_set_colors_mzx(const struct graphics_data *graphics,
- Uint32 * restrict char_colors, Uint8 bg, Uint8 fg);
+ Uint32 * RESTRICT char_colors, Uint8 bg, Uint8 fg);
 void yvyu_subsample_set_colors_mzx(const struct graphics_data *graphics,
- Uint32 * restrict char_colors, Uint8 bg, Uint8 fg);
+ Uint32 * RESTRICT char_colors, Uint8 bg, Uint8 fg);
 
-void render_graph8(Uint8 * restrict pixels, Uint32 pitch,
+void render_graph8(Uint8 * RESTRICT pixels, Uint32 pitch,
  const struct graphics_data *graphics,
- void (*set_colors)(const struct graphics_data *, Uint32 * restrict, Uint8, Uint8));
-void render_graph16(Uint16 * restrict pixels, Uint32 pitch,
+ void (*set_colors)(const struct graphics_data *, Uint32 * RESTRICT, Uint8, Uint8));
+void render_graph16(Uint16 * RESTRICT pixels, Uint32 pitch,
  const struct graphics_data *graphics,
- void (*set_colors)(const struct graphics_data *, Uint32 * restrict, Uint8, Uint8));
-void render_graph32(Uint32 * restrict pixels, Uint32 pitch,
+ void (*set_colors)(const struct graphics_data *, Uint32 * RESTRICT, Uint8, Uint8));
+void render_graph32(Uint32 * RESTRICT pixels, Uint32 pitch,
  const struct graphics_data *graphics,
- void (*set_colors)(const struct graphics_data *, Uint32 * restrict, Uint8, Uint8));
-void render_graph32s(Uint32 * restrict pixels, Uint32 pitch,
+ void (*set_colors)(const struct graphics_data *, Uint32 * RESTRICT, Uint8, Uint8));
+void render_graph32s(Uint32 * RESTRICT pixels, Uint32 pitch,
  const struct graphics_data *graphics,
- void (*set_colors)(const struct graphics_data *, Uint32 * restrict, Uint8, Uint8));
+ void (*set_colors)(const struct graphics_data *, Uint32 * RESTRICT, Uint8, Uint8));
 
 void render_cursor(Uint32 *pixels, Uint32 pitch, Uint8 bpp, Uint32 x, Uint32 y,
  Uint32 color, Uint8 lines, Uint8 offset);

--- a/src/render_layer.cpp
+++ b/src/render_layer.cpp
@@ -38,23 +38,24 @@
 
 #include "render_layer_code.hpp"
 
-#if 0
+#ifdef BUILD_REFERENCE_RENDERER
 // This layer renderer is very slow, but it should work properly.
-// The renderers in render_layer_code.h should generally be used instead.
+// The renderers in render_layer_code.hpp should generally be used instead.
+// It might be useful to build for tests or benchmarking, though.
 
-static inline void reference_renderer(Uint32 *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer)
+static inline void reference_renderer(Uint32 * RESTRICT pixels, Uint32 pitch,
+ const struct graphics_data *graphics, const struct video_layer *layer)
 {
   Uint32 mode = layer->mode;
 
   Uint32 ch_x, ch_y;
   Uint16 c;
 
-  struct char_element *src = layer->data;
+  const struct char_element *src = layer->data;
   int row, col;
   int tcol = layer->transparent_col;
 
-  Uint8 *char_ptr;
+  const Uint8 *char_ptr;
   Uint8 current_char_byte;
 
   Uint32 *drawPtr;
@@ -167,26 +168,8 @@ static inline void reference_renderer(Uint32 *pixels, Uint32 pitch,
 }
 #endif
 
-void render_layer_32bpp(void *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer)
-{
-  render_layer(pixels, 32, pitch, graphics, layer);
-}
-
-void render_layer_16bpp(void *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer)
-{
-  render_layer(pixels, 16, pitch, graphics, layer);
-}
-
-void render_layer_8bpp(void *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer)
-{
-  render_layer(pixels, 8, pitch, graphics, layer);
-}
-
-void render_layer(void *pixels, int force_bpp, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer)
+void render_layer(void * RESTRICT pixels, int force_bpp, Uint32 pitch,
+ const struct graphics_data *graphics, const struct video_layer *layer)
 {
   //reference_renderer(pixels, pitch, graphics, layer); return;
 

--- a/src/render_layer.h
+++ b/src/render_layer.h
@@ -26,15 +26,8 @@ __M_BEGIN_DECLS
 
 #include "graphics.h"
 
-void render_layer(void *pixels, int force_bpp, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer);
-
-void render_layer_32bpp(void *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer);
-void render_layer_16bpp(void *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer);
-void render_layer_8bpp(void *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer);
+void render_layer(void * RESTRICT pixels, int force_bpp, Uint32 pitch,
+ const struct graphics_data *graphics, const struct video_layer *layer);
 
 __M_END_DECLS
 

--- a/src/render_layer_code.hpp
+++ b/src/render_layer_code.hpp
@@ -62,7 +62,7 @@ static void render_layer_func(void *pixels, Uint32 pitch,
  int clip);
 
 template<typename PIXTYPE, typename ALIGNTYPE, int SMZX, int PPAL, int TR, int CLIP>
-static void render_layer_func(void * restrict pixels, Uint32 pitch,
+static void render_layer_func(void * RESTRICT pixels, Uint32 pitch,
  const struct graphics_data *graphics, const struct video_layer *layer);
 
 /**
@@ -495,7 +495,7 @@ static inline ALIGNTYPE get_colors_mzx(ALIGNTYPE (&set_colors)[16],
  * The optimizer will optimize out the unnecessary parts for relevant renderers.
  */
 template<typename PIXTYPE, typename ALIGNTYPE, int SMZX, int PPAL, int TR, int CLIP>
-static inline void render_layer_func(void * restrict pixels, Uint32 pitch,
+static inline void render_layer_func(void * RESTRICT pixels, Uint32 pitch,
  const struct graphics_data *graphics, const struct video_layer *layer)
 {
 #ifdef IS_CXX_11

--- a/src/render_layer_code.hpp
+++ b/src/render_layer_code.hpp
@@ -37,28 +37,28 @@
 #endif
 
 template<typename PIXTYPE>
-static void render_layer_func(void *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer,
+static void render_layer_func(void * RESTRICT pixels, Uint32 pitch,
+ const struct graphics_data *graphics, const struct video_layer *layer,
  int align, int smzx, int ppal, int trans, int clip);
 
 template<typename PIXTYPE, typename ALIGNTYPE>
-static void render_layer_func(void *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer,
+static void render_layer_func(void * RESTRICT pixels, Uint32 pitch,
+ const struct graphics_data *graphics, const struct video_layer *layer,
  int smzx, int ppal, int trans, int clip);
 
 template<typename PIXTYPE, typename ALIGNTYPE, int SMZX>
-static void render_layer_func(void *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer,
+static void render_layer_func(void * RESTRICT pixels, Uint32 pitch,
+ const struct graphics_data *graphics, const struct video_layer *layer,
  int ppal, int trans, int clip);
 
 template<typename PIXTYPE, typename ALIGNTYPE, int SMZX, int PPAL>
-static void render_layer_func(void *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer,
+static void render_layer_func(void * RESTRICT pixels, Uint32 pitch,
+ const struct graphics_data *graphics, const struct video_layer *layer,
  int trans, int clip);
 
 template<typename PIXTYPE, typename ALIGNTYPE, int SMZX, int PPAL, int TR>
-static void render_layer_func(void *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer,
+static void render_layer_func(void * RESTRICT pixels, Uint32 pitch,
+ const struct graphics_data *graphics, const struct video_layer *layer,
  int clip);
 
 template<typename PIXTYPE, typename ALIGNTYPE, int SMZX, int PPAL, int TR, int CLIP>
@@ -70,8 +70,8 @@ static void render_layer_func(void * RESTRICT pixels, Uint32 pitch,
  * This always must be >= the current renderer's bits-per-pixel.
  */
 template<>
-inline void render_layer_func<Uint8>(void *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer,
+inline void render_layer_func<Uint8>(void * RESTRICT pixels, Uint32 pitch,
+ const struct graphics_data *graphics, const struct video_layer *layer,
  int align, int smzx, int ppal, int trans, int clip)
 {
   switch(align)
@@ -110,8 +110,8 @@ inline void render_layer_func<Uint8>(void *pixels, Uint32 pitch,
  * This always must be >= the current renderer's bits-per-pixel.
  */
 template<>
-inline void render_layer_func<Uint16>(void *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer,
+inline void render_layer_func<Uint16>(void * RESTRICT pixels, Uint32 pitch,
+ const struct graphics_data *graphics, const struct video_layer *layer,
  int align, int smzx, int ppal, int trans, int clip)
 {
   switch(align)
@@ -145,8 +145,8 @@ inline void render_layer_func<Uint16>(void *pixels, Uint32 pitch,
  * This always must be >= the current renderer's bits-per-pixel.
  */
 template<>
-inline void render_layer_func<Uint32>(void *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer,
+inline void render_layer_func<Uint32>(void * RESTRICT pixels, Uint32 pitch,
+ const struct graphics_data *graphics, const struct video_layer *layer,
  int align, int smzx, int ppal, int trans, int clip)
 {
   switch(align)
@@ -176,8 +176,8 @@ inline void render_layer_func<Uint32>(void *pixels, Uint32 pitch,
  * alignment options, so several platforms disable them altogether to reduce
  * executable size and/or compilation time.
  */
-static inline void render_layer_func(void *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer,
+static inline void render_layer_func(void * RESTRICT pixels, Uint32 pitch,
+ const struct graphics_data *graphics, const struct video_layer *layer,
  int bpp, int align, int smzx, int ppal, int trans, int clip)
 {
   switch(bpp)
@@ -212,8 +212,8 @@ static inline void render_layer_func(void *pixels, Uint32 pitch,
  * Renderer is SMZX (1) or normal MZX (0).
  */
 template<typename PIXTYPE, typename ALIGNTYPE>
-static inline void render_layer_func(void *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer,
+static inline void render_layer_func(void * RESTRICT pixels, Uint32 pitch,
+ const struct graphics_data *graphics, const struct video_layer *layer,
  int smzx, int ppal, int trans, int clip)
 {
   switch(smzx)
@@ -242,8 +242,8 @@ static inline void render_layer_func(void *pixels, Uint32 pitch,
  * 256 is valid for MZX mode, but 16 is invalid for SMZX.
  */
 template<typename PIXTYPE, typename ALIGNTYPE, int SMZX>
-static void render_layer_func(void *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer,
+static void render_layer_func(void * RESTRICT pixels, Uint32 pitch,
+ const struct graphics_data *graphics, const struct video_layer *layer,
  int ppal, int trans, int clip)
 {
   switch(ppal)
@@ -283,8 +283,8 @@ static void render_layer_func(void *pixels, Uint32 pitch,
  * Layer transparency enabled (1) or disabled (0).
  */
 template<typename PIXTYPE, typename ALIGNTYPE, int SMZX, int PPAL>
-static inline void render_layer_func(void *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer,
+static inline void render_layer_func(void * RESTRICT pixels, Uint32 pitch,
+ const struct graphics_data *graphics, const struct video_layer *layer,
  int trans, int clip)
 {
   switch(trans)
@@ -310,8 +310,8 @@ static inline void render_layer_func(void *pixels, Uint32 pitch,
  * Renderer should clip the layer at the screen boundaries (1) or not (0).
  */
 template<typename PIXTYPE, typename ALIGNTYPE, int SMZX, int PPAL, int TR>
-static inline void render_layer_func(void *pixels, Uint32 pitch,
- struct graphics_data *graphics, struct video_layer *layer,
+static inline void render_layer_func(void * RESTRICT pixels, Uint32 pitch,
+ const struct graphics_data *graphics, const struct video_layer *layer,
  int clip)
 {
   switch(clip)

--- a/src/render_softscale.c
+++ b/src/render_softscale.c
@@ -49,7 +49,7 @@ struct softscale_render_data
 {
   struct sdl_render_data sdl;
   Uint32 (*rgb_to_yuv)(Uint8 r, Uint8 g, Uint8 b);
-  void (*subsample_set_colors)(const struct graphics_data *, Uint32 * restrict,
+  void (*subsample_set_colors)(const struct graphics_data *, Uint32 * RESTRICT,
    Uint8, Uint8);
   SDL_PixelFormat *sdl_format;
   SDL_Rect texture_rect;

--- a/src/render_yuv.c
+++ b/src/render_yuv.c
@@ -41,7 +41,7 @@
 struct yuv_render_data
 {
   struct sdl_render_data sdl;
-  void (*set_colors_mzx)(const struct graphics_data *, Uint32 * restrict,
+  void (*set_colors_mzx)(const struct graphics_data *, Uint32 * RESTRICT,
    Uint8, Uint8);
   Uint32 (*rgb_to_yuv)(Uint8 r, Uint8 g, Uint8 b);
   Uint32 bpp;


### PR DESCRIPTION
MSVC uses `restrict` as part of an attribute so defining `restrict` in compat.h isn't really a great idea. This patch replaces it with `RESTRICT`, documents this in STYLE.md,  and also adds it to more render_layer functions it should have originally been added to.