### PR TITLE
Add vtempfile and improve memory vfile expansion.

### DIFF
--- a/src/io/vfile.h
+++ b/src/io/vfile.h
@@ -44,6 +44,7 @@ vfile *vfile_init_fp(FILE *fp, const char *mode);
 vfile *vfile_init_mem(void *buffer, size_t size, const char *mode);
 vfile *vfile_init_mem_ext(void **external_buffer, size_t *external_buffer_size,
  const char *mode);
+UTILS_LIBSPEC vfile *vtempfile(size_t initial_size);
 UTILS_LIBSPEC int vfclose(vfile *vf);
 
 struct memfile *vfile_get_memfile(vfile *vf);

--- a/src/io/vfile_posix.h
+++ b/src/io/vfile_posix.h
@@ -38,6 +38,11 @@ static inline FILE *platform_fopen_unsafe(const char *path, const char *mode)
   return fopen_unsafe(path, mode);
 }
 
+static inline FILE *platform_tmpfile(void)
+{
+  return tmpfile();
+}
+
 static inline char *platform_getcwd(char *buf, size_t size)
 {
   return getcwd(buf, size);

--- a/src/io/vfile_win32.h
+++ b/src/io/vfile_win32.h
@@ -100,6 +100,27 @@ static inline FILE *platform_fopen_unsafe(const char *path, const char *mode)
   return fopen_unsafe(path, mode);
 }
 
+static inline FILE *platform_tmpfile(void)
+{
+#ifdef WIDE_PATHS
+  /**
+   * The non-terrible solution to doing this was introduced around roughly the
+   * same time wide path support was so just tie them together. This also
+   * hopefully means that user dirs with unicode characters won't break.
+   */
+  wchar_t wpath[MAX_PATH];
+  wchar_t wfile[MAX_PATH];
+
+  if(GetTempPathW(MAX_PATH, wpath))
+  {
+    if(GetTempFileNameW(wpath, L"MZX", 0, wfile))
+      return _wfopen(wfile, L"wb+");
+  }
+#endif
+  /* This attempts to put a file in C:\ and generally is terrible! */
+  return tmpfile();
+}
+
 static inline char *platform_getcwd(char *buf, size_t size)
 {
 #ifdef WIDE_PATHS

--- a/unit/io/vfile.cpp
+++ b/unit/io/vfile.cpp
@@ -707,6 +707,30 @@ UNITTEST(vfsafegets)
   }
 }
 
+UNITTEST(vtempfile)
+{
+  SECTION(File)
+  {
+    ScopedFile<vfile, vfclose> vf = vtempfile(0);
+    ASSERT(vf);
+    test_vfwrite(vf);
+  }
+
+  SECTION(Memory)
+  {
+    ScopedFile<vfile, vfclose> vf = vtempfile(arraysize(test_data));
+    ASSERT(vf);
+    test_vfwrite(vf);
+  }
+
+  SECTION(MemorySmallInit)
+  {
+    ScopedFile<vfile, vfclose> vf = vtempfile(1);
+    ASSERT(vf);
+    test_vfputc(vf);
+  }
+}
+
 UNITTEST(Filesystem)
 {
   static char execdir[1024];


### PR DESCRIPTION
Adds a function to create real and/or memory vfiles. Also changes vfile expansion to occur in powers of two instead of incrementally.

- [x] More platform testing since the Windows handling for `platform_tmpfile` wasn't irritating enough :(