### PR TITLE
Add intake2 events, unit test, remove intake2 draw/click handlers.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -84,6 +84,11 @@ DEVELOPERS
 + Board input strings, charset paths, and palette paths are now
   heap allocated on-demand to save RAM for low-memory systems.
 + Refactored the 3DS renderer to use templates. (asie)
++ intake2() now supports custom handling of intake events, i.e.
+  it can now be used without providing a fixed size buffer.
++ The draw and click handlers have been removed from intake2().
+  This should provide more flexibility to the parent context for
+  displaying the string that is being edited.
 
 
 November 22nd, 2020 - MZX 2.92f

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -4211,6 +4211,7 @@ static void robot_editor_destroy(context *ctx)
   delete_robot_lines(rstate->cur_robot, rstate);
 
   restore_screen();
+  cursor_off();
 }
 
 void robot_editor(context *parent, struct robot *cur_robot)

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -3218,10 +3218,16 @@ static boolean robot_editor_draw(context *ctx)
 
   struct editor_config_info *editor_conf = get_editor_config();
   int intk_color = combine_colors(editor_conf->color_codes[0], bg_color);
+  boolean use_mask = get_config()->mask_midchars;
 
   struct robot_line *draw_rline;
   int first_line_draw_position;
   int first_line_count_back;
+  int middle_line_len;
+  int start_offset = 0;
+  int temp_char = 0;
+  int temp_pos = 0;
+  int cursor_x;
   int i;
 
   fill_line(80, 0, 0, top_char, top_color);
@@ -3394,11 +3400,55 @@ static boolean robot_editor_draw(context *ctx)
   else
     draw_char('\xaf', intk_color, 79, rstate->scr_line_middle);
 
-  // Update the intake position and color so it draws correctly.
-  intake_set_screen_pos(rstate->intk, 2, rstate->scr_line_middle);
-  intake_set_color(rstate->intk, intk_color);
+  // Current line.
+  middle_line_len = rstate->current_line_len;
+  cursor_x = rstate->current_x;
+  if(rstate->current_x >= 76)
+  {
+    if(rstate->command_buffer[rstate->current_x])
+    {
+      temp_pos = rstate->current_x + 1;
+      temp_char = rstate->command_buffer[temp_pos];
+      rstate->command_buffer[temp_pos] = 0;
+    }
+    start_offset = rstate->current_x - 76 + 1;
+    middle_line_len = strlen(rstate->command_buffer + start_offset);
+    cursor_x = 75;
+  }
+  else
 
+  if(middle_line_len > 76)
+  {
+    temp_pos = 76;
+    temp_char = rstate->command_buffer[temp_pos];
+    rstate->command_buffer[temp_pos] = 0;
+    middle_line_len = 76;
+  }
+
+  if(intake_get_insert())
+    cursor_underline(cursor_x + 2, rstate->scr_line_middle);
+  else
+    cursor_solid(cursor_x + 2, rstate->scr_line_middle);
+
+  if(use_mask)
+  {
+    write_string_mask(rstate->command_buffer + start_offset,
+     2, rstate->scr_line_middle, intk_color, false);
+  }
+  else
+  {
+    write_string_ext(rstate->command_buffer + start_offset,
+     2, rstate->scr_line_middle, intk_color, false, 0, 16);
+  }
+
+  // Fill non-text portions of the middle line.
+  fill_line(76 + 1 - middle_line_len,
+   2 + middle_line_len, rstate->scr_line_middle, 32, intk_color);
   draw_char(bg_char, intk_color, 1, rstate->scr_line_middle);
+
+  if(temp_pos)
+    rstate->command_buffer[temp_pos] = temp_char;
+
   return true;
 }
 
@@ -3417,7 +3467,7 @@ static boolean robot_editor_idle(context *ctx)
 #endif
 
   // Disable the cursor so it doesn't display over other interfaces.
-  // Intake will enable it again if needed.
+  // The draw function will enable it again if needed.
   cursor_off();
 
   rstate->macro_repeat_level = 0;
