### PR TITLE
Update libxmp for LIBXMP_NO_PROWIZARD, misc. fixes.

### DIFF
--- a/contrib/libxmp/Makefile.megazeux
+++ b/contrib/libxmp/Makefile.megazeux
@@ -16,6 +16,7 @@ libxmp_cflags := \
  -I${libxmp_base}/src/loaders \
  ${libxmp_include} \
  -include src/platform_endian.h \
+ -DLIBXMP_NO_PROWIZARD \
  -DLIBXMP_NO_DEPACKERS
 
 #

--- a/contrib/libxmp/docs/Changelog
+++ b/contrib/libxmp/docs/Changelog
@@ -3,6 +3,7 @@ Stable versions
 
 4.5.0 ():
 	Changes by Alice Rowan:
+	- fix xmp_set_position et al. when used during loops, pattern delay
 	- make xmp_set_position() consistently clear pattern break/jump vars
 	- fix volume event handling for FAR modules
 	- fix GDM loader to correctly handle empty notes
@@ -22,6 +23,7 @@ Stable versions
 	- fix IT bug where Cxx on same row as SBx would not be ignored
 	- fix IT bug where Qxy would ignore the volume parameter
 	- fix IT sample global volume and sample vibrato
+	- fix two IT bugs related to note off and volume handling
 	- fix event out-of-bounds reads due to invalid key values
 	- check external sample file names before opening them
 	- make it possible to disable module depacker functionality

--- a/contrib/libxmp/include/xmp.h
+++ b/contrib/libxmp/include/xmp.h
@@ -41,8 +41,16 @@ extern "C" {
 # define LIBXMP_EXPORT __attribute__((visibility ("default")))
 #elif defined(__SUNPRO_C) && defined(XMP_LDSCOPE_GLOBAL)
 # define LIBXMP_EXPORT __global
+#elif defined(EMSCRIPTEN)
+# include <emscripten.h>
+# define LIBXMP_EXPORT EMSCRIPTEN_KEEPALIVE
+# define LIBXMP_EXPORT_VAR
 #else
 # define LIBXMP_EXPORT
+#endif
+
+#if !defined (LIBXMP_EXPORT_VAR)
+# define LIBXMP_EXPORT_VAR LIBXMP_EXPORT
 #endif
 
 #define XMP_NAME_SIZE		64	/* Size of module name and type */
@@ -331,8 +339,8 @@ struct xmp_frame_info {			/* Current frame information */
 
 typedef char *xmp_context;
 
-LIBXMP_EXPORT extern const char *xmp_version;
-LIBXMP_EXPORT extern const unsigned int xmp_vercode;
+LIBXMP_EXPORT_VAR extern const char *xmp_version;
+LIBXMP_EXPORT_VAR extern const unsigned int xmp_vercode;
 
 LIBXMP_EXPORT xmp_context xmp_create_context  (void);
 LIBXMP_EXPORT void        xmp_free_context    (xmp_context);

--- a/contrib/libxmp/src/common.h
+++ b/contrib/libxmp/src/common.h
@@ -6,6 +6,14 @@
 #include <string.h>
 #include "xmp.h"
 
+#undef  LIBXMP_EXPORT_VAR
+#if defined(EMSCRIPTEN)
+#include <emscripten.h>
+#define LIBXMP_EXPORT_VAR EMSCRIPTEN_KEEPALIVE
+#else
+#define LIBXMP_EXPORT_VAR
+#endif
+
 #if defined(__MORPHOS__) || defined(__AROS__) || defined(AMIGAOS) || \
     defined(__amigaos__) || defined(__amigaos4__) ||defined(__amigados__) || \
     defined(AMIGA) || defined(_AMIGA) || defined(__AMIGA__)
@@ -65,6 +73,7 @@ typedef signed long long int64;
 } while (0)
 #define MIN(x,y) ((x) < (y) ? (x) : (y))
 #define MAX(x,y) ((x) > (y) ? (x) : (y))
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 
 #define TRACK_NUM(a,c)	m->mod.xxp[a]->index[c]
 #define EVENT(a,c,r)	m->mod.xxt[TRACK_NUM((a),(c))]->event[r]

--- a/contrib/libxmp/src/control.c
+++ b/contrib/libxmp/src/control.c
@@ -30,10 +30,10 @@
 #include "virtual.h"
 #include "mixer.h"
 
-const char *xmp_version = XMP_VERSION;
-const unsigned int xmp_vercode = XMP_VERCODE;
+const char *xmp_version LIBXMP_EXPORT_VAR = XMP_VERSION;
+const unsigned int xmp_vercode LIBXMP_EXPORT_VAR = XMP_VERCODE;
 
-xmp_context xmp_create_context()
+xmp_context xmp_create_context(void)
 {
 	struct context_data *ctx;
 
@@ -124,6 +124,10 @@ static void set_position(struct context_data *ctx, int pos, int dir)
 			f->jumpline = 0;
 			f->jump = -1;
 			f->pbreak = 0;
+			f->loop_chn = 0;
+			f->delay = 0;
+			f->rowdelay = 0;
+			f->rowdelay_set = 0;
 		}
 	}
 }

