### PR TITLE
MSVC project update: fnmatch.c -> xfnmatch.c

### DIFF
--- a/arch/msvc/Core.vcxproj
+++ b/arch/msvc/Core.vcxproj
@@ -229,7 +229,6 @@ echo #define VERSION_DATE " ($(BuildDate))"&gt;&gt;$(SolutionDir)version.h</Comm
     <ClCompile Include="..\..\contrib\libxmp\src\effects.c" />
     <ClCompile Include="..\..\contrib\libxmp\src\extras.c" />
     <ClCompile Include="..\..\contrib\libxmp\src\filter.c" />
-    <ClCompile Include="..\..\contrib\libxmp\src\fnmatch.c" />
     <ClCompile Include="..\..\contrib\libxmp\src\format.c" />
     <ClCompile Include="..\..\contrib\libxmp\src\hio.c" />
     <ClCompile Include="..\..\contrib\libxmp\src\hmn_extras.c" />
@@ -274,6 +273,7 @@ echo #define VERSION_DATE " ($(BuildDate))"&gt;&gt;$(SolutionDir)version.h</Comm
     <ClCompile Include="..\..\contrib\libxmp\src\scan.c" />
     <ClCompile Include="..\..\contrib\libxmp\src\smix.c" />
     <ClCompile Include="..\..\contrib\libxmp\src\virtual.c" />
+    <ClCompile Include="..\..\contrib\libxmp\src\xfnmatch.c" />
     <ClCompile Include="..\..\src\audio\audio.c" />
     <ClCompile Include="..\..\src\audio\audio_pcs.c" />
     <ClCompile Include="..\..\src\audio\audio_reality.cpp" />
@@ -350,7 +350,6 @@ echo #define VERSION_DATE " ($(BuildDate))"&gt;&gt;$(SolutionDir)version.h</Comm
     <ClInclude Include="..\..\contrib\libxmp\src\common.h" />
     <ClInclude Include="..\..\contrib\libxmp\src\effects.h" />
     <ClInclude Include="..\..\contrib\libxmp\src\extras.h" />
-    <ClInclude Include="..\..\contrib\libxmp\src\fnmatch.h" />
     <ClInclude Include="..\..\contrib\libxmp\src\format.h" />
     <ClInclude Include="..\..\contrib\libxmp\src\hio.h" />
     <ClInclude Include="..\..\contrib\libxmp\src\hmn_extras.h" />
@@ -368,15 +367,14 @@ echo #define VERSION_DATE " ($(BuildDate))"&gt;&gt;$(SolutionDir)version.h</Comm
     <ClInclude Include="..\..\contrib\libxmp\src\med_extras.h" />
     <ClInclude Include="..\..\contrib\libxmp\src\memio.h" />
     <ClInclude Include="..\..\contrib\libxmp\src\mixer.h" />
-    <ClInclude Include="..\..\contrib\libxmp\src\paula.h" />
     <ClInclude Include="..\..\contrib\libxmp\src\period.h" />
     <ClInclude Include="..\..\contrib\libxmp\src\player.h" />
-    <ClInclude Include="..\..\contrib\libxmp\src\precomp_blep.h" />
     <ClInclude Include="..\..\contrib\libxmp\src\precomp_lut.h" />
     <ClInclude Include="..\..\contrib\libxmp\src\virtual.h" />
     <ClInclude Include="..\..\contrib\libxmp\src\win32\osdcomm.h" />
     <ClInclude Include="..\..\contrib\libxmp\src\win32\ptpopen.h" />
     <ClInclude Include="..\..\contrib\libxmp\src\win32\unistd.h" />
+    <ClInclude Include="..\..\contrib\libxmp\src\xfnmatch.h" />
     <ClInclude Include="..\..\src\audio\audio.h" />
     <ClInclude Include="..\..\src\audio\audio_pcs.h" />
     <ClInclude Include="..\..\src\audio\audio_reality.h" />

--- a/arch/msvc/Core.vcxproj.filters
+++ b/arch/msvc/Core.vcxproj.filters
@@ -225,9 +225,6 @@
     <ClCompile Include="..\..\contrib\libxmp\src\filter.c">
       <Filter>Source Files\contrib\libxmp</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\contrib\libxmp\src\fnmatch.c">
-      <Filter>Source Files\contrib\libxmp</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\contrib\libxmp\src\format.c">
       <Filter>Source Files\contrib\libxmp</Filter>
     </ClCompile>
@@ -420,6 +417,9 @@
     <ClCompile Include="..\..\contrib\libxmp\src\loaders\ice_load.c">
       <Filter>Source Files\contrib\libxmp\loaders</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\contrib\libxmp\src\xfnmatch.c">
+      <Filter>Source Files\contrib\libxmp</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\block.h">
@@ -521,9 +521,6 @@
     <ClInclude Include="..\..\contrib\libxmp\src\extras.h">
       <Filter>Header Files\contrib\libxmp</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\contrib\libxmp\src\fnmatch.h">
-      <Filter>Header Files\contrib\libxmp</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\contrib\libxmp\src\format.h">
       <Filter>Header Files\contrib\libxmp</Filter>
     </ClInclude>
@@ -554,16 +551,10 @@
     <ClInclude Include="..\..\contrib\libxmp\src\mixer.h">
       <Filter>Header Files\contrib\libxmp</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\contrib\libxmp\src\paula.h">
-      <Filter>Header Files\contrib\libxmp</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\contrib\libxmp\src\period.h">
       <Filter>Header Files\contrib\libxmp</Filter>
     </ClInclude>
     <ClInclude Include="..\..\contrib\libxmp\src\player.h">
-      <Filter>Header Files\contrib\libxmp</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\contrib\libxmp\src\precomp_blep.h">
       <Filter>Header Files\contrib\libxmp</Filter>
     </ClInclude>
     <ClInclude Include="..\..\contrib\libxmp\src\precomp_lut.h">
@@ -763,6 +754,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\hashtable.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\contrib\libxmp\src\xfnmatch.h">
+      <Filter>Header Files\contrib\libxmp</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Accommodates the change from `fnmatch.c` to `xfnmatch.c`. There were also some references to nonexistent `libxmp` headers in the VC project that I'd forgotten to clear out. Header references don't affect the build process, but they're useful when editing the code.