### PR TITLE
Use vfile et al. instead of stdio/unistd in main.c, file manager.

### DIFF
--- a/arch/msvc/Core.vcxproj
+++ b/arch/msvc/Core.vcxproj
@@ -310,7 +310,7 @@ echo #define VERSION_DATE " ($(BuildDate))"&gt;&gt;$(SolutionDir)version.h</Comm
     <ClCompile Include="..\..\src\io\dir.c" />
     <ClCompile Include="..\..\src\io\fsafeopen.c" />
     <ClCompile Include="..\..\src\io\path.c" />
-    <ClCompile Include="..\..\src\io\vfile.c" />
+    <ClCompile Include="..\..\src\io\vio.c" />
     <ClCompile Include="..\..\src\io\zip.c" />
     <ClCompile Include="..\..\src\io\zip_stream.c" />
     <ClCompile Include="..\..\src\legacy_board.c" />
@@ -414,7 +414,8 @@ echo #define VERSION_DATE " ($(BuildDate))"&gt;&gt;$(SolutionDir)version.h</Comm
     <ClInclude Include="..\..\src\io\memfile.h" />
     <ClInclude Include="..\..\src\io\path.h" />
     <ClInclude Include="..\..\src\io\vfile.h" />
-    <ClInclude Include="..\..\src\io\vfile_win32.h" />
+    <ClInclude Include="..\..\src\io\vio.h" />
+    <ClInclude Include="..\..\src\io\vio_win32.h" />
     <ClInclude Include="..\..\src\io\zip.h" />
     <ClInclude Include="..\..\src\io\zip_deflate.h" />
     <ClInclude Include="..\..\src\io\zip_deflate64.h" />

--- a/arch/msvc/Core.vcxproj.filters
+++ b/arch/msvc/Core.vcxproj.filters
@@ -405,7 +405,7 @@
     <ClCompile Include="..\..\src\io\path.c">
       <Filter>Source Files\io</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\io\vfile.c">
+    <ClCompile Include="..\..\src\io\vio.c">
       <Filter>Source Files\io</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\io\zip.c">
@@ -725,7 +725,10 @@
     <ClInclude Include="..\..\src\io\vfile.h">
       <Filter>Header Files\io</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\io\vfile_win32.h">
+    <ClInclude Include="..\..\src\io\vio.h">
+      <Filter>Header Files\io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\io\vio_win32.h">
       <Filter>Header Files\io</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\io\zip.h">

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -127,7 +127,7 @@ core_cobjs := \
   ${io_obj}/dir.o                 \
   ${io_obj}/fsafeopen.o           \
   ${io_obj}/path.o                \
-  ${io_obj}/vfile.o               \
+  ${io_obj}/vio.o                 \
   ${io_obj}/zip.o                 \
   ${io_obj}/zip_stream.o
 

--- a/src/audio/audio_mikmod.c
+++ b/src/audio/audio_mikmod.c
@@ -27,7 +27,7 @@
 
 #include "../const.h"
 #include "../util.h"
-#include "../io/vfile.h"
+#include "../io/vio.h"
 
 #ifdef _WIN32
 #define MIKMOD_STATIC

--- a/src/editor/ansi.c
+++ b/src/editor/ansi.c
@@ -28,7 +28,7 @@
 #include "../robot.h"
 #include "../util.h"
 #include "../world_struct.h"
-#include "../io/vfile.h"
+#include "../io/vio.h"
 
 #include <stdio.h>
 #include <time.h>

--- a/src/editor/board.c
+++ b/src/editor/board.c
@@ -27,6 +27,7 @@
 #include "../world.h"
 #include "../world_format.h"
 #include "../util.h"
+#include "../io/vio.h"
 #include "../io/zip.h"
 
 #include "world.h"

--- a/src/editor/world.c
+++ b/src/editor/world.c
@@ -34,6 +34,7 @@
 #include "../idput.h"
 #include "../util.h"
 #include "../io/memfile.h"
+#include "../io/vio.h"
 #include "../io/zip.h"
 
 #include "../world_format.h"

--- a/src/game.c
+++ b/src/game.c
@@ -48,6 +48,7 @@
 #include "world.h"
 #include "world_struct.h"
 #include "io/fsafeopen.h"
+#include "io/vio.h"
 
 #include "audio/audio.h"
 #include "audio/sfx.h"