--- a/contrib/libxmp/src/format.c
+++ b/contrib/libxmp/src/format.c
@@ -24,6 +24,10 @@
 #include <string.h>
 #include "format.h"
 
+#ifndef LIBXMP_NO_PROWIZARD
+#include "loaders/prowizard/prowiz.h"
+#endif
+
 extern const struct format_loader libxmp_loader_xm;
 extern const struct format_loader libxmp_loader_mod;
 extern const struct format_loader libxmp_loader_flt;
@@ -47,9 +51,11 @@ extern const struct format_loader libxmp_loader_far;
 extern const struct format_loader libxmp_loader_669;
 extern const struct format_loader libxmp_loader_hmn;
 
+#ifndef LIBXMP_NO_PROWIZARD
 extern const struct pw_format *const pw_formats[];
+#endif
 
-const struct format_loader *const format_loaders[NUM_FORMATS + 2] = {
+const struct format_loader *const format_loaders[] = {
 	&libxmp_loader_xm,
 	&libxmp_loader_mod,
 	&libxmp_loader_flt,
@@ -75,7 +81,7 @@ const struct format_loader *const format_loaders[NUM_FORMATS + 2] = {
 	NULL
 };
 
-static const char *_farray[NUM_FORMATS + 1] = { NULL };
+static const char *_farray[ARRAY_SIZE(format_loaders)] = { NULL };
 
 const char *const *format_list(void)
 {
@@ -83,6 +89,16 @@ const char *const *format_list(void)
 
 	if (_farray[0] == NULL) {
 		for (count = i = 0; format_loaders[i] != NULL; i++) {
+#ifndef LIBXMP_NO_PROWIZARD
+			if (strcmp(format_loaders[i]->name, "prowizard") == 0) {
+				int j;
+
+				for (j = 0; pw_formats[j] != NULL; j++) {
+					_farray[count++] = pw_formats[j]->name;
+				}
+				continue;
+			}
+#endif
 			_farray[count++] = format_loaders[i]->name;
 		}
 

--- a/contrib/libxmp/src/format.h
+++ b/contrib/libxmp/src/format.h
@@ -14,8 +14,13 @@ struct format_loader {
 const char *const *format_list(void);
 
 #ifndef LIBXMP_CORE_PLAYER
-#define NUM_FORMATS 22
+
+#define NUM_FORMATS 52
 #define NUM_PW_FORMATS 43
+
+#ifndef LIBXMP_NO_PROWIZARD
+int pw_test_format(HIO_HANDLE *, char *, const int, struct xmp_test_info *);
+#endif
 #endif
 
 #endif

--- a/contrib/libxmp/src/hmn_extras.c
+++ b/contrib/libxmp/src/hmn_extras.c
@@ -111,6 +111,7 @@ void libxmp_hmn_reset_channel_extras(struct channel_data *xc)
 void libxmp_hmn_release_channel_extras(struct channel_data *xc)
 {
 	free(xc->extra);
+	xc->extra = NULL;
 }
 
 int libxmp_hmn_new_module_extras(struct module_data *m)
@@ -126,6 +127,7 @@ int libxmp_hmn_new_module_extras(struct module_data *m)
 void libxmp_hmn_release_module_extras(struct module_data *m)
 {
 	free(m->extra);
+	m->extra = NULL;
 }
 
 void libxmp_hmn_extras_process_fx(struct context_data *ctx, struct channel_data *xc,

--- a/contrib/libxmp/src/load.c
+++ b/contrib/libxmp/src/load.c
@@ -314,6 +314,14 @@ static int test_module(struct xmp_test_info *info, HIO_HANDLE *h)
 		if (format_loaders[i]->test(h, buf, 0) == 0) {
 			int is_prowizard = 0;
 
+#if !defined(LIBXMP_CORE_PLAYER) && !defined(LIBXMP_NO_PROWIZARD)
+			if (strcmp(format_loaders[i]->name, "prowizard") == 0) {
+				hio_seek(h, 0, SEEK_SET);
+				pw_test_format(h, buf, 0, info);
+				is_prowizard = 1;
+			}
+#endif
+
 			if (info != NULL && !is_prowizard) {
 				strncpy(info->name, buf, XMP_NAME_SIZE - 1);
 				info->name[XMP_NAME_SIZE - 1] = '\0';
@@ -461,8 +469,7 @@ static int load_module(xmp_context opaque, HIO_HANDLE *h)
 #endif
 
 	if (test_result < 0) {
-		free(m->basename);
-		free(m->dirname);
+		xmp_release_module(opaque);
 		return -XMP_ERROR_FORMAT;
 	}
 
@@ -593,6 +600,10 @@ int xmp_load_module(xmp_context opaque, const char *path)
 
 	m->filename = path;	/* For ALM, SSMT, etc */
 	m->size = size;
+#else
+	ctx->m.filename = NULL;
+	ctx->m.dirname = NULL;
+	ctx->m.basename = NULL;
 #endif
 
 	ret = load_module(opaque, h);
@@ -697,6 +708,7 @@ void xmp_release_module(xmp_context opaque)
 			free(mod->xxt[i]);
 		}
 		free(mod->xxt);
+		mod->xxt = NULL;
 	}
 
 	if (mod->xxp != NULL) {
@@ -704,6 +716,7 @@ void xmp_release_module(xmp_context opaque)
 			free(mod->xxp[i]);
 		}
 		free(mod->xxp);
+		mod->xxp = NULL;
 	}
 
 	if (mod->xxi != NULL) {
@@ -712,6 +725,7 @@ void xmp_release_module(xmp_context opaque)
 			free(mod->xxi[i].extra);
 		}
 		free(mod->xxi);
+		mod->xxi = NULL;
 	}
 
 	if (mod->xxs != NULL) {
@@ -720,6 +734,8 @@ void xmp_release_module(xmp_context opaque)
 		}
 		free(mod->xxs);
 		free(m->xtra);
+		mod->xxs = NULL;
+		m->xtra = NULL;
 	}
 
 #ifndef LIBXMP_CORE_DISABLE_IT
@@ -728,16 +744,20 @@ void xmp_release_module(xmp_context opaque)
 			libxmp_free_sample(&m->xsmp[i]);
 		}
 		free(m->xsmp);
+		m->xsmp = NULL;
 	}
 #endif
 
 	libxmp_free_scan(ctx);
 
 	free(m->comment);
+	m->comment = NULL;
 
 	D_("free dirname/basename");
 	free(m->dirname);
 	free(m->basename);
+	m->basename = NULL;
+	m->dirname = NULL;
 }
 
 void xmp_scan_module(xmp_context opaque)

