### PR TITLE
Add experimental player key buffering.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -2,6 +2,10 @@ GIT
 
 USERS
 
++ Added experimental player "input buffering". When a player key
+  is pressed and released on the same cycle, the player will now
+  respond to that key press. This also affects IF UPPRESSED and
+  similar (but currently not the KEYn counters).
 + Protected worlds are now decrypted to RAM or a temporary file
   when 'auto_decrypt_worlds' is enabled and the original file is
   left unmodified. This setting is now enabled by default.

--- a/src/event.c
+++ b/src/event.c
@@ -831,8 +831,25 @@ Uint32 get_key_status(enum keycode_type type, Uint32 index)
       return status->keymap[index];
 
     case keycode_internal_wrt_numlock:
-      return status->keymap[index] ||
-        status->keymap[reverse_keysym_numlock(index)];
+    {
+      enum keycode alt = reverse_keysym_numlock(index);
+
+      if(status->keymap[index])
+        return status->keymap[index];
+      if(status->keymap[alt])
+        return status->keymap[alt];
+
+      /* This is used mainly for UI and built-in player controls so, finally,
+       * if the keymap isn't set but this value is the pressed key (meaning it
+       * was pressed and released during the same cycle), treat it as 1 (pressed).
+       */
+      if(status->key == index)
+        trace("Buffered press for key # %d\n", index);
+      if(status->key == alt && alt != index)
+        trace("Buffered press for key # %d\n", alt);
+
+      return status->key == index || status->key == alt;
+    }
 
     default:
       return 0;

--- a/src/game.c
+++ b/src/game.c
@@ -629,7 +629,6 @@ static boolean game_key(context *ctx, int *key)
   struct board *cur_board = mzx_world->current_board;
   char keylbl[] = "KEY?";
 
-  int key_status = get_key_status(keycode_internal_wrt_numlock, *key);
   boolean exit_status = get_exit_status();
   boolean confirm_exit = false;
 
@@ -795,6 +794,7 @@ static boolean game_key(context *ctx, int *key)
 
       case IKEY_RETURN:
       {
+        int key_status = get_key_status(keycode_internal_wrt_numlock, IKEY_RETURN);
         send_robot_all_def(mzx_world, "KeyEnter");
 
         // Ignore if this isn't a fresh press
@@ -813,6 +813,7 @@ static boolean game_key(context *ctx, int *key)
       {
         // Ignore if this isn't a fresh press
         // NOTE: disabled because it breaks the joystick action.
+        //int key_status = get_key_status(keycode_internal_wrt_numlock, IKEY_ESCAPE);
         //if(key_status != 1)
           //return true;
 

--- a/src/game_update.c
+++ b/src/game_update.c
@@ -331,6 +331,42 @@ static void update_player_input(struct world *mzx_world)
   int left_pressed = get_key_status(keycode_internal_wrt_numlock, IKEY_LEFT);
   int del_pressed = get_key_status(keycode_internal_wrt_numlock, IKEY_DELETE);
 
+  // Experimental buffering.
+  int key_pressed = get_key(keycode_internal);
+  switch(key_pressed)
+  {
+    case IKEY_SPACE:
+      if(!space_pressed)
+        trace("Buffered space press!\n");
+      space_pressed = 1;
+      break;
+    case IKEY_DELETE:
+      if(!del_pressed)
+        trace("Buffered delete press!\n");
+      del_pressed = 1;
+      break;
+    case IKEY_UP:
+      if(!up_pressed)
+        trace("Buffered up press!\n");
+      up_pressed = 1;
+      break;
+    case IKEY_DOWN:
+      if(!down_pressed)
+        trace("Buffered down press!\n");
+      down_pressed = 1;
+      break;
+    case IKEY_RIGHT:
+      if(!right_pressed)
+        trace("Buffered right press!\n");
+      right_pressed = 1;
+      break;
+    case IKEY_LEFT:
+      if(!left_pressed)
+        trace("Buffered left press!\n");
+      left_pressed = 1;
+      break;
+  }
+
   // Shoot
   if(space_pressed && mzx_world->bi_shoot_status)
   {

--- a/src/game_update.c
+++ b/src/game_update.c
@@ -331,42 +331,6 @@ static void update_player_input(struct world *mzx_world)
   int left_pressed = get_key_status(keycode_internal_wrt_numlock, IKEY_LEFT);
   int del_pressed = get_key_status(keycode_internal_wrt_numlock, IKEY_DELETE);
 
-  // Experimental buffering.
-  int key_pressed = get_key(keycode_internal);
-  switch(key_pressed)
-  {
-    case IKEY_SPACE:
-      if(!space_pressed)
-        trace("Buffered space press!\n");
-      space_pressed = 1;
-      break;
-    case IKEY_DELETE:
-      if(!del_pressed)
-        trace("Buffered delete press!\n");
-      del_pressed = 1;
-      break;
-    case IKEY_UP:
-      if(!up_pressed)
-        trace("Buffered up press!\n");
-      up_pressed = 1;
-      break;
-    case IKEY_DOWN:
-      if(!down_pressed)
-        trace("Buffered down press!\n");
-      down_pressed = 1;
-      break;
-    case IKEY_RIGHT:
-      if(!right_pressed)
-        trace("Buffered right press!\n");
-      right_pressed = 1;
-      break;
-    case IKEY_LEFT:
-      if(!left_pressed)
-        trace("Buffered left press!\n");
-      left_pressed = 1;
-      break;
-  }
-
   // Shoot
   if(space_pressed && mzx_world->bi_shoot_status)
   {


### PR DESCRIPTION
When a player input key is pressed and released on the same cycle, the player and IF UPPRESSED will now detect that as a key press. This helps a lot for playing at very low MZX speeds.

- [ ] TODO: it may be desirable to have this affect all calls of `get_key_status` instead of only for `keycode_internal_wrt_numlock`, as this would mean that the `KEYn` counters (which use `keycode_pc_xt`) would also benefit from this. Further feedback is required.