@@ -3432,13 +3482,14 @@ static boolean robot_editor_mouse(context *ctx, int *key, int button,
 
   if(button && (button <= MOUSE_BUTTON_RIGHT))
   {
-    // NOTE: let intake handle clicks on scr_line_middle.
     if((y >= rstate->scr_line_start) && (y <= rstate->scr_line_end) &&
-     (y != rstate->scr_line_middle) && (x >= 2) && (x <= 78))
+     (x >= 2) && (x <= 78))
     {
       move_and_update(rstate, y - rstate->scr_line_middle);
       rstate->current_x = x - 2;
-      warp_mouse(x, rstate->scr_line_middle);
+
+      if(y != rstate->scr_line_middle)
+        warp_mouse(x, rstate->scr_line_middle);
       return true;
     }
   }
@@ -4208,7 +4259,7 @@ void robot_editor(context *parent, struct robot *cur_robot)
 
   rstate->intk =
    intake2((context *)rstate, rstate->command_buffer, MAX_COMMAND_LEN,
-   2, 12, 76, line_color, &(rstate->current_x), &(rstate->current_line_len));
+   &(rstate->current_x), &(rstate->current_line_len));
 
   caption_set_robot(parent->world, cur_robot);
   save_screen();

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -237,6 +237,7 @@ CORE_LIBSPEC void write_string_mask(const char *str, Uint32 x, Uint32 y,
 
 CORE_LIBSPEC void clear_screen(void);
 
+CORE_LIBSPEC void cursor_underline(Uint32 x, Uint32 y);
 CORE_LIBSPEC void cursor_solid(Uint32 x, Uint32 y);
 CORE_LIBSPEC void cursor_hint(Uint32 x, Uint32 y);
 CORE_LIBSPEC void cursor_off(void);
@@ -313,8 +314,6 @@ void write_line_mask(const char *str, Uint32 x, Uint32 y,
  Uint8 color, Uint32 tab_allowed);
 
 Uint8 get_color_linear(Uint32 offset);
-
-void cursor_underline(Uint32 x, Uint32 y);
 
 boolean change_video_output(struct config_info *conf, const char *output);
 int get_available_video_output_list(const char **buffer, int buffer_len);

--- a/src/intake.c
+++ b/src/intake.c
@@ -1130,8 +1130,7 @@ const char *intake_input_string(subcontext *sub, const char *src,
 
 /**
  * Set the intake event callback function. This feature is used to report
- * individual intake events immediately to the parent context as they occur,
- * which can be used to implement an undo stack.
+ * individual intake events immediately to the parent context as they occur.
  */
 void intake_event_callback(subcontext *sub, void *priv,
  boolean (*event_cb)(void *priv, subcontext *sub, enum intake_event_type type,

--- a/src/intake.c
+++ b/src/intake.c
@@ -500,12 +500,6 @@ struct intake_subcontext
   int *pos_external;
   int *length_external;
   boolean select_char;
-
-  // Display info.
-  int x;
-  int y;
-  int width;
-  int color;
 };
 
 /**

--- a/src/intake.c
+++ b/src/intake.c
@@ -712,9 +712,12 @@ boolean intake_apply_event_fixed(subcontext *sub, enum intake_event_type type,
           intake_skip_back(intk);
           value--;
         }
-        memmove(intk->dest + intk->pos, intk->dest + old_pos,
-         intk->current_length - old_pos + 1);
-        intake_set_length(intk, intk->current_length - (old_pos - intk->pos));
+        if(intk->pos < old_pos)
+        {
+          memmove(intk->dest + intk->pos, intk->dest + old_pos,
+           intk->current_length - old_pos + 1);
+          intake_set_length(intk, intk->current_length - (old_pos - intk->pos));
+        }
       }
       break;
     }

--- a/src/intake.h
+++ b/src/intake.h
@@ -49,6 +49,9 @@ enum intake_event_type
   INTK_OVERWRITE_BLOCK, /* Text block overwritten via intake_input_string. */
 };
 
+CORE_LIBSPEC boolean intake_get_insert(void);
+CORE_LIBSPEC void intake_set_insert(boolean new_insert_state);
+
 CORE_LIBSPEC int intake(struct world *mzx_world, char *string, int max_len,
  int x, int y, char color, enum intake_exit_type exit_type, int *return_x_pos);
 
@@ -59,9 +62,9 @@ CORE_LIBSPEC void intake_sync(subcontext *intk);
 CORE_LIBSPEC void intake_set_color(subcontext *intk, int color);
 CORE_LIBSPEC void intake_set_screen_pos(subcontext *intk, int x, int y);
 CORE_LIBSPEC const char *intake_input_string(subcontext *intk, const char *src,
- char linebreak_char);
+ int linebreak_char);
 CORE_LIBSPEC void intake_event_callback(subcontext *intk, void *priv,
- boolean (*event_cb)(void *priv, enum intake_event_type type,
+ boolean (*event_cb)(void *priv, subcontext *sub, enum intake_event_type type,
  int old_pos, int new_pos, int value, const char *data));
 
 CORE_LIBSPEC boolean intake_apply_event_fixed(subcontext *sub,

--- a/src/intake.h
+++ b/src/intake.h
@@ -38,10 +38,12 @@ enum intake_event_type
 {
   INTK_NO_EVENT,
   INTK_MOVE,            /* Cursor moved within the intake line. */
+  INTK_MOVE_WORDS,      /* Cursor moved a number of words within the intake line. */
   INTK_INSERT,          /* Text inserted. */
   INTK_OVERWRITE,       /* Text overwritten. */
   INTK_DELETE,          /* Text deleted with Delete. */
   INTK_BACKSPACE,       /* Text deleted with Backspace. */
+  INTK_BACKSPACE_WORDS, /* Text deleted with Ctrl+Backspace (value=#words). */
   INTK_CLEAR,           /* Text deleted with Alt+Backspace. */
   INTK_INSERT_BLOCK,    /* Text block inserted via intake_input_string. */
   INTK_OVERWRITE_BLOCK, /* Text block overwritten via intake_input_string. */
@@ -59,8 +61,11 @@ CORE_LIBSPEC void intake_set_screen_pos(subcontext *intk, int x, int y);
 CORE_LIBSPEC const char *intake_input_string(subcontext *intk, const char *src,
  char linebreak_char);
 CORE_LIBSPEC void intake_event_callback(subcontext *intk, void *priv,
- void (*event_cb)(void *priv, enum intake_event_type type,
+ boolean (*event_cb)(void *priv, enum intake_event_type type,
  int old_pos, int new_pos, int value, const char *data));
+
+CORE_LIBSPEC boolean intake_apply_event_fixed(subcontext *sub,
+ enum intake_event_type type, int new_pos, int value, const char *data);
 
 __M_END_DECLS
 

--- a/src/intake.h
+++ b/src/intake.h
@@ -56,11 +56,9 @@ CORE_LIBSPEC int intake(struct world *mzx_world, char *string, int max_len,
  int x, int y, char color, enum intake_exit_type exit_type, int *return_x_pos);
 
 CORE_LIBSPEC subcontext *intake2(context *parent, char *dest, int max_length,
- int x, int y, int width, int color, int *pos_external, int *length_external);
+ int *pos_external, int *length_external);
 
 CORE_LIBSPEC void intake_sync(subcontext *intk);
-CORE_LIBSPEC void intake_set_color(subcontext *intk, int color);
-CORE_LIBSPEC void intake_set_screen_pos(subcontext *intk, int x, int y);
 CORE_LIBSPEC const char *intake_input_string(subcontext *intk, const char *src,
  int linebreak_char);
 CORE_LIBSPEC void intake_event_callback(subcontext *intk, void *priv,

--- a/src/intake.h
+++ b/src/intake.h
@@ -34,6 +34,19 @@ enum intake_exit_type
   INTK_EXIT_ANY
 };
 
+enum intake_event_type
+{
+  INTK_NO_EVENT,
+  INTK_MOVE,            /* Cursor moved within the intake line. */
+  INTK_INSERT,          /* Text inserted. */
+  INTK_OVERWRITE,       /* Text overwritten. */
+  INTK_DELETE,          /* Text deleted with Delete. */
+  INTK_BACKSPACE,       /* Text deleted with Backspace. */
+  INTK_CLEAR,           /* Text deleted with Alt+Backspace. */
+  INTK_INSERT_BLOCK,    /* Text block inserted via intake_input_string. */
+  INTK_OVERWRITE_BLOCK, /* Text block overwritten via intake_input_string. */
+};
+
 CORE_LIBSPEC int intake(struct world *mzx_world, char *string, int max_len,
  int x, int y, char color, enum intake_exit_type exit_type, int *return_x_pos);
 
@@ -45,6 +58,9 @@ CORE_LIBSPEC void intake_set_color(subcontext *intk, int color);
 CORE_LIBSPEC void intake_set_screen_pos(subcontext *intk, int x, int y);
 CORE_LIBSPEC const char *intake_input_string(subcontext *intk, const char *src,
  char linebreak_char);
+CORE_LIBSPEC void intake_event_callback(subcontext *intk, void *priv,
+ void (*event_cb)(void *priv, enum intake_event_type type,
+ int old_pos, int new_pos, int value, const char *data));
 
 __M_END_DECLS
 

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -53,6 +53,7 @@ ifneq (${BUILD_MODULAR},)
 
 unit_objs += \
   ${unit_obj}/configure${unit_ext}     \
+  ${unit_obj}/intake${unit_ext}        \
   ${unit_obj_io}/zip${unit_ext}
 
 unit_ldflags += -L. -lcore

--- a/unit/intake.cpp
+++ b/unit/intake.cpp
@@ -1,0 +1,347 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2021 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * Automated test for the parts of intake that are testable.
+ * Currently, this is mainly intake_apply_event_fixed.
+ */
+
+#include "Unit.hpp"
+#include "../src/intake.c"
+
+// TODO shut up the linker as these aren't CORE_LIBSPEC currently.
+void cursor_underline(Uint32 x, Uint32 y) {}
+boolean has_unicode_input() { return false; }
+
+struct int_pairs
+{
+  int input;
+  int expected;
+};
+
+/**
+ * Test internal and external functions for manipulating the position and
+ * current length of the intake editor. A large portion of this is making sure
+ * the external position and length pointers are syncronized correctly.
+ */
+UNITTEST(PosLength)
+{
+  static const struct int_pairs pos_data[] =
+  {
+    { 0, 0 },
+    { 50, 50 },
+    { 100, 100 },
+    { 1000000, 100 },
+    { -1, 0 },
+    { -12781831, 0 },
+  };
+  static const struct int_pairs length_data[] =
+  {
+    { 0, 0 },
+    { 50, 50 },
+    { 240, 240 },
+    { 1000, 240 },
+    { 1000000, 240 },
+    { -1, 0 },
+    { -4983412, 0 },
+  };
+
+  struct intake_subcontext intk{};
+  char dest[256] = "Test string.";
+  char buf[80];
+  int ext = 0;
+
+  intk.current_length = 100;
+  intk.max_length = 240;
+
+  SECTION(intake_set_pos_no_external)
+  {
+    for(const struct int_pairs &d : pos_data)
+    {
+      snprintf(buf, arraysize(buf), "%d -> %d", d.input, d.expected);
+      intake_set_pos(&intk, d.input);
+      ASSERTEQX(intk.pos, d.expected, buf);
+    }
+  }
+
+  SECTION(intake_set_pos_external)
+  {
+    intk.pos_external = &ext;
+
+    for(const struct int_pairs &d : pos_data)
+    {
+      snprintf(buf, arraysize(buf), "%d -> %d", d.input, d.expected);
+      intake_set_pos(&intk, d.input);
+      ASSERTEQX(intk.pos, d.expected, buf);
+      ASSERTEQX(ext, d.expected, buf);
+    }
+  }
+
+  SECTION(intake_set_length_no_external)
+  {
+    for(const struct int_pairs &d : length_data)
+    {
+      snprintf(buf, arraysize(buf), "%d -> %d", d.input, d.expected);
+      intake_set_length(&intk, d.input);
+      ASSERTEQX(intk.current_length, d.expected, buf);
+    }
+  }
+
+  SECTION(intake_set_length_external)
+  {
+    intk.length_external = &ext;
+
+    for(const struct int_pairs &d : length_data)
+    {
+      snprintf(buf, arraysize(buf), "%d -> %d", d.input, d.expected);
+      intake_set_length(&intk, d.input);
+      ASSERTEQX(intk.current_length, d.expected, buf);
+      ASSERTEQX(ext, d.expected, buf);
+    }
+  }
+
+  // intake_sync should not crash when the provided intake is null.
+  SECTION(intake_sync_null)
+  {
+    intake_sync(nullptr);
+  }
+
+  /**
+   * When no buffer/external pointers are present, intake_sync should not
+   * modify the intake position or current length values.
+   */
+  SECTION(intake_sync_no_data_or_external)
+  {
+    for(const struct int_pairs &d : pos_data)
+    {
+      snprintf(buf, arraysize(buf), "%d -> %d", d.input, d.expected);
+      intake_set_pos(&intk, d.input);
+      intake_sync((subcontext *)&intk);
+      ASSERTEQX(intk.pos, d.expected, buf);
+    }
+
+    for(const struct int_pairs &d : length_data)
+    {
+      snprintf(buf, arraysize(buf), "%d -> %d", d.input, d.expected);
+      intake_set_length(&intk, d.input);
+      intake_sync((subcontext *)&intk);
+      ASSERTEQX(intk.current_length, d.expected, buf);
+    }
+  }
+
+  /**
+   * When an external position pointer is present, intake_sync should update
+   * the position to reflect the provided external position, bounded to the
+   * current length.
+   */
+  SECTION(intake_sync_pos)
+  {
+    intk.pos_external = &ext;
+
+    for(const struct int_pairs &d : pos_data)
+    {
+      snprintf(buf, arraysize(buf), "%d -> %d", d.input, d.expected);
+      ext = d.input;
+      intake_sync((subcontext *)&intk);
+      ASSERTEQX(intk.pos, d.expected, buf);
+      ASSERTEQX(ext, d.expected, buf);
+    }
+  }
+
+  /**
+   * When a buffer is present, intake_sync should update the current length to
+   * the length of the buffer string.
+   */
+  SECTION(intake_sync_no_external)
+  {
+    int dest_len = strlen(dest);
+    intk.current_length = 100;
+    intk.dest = dest;
+    intk.pos = 97;
+
+    for(const struct int_pairs &d : length_data)
+    {
+      dest_len = std::max(0, std::min(dest_len, d.input));
+      snprintf(buf, arraysize(buf), "%d -> %d", d.input, dest_len);
+      intake_set_length(&intk, d.input);
+      intake_sync((subcontext *)&intk);
+      ASSERTEQX(intk.current_length, dest_len, buf);
+      ASSERTEQX(intk.pos, 97, buf);
+    }
+  }
+
+  /**
+   * When external pointers are present but there is no buffer, intake_sync
+   * should update the current length to the external length.
+   */
+  SECTION(intake_sync_no_dest)
+  {
+    intk.length_external = &ext;
+    intk.dest = nullptr;
+
+    for(const struct int_pairs &d : length_data)
+    {
+      snprintf(buf, arraysize(buf), "%d -> %d", d.input, d.expected);
+      ext = d.input;
+      intake_sync((subcontext *)&intk);
+      ASSERTEQX(intk.current_length, d.expected, buf);
+      ASSERTEQX(ext, d.expected, buf);
+    }
+  }
+
+  /**
+   * When both dest and external length are present, dest should be preferred
+   * for updating the length.
+   */
+  SECTION(intake_sync_dest_and_external)
+  {
+    int dest_len = strlen(dest);
+    intk.length_external = &ext;
+    intk.dest = dest;
+
+    for(const struct int_pairs &d : length_data)
+    {
+      snprintf(buf, arraysize(buf), "%d -> %d", d.input, dest_len);
+      ext = d.input;
+      intake_sync((subcontext *)&intk);
+      ASSERTEQX(intk.current_length, dest_len, buf);
+      ASSERTEQX(ext, dest_len, buf);
+    }
+  }
+}
+
+/**
+ * Test the default fixed-size buffer intake editing operations.
+ */
+UNITTEST(EventFixed)
+{
+  struct intake_subcontext intk{};
+  char dest[256] = "Test string.";
+//  char buf[80];
+
+  intk.max_length = 240;
+  intk.current_length = 100;
+
+  SECTION(intake_skip_back)
+  {
+    UNIMPLEMENTED(); // FIXME
+  }
+
+  SECTION(intake_skip_forward)
+  {
+    UNIMPLEMENTED(); // FIXME
+  }
+
+  SECTION(intake_apply_event_fixed_errs)
+  {
+    // Should not crash with a null intake.
+    boolean r = intake_apply_event_fixed(nullptr, INTK_MOVE, 0, 0, nullptr);
+    ASSERTEQ(r, false);
+
+    // Should not crash with a null dest.
+    intk.dest = nullptr;
+    r = intake_apply_event_fixed((subcontext *)&intk, INTK_MOVE, 0, 0, nullptr);
+    ASSERTEQ(r, false);
+    intk.dest = dest;
+
+    // Should not crash if intk->pos is somehow invalid.
+    int invalid_pos[] = { -1, -12431, intk.current_length + 1, 100000 };
+    for(int i : invalid_pos)
+    {
+      intk.pos = i;
+      r = intake_apply_event_fixed((subcontext *)&intk, INTK_MOVE, 0, 0, nullptr);
+      ASSERTEQ(r, false);
+    }
+  }
+
+  SECTION(INTK_NO_EVENT)
+  {
+    // Nothing should ever actually send this event (if it does, it's a bug).
+    boolean r = intake_apply_event_fixed((subcontext *)&intk, INTK_NO_EVENT, 0, 0, nullptr);
+    ASSERTEQ(r, false);
+  }
+
+  SECTION(INTK_MOVE)
+  {
+    UNIMPLEMENTED(); // FIXME
+  }
+
+  SECTION(INTK_MOVE_WORDS)
+  {
+    UNIMPLEMENTED(); // FIXME
+  }
+
+  SECTION(INTK_INSERT)
+  {
+    UNIMPLEMENTED(); // FIXME
+  }
+
+  SECTION(INTK_OVERWRITE)
+  {
+    UNIMPLEMENTED(); // FIXME
+  }
+
+  SECTION(INTK_DELETE)
+  {
+    UNIMPLEMENTED(); // FIXME
+  }
+
+  SECTION(INTK_BACKSPACE)
+  {
+    UNIMPLEMENTED(); // FIXME
+  }
+
+  SECTION(INTK_BACKSPACE_WORDS)
+  {
+    UNIMPLEMENTED(); // FIXME
+  }
+
+  SECTION(INTK_CLEAR)
+  {
+    UNIMPLEMENTED(); // FIXME
+  }
+
+  SECTION(INTK_INSERT_BLOCK)
+  {
+    UNIMPLEMENTED(); // FIXME
+  }
+
+  SECTION(INTK_OVERWRITE_BLOCK)
+  {
+    UNIMPLEMENTED(); // FIXME
+  }
+}
+
+/**
+ * Just make sure that the event callback is called and that the buffer (if
+ * present) and intk->pos have not been modified at the time the callback is
+ * called.
+ */
+UNITTEST(EventCallback)
+{
+  SECTION(intake_event_ext_no_dest)
+  {
+    UNIMPLEMENTED(); // FIXME
+  }
+
+  SECTION(intake_event_ext_dest)
+  {
+    UNIMPLEMENTED(); // FIXME
+  }
+}

--- a/unit/intake.cpp
+++ b/unit/intake.cpp
@@ -25,8 +25,7 @@
 #include "Unit.hpp"
 #include "../src/intake.c"
 
-// TODO shut up the linker as these aren't CORE_LIBSPEC currently.
-void cursor_underline(Uint32 x, Uint32 y) {}
+// TODO shut up the linker as this isn't CORE_LIBSPEC currently.
 boolean has_unicode_input() { return false; }
 
 struct int_pair


### PR DESCRIPTION
This branch adds a layer of indirection to intake2's text editing event processing and provides functions to override (or manually invoke) the default event handling. This is necessary to fix undo/redo bugs in the robot editor, and also to allow custom implementations of the events for e.g. non-continuous text buffers. It also made it easier to add a unit test for the default fixed buffer operations, so I did.

The draw and click handlers have also been removed from intake2, meaning it no longer needs to be provided a continuous buffer pointer at all. This also opens up the robot editor to future improvements to how it draws the current editing line.

- [x] More testing.