--- a/contrib/libxmp/src/loaders/669_load.c
+++ b/contrib/libxmp/src/loaders/669_load.c
@@ -80,7 +80,7 @@ struct c669_instrument_header {
 
 /* Effects bug fixed by Miod Vallat <miodrag@multimania.com> */
 
-static const uint8 fx[] = {
+static const uint8 fx[6] = {
     FX_669_PORTA_UP,
     FX_669_PORTA_DN,
     FX_669_TPORTA,
@@ -226,7 +226,7 @@ static int c669_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		event->vol = (LSN(ev[1]) << 2) + 1;
 
 	    if (ev[2] != 0xff) {
-		if (MSN(ev[2]) > 5)
+		if (MSN(ev[2]) >= ARRAY_SIZE(fx))
 		    continue;
 
 		event->fxt = fx[MSN(ev[2])];

--- a/contrib/libxmp/src/loaders/far_load.c
+++ b/contrib/libxmp/src/loaders/far_load.c
@@ -101,7 +101,7 @@ static int far_test(HIO_HANDLE *f, char *t, const int start)
 #define FX_FAR_PORTA_UP		0xf9
 #define FX_FAR_PORTA_DN		0xf8
 
-static const uint8 fx[] = {
+static const uint8 fx[16] = {
     NONE,
     FX_FAR_PORTA_UP,		/* 0x1?  Pitch Adjust */
     FX_FAR_PORTA_DN,		/* 0x2?  Pitch Adjust */

--- a/contrib/libxmp/src/loaders/gdm_load.c
+++ b/contrib/libxmp/src/loaders/gdm_load.c
@@ -36,7 +36,7 @@ static int gdm_test(HIO_HANDLE *, char *, const int);
 static int gdm_load (struct module_data *, HIO_HANDLE *, const int);
 
 const struct format_loader libxmp_loader_gdm = {
-	"Generic Digital Music",
+	"General Digital Music",
 	gdm_test,
 	gdm_load
 };

--- a/contrib/libxmp/src/loaders/it_load.c
+++ b/contrib/libxmp/src/loaders/it_load.c
@@ -56,7 +56,7 @@ static int it_test(HIO_HANDLE *f, char *t, const int start)
 #define L_CHANNELS 64
 
 
-static const uint8 fx[] = {
+static const uint8 fx[32] = {
 	/*   */ FX_NONE,
 	/* A */ FX_S3M_SPEED,
 	/* B */ FX_JUMP,
@@ -83,7 +83,12 @@ static const uint8 fx[] = {
 	/* W */ FX_GVOL_SLIDE,
 	/* X */ FX_SETPAN,
 	/* Y */ FX_PANBRELLO,
-	/* Z */ FX_FLT_CUTOFF
+	/* Z */ FX_FLT_CUTOFF,
+	/* ? */ FX_NONE,
+	/* ? */ FX_NONE,
+	/* ? */ FX_NONE,
+	/* ? */ FX_NONE,
+	/* ? */ FX_NONE
 };
 
 
@@ -516,7 +521,7 @@ static int load_new_it_instrument(struct xmp_instrument *xxi, HIO_HANDLE *f)
 	int inst_map[120], inst_rmap[XMP_MAX_KEYS];
 	struct it_instrument2_header i2h;
 	struct it_envelope env;
-	int dca2nna[] = { 0, 2, 3 };
+	int dca2nna[] = { 0, 2, 3, 3 /* Northern Sky (cj-north.it) has this... */ };
 	int c, k, j;
 	uint8 buf[64];
 
@@ -970,7 +975,7 @@ static int load_it_pattern(struct module_data *m, int i, int new_fx,
 		}
 		if (mask[c] & 0x08) {
 			b = hio_read8(f);
-			if (b > 31) {
+			if (b >= ARRAY_SIZE(fx)) {
 				D_(D_WARN "invalid effect %#02x", b);
 				hio_read8(f);
 				

--- a/contrib/libxmp/src/loaders/med3_load.c
+++ b/contrib/libxmp/src/loaders/med3_load.c
@@ -103,6 +103,7 @@ static int unpack_block(struct module_data *m, uint16 bnum, uint8 *from, uint16 
 	uint16 fromn = 0, lmsk;
 	uint8 *fromst = from + 16, bcnt, *tmpto;
 	uint8 *patbuf, *to;
+	uint32 nibs_left = convsz * 2;
 	int i, j, trkn = mod->chn;
 
 	/*from += 16;*/
@@ -118,10 +119,10 @@ static int unpack_block(struct module_data *m, uint16 bnum, uint8 *from, uint16 
 		}
 
 		if (*lmptr & MASK) {
-			if (trkn / 2 > convsz) {
+			if (trkn / 4 > nibs_left) {
 				goto err2;
-			}	
-			convsz -= trkn / 2;
+			}
+			nibs_left -= trkn / 4;
 
 			lmsk = get_nibbles(fromst, &fromn, (uint8)(trkn / 4));
 			lmsk <<= (16 - trkn);
@@ -129,6 +130,10 @@ static int unpack_block(struct module_data *m, uint16 bnum, uint8 *from, uint16 
 
 			for (bcnt = 0; bcnt < trkn; bcnt++) {
 				if (lmsk & 0x8000) {
+					if (nibs_left < 3) {
+						goto err2;
+					}
+					nibs_left -= 3;
 					*tmpto = (uint8)get_nibbles(fromst,
 						&fromn,2);
 					*(tmpto + 1) = (get_nibble(fromst,
@@ -140,10 +145,10 @@ static int unpack_block(struct module_data *m, uint16 bnum, uint8 *from, uint16 
 		}
 
 		if (*fxptr & MASK) {
-			if (trkn / 2 > convsz) {
+			if (trkn / 4 > nibs_left) {
 				goto err2;
-			}	
-			convsz -= trkn / 2;
+			}
+			nibs_left -= trkn / 4;
 
 			lmsk = get_nibbles(fromst,&fromn,(uint8)(trkn / 4));
 			lmsk <<= (16 - trkn);
@@ -151,6 +156,10 @@ static int unpack_block(struct module_data *m, uint16 bnum, uint8 *from, uint16 
 
 			for (bcnt = 0; bcnt < trkn; bcnt++) {
 				if (lmsk & 0x8000) {
+					if (nibs_left < 3) {
+						goto err2;
+					}
+					nibs_left -= 3;
 					*(tmpto+1) |= get_nibble(fromst,
 							&fromn);
 					*(tmpto+2) = (uint8)get_nibbles(fromst,

--- a/contrib/libxmp/src/loaders/med4_load.c
+++ b/contrib/libxmp/src/loaders/med4_load.c
@@ -237,7 +237,7 @@ static int med4_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	num_ins = 0;
 	memset(temp_inst, 0, sizeof(temp_inst));
 	for (i = 0; mask != 0 && i < 64; i++, mask <<= 1) {
-		uint8 c, size, buf[40];
+		uint8 c, size;
 		uint16 loop_len = 0;
 
 		if ((int64)mask > 0)

--- a/contrib/libxmp/src/loaders/mmd1_load.c
+++ b/contrib/libxmp/src/loaders/mmd1_load.c
@@ -307,7 +307,8 @@ static int mmd1_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	}
 
 	/* Sanity check */
-	if (mod->chn > XMP_MAX_CHANNELS) {
+	/* MMD0/MMD1 can't have more than 16 channels... */
+	if (mod->chn > MIN(16, XMP_MAX_CHANNELS)) {
 		return -1;
 	}
 
@@ -315,7 +316,7 @@ static int mmd1_load(struct module_data *m, HIO_HANDLE *f, const int start)
 
 	libxmp_set_type(m, ver == 0 ? mod->chn > 4 ? "OctaMED 2.00 MMD0" :
 				"MED 2.10 MMD0" : "OctaMED 4.00 MMD1");
-	
+
 	MODULE_INFO();
 
 	D_(D_INFO "BPM mode: %s (length = %d)", bpm_on ? "on" : "off", bpmlen);

--- a/contrib/libxmp/src/loaders/mtm_load.c
+++ b/contrib/libxmp/src/loaders/mtm_load.c
@@ -102,7 +102,7 @@ static int mtm_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		return -1;
 
 	mfh.channels = hio_read8(f);	/* Number of tracks per pattern */
-	if (mfh.channels > XMP_MAX_CHANNELS) {
+	if (mfh.channels > MIN(32, XMP_MAX_CHANNELS)) {
 		return -1;
 	}
 

--- a/contrib/libxmp/src/loaders/okt_load.c
+++ b/contrib/libxmp/src/loaders/okt_load.c
@@ -63,9 +63,12 @@ struct local_data {
 	int idx[36];
 	int pattern;
 	int sample;
+	int has_cmod;
+	int has_samp;
+	int has_slen;
 };
 
-static const int fx[] = {
+static const int fx[32] = {
 	NONE,
 	FX_PORTA_UP,		/*  1 */
 	FX_PORTA_DN,		/*  2 */
@@ -103,7 +106,14 @@ static const int fx[] = {
 static int get_cmod(struct module_data *m, int size, HIO_HANDLE *f, void *parm)
 {
 	struct xmp_module *mod = &m->mod;
+	struct local_data *data = (struct local_data *)parm;
 	int i;
+
+	/* Sanity check */
+	if (data->has_cmod || size < 8) {
+		return -1;
+	}
+	data->has_cmod = 1;
 
 	mod->chn = 0;
 	for (i = 0; i < 4; i++) {
@@ -132,8 +142,10 @@ static int get_samp(struct module_data *m, int size, HIO_HANDLE *f, void *parm)
 	int looplen;
 
 	/* Sanity check */
-	if (size != 36 * 32)
+	if (data->has_samp || size != 36 * 32) {
 		return -1;
+	}
+	data->has_samp = 1;
 
 	/* Should be always 36 */
 	mod->ins = size / 32;	/* sizeof(struct okt_instrument_header); */
@@ -191,6 +203,13 @@ static int get_spee(struct module_data *m, int size, HIO_HANDLE *f, void *parm)
 static int get_slen(struct module_data *m, int size, HIO_HANDLE *f, void *parm)
 {
 	struct xmp_module *mod = &m->mod;
+	struct local_data *data = (struct local_data *)parm;
+
+	/* Sanity check */
+	if (data->has_slen || size < 2) {
+		return -1;
+	}
+	data->has_slen = 1;
 
 	mod->pat = hio_read16b(f);
 	mod->trk = mod->pat * mod->chn;
@@ -260,7 +279,7 @@ static int get_pbod(struct module_data *m, int size, HIO_HANDLE *f, void *parm)
 		}
 
 		fxt = hio_read8(f);
-		if (fxt >= 32) {
+		if (fxt >= ARRAY_SIZE(fx)) {
 			return -1;
 		}
 		e->fxt = fx[fxt];

--- a/contrib/libxmp/src/loaders/s3m_load.c
+++ b/contrib/libxmp/src/loaders/s3m_load.c
@@ -113,7 +113,7 @@ static int s3m_test(HIO_HANDLE *f, char *t, const int start)
 	} while (0)
 
 /* Effect conversion table */
-static const uint8 fx[] = {
+static const uint8 fx[27] = {
 	NONE,
 	FX_S3M_SPEED,		/* Axx  Set speed to xx (the default is 06) */
 	FX_JUMP,		/* Bxx  Jump to order xx (hexadecimal) */
@@ -148,7 +148,7 @@ static void xlat_fx(int c, struct xmp_event *e)
 {
 	uint8 h = MSN(e->fxp), l = LSN(e->fxp);
 
-	if (e->fxt > 26) {
+	if (e->fxt >= ARRAY_SIZE(fx)) {
 		D_(D_WARN "invalid effect %02x", e->fxt);
 		e->fxt = e->fxp = 0;
 		return;

--- a/contrib/libxmp/src/med_extras.c
+++ b/contrib/libxmp/src/med_extras.c
@@ -371,6 +371,7 @@ void libxmp_med_reset_channel_extras(struct channel_data *xc)
 void libxmp_med_release_channel_extras(struct channel_data *xc)
 {
 	free(xc->extra);
+	xc->extra = NULL;
 }
 
 int libxmp_med_new_module_extras(struct module_data *m)
@@ -416,6 +417,7 @@ void libxmp_med_release_module_extras(struct module_data *m)
         }
 
 	free(m->extra);
+	m->extra = NULL;
 }
 
 void libxmp_med_extras_process_fx(struct context_data *ctx, struct channel_data *xc,

--- a/contrib/libxmp/src/player.c
+++ b/contrib/libxmp/src/player.c
@@ -336,6 +336,23 @@ static int ft2_arpeggio(struct context_data *ctx, struct channel_data *xc)
 	return xc->arpeggio.val[i % 3];
 }
 
+static int arpeggio(struct context_data *ctx, struct channel_data *xc)
+{
+	struct module_data *m = &ctx->m;
+	int arp;
+
+	if (HAS_QUIRK(QUIRK_FT2BUGS)) {
+		arp = ft2_arpeggio(ctx, xc);
+	} else {
+		arp = xc->arpeggio.val[xc->arpeggio.count];
+	}
+
+	xc->arpeggio.count++;
+	xc->arpeggio.count %= xc->arpeggio.size;
+
+	return arp;
+}
+
 static int is_first_frame(struct context_data *ctx)
 {
 	struct player_data *p = &ctx->p;
@@ -769,6 +786,7 @@ static void process_frequency(struct context_data *ctx, int chn, int act)
 	struct channel_data *xc = &p->xc_data[chn];
 	struct xmp_instrument *instrument;
 	double period, vibrato;
+	double final_period;
 	int linear_bend;
 	int frq_envelope;
 	int arp;
@@ -834,39 +852,22 @@ static void process_frequency(struct context_data *ctx, int chn, int act)
 	period += libxmp_extras_get_period(ctx, xc);
 #endif
 
+	if (HAS_QUIRK(QUIRK_ST3BUGS)) {
+		if (period < 0.25) {
+			libxmp_virt_resetchannel(ctx, chn);
+		}
+	}
 	/* Sanity check */
 	if (period < 0.1) {
 		period = 0.1;
 	} 
 
 	/* Arpeggio */
-
-	if (HAS_QUIRK(QUIRK_FT2BUGS)) {
-		arp = ft2_arpeggio(ctx, xc);
-	} else {
-		arp = xc->arpeggio.val[xc->arpeggio.count];
-	}
+	arp = arpeggio(ctx, xc);
 
 	/* Pitch bend */
 
- 	/* From OpenMPT PeriodLimit.s3m:
-	 * "ScreamTracker 3 limits the final output period to be at least 64,
-	 *  i.e. when playing a note that is too high or when sliding the
-	 *  period lower than 64, the output period will simply be clamped to
-	 *  64. However, when reaching a period of 0 through slides, the
-	 *  output on the channel should be stopped."
-	 */
-	/* ST3 uses periods*4, so the limit is 16. Adjusted to the exact
-	 * A6 value because we compute periods in floating point.
-	 */
-	if (HAS_QUIRK(QUIRK_ST3BUGS)) {
-		if (period < 16.239270) {	/* A6 */
-			period = 16.239270;
-		}
-	}
-
-	linear_bend = libxmp_period_to_bend(ctx, period + vibrato, xc->note,
-							xc->per_adj);
+	linear_bend = libxmp_period_to_bend(ctx, period + vibrato, xc->note, xc->per_adj);
 
 	if (TEST_NOTE(NOTE_GLISSANDO) && TEST(TONEPORTA)) {
 		if (linear_bend > 0) {
@@ -920,12 +921,29 @@ static void process_frequency(struct context_data *ctx, int chn, int act)
 	linear_bend += libxmp_extras_get_linear_bend(ctx, xc);
 #endif
 
-	period = libxmp_note_to_period_mix(xc->note, linear_bend);
-	libxmp_virt_setperiod(ctx, chn, period);
+	final_period = libxmp_note_to_period_mix(xc->note, linear_bend);
+
+	/* From OpenMPT PeriodLimit.s3m:
+	 * "ScreamTracker 3 limits the final output period to be at least 64,
+	 *  i.e. when playing a note that is too high or when sliding the
+	 *  period lower than 64, the output period will simply be clamped to
+	 *  64. However, when reaching a period of 0 through slides, the
+	 *  output on the channel should be stopped."
+	 */
+	/* ST3 uses periods*4, so the limit is 16. Adjusted to the exact
+	 * A6 value because we compute periods in floating point.
+	 */
+	if (HAS_QUIRK(QUIRK_ST3BUGS)) {
+		if (final_period < 16.239270) {	/* A6 */
+			final_period = 16.239270;
+		}
+	}
+
+	libxmp_virt_setperiod(ctx, chn, final_period);
 
 	/* For xmp_get_frame_info() */
 	xc->info_pitchbend = linear_bend >> 7;
-	xc->info_period = period * 4096;
+	xc->info_period = final_period * 4096;
 
 	if (IS_PERIOD_MODRNG()) {
 		CLAMP(xc->info_period,
@@ -1186,9 +1204,6 @@ static void update_frequency(struct context_data *ctx, int chn)
 		break;
 	}
 
-	xc->arpeggio.count++;
-	xc->arpeggio.count %= xc->arpeggio.size;
-
 	/* Check for invalid periods (from Toru Egashira's NSPmod)
 	 * panic.s3m has negative periods
 	 * ambio.it uses low (~8) period values
@@ -1293,13 +1308,13 @@ static void play_channel(struct context_data *ctx, int chn)
 
 	libxmp_virt_release(ctx, chn, TEST_NOTE(NOTE_RELEASE));
 
-	process_volume(ctx, chn, act);
-	process_frequency(ctx, chn, act);
-	process_pan(ctx, chn, act);
-
 	update_volume(ctx, chn);
 	update_frequency(ctx, chn);
 	update_pan(ctx, chn);
+
+	process_volume(ctx, chn, act);
+	process_frequency(ctx, chn, act);
+	process_pan(ctx, chn, act);
 
 #ifndef LIBXMP_CORE_PLAYER
 	if (HAS_QUIRK(QUIRK_PROTRACK) && xc->ins < mod->ins) {

--- a/contrib/libxmp/src/read_event.c
+++ b/contrib/libxmp/src/read_event.c
@@ -1158,8 +1158,14 @@ static int read_event_it(struct context_data *ctx, struct xmp_event *e, int chn)
 				SET_NOTE(NOTE_RELEASE);
 			}
 			SET(KEY_OFF);
+			/* Use instrument volume if an instrument was explicitly
+			 * provided on this row (see OpenMPT NoteOffInstr.it row 4).
+			 * However, never reset the envelope (see OpenMPT wnoteoff.it).
+			 */
 			reset_env = 0;
-			use_ins_vol = 0;
+			if (!ev.ins) {
+				use_ins_vol = 0;
+			}
 		} else {
 			/* portamento_after_keyoff.it test case */
 			/* also see suburban_streets o13 c45 */
@@ -1308,13 +1314,12 @@ static int read_event_it(struct context_data *ctx, struct xmp_event *e, int chn)
 			RESET_NOTE(NOTE_CUT);
 		}
 	}
-	
+
 	/* Process new volume */
 	if (ev.vol && (!TEST_NOTE(NOTE_CUT) || ev.ins != 0)) {
-		if (key != XMP_KEY_OFF) {    /* See OpenMPT NoteOffInstr.it */
-			xc->volume = ev.vol - 1;
-			SET(NEW_VOL);
-		}
+		/* Do this even for XMP_KEY_OFF (see OpenMPT NoteOffInstr.it row 4). */
+		xc->volume = ev.vol - 1;
+		SET(NEW_VOL);
 	}
 
 	/* IT: always reset sample offset */


### PR DESCRIPTION
Updates libxmp for the following patches:

* `LIBXMP_NO_PROWIZARD`, which reduces the patch surface area for this fork down to +18 -88, mostly in format.c.
* A fix for Emscripten builds that doesn't affect MZX since libxmp is built directly into MZX. MZX builds still work after adding these changes.
* A fix for the volume/panning/slide update order that affected most formats.
* Crash fixes for various loaders and other misc. fixes.