### PR TITLE
Robot editor fixes and cleanup.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -63,6 +63,14 @@ USERS
   ending with ? to sometimes fail.
 + Fixed a bug where multichar char tile movement could still
   sometimes jump to the -/+/= chars in the main charset.
++ Fixed a bug in the robot editor where Ctrl+Home and Ctrl+End
+  would only set the current line (and not the current column).
++ Fixed a robot editor extended macro crash that would occur:
+    when pasting a line containing a macro from the clipboard;
+    when importing a Robotic source file that invokes macros;
+    when invoking nested extended macros.
++ Invoking an extended macro with enter/return no longer inserts
+  an extra blank line.
 - Removed 3DS CIA support. (asie)
 
 DEVELOPERS

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -63,6 +63,8 @@ USERS
   ending with ? to sometimes fail.
 + Fixed a bug where multichar char tile movement could still
   sometimes jump to the -/+/= chars in the main charset.
++ Opening the block action menu in the robot editor now updates
+  the contents of the current line.
 + Fixed a bug in the robot editor where Ctrl+Home and Ctrl+End
   would only set the current line (and not the current column).
 + Fixed a robot editor extended macro crash that would occur:

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -917,7 +917,6 @@ static void split_current_line(struct robot_editor_context *rstate)
   memmove(command_buffer, command_buffer + rstate->current_x, remainder_len);
   command_buffer[remainder_len] = '\0';
   rstate->current_x = 0;
-
   update_current_line(rstate);
 }
 

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -882,13 +882,17 @@ static void add_line(struct robot_editor_context *rstate, char *value, int relat
     else
     {
       // Line was consumed by update_current_line (likely because of a macro),
-      // so remove it.
+      // so remove it. Space and bytecode size might have been counted for this
+      // as part of processing the macro.
+#ifndef CONFIG_DEBYTECODE
+      rstate->size -= new_rline->line_bytecode_length;
+#endif
       rstate->current_rline = current_rline;
       if(new_rline->previous)
         new_rline->previous->next = new_rline->next;
       if(new_rline->next)
         new_rline->next->previous = new_rline->previous;
-      free(new_rline);
+      delete_line_contents(new_rline);
     }
 
     rstate->command_buffer = tmp;

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -585,12 +585,20 @@ static void update_program_status(struct robot_editor_context *rstate,
           }
         }
 
-        current_rline->color_codes = crealloc(current_rline->color_codes,
-         num_color_codes * sizeof(struct color_code_pair));
-        current_rline->num_color_codes = num_color_codes;
+        if(num_color_codes)
+        {
+          current_rline->color_codes = crealloc(current_rline->color_codes,
+           num_color_codes * sizeof(struct color_code_pair));
 
-        memcpy(current_rline->color_codes, color_codes,
-         num_color_codes * sizeof(struct color_code_pair));
+          memcpy(current_rline->color_codes, color_codes,
+           num_color_codes * sizeof(struct color_code_pair));
+        }
+        else
+        {
+          free(current_rline->color_codes);
+          current_rline->color_codes = NULL;
+        }
+        current_rline->num_color_codes = num_color_codes;
 
         num_color_codes = 0;
 

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -703,7 +703,8 @@ static boolean update_current_line(struct robot_editor_context *rstate)
   bytecode_length = legacy_assemble_line(command_buffer, bytecode_buffer,
    error_buffer, arg_types, &arg_count);
 
-  // Trigger macro expansion; if the macro doesn't exist, do nothing
+  // Trigger macro expansion; if the macro exists, return false to let the
+  // caller know this line can be discarded if necessary.
   if(command_buffer[0] == '#')
     if(execute_named_macro(rstate, command_buffer + 1))
       return false;


### PR DESCRIPTION
Fixes the following bugs:
* When no block is marked, pressing Alt+B on a line is supposed to update the line before copying it to the buffer. This bug was introduced by the 2.80X robot editor rewrite.
* Any operation that can send a line containing a extended macro to `add_line` (pasting the clipboard; importing Robotic from a text file; nested macros) caused a crash due to faulty behavior when `add_line` received an error state from `update_current_line` (indicating the added line should be discarded). This regression occurred some time between 2.82 and 2.82b.
* Some bad code/workarounds for the above issue caused an extra line to be emitted when evaluating an extended macro with `split_current_line`. This behavior was also introduced in 2.82b.

Cleanup:
* The debytecode update/package functions now use check alloc. This required fixing a place in `update_program_status` that relied on implementation-defined behavior of `realloc(p, 0)`.
* `add_line` takes a `char *` containing the nul-terminated contents of the new line to be added. Previously, this function expected the caller to set `rstate->command_buffer` (and fix it) manually.
* `update_current_line` and `execute_named_macro` now return booleans instead of ints.
* `goto_line` now takes both a line and a column instead of just a line.
* Ctrl+Home and Ctrl+End set the column now instead of ignoring it.

TODO:
- [x] More testing.