### PR TITLE
Replace file manager dirs/allow_new flags with enums, fix bugs.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -23,6 +23,14 @@ USERS
   the Nintendo DS port.
 + Fixed crashes in the RAD player that could be caused by
   references to uninitialized instruments.
++ Fixed a bug where the 3DS and Switch ports would display .. in
+  the file manager when selecting a board module, board charset,
+  or board palette.
++ Fixed a bug where, when a faulty dirent implementation returns
+  .. when listing the contents of a root directory, .. would be
+  displayed despite being meaningless.
++ Fixed a bug where some checks in the file manager could fail
+  when getcwd returns different slashes than expected.
 - Removed 3DS CIA support. (asie)
 
 DEVELOPERS

--- a/src/editor/char_ed.c
+++ b/src/editor/char_ed.c
@@ -952,7 +952,8 @@ static void char_import(struct world *mzx_world, int char_offset, int charset,
 
   strcpy(import_string, saved_import_string);
   if(!file_manager(mzx_world, chr_ext, NULL, import_string,
-   "Import character set(s)", 1, 2, elements, ARRAY_SIZE(elements), 2))
+   "Import character set(s)", ALLOW_ALL_DIRS, ALLOW_WILDCARD_FILES,
+   elements, ARRAY_SIZE(elements), 2))
   {
     int num_files_present = num_files;
 
@@ -1048,7 +1049,8 @@ static void char_export(struct world *mzx_world, int char_offset, int charset,
 
   strcpy(export_string, saved_export_string);
   if(!file_manager(mzx_world, chr_ext, ".chr", export_string,
-   "Export character set(s)", 1, 1, elements, ARRAY_SIZE(elements), 2))
+   "Export character set(s)", ALLOW_ALL_DIRS, ALLOW_NEW_FILES,
+   elements, ARRAY_SIZE(elements), 2))
   {
     int num_files_present = num_files;
 

--- a/src/editor/debug.c
+++ b/src/editor/debug.c
@@ -3207,7 +3207,7 @@ void __debug_counters(context *ctx)
         export_name[0] = 0;
 
         if(!new_file(mzx_world, txt_ext, ".txt", export_name,
-         "Export counters/strings text file...", 1))
+         "Export counters/strings text file...", ALLOW_ALL_DIRS))
         {
           struct counter_list *counter_list = &(mzx_world->counter_list);
           struct string_list *string_list = &(mzx_world->string_list);

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -2422,7 +2422,7 @@ static boolean editor_key(context *ctx, int *key)
             strcpy(export_name, editor->mzm_name_buffer);
 
             if(!new_file(mzx_world, mzm_ext, ".mzm", export_name,
-             "Export MZM", 1))
+             "Export MZM", ALLOW_ALL_DIRS))
             {
               enum mzm_save_mode save_mode;
 
@@ -2789,7 +2789,7 @@ static boolean editor_key(context *ctx, int *key)
             {
               strcpy(import_name, editor->mzb_name_buffer);
               if(!choose_file(mzx_world, mzb_ext, import_name,
-               "Choose board to import", 1))
+               "Choose board to import", ALLOW_ALL_DIRS))
               {
                 strcpy(editor->mzb_name_buffer, import_name);
                 replace_current_board(mzx_world, import_name);
@@ -2835,7 +2835,7 @@ static boolean editor_key(context *ctx, int *key)
 
               strcpy(import_name, editor->chr_name_buffer);
               if(!file_manager(mzx_world, chr_ext, NULL, import_name,
-               "Choose character set to import", 1, 0,
+               "Choose character set to import", ALLOW_ALL_DIRS, NO_NEW_FILES,
                elements, ARRAY_SIZE(elements), 2))
               {
                 strcpy(editor->chr_name_buffer, import_name);
@@ -2849,7 +2849,7 @@ static boolean editor_key(context *ctx, int *key)
             {
               // World file
               if(!choose_file(mzx_world, world_ext, import_name,
-               "Choose world to import", 1))
+               "Choose world to import", ALLOW_ALL_DIRS))
               {
                 // FIXME: Check retval?
                 append_world(mzx_world, import_name);
@@ -2876,7 +2876,7 @@ static boolean editor_key(context *ctx, int *key)
             {
               // Sound effects
               if(!choose_file(mzx_world, sfx_ext, import_name,
-               "Choose SFX file to import", 1))
+               "Choose SFX file to import", ALLOW_ALL_DIRS))
               {
                 FILE *sfx_file;
 
@@ -2897,7 +2897,7 @@ static boolean editor_key(context *ctx, int *key)
               // MZM file
               strcpy(import_name, editor->mzm_name_buffer);
               if(!choose_file(mzx_world, mzm_ext, import_name,
-               "Choose image file to import", 1))
+               "Choose image file to import", ALLOW_ALL_DIRS))
               {
                 struct mzm_header mzm;
                 if(load_mzm_header(import_name, &mzm))
@@ -2958,7 +2958,7 @@ static boolean editor_key(context *ctx, int *key)
         char test_wav[MAX_PATH] = { 0, };
 
         if(!choose_file(mzx_world, sam_ext, test_wav,
-         "Choose a wav file", 1))
+         "Choose a wav file", ALLOW_ALL_DIRS))
         {
           audio_play_sample(test_wav, false, 0);
         }