@@ -766,7 +767,7 @@ static boolean game_key(context *ctx, int *key)
         {
           struct stat file_info;
 
-          if(!stat(curr_sav, &file_info))
+          if(!vstat(curr_sav, &file_info))
             load_savegame(game, curr_sav);
         }
         return true;
@@ -1132,7 +1133,7 @@ static boolean title_key(context *ctx, int *key)
       {
         struct stat file_info;
 
-        if(!stat(curr_sav, &file_info) && load_savegame(title, curr_sav))
+        if(!vstat(curr_sav, &file_info) && load_savegame(title, curr_sav))
         {
           play_game(ctx, &(title->fade_in));
           title->need_reload = true;

--- a/src/io/dir.c
+++ b/src/io/dir.c
@@ -34,7 +34,7 @@
 
 #ifdef __WIN32__
 // utf8_to_utf16, utf16_to_utf8
-#include "vfile_win32.h"
+#include "vio_win32.h"
 #endif
 
 static inline boolean platform_opendir(struct mzx_dir *dir, const char *path)

--- a/src/io/path.c
+++ b/src/io/path.c
@@ -23,7 +23,7 @@
 #include <sys/stat.h>
 
 #include "path.h"
-#include "vfile.h"
+#include "vio.h"
 
 /**
  * Force a given filename path to use the provided file extension. If the

--- a/src/io/vfile.h
+++ b/src/io/vfile.h
@@ -17,6 +17,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+/**
+ * Types for vio.h (so it doesn't have to be included in world_struct.h).
+ */
+
 #ifndef __IO_VFILE_H
 #define __IO_VFILE_H
 
@@ -24,54 +28,8 @@
 
 __M_BEGIN_DECLS
 
-#include "memfile.h"
-
-#include <stdio.h>
-
 typedef struct vfile vfile;
 struct stat;
-
-enum vfileflags
-{
-  V_SMALL_BUFFER = (1<<29), // setvbuf <= 256 for real files in binary mode.
-  V_LARGE_BUFFER = (1<<30), // setvbuf >= 8192 for real files in binary mode.
-};
-
-UTILS_LIBSPEC vfile *vfopen_unsafe_ext(const char *filename, const char *mode,
- int user_flags);
-UTILS_LIBSPEC vfile *vfopen_unsafe(const char *filename, const char *mode);
-vfile *vfile_init_fp(FILE *fp, const char *mode);
-vfile *vfile_init_mem(void *buffer, size_t size, const char *mode);
-vfile *vfile_init_mem_ext(void **external_buffer, size_t *external_buffer_size,
- const char *mode);
-UTILS_LIBSPEC vfile *vtempfile(size_t initial_size);
-UTILS_LIBSPEC int vfclose(vfile *vf);
-
-struct memfile *vfile_get_memfile(vfile *vf);
-
-UTILS_LIBSPEC int vchdir(const char *path);
-UTILS_LIBSPEC char *vgetcwd(char *buf, size_t size);
-UTILS_LIBSPEC int vmkdir(const char *path, int mode);
-UTILS_LIBSPEC int vunlink(const char *path);
-UTILS_LIBSPEC int vrmdir(const char *path);
-UTILS_LIBSPEC int vaccess(const char *path, int mode);
-UTILS_LIBSPEC int vstat(const char *path, struct stat *buf);
-
-UTILS_LIBSPEC int vfgetc(vfile *vf);
-UTILS_LIBSPEC int vfgetw(vfile *vf);
-UTILS_LIBSPEC int vfgetd(vfile *vf);
-UTILS_LIBSPEC int vfputc(int character, vfile *vf);
-UTILS_LIBSPEC int vfputw(int character, vfile *vf);
-UTILS_LIBSPEC int vfputd(int character, vfile *vf);
-UTILS_LIBSPEC int vfread(void *dest, size_t size, size_t count, vfile *vf);
-UTILS_LIBSPEC int vfwrite(const void *src, size_t size, size_t count, vfile *vf);
-UTILS_LIBSPEC char *vfsafegets(char *dest, int size, vfile *vf);
-UTILS_LIBSPEC int vfputs(const char *src, vfile *vf);
-UTILS_LIBSPEC int vungetc(unsigned char ch, vfile *vf);
-UTILS_LIBSPEC int vfseek(vfile *vf, long int offset, int whence);
-UTILS_LIBSPEC long int vftell(vfile *vf);
-UTILS_LIBSPEC void vrewind(vfile *vf);
-UTILS_LIBSPEC long vfilelength(vfile *vf, boolean rewind);
 
 __M_END_DECLS
 

--- a/src/io/vio.c
+++ b/src/io/vio.c
@@ -758,11 +758,18 @@ int vfputs(const char *src, vfile *vf)
 /**
  * Place a character back into the stream. This can be used once only for
  * memory streams and is only guaranteed to be usable once for files.
+ * If chr is EOF or otherwise does not represent a valid char, this function
+ * will fail and the stream will be unmodified.
  */
-int vungetc(unsigned char chr, vfile *vf)
+int vungetc(int chr, vfile *vf)
 {
   assert(vf);
   assert(vf->flags & VF_STORAGE_MASK);
+
+  // Note: MSVCRT &255s non-EOF values so this may not be 100% accurate to stdio.
+  // If this somehow breaks something it can be reverted later.
+  if(chr < 0 || chr >= 256)
+    return EOF;
 
   if(vf->flags & VF_MEMORY)
   {

--- a/src/io/vio.c
+++ b/src/io/vio.c
@@ -22,13 +22,13 @@
 #include <sys/stat.h>
 
 #include "memfile.h"
-#include "vfile.h"
+#include "vio.h"
 //#include "zip.h"
 
 #ifdef __WIN32__
-#include "vfile_win32.h"
+#include "vio_win32.h"
 #else
-#include "vfile_posix.h"
+#include "vio_posix.h"
 #endif
 
 #ifndef VFILE_SMALL_BUFFER_SIZE
@@ -327,6 +327,15 @@ int vmkdir(const char *path, int mode)
 {
   // TODO archive detection, etc
   return platform_mkdir(path, mode);
+}
+
+/**
+ * Rename a file or directory.
+ */
+int vrename(const char *oldpath, const char *newpath)
+{
+  // TODO archive detection, etc
+  return platform_rename(oldpath, newpath);
 }
 
 /**

--- a/src/io/vio.h
+++ b/src/io/vio.h
@@ -67,7 +67,7 @@ UTILS_LIBSPEC int vfread(void *dest, size_t size, size_t count, vfile *vf);
 UTILS_LIBSPEC int vfwrite(const void *src, size_t size, size_t count, vfile *vf);
 UTILS_LIBSPEC char *vfsafegets(char *dest, int size, vfile *vf);
 UTILS_LIBSPEC int vfputs(const char *src, vfile *vf);
-UTILS_LIBSPEC int vungetc(unsigned char ch, vfile *vf);
+UTILS_LIBSPEC int vungetc(int ch, vfile *vf);
 UTILS_LIBSPEC int vfseek(vfile *vf, long int offset, int whence);
 UTILS_LIBSPEC long int vftell(vfile *vf);
 UTILS_LIBSPEC void vrewind(vfile *vf);

--- a/src/io/vio.h
+++ b/src/io/vio.h
@@ -1,0 +1,78 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2019 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef __IO_VIO_H
+#define __IO_VIO_H
+
+#include "../compat.h"
+
+__M_BEGIN_DECLS
+
+#include "memfile.h"
+#include "vfile.h"
+
+#include <stdio.h>
+#include <sys/stat.h>
+
+enum vfileflags
+{
+  V_SMALL_BUFFER = (1<<29), // setvbuf <= 256 for real files in binary mode.
+  V_LARGE_BUFFER = (1<<30), // setvbuf >= 8192 for real files in binary mode.
+};
+
+UTILS_LIBSPEC vfile *vfopen_unsafe_ext(const char *filename, const char *mode,
+ int user_flags);
+UTILS_LIBSPEC vfile *vfopen_unsafe(const char *filename, const char *mode);
+vfile *vfile_init_fp(FILE *fp, const char *mode);
+vfile *vfile_init_mem(void *buffer, size_t size, const char *mode);
+vfile *vfile_init_mem_ext(void **external_buffer, size_t *external_buffer_size,
+ const char *mode);
+UTILS_LIBSPEC vfile *vtempfile(size_t initial_size);
+UTILS_LIBSPEC int vfclose(vfile *vf);
+
+struct memfile *vfile_get_memfile(vfile *vf);
+
+UTILS_LIBSPEC int vchdir(const char *path);
+UTILS_LIBSPEC char *vgetcwd(char *buf, size_t size);
+UTILS_LIBSPEC int vmkdir(const char *path, int mode);
+UTILS_LIBSPEC int vrename(const char *oldpath, const char *newpath);
+UTILS_LIBSPEC int vunlink(const char *path);
+UTILS_LIBSPEC int vrmdir(const char *path);
+UTILS_LIBSPEC int vaccess(const char *path, int mode);
+UTILS_LIBSPEC int vstat(const char *path, struct stat *buf);
+
+UTILS_LIBSPEC int vfgetc(vfile *vf);
+UTILS_LIBSPEC int vfgetw(vfile *vf);
+UTILS_LIBSPEC int vfgetd(vfile *vf);
+UTILS_LIBSPEC int vfputc(int character, vfile *vf);
+UTILS_LIBSPEC int vfputw(int character, vfile *vf);
+UTILS_LIBSPEC int vfputd(int character, vfile *vf);
+UTILS_LIBSPEC int vfread(void *dest, size_t size, size_t count, vfile *vf);
+UTILS_LIBSPEC int vfwrite(const void *src, size_t size, size_t count, vfile *vf);
+UTILS_LIBSPEC char *vfsafegets(char *dest, int size, vfile *vf);
+UTILS_LIBSPEC int vfputs(const char *src, vfile *vf);
+UTILS_LIBSPEC int vungetc(unsigned char ch, vfile *vf);
+UTILS_LIBSPEC int vfseek(vfile *vf, long int offset, int whence);
+UTILS_LIBSPEC long int vftell(vfile *vf);
+UTILS_LIBSPEC void vrewind(vfile *vf);
+UTILS_LIBSPEC long vfilelength(vfile *vf, boolean rewind);
+
+__M_END_DECLS
+
+#endif /* __IO_VIO_H */

--- a/src/io/vio_posix.h
+++ b/src/io/vio_posix.h
@@ -17,8 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __IO_VFILE_WIN32_H
-#define __IO_VFILE_WIN32_H
+#ifndef __IO_VIO_POSIX_H
+#define __IO_VIO_POSIX_H
 
 #include "../compat.h"
 
@@ -58,6 +58,11 @@ static inline int platform_mkdir(const char *path, int mode)
   return mkdir(path, mode);
 }
 
+static inline int platform_rename(const char *oldpath, const char *newpath)
+{
+  return rename(oldpath, newpath);
+}
+
 static inline int platform_unlink(const char *path)
 {
   return unlink(path);
@@ -80,4 +85,4 @@ static inline int platform_stat(const char *path, struct stat *buf)
 
 __M_END_DECLS
 
-#endif /* __IO_VFILE_WIN32_H */
+#endif /* __IO_VIO_POSIX_H */

--- a/src/io/vio_win32.h
+++ b/src/io/vio_win32.h
@@ -17,8 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __IO_VFILE_WIN32_H
-#define __IO_VFILE_WIN32_H
+#ifndef __IO_VIO_WIN32_H
+#define __IO_VIO_WIN32_H
 
 #include "../compat.h"
 
@@ -157,6 +157,19 @@ static inline int platform_mkdir(const char *path, int mode)
   return mkdir(path);
 }
 
+static inline int platform_rename(const char *oldpath, const char *newpath)
+{
+#ifdef WIDE_PATHS
+  wchar_t woldpath[MAX_PATH];
+  wchar_t wnewpath[MAX_PATH];
+
+  if(utf8_to_utf16(oldpath, woldpath, MAX_PATH))
+    if(utf8_to_utf16(newpath, wnewpath, MAX_PATH))
+      return _wrename(woldpath, wnewpath);
+#endif
+  return rename(oldpath, newpath);
+}
+
 static inline int platform_unlink(const char *path)
 {
 #ifdef WIDE_PATHS
@@ -226,4 +239,4 @@ static inline int platform_stat(const char *path, struct stat *buf)
 
 __M_END_DECLS
 
-#endif /* __IO_VFILE_WIN32_H */
+#endif /* __IO_VIO_WIN32_H */

--- a/src/io/zip.c
+++ b/src/io/zip.c
@@ -35,7 +35,7 @@
 #include "../util.h"
 
 #include "memfile.h"
-#include "vfile.h"
+#include "vio.h"
 #include "zip.h"
 #include "zip_stream.h"
 

--- a/src/legacy_board.c
+++ b/src/legacy_board.c
@@ -32,7 +32,7 @@
 #include "util.h"
 #include "world.h"
 #include "world_struct.h"
-#include "io/vfile.h"
+#include "io/vio.h"
 
 /* 13 (not NULL terminated in format) */
 #define LEGACY_MOD_FILENAME_MAX 13

--- a/src/legacy_robot.c
+++ b/src/legacy_robot.c
@@ -33,7 +33,7 @@
 #include "util.h"
 #include "world.h"
 #include "world_struct.h"
-#include "io/vfile.h"
+#include "io/vio.h"
 
 struct robot *legacy_load_robot_allocate(struct world *mzx_world, vfile *vf,
  int savegame, int file_version, boolean *truncated)

--- a/src/legacy_world.c
+++ b/src/legacy_world.c
@@ -43,7 +43,7 @@
 #include "world.h"
 #include "util.h"
 #include "io/path.h"
-#include "io/vfile.h"
+#include "io/vio.h"
 
 #include "audio/sfx.h"
 

--- a/src/legacy_world.c
+++ b/src/legacy_world.c
@@ -758,7 +758,7 @@ vfile *validate_legacy_world_file(struct world *mzx_world,
   vfile *vf;
 
   /* TEST 1: make sure it's even a file. */
-  if(stat(file, &stat_result) || !S_ISREG(stat_result.st_mode))
+  if(vstat(file, &stat_result) || !S_ISREG(stat_result.st_mode))
   {
     error_message(E_FILE_DOES_NOT_EXIST, 0, NULL);
     return NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -48,6 +48,7 @@
 #include "counter.h"
 #include "run_stubs.h"
 #include "io/path.h"
+#include "io/vio.h"
 
 #include "audio/audio.h"
 #include "audio/sfx.h"
@@ -168,7 +169,7 @@ __libspec int main(int argc, char *argv[])
 
   // We need to store the current working directory so it's
   // always possible to get back to it..
-  getcwd(startup_dir, MAX_PATH);
+  vgetcwd(startup_dir, MAX_PATH);
   snprintf(current_dir, MAX_PATH, "%s", startup_dir);
 
 #ifdef CONFIG_STDIO_REDIRECT
@@ -220,7 +221,7 @@ __libspec int main(int argc, char *argv[])
   // Move into the configuration file's directory so that any
   // "include" statements are done wrt this path. Move back
   // into the "current" directory after loading.
-  chdir(config_dir);
+  vchdir(config_dir);
 
   default_config();
   default_editor_config();
@@ -233,7 +234,7 @@ __libspec int main(int argc, char *argv[])
   init_macros();
 
   // Startup path might be relative, so change back before checking it.
-  chdir(current_dir);
+  vchdir(current_dir);
 
   // At this point argv should have all the config options
   // of the form var=value removed, leaving only unparsed
@@ -254,7 +255,7 @@ __libspec int main(int argc, char *argv[])
     snprintf(current_dir, MAX_PATH, "%s", conf->startup_path);
   }
 
-  chdir(current_dir);
+  vchdir(current_dir);
 
   counter_fsg();
 
@@ -341,7 +342,7 @@ update_restart_mzx:
     char **new_argv = rewrite_argv_for_execv(argc, argv);
 
     info("Attempting to restart MegaZeux...\n");
-    if(!chdir(startup_dir))
+    if(!vchdir(startup_dir))
     {
       execv(argv[0], (const void *)new_argv);
       perror("execv");

--- a/src/mzm.c
+++ b/src/mzm.c
@@ -37,7 +37,7 @@
 #include "world_format.h"
 #include "world_struct.h"
 #include "io/memfile.h"
-#include "io/vfile.h"
+#include "io/vio.h"
 #include "io/zip.h"
 
 
@@ -304,7 +304,7 @@ static size_t save_mzm_common(struct world *mzx_world,
 void save_mzm(struct world *mzx_world, char *name, int start_x, int start_y,
  int width, int height, int mode, int savegame)
 {
-  FILE *output_file = fopen_unsafe(name, "wb");
+  vfile *output_file = vfopen_unsafe(name, "wb");
   enum mzm_storage_mode storage_mode;
   struct memfile mf;
   void *buffer;
@@ -321,9 +321,9 @@ void save_mzm(struct world *mzx_world, char *name, int start_x, int start_y,
     mzm_size = save_mzm_common(mzx_world, start_x, start_y, width, height, mode,
      savegame, storage_mode, &mf);
 
-    fwrite(buffer, mzm_size, 1, output_file);
+    vfwrite(buffer, mzm_size, 1, output_file);
     free(buffer);
-    fclose(output_file);
+    vfclose(output_file);
   }
 }
 

--- a/src/network/HTTPHost.cpp
+++ b/src/network/HTTPHost.cpp
@@ -27,6 +27,7 @@
 #include "HTTPHost.hpp"
 #include "Scoped.hpp"
 #include "../util.h"
+#include "../io/vio.h"
 
 #ifdef IS_CXX_11
 #include <type_traits>

--- a/src/render_glsl.c
+++ b/src/render_glsl.c
@@ -32,6 +32,7 @@
 #include "renderers.h"
 #include "util.h"
 #include "io/path.h"
+#include "io/vio.h"
 
 // Uncomment to enable GL debug output (requires OpenGL 4.3+).
 //#define ENABLE_GL_DEBUG_OUTPUT 1
@@ -347,27 +348,27 @@ static char *glsl_load_string(const char *filename)
 {
   char *buffer = NULL;
   unsigned long size;
-  FILE *f;
+  vfile *vf;
 
-  f = fopen_unsafe(filename, "rb");
-  if(!f)
+  vf = vfopen_unsafe(filename, "rb");
+  if(!vf)
     goto err_out;
 
-  size = ftell_and_rewind(f);
-  if(!size)
+  size = vfilelength(vf, false);
+  if(size <= 0)
     goto err_close;
 
   buffer = cmalloc(size + 1);
   buffer[size] = '\0';
 
-  if(fread(buffer, size, 1, f) != 1)
+  if(vfread(buffer, size, 1, vf) != 1)
   {
     free(buffer);
     buffer = NULL;
   }
 
 err_close:
-  fclose(f);
+  vfclose(vf);
 err_out:
   return buffer;
 }

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -28,6 +28,7 @@
 #include "updater.h"
 #include "util.h"
 #include "window.h"
+#include "io/memfile.h"
 #include "io/path.h"
 
 #include "editor/window.h"

--- a/src/utils/Makefile.in
+++ b/src/utils/Makefile.in
@@ -16,7 +16,7 @@ utils_obj = src/utils/.build
 # Define UTILS_LIBSPEC so these properly link.
 utils_cflags := ${LIBPNG_CFLAGS} -DUTILS_LIBSPEC=
 
-zip_objs  := ${io_obj}/vfile.o ${io_obj}/zip.o ${io_obj}/zip_stream.o
+zip_objs  := ${io_obj}/vio.o ${io_obj}/zip.o ${io_obj}/zip_stream.o
 
 checkres := ${utils_src}/checkres${BINEXT}
 checkres_objs := ${utils_obj}/checkres.o \
@@ -40,7 +40,7 @@ txt2hlp_objs := ${utils_obj}/txt2hlp.o
 png2smzx := ${utils_src}/png2smzx${BINEXT}
 png2smzx_objs := ${utils_obj}/png2smzx.o ${utils_obj}/smzxconv.o
 png2smzx_objs += ${core_obj}/pngops.o
-png2smzx_objs += ${io_obj}/path.o ${io_obj}/vfile.o
+png2smzx_objs += ${io_obj}/path.o ${io_obj}/vio.o
 png2smzx_ldflags := ${LIBPNG_LDFLAGS} ${ZLIB_LDFLAGS}
 
 ccv := ${utils_src}/ccv${BINEXT}

--- a/src/utils/downver.c
+++ b/src/utils/downver.c
@@ -58,7 +58,7 @@
 #include "../world.h"
 #include "../world_format.h"
 #include "../io/memfile.h"
-#include "../io/vfile.h"
+#include "../io/vio.h"
 #include "../io/zip.h"
 
 #define DOWNVER_VERSION "2.92"

--- a/src/world.c
+++ b/src/world.c
@@ -2515,7 +2515,7 @@ static void load_world(struct world *mzx_world, struct zip_archive *zp,
   snprintf(config_file_name, MAX_PATH, "%.*s.cnf", file_name_len, file);
   config_file_name[MAX_PATH - 1] = '\0';
 
-  if(stat(config_file_name, &file_info) >= 0)
+  if(vstat(config_file_name, &file_info) >= 0)
     set_config_from_file(GAME_CNF, config_file_name);
 
   // Some initial setting(s)

--- a/src/world.c
+++ b/src/world.c
@@ -53,7 +53,7 @@
 #include "io/fsafeopen.h"
 #include "io/memfile.h"
 #include "io/path.h"
-#include "io/vfile.h"
+#include "io/vio.h"
 #include "io/zip.h"
 
 #include "audio/audio.h"
@@ -2502,13 +2502,13 @@ static void load_world(struct world *mzx_world, struct zip_archive *zp,
   char file_path[MAX_PATH];
   struct stat file_info;
 
-  // chdir to game directory
+  // Change to the game (or save) directory.
   if(path_get_directory(file_path, MAX_PATH, file) > 0)
   {
-    getcwd(current_dir, MAX_PATH);
+    vgetcwd(current_dir, MAX_PATH);
 
     if(strcmp(current_dir, file_path))
-      chdir(file_path);
+      vchdir(file_path);
   }
 
   // load world config file
@@ -3055,7 +3055,7 @@ boolean reload_world(struct world *mzx_world, const char *file, boolean *faded)
     char save_name[MAX_PATH];
     path_get_filename(save_name, MAX_PATH, curr_sav);
 
-    getcwd(curr_sav, MAX_PATH);
+    vgetcwd(curr_sav, MAX_PATH);
     path_append(curr_sav, MAX_PATH, save_name);
   }
 
@@ -3117,7 +3117,7 @@ boolean reload_swap(struct world *mzx_world, const char *file, boolean *faded)
 
   // Give curr_file a full path
   path_get_filename(file_name, MAX_PATH, file);
-  getcwd(curr_file, MAX_PATH);
+  vgetcwd(curr_file, MAX_PATH);
   path_append(curr_file, MAX_PATH, file_name);
 
   return true;

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -28,7 +28,7 @@ unit_objs := \
   ${unit_obj_io}/bitstream${unit_ext}  \
   ${unit_obj_io}/memfile${unit_ext}    \
   ${unit_obj_io}/path${unit_ext}       \
-  ${unit_obj_io}/vfile${unit_ext}      \
+  ${unit_obj_io}/vio${unit_ext}        \
 
 ifneq (${BUILD_EDITOR},)
 

--- a/unit/io/vio.cpp
+++ b/unit/io/vio.cpp
@@ -21,7 +21,7 @@
 
 #include "../Unit.hpp"
 #include "../../src/network/Scoped.hpp"
-#include "../../src/io/vfile.c"
+#include "../../src/io/vio.c"
 
 static constexpr char TEST_READ_FILENAME[]  = "VFILE_TEST_DATA";
 static constexpr char TEST_WRITE_FILENAME[] = "VFILE_TEST_WRITE";

--- a/unit/io/vio.cpp
+++ b/unit/io/vio.cpp
@@ -413,6 +413,15 @@ static void test_vungetc(vfile *vf)
   vfread(last_5, 5, 1, vf);
   vrewind(vf);
 
+  // vungetc should fail if EOF or some other junk is provided.
+  // Note: MSVCRT stdio &255s non-EOF values (?).
+  ret = vungetc(EOF, vf);
+  ASSERTEQ(ret, EOF);
+  ret = vungetc(-128141, vf);
+  ASSERTEQ(ret, EOF);
+  ret = vungetc(256, vf);
+  ASSERTEQ(ret, EOF);
+
   // vfgetc should read the buffered char.
   ret = vungetc(0xAB, vf);
   ASSERTEQ(ret, 0xAB);


### PR DESCRIPTION
Replaces more stdio.h, stat.h, and unistd.h usage in various places (mainly main.c, util.c, and the file manager). Also renames `vfile.*` to `vio.*` because one rename wasn't enough

Things intentionally avoided by this branch: anything that uses `fsafeopen` (counter.c, graphics.c, rasm.c, legacy_rasm.c, str.c), the help system (file handle is in the world struct for some reason...), anything in the audio code, anything in the editor, anything in the netcode, anything in the utils, pngops (ugh).

- [x] configure.c (oops).
- [x] Some other misc. `stat` usage I missed.
- [x] ~~Probably should drop some `unistd.h` includes and their ugly ifdefs.~~ Might break something, nevermind...
- [x] Unit test for vrename.