@@ -2976,7 +2976,7 @@ static boolean editor_key(context *ctx, int *key)
           strcpy(load_world, editor->current_world);
 
           if(!choose_file_ch(mzx_world, world_ext, load_world,
-           "Load World", 1))
+           "Load World", ALLOW_ALL_DIRS))
           {
             // Load world curr_file
             strcpy(editor->current_world, load_world);
@@ -3078,7 +3078,7 @@ static boolean editor_key(context *ctx, int *key)
             char new_mod[MAX_PATH] = { 0 };
 
             if(!choose_file(mzx_world, mod_ext, new_mod,
-             "Choose a module file", 2)) // 2:subdirsonly
+             "Choose a module file", ALLOW_SUBDIRS))
             {
               const char *ext_pos = new_mod + strlen(new_mod) - 4;
               if(ext_pos >= new_mod && !strcasecmp(ext_pos, ".WAV"))
@@ -3115,7 +3115,7 @@ static boolean editor_key(context *ctx, int *key)
             chdir(editor->current_listening_dir);
 
             if(!choose_file(mzx_world, mod_ext, new_mod,
-             "Choose a module file (listening only)", 1))
+             "Choose a module file (listening only)", ALLOW_ALL_DIRS))
             {
               audio_play_module(new_mod, false, 255);
               strcpy(editor->current_listening_mod, new_mod);
@@ -3306,7 +3306,7 @@ static boolean editor_key(context *ctx, int *key)
           char new_path[MAX_PATH];
           strcpy(world_name, editor->current_world);
           if(!new_file(mzx_world, world_ext, ".mzx", world_name,
-           "Save world", 1))
+           "Save world", ALLOW_ALL_DIRS))
           {
             debug("Save path: %s\n", world_name);
 
@@ -3439,7 +3439,7 @@ static boolean editor_key(context *ctx, int *key)
               // Board file
               strcpy(export_name, editor->mzb_name_buffer);
               if(!new_file(mzx_world, mzb_ext, ".mzb", export_name,
-               "Export board file", 1))
+               "Export board file", ALLOW_ALL_DIRS))
               {
                 strcpy(editor->mzb_name_buffer, export_name);
                 save_board_file(mzx_world, cur_board, export_name);
@@ -3462,7 +3462,8 @@ static boolean editor_key(context *ctx, int *key)
 
               strcpy(export_name, editor->chr_name_buffer);
               if(!file_manager(mzx_world, chr_ext, NULL, export_name,
-               "Export character set", 1, 1, elements, ARRAY_SIZE(elements), 2))
+               "Export character set", ALLOW_ALL_DIRS, ALLOW_NEW_FILES,
+               elements, ARRAY_SIZE(elements), 2))
               {
                 path_force_ext(export_name, MAX_PATH, ".chr");
                 ec_save_set_var(export_name, char_offset, char_size);
@@ -3483,7 +3484,7 @@ static boolean editor_key(context *ctx, int *key)
             {
               // Sound effects
               if(!new_file(mzx_world, sfx_ext, ".sfx", export_name,
-               "Export SFX file", 1))
+               "Export SFX file", ALLOW_ALL_DIRS))
               {
                 FILE *sfx_file;
 
@@ -3511,7 +3512,7 @@ static boolean editor_key(context *ctx, int *key)
                (MZX_VERSION_PREV >> 8) & 0xFF, MZX_VERSION_PREV & 0xFF);
 
               if(!new_file(mzx_world, world_ext, ".mzx", export_name,
-               title, 1))
+               title, ALLOW_ALL_DIRS))
               {
                 save_world(mzx_world, export_name, false, MZX_VERSION_PREV);
               }

--- a/src/editor/pal_ed.c
+++ b/src/editor/pal_ed.c
@@ -2526,7 +2526,7 @@ void import_palette(context *ctx)
   // Palette
   strcpy(filename_buffer, pal_filename);
   if(!choose_file(ctx->world, pal_ext, filename_buffer,
-   "Choose palette to import", true))
+   "Choose palette to import", ALLOW_ALL_DIRS))
   {
     strcpy(pal_filename, filename_buffer);
     load_palette(filename_buffer);
@@ -2536,7 +2536,7 @@ void import_palette(context *ctx)
   strcpy(filename_buffer, palidx_filename);
   if((get_screen_mode() == 3) &&
    !choose_file(ctx->world, idx_ext, filename_buffer,
-    "Choose indices to import (.PALIDX)", true))
+    "Choose indices to import (.PALIDX)", ALLOW_ALL_DIRS))
   {
     strcpy(palidx_filename, filename_buffer);
     load_index_file(filename_buffer);
@@ -2554,7 +2554,7 @@ void export_palette(context *ctx)
   // Palette
   strcpy(filename_buffer, pal_filename);
   if(!new_file(ctx->world, pal_ext, ".pal", filename_buffer,
-   "Export palette", true))
+   "Export palette", ALLOW_ALL_DIRS))
   {
     strcpy(pal_filename, filename_buffer);
     save_palette(filename_buffer);
@@ -2564,7 +2564,7 @@ void export_palette(context *ctx)
   strcpy(filename_buffer, palidx_filename);
   if((get_screen_mode() == 3) &&
    !new_file(ctx->world, idx_ext, ".palidx", filename_buffer,
-    "Export indices (.PALIDX)", true))
+    "Export indices (.PALIDX)", ALLOW_ALL_DIRS))
   {
     strcpy(palidx_filename, filename_buffer);
     save_index_file(filename_buffer);

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -1516,7 +1516,7 @@ static void export_block(struct robot_editor_context *rstate,
   export_name[0] = 0;
 
   if(!file_manager(mzx_world, export_ext, NULL, export_name,
-   "Export robot", 1, 1, elements, num_elements, 3))
+   "Export robot", ALLOW_ALL_DIRS, ALLOW_NEW_FILES, elements, num_elements, 3))
   {
     FILE *export_file;
 
@@ -1579,7 +1579,7 @@ static void import_block(struct robot_editor_context *rstate)
 
   txt_ext[1] = ".BC";
 
-  if(choose_file(mzx_world, txt_ext, import_name, "Import Robot", 1))
+  if(choose_file(mzx_world, txt_ext, import_name, "Import Robot", ALLOW_ALL_DIRS))
     return;
 
 #else // CONFIG_DEBYTECODE
@@ -1590,8 +1590,8 @@ static void import_block(struct robot_editor_context *rstate)
     construct_check_box(21, 20, label, 1, strlen(label[0]), &is_legacy)
   };
 
-  if(file_manager(mzx_world, txt_ext, NULL, import_name, "Import Robot", 1,
-   0, elements, 1, 2))
+  if(file_manager(mzx_world, txt_ext, NULL, import_name, "Import Robot",
+   ALLOW_ALL_DIRS, NO_NEW_FILES, elements, 1, 2))
     return;
 
 #endif

--- a/src/editor/window.c
+++ b/src/editor/window.c
@@ -1218,8 +1218,8 @@ int choose_board(struct world *mzx_world, int current, const char *title,
 }
 
 int choose_file(struct world *mzx_world, const char *const *wildcards,
- char *ret, const char *title, int dirs_okay)
+ char *ret, const char *title, enum allow_dirs allow_dirs)
 {
-  return file_manager(mzx_world, wildcards, NULL, ret, title, dirs_okay,
-   0, NULL, 0, 0);
+  return file_manager(mzx_world, wildcards, NULL, ret, title, allow_dirs,
+   NO_NEW_FILES, NULL, 0, 0);
 }

--- a/src/editor/window.h
+++ b/src/editor/window.h
@@ -53,7 +53,7 @@ int add_board(struct world *mzx_world, int current);
 int choose_board(struct world *mzx_world, int current, const char *title,
  int board0_none);
 int choose_file(struct world *mzx_world, const char *const *wildcards,
- char *ret, const char *title, int dirs_okay);
+ char *ret, const char *title, enum allow_dirs allow_dirs);
 
 __M_END_DECLS
 

--- a/src/game.c
+++ b/src/game.c
@@ -375,7 +375,8 @@ static boolean load_world_title_selection(struct game_context *game)
   struct world *mzx_world = ((context *)game)->world;
   char world_name[MAX_PATH] = { 0 };
 
-  if(!choose_file_ch(mzx_world, world_ext, world_name, "Load World", true))
+  if(!choose_file_ch(mzx_world, world_ext, world_name, "Load World",
+   ALLOW_ALL_DIRS))
   {
     return load_world_title(game, world_name);
   }
@@ -404,8 +405,9 @@ static boolean load_savegame_selection(struct game_context *game)
     }
   }
 
-  if(slot_result == SLOTSEL_OK_RESULT || !choose_file_ch(mzx_world, save_ext,
-   save_file_name, "Choose game to restore", true))
+  if(slot_result == SLOTSEL_OK_RESULT ||
+   !choose_file_ch(mzx_world, save_ext, save_file_name,
+    "Choose game to restore", ALLOW_ALL_DIRS))
   {
     return load_savegame(game, save_file_name);
   }
@@ -688,7 +690,8 @@ static boolean game_key(context *ctx, int *key)
           }
 
           if(slot_result == SLOTSEL_OK_RESULT ||
-           !new_file(mzx_world, save_ext, ".sav", save_game, "Save game", 1))
+           !new_file(mzx_world, save_ext, ".sav", save_game, "Save game",
+            ALLOW_ALL_DIRS))
           {
             strcpy(curr_sav, save_game);
             save_world(mzx_world, curr_sav, true, MZX_VERSION);

--- a/src/io/path.h
+++ b/src/io/path.h
@@ -60,6 +60,8 @@ static inline boolean isslash(const char chr)
 UTILS_LIBSPEC boolean path_force_ext(char *path, size_t buffer_len, const char *ext);
 UTILS_LIBSPEC ssize_t path_get_ext_offset(const char *path);
 
+UTILS_LIBSPEC ssize_t path_is_absolute(const char *path);
+UTILS_LIBSPEC boolean path_is_root(const char *path);
 UTILS_LIBSPEC boolean path_has_directory(const char *path);
 UTILS_LIBSPEC ssize_t path_to_directory(char *path, size_t buffer_len);
 UTILS_LIBSPEC ssize_t path_to_filename(char *path, size_t buffer_len);

--- a/src/window.c
+++ b/src/window.c
@@ -3397,9 +3397,11 @@ __editor_maybe_static int file_manager(struct world *mzx_world,
       goto skip_dir;
 
     // Hide .. if changing directories isn't allowed or if the selected file
-    // should be in the current directory or a subdirectory of it.
+    // should be in the current directory or a subdirectory of it. Also hide it
+    // if this is a root directory.
     if(allow_dirs == NO_DIRS ||
-     (allow_dirs == ALLOW_SUBDIRS && !strcmp(current_dir_name, base_dir_name)))
+     (allow_dirs == ALLOW_SUBDIRS && !strcmp(current_dir_name, base_dir_name)) ||
+     path_is_root(current_dir_name))
     {
       show_parent_dir = false;
     }
@@ -3407,7 +3409,7 @@ __editor_maybe_static int file_manager(struct world *mzx_world,
       show_parent_dir = true;
 
 #if defined(CONFIG_3DS) || defined(CONFIG_SWITCH)
-    if(show_parent_dir && strlen(current_dir_name) > 1)
+    if(show_parent_dir)
     {
       dir_list[num_dirs] = cmalloc(3);
       dir_list[num_dirs][0] = '.';

--- a/src/window.c
+++ b/src/window.c
@@ -3337,11 +3337,6 @@ __editor_maybe_static int file_manager(struct world *mzx_world,
   char ret_path[MAX_PATH];
   char ret_file[MAX_PATH];
 
-  // TODO: some platforms don't return this in the format MZX needs it.
-  if(!vgetcwd(ret_path, MAX_PATH) ||
-   path_clean_slashes(ret_path, MAX_PATH) <= 0)
-    return -1;
-
   // Prevent previous keys from carrying through.
   force_release_all_keys();
 
@@ -3361,9 +3356,11 @@ __editor_maybe_static int file_manager(struct world *mzx_world,
   if(allow_new != NO_NEW_FILES)
     last_element = FILESEL_FILENAME;
 
-  snprintf(return_dir_name, MAX_PATH, "%s", ret_path);
-  return_dir_name[MAX_PATH - 1] = '\0';
-  snprintf(current_dir_name, MAX_PATH, "%s", ret_path);
+  // TODO: some platforms don't return this in the format MZX needs it.
+  getcwd(return_dir_name, MAX_PATH);
+  path_clean_slashes(return_dir_name, MAX_PATH);
+
+  snprintf(current_dir_name, MAX_PATH, "%s", return_dir_name);
   current_dir_name[MAX_PATH - 1] = '\0';
 
   // Check the input path for a directory. If there is a directory component

--- a/src/window.c
+++ b/src/window.c
@@ -1962,7 +1962,7 @@ static int key_file_selector(struct world *mzx_world, struct dialog *di,
       strcpy(new_path, src->base_path);
 
       if(!choose_file_ch(mzx_world, src->file_manager_exts, new_path,
-       src->file_manager_title, 2))
+       src->file_manager_title, ALLOW_SUBDIRS))
       {
         strcpy(src->result, new_path);
         di->done = 1;
@@ -3018,8 +3018,6 @@ int slot_manager(struct world *mzx_world, char *ret,
 }
 
 // Shell for list_menu() (copies file chosen to ret and returns -1 for ESC)
-// dirs_okay of 1 means drive and directory changing is allowed.
-// dirs_okay of 2 means only subdirectories of the current dir are allowed
 
 #define FILESEL_MAX_ELEMENTS  64
 #define FILESEL_BASE_ELEMENTS 7
@@ -3300,11 +3298,10 @@ static boolean remove_files(char *directory_name, boolean remove_recursively)
 
 __editor_maybe_static int file_manager(struct world *mzx_world,
  const char *const *wildcards, const char *default_ext, char *ret,
- const char *title, int dirs_okay, int allow_new, struct element **dialog_ext,
- int num_ext, int ext_height)
+ const char *title, enum allow_dirs allow_dirs, enum allow_new allow_new,
+ struct element **dialog_ext, int num_ext, int ext_height)
 {
   // FIXME no buffer size parameter for ret. this function assumes MAX_PATH.
-  // dirs_okay -- 0:none -- 1:all -- 2:subdirsonly
   struct mzx_dir current_dir;
   char *file_name;
   struct stat file_info;
@@ -3328,6 +3325,8 @@ __editor_maybe_static int file_manager(struct world *mzx_world,
   struct element *elements[FILESEL_MAX_ELEMENTS];
   int list_length = 17 - ext_height;
   int last_element = FILESEL_FILE_LIST;
+  boolean return_dir_is_base_dir = true;
+  boolean show_parent_dir;
   int i;
 
 #ifdef __WIN32__
@@ -3337,6 +3336,11 @@ __editor_maybe_static int file_manager(struct world *mzx_world,
   // Buffers for the return file's path and name.
   char ret_path[MAX_PATH];
   char ret_file[MAX_PATH];
+
+  // TODO: some platforms don't return this in the format MZX needs it.
+  if(!vgetcwd(ret_path, MAX_PATH) ||
+   path_clean_slashes(ret_path, MAX_PATH) <= 0)
+    return -1;
 
   // Prevent previous keys from carrying through.
   force_release_all_keys();
@@ -3354,18 +3358,22 @@ __editor_maybe_static int file_manager(struct world *mzx_world,
   // Where the file manager needs to return on exit.
   return_dir_name = cmalloc(MAX_PATH);
 
-  if(allow_new)
+  if(allow_new != NO_NEW_FILES)
     last_element = FILESEL_FILENAME;
 
-  getcwd(return_dir_name, MAX_PATH);
-  snprintf(current_dir_name, MAX_PATH, "%s", return_dir_name);
+  snprintf(return_dir_name, MAX_PATH, "%s", ret_path);
+  return_dir_name[MAX_PATH - 1] = '\0';
+  snprintf(current_dir_name, MAX_PATH, "%s", ret_path);
   current_dir_name[MAX_PATH - 1] = '\0';
 
   // Check the input path for a directory. If there is a directory component
   // to the input, that should be used as the base directory.
   // TODO: this is a bad way to do this. The base dir should be a param instead.
   if(path_get_directory(ret_path, MAX_PATH, ret) > 0)
+  {
     path_navigate(current_dir_name, MAX_PATH, ret_path);
+    return_dir_is_base_dir = false;
+  }
 
   snprintf(base_dir_name, MAX_PATH, "%s", current_dir_name);
   base_dir_name[MAX_PATH - 1] = '\0';
@@ -3388,8 +3396,18 @@ __editor_maybe_static int file_manager(struct world *mzx_world,
     if(!dir_open(&current_dir, current_dir_name))
       goto skip_dir;
 
+    // Hide .. if changing directories isn't allowed or if the selected file
+    // should be in the current directory or a subdirectory of it.
+    if(allow_dirs == NO_DIRS ||
+     (allow_dirs == ALLOW_SUBDIRS && !strcmp(current_dir_name, base_dir_name)))
+    {
+      show_parent_dir = false;
+    }
+    else
+      show_parent_dir = true;
+
 #if defined(CONFIG_3DS) || defined(CONFIG_SWITCH)
-    if(dirs_okay == 1 && strlen(current_dir_name) > 1)
+    if(show_parent_dir && strlen(current_dir_name) > 1)
     {
       dir_list[num_dirs] = cmalloc(3);
       dir_list[num_dirs][0] = '.';
@@ -3429,9 +3447,8 @@ __editor_maybe_static int file_manager(struct world *mzx_world,
       if(dir_type == DIR_TYPE_DIR)
       {
         // Exclude .. from base dir in subdirsonly mode
-        if(dirs_okay &&
-         !(dirs_okay == 2 && !strcmp(file_name, "..") &&
-          !strcmp(current_dir_name, base_dir_name) ))
+        if(allow_dirs != NO_DIRS &&
+         !(!show_parent_dir && !strcmp(file_name, "..")))
         {
           dir_list[num_dirs] = cmalloc(file_name_length + 1);
           memcpy(dir_list[num_dirs], file_name, file_name_length + 1);
@@ -3486,7 +3503,7 @@ skip_dir:
     qsort(dir_list, num_dirs, sizeof(char *), sort_function);
 
 #ifdef __WIN32__
-    if(dirs_okay == 1)
+    if(allow_dirs == ALLOW_ALL_DIRS)
     {
       drive_letter_bitmap = GetLogicalDrives();
 
@@ -3513,7 +3530,7 @@ skip_dir:
 #endif
 
 #ifdef CONFIG_WII
-    if(dirs_okay == 1)
+    if(allow_dirs == ALLOW_ALL_DIRS)
     {
       for(i = 0; i < STD_MAX; i++)
       {
@@ -3677,10 +3694,10 @@ skip_dir:
         }
 
         // We're creating a new file
-        if(allow_new)
+        if(allow_new != NO_NEW_FILES)
         {
           // File Exists
-          if((stat_result >= 0) && (allow_new == 1))
+          if((stat_result >= 0) && (allow_new == ALLOW_NEW_FILES))
           {
             char confirm_string[512];
             snprintf(confirm_string, 512, "%s already exists, overwrite?",
@@ -3867,8 +3884,8 @@ skip_dir:
       }
     }
 
-    // No unallowed paths kthx
-    if(dirs_okay != 1)
+    // Filter out paths that violate the allowed directories mode.
+    if(allow_dirs != ALLOW_ALL_DIRS)
     {
       size_t base_dir_len = strlen(base_dir_name);
 
@@ -3877,7 +3894,7 @@ skip_dir:
        strstr(current_dir_name, "..") ||
 
       // or if there's an unallowed subdirectory
-       (!dirs_okay && path_has_directory(current_dir_name + base_dir_len)))
+       (allow_dirs == NO_DIRS && path_has_directory(current_dir_name + base_dir_len)))
       {
         memcpy(current_dir_name, base_dir_name, base_dir_len + 1);
         return_value = 1;
@@ -3890,7 +3907,7 @@ skip_dir:
       // for files selected for use in a game from the editor.
       // TODO should maybe do this regardless of the return path. The only
       // thing that would be affected is probably GLSL shader selection.
-      if(!strcmp(base_dir_name, return_dir_name))
+      if(return_dir_is_base_dir)
       {
         path_remove_prefix(ret, MAX_PATH, base_dir_name, base_dir_len);
       }
@@ -3937,17 +3954,17 @@ skip_dir:
 }
 
 int choose_file_ch(struct world *mzx_world, const char *const *wildcards,
- char *ret, const char *title, int dirs_okay)
+ char *ret, const char *title, enum allow_dirs allow_dirs)
 {
-  return file_manager(mzx_world, wildcards, NULL, ret, title, dirs_okay,
-   0, NULL, 0, 0);
+  return file_manager(mzx_world, wildcards, NULL, ret, title, allow_dirs,
+   NO_NEW_FILES, NULL, 0, 0);
 }
 
 int new_file(struct world *mzx_world, const char *const *wildcards,
- const char *default_ext, char *ret, const char *title, int dirs_okay)
+ const char *default_ext, char *ret, const char *title, enum allow_dirs allow_dirs)
 {
-  return file_manager(mzx_world, wildcards, default_ext, ret, title, dirs_okay,
-   1, NULL, 0, 0);
+  return file_manager(mzx_world, wildcards, default_ext, ret, title, allow_dirs,
+   ALLOW_NEW_FILES, NULL, 0, 0);
 }
 
 #if defined(CONFIG_UPDATER) || defined(CONFIG_LOADSAVE_METER)

--- a/src/window.h
+++ b/src/window.h
@@ -227,6 +227,20 @@ struct file_selector
   char *result;
 };
 
+enum allow_dirs
+{
+  NO_DIRS,
+  ALLOW_ALL_DIRS,
+  ALLOW_SUBDIRS,
+};
+
+enum allow_new
+{
+  NO_NEW_FILES,
+  ALLOW_NEW_FILES,
+  ALLOW_WILDCARD_FILES,
+};
+
 CORE_LIBSPEC int input_window(struct world *mzx_world, const char *title,
  char *buffer, int max_len);
 
@@ -257,10 +271,11 @@ CORE_LIBSPEC struct element *construct_list_box(int x, int y,
  boolean respect_color_codes);
 
 CORE_LIBSPEC int choose_file_ch(struct world *mzx_world,
- const char *const *wildcards, char *ret, const char *title, int dirs_okay);
+ const char *const *wildcards, char *ret, const char *title,
+ enum allow_dirs allow_dirs);
 CORE_LIBSPEC int new_file(struct world *mzx_world,
  const char *const *wildcards, const char *default_ext, char *ret,
- const char *title, int dirs_okay);
+ const char *title, enum allow_dirs allow_dirs);
 
 #if defined(CONFIG_UPDATER) || defined(CONFIG_LOADSAVE_METER)
 CORE_LIBSPEC void meter(const char *title, unsigned int progress,
@@ -357,7 +372,7 @@ CORE_LIBSPEC int char_select_next_tile(int current_char,
 
 CORE_LIBSPEC int file_manager(struct world *mzx_world,
  const char *const *wildcards, const char *default_ext, char *ret,
- const char *title, int dirs_okay, int allow_new,
+ const char *title, enum allow_dirs allow_dirs, enum allow_new allow_new,
  struct element **dialog_ext, int num_ext, int ext_height);
 #endif // CONFIG_EDITOR
 

--- a/unit/io/path.cpp
+++ b/unit/io/path.cpp
@@ -166,6 +166,93 @@ UNITTEST(path_force_ext)
   }
 }
 
+struct path_is_abs_result
+{
+  const char *path;
+  ssize_t root_len;
+  boolean is_root;
+};
+
+UNITTEST(path_is_absolute)
+{
+  static const path_is_abs_result data[]
+  {
+    {
+      "",
+      0,
+      false
+    },
+    {
+      "sdhfjkshfjkds",
+      0,
+      false
+    },
+    {
+      "relative/path/here",
+      0,
+      false
+    },
+    {
+      "malformed:dos/path",
+      0,
+      false
+    },
+    {
+      ":/wtf",
+      0,
+      false
+    },
+    {
+      "/",
+      1,
+      true
+    },
+    {
+      "A:",
+      2,
+      true
+    },
+    {
+      "C:\\",
+      3,
+      true
+    },
+    {
+      "sdcard:/",
+      8,
+      true
+    },
+    {
+      "/absolute/but/not/root",
+      1,
+      false
+    },
+    {
+      "C:\\absolute/not\\root",
+      3,
+      false
+    },
+  };
+
+  SECTION(path_is_absolute)
+  {
+    for(int i = 0; i < arraysize(data); i++)
+    {
+      ssize_t len = path_is_absolute(data[i].path);
+      ASSERTEQX(len, data[i].root_len, data[i].path);
+    }
+  }
+
+  SECTION(path_is_root)
+  {
+    for(int i = 0; i < arraysize(data); i++)
+    {
+      boolean is_root = path_is_root(data[i].path);
+      ASSERTEQX(is_root, data[i].is_root, data[i].path);
+    }
+  }
+}
+
 struct path_output_pair
 {
   const char *path;
@@ -1019,6 +1106,13 @@ UNITTEST(path_navigate)
     {
       "",
       "lol",
+      nullptr,
+      nullptr,
+      -1
+    },
+    {
+      "/abc",
+      "malformed/root:/path/",
       nullptr,
       nullptr,
       -1


### PR DESCRIPTION
Cleans up some ambiguous parameters to the `file_manager` family of functions and also fixes some minor bugs related to directory selection:

* `allow_dirs` (previously `dirs_okay`) now uses enum values explicitly named `NO_DIRS`, `ALLOW_ALL_DIRS`, and `ALLOW_SUBDIRS`.
* `allow_new` now uses enum values explicitly named `NO_NEW_FILES`, `ALLOW_NEW_FILES`, and `ALLOW_WILDCARD_FILES` (only used by char editor aggregate importing).
* Fixed a bug where `..` would appear in the root for the 3DS and Switch ports (introduced in 2.91X).
* Fixed a bug where `base_dir_name` and `current_dir_name` could sometimes contain different slashes, preventing module/board charset/board palette selection. This issue currently is only known to affect the DJGPP port and was probably introduced in 2.84X (not verified). The current fix for this (normalize slashes returned from getcwd) is kind of tacky and I should probably just add path compare and prefix check functions.

TODO:
- [x] ~~Probably revise the fixes with new path functions (not sure yet).~~ I think it's ok to just leave this as is for now...
- [x] Aside from the fix above a simple path function `path_is_root` would help both the 3DS/Switch check and fix the same bug for the DJGPP port without any extra platform-specific code (caused by DJGPP dirent returning `..` even at drive roots).
- [x] Changelog entry.
- [x] More testing.