### PR TITLE
Add mzxout and mzxerr, use instead of freopen for stdio redirect.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -92,6 +92,8 @@ USERS
   an extra blank line.
 + Pressing enter at the start of a line with an extended macro
   now invokes the macro instead of just inserting a line.
++ Fixed a bug where stdio redirect could generate corrupted log
+  files on the Nintendo DS due to poor freopen support.
 - Removed 3DS CIA support. (asie)
 
 DEVELOPERS
@@ -109,6 +111,10 @@ DEVELOPERS
 + The draw and click handlers have been removed from intake2().
   This should provide more flexibility to the parent context for
   displaying the string that is being edited.
++ Added "mzxout" and "mzxerr" streams for printing console
+  messages. In most places these should be used instead of
+  "stdout" and "stderr" to allow debug and warning messages
+  print to the correct log files when stdio redirect is enabled.
 
 
 November 22nd, 2020 - MZX 2.92f

--- a/src/audio/audio_openmpt.c
+++ b/src/audio/audio_openmpt.c
@@ -181,7 +181,7 @@ static void omp_log(const char *message, void *data)
   (void)data;
 
   if(message)
-     fprintf(stderr, "%s\n", message);
+     fprintf(mzxerr, "%s\n", message);
 }
 
 static struct audio_stream *construct_openmpt_stream(char *filename,

--- a/src/core.c
+++ b/src/core.c
@@ -262,7 +262,7 @@ static void print_ctx_line(context_data *ctx_data)
   if(ctx_data->functions.click == ctx_data->functions.drag)
     click_drag_same = true;
 
-  fprintf(stderr, "%-*.*s | %3s %3s %3s %3s %3s %3s %3s %3s | %-3s %3s %s\n",
+  fprintf(mzxerr, "%-*.*s | %3s %3s %3s %3s %3s %3s %3s %3s | %-3s %3s %s\n",
     16, 16, name,
     ctx_data->functions.resume    ? "Yes" : "",
     ctx_data->functions.draw      ? "Yes" : "",
@@ -293,26 +293,26 @@ static void __print_core_stack(context *_ctx, const char *file, int line)
   int i2;
 
   if(file)
-    fprintf(stderr, "%s line %d:\n", file, line);
+    fprintf(mzxerr, "%s line %d:\n", file, line);
 
   if(!_ctx)
   {
-    fprintf(stderr, "Context is NULL!\n");
-    fflush(stderr);
+    fprintf(mzxerr, "Context is NULL!\n");
+    fflush(mzxerr);
     return;
   }
   else
 
   if(!_ctx->root)
   {
-    fprintf(stderr, "Context root is NULL!\n");
-    fflush(stderr);
+    fprintf(mzxerr, "Context root is NULL!\n");
+    fflush(mzxerr);
     return;
   }
 
   root = _ctx->root;
 
-  fprintf(stderr,
+  fprintf(mzxerr,
    "CONTEXT STACK    | Res Drw Idl Key Joy Clk Drg Dst | Fr. CbQ Pri\n"
    "-----------------|---------------------------------|-------------\n");
 
@@ -328,8 +328,8 @@ static void __print_core_stack(context *_ctx, const char *file, int line)
 
     print_ctx_line(ctx_data);
   }
-  fprintf(stderr, "\n");
-  fflush(stderr);
+  fprintf(mzxerr, "\n");
+  fflush(mzxerr);
 }
 
 /**

--- a/src/error.c
+++ b/src/error.c
@@ -227,6 +227,9 @@ int error(const char *string, enum error_type type, unsigned int options,
   m_show();
   if(ret == ERROR_OPT_EXIT) // Exit the program
   {
+#ifdef CONFIG_STDIO_REDIRECT
+    redirect_stdio_exit();
+#endif
     platform_quit();
     exit(-1);
   }

--- a/src/legacy_rasm.c
+++ b/src/legacy_rasm.c
@@ -2804,7 +2804,7 @@ static void validate_legacy_bytecode_print(char *bc, int program_length,
 
   if(offset > program_length)
   {
-    fprintf(stderr, "\n");
+    fprintf(mzxerr, "\n");
     debug("Offset exceeded program length\n");
     debug("Prog len: %d    Offset: %d\n", program_length, offset);
     return;

--- a/src/main.c
+++ b/src/main.c
@@ -179,9 +179,9 @@ __libspec int main(int argc, char *argv[])
 #ifdef CONFIG_STDIO_REDIRECT
   // Do this after platform_init() since, even though platform_init() might
   // log stuff, it actually initializes the filesystem on some platforms.
-  if(!redirect_stdio(startup_dir, true))
-    if(!redirect_stdio(SHAREDIR, false))
-      redirect_stdio(getenv("HOME"), false);
+  if(!redirect_stdio_init(startup_dir, true))
+    if(!redirect_stdio_init(SHAREDIR, false))
+      redirect_stdio_init(getenv("HOME"), false);
 #endif
 
 #ifdef __APPLE__
@@ -370,6 +370,9 @@ err_free_config:
   free_config();
   free_editor_config();
 err_free_res:
+#ifdef CONFIG_STDIO_REDIRECT
+  redirect_stdio_exit();
+#endif
   mzx_res_free();
   platform_quit();
 err_out:

--- a/src/network/HTTPHost.cpp
+++ b/src/network/HTTPHost.cpp
@@ -140,7 +140,7 @@ void HTTPRequestInfo::clear_response()
 void HTTPRequestInfo::print_response() const
 {
   boolean params = this->content_type_params[0] != '\0';
-  fprintf(stderr,
+  fprintf(mzxerr,
     "  URL               : %s\n"
     "  Status            : %d %s\n"
     "  Content-Type      : %s%s%s\n"
@@ -156,7 +156,7 @@ void HTTPRequestInfo::print_response() const
     this->transfer_encoding,
     this->content_length
   );
-  fflush(stderr);
+  fflush(mzxerr);
 }
 
 const char *HTTPHost::get_error_string(HTTPHostStatus status)

--- a/src/network/Host.cpp
+++ b/src/network/Host.cpp
@@ -417,9 +417,9 @@ boolean Host::send(const void *buffer, size_t len)
     {
       trace("--HOST-- Host::send    ");
       for(size_t i = pos; i < pos + count; i++)
-        fprintf(stderr, "%02x ", buf[i]);
-      fprintf(stderr, "\n");
-      fflush(stderr);
+        fprintf(mzxerr, "%02x ", buf[i]);
+      fprintf(mzxerr, "\n");
+      fflush(mzxerr);
     }
 #endif
   }
@@ -468,9 +468,9 @@ boolean Host::receive(void *buffer, size_t len)
     {
       trace("--HOST-- Host::receive ");
       for(size_t i = pos; i < pos + count; i++)
-        fprintf(stderr, "%02x ", buf[i]);
-      fprintf(stderr, "\n");
-      fflush(stderr);
+        fprintf(mzxerr, "%02x ", buf[i]);
+      fprintf(mzxerr, "\n");
+      fflush(mzxerr);
     }
 #endif
   }

--- a/src/nostdc++.cpp
+++ b/src/nostdc++.cpp
@@ -24,6 +24,7 @@
  */
 
 #include "compat.h"
+#include "util.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -31,15 +32,15 @@
 
 extern "C" CORE_LIBSPEC void __cxa_pure_virtual()
 {
-  fprintf(stderr, "Attempted to call pure virtual function! Aborting!\n");
-  fflush(stderr);
+  fprintf(mzxerr, "Attempted to call pure virtual function! Aborting!\n");
+  fflush(mzxerr);
   exit(1);
 }
 
 extern "C" CORE_LIBSPEC void __cxa_deleted_virtual()
 {
-  fprintf(stderr, "Attempted to call deleted virtual function! Aborting!\n");
-  fflush(stderr);
+  fprintf(mzxerr, "Attempted to call deleted virtual function! Aborting!\n");
+  fflush(mzxerr);
   exit(1);
 }
 
@@ -49,8 +50,8 @@ CORE_LIBSPEC void *operator new(size_t count) noexcept
   if(!ptr)
   {
     // Allocation failed in thread--abort!
-    fprintf(stderr, "Failed to allocate memory for new! Aborting!\n");
-    fflush(stderr);
+    fprintf(mzxerr, "Failed to allocate memory for new! Aborting!\n");
+    fflush(mzxerr);
     exit(1);
   }
   return ptr;
@@ -62,8 +63,8 @@ CORE_LIBSPEC void *operator new[](size_t count) noexcept
   if(!ptr)
   {
     // Allocation failed in thread--abort!
-    fprintf(stderr, "Failed to allocate memory for new[]! Aborting!\n");
-    fflush(stderr);
+    fprintf(mzxerr, "Failed to allocate memory for new[]! Aborting!\n");
+    fflush(mzxerr);
     exit(1);
   }
   return ptr;

--- a/src/render_glsl.c
+++ b/src/render_glsl.c
@@ -818,11 +818,9 @@ static void glsl_debug_callback(GLenum source, GLenum type, GLuint id,
  GLenum severity, GLsizei length, const GLchar *message, const void *userParam)
 {
   length = length < 0 ? (GLsizei)strlen(message) : length;
-  fprintf(stderr,
-    "GL DEBUG (source 0x%x, type 0x%x, severity 0x%x): %.*s\n",
+  debug("GL (source 0x%x, type 0x%x, severity 0x%x): %.*s\n",
     source, type, severity, length, message
   );
-  fflush(stderr);
 }
 #endif
 

--- a/src/render_layer_code.hpp
+++ b/src/render_layer_code.hpp
@@ -27,6 +27,7 @@
 // stream to a file.
 
 #include "platform.h"
+#include "util.h"
 
 #ifdef IS_CXX_11
 #include <type_traits>
@@ -99,7 +100,7 @@ inline void render_layer_func<Uint8>(void * RESTRICT pixels, Uint32 pitch,
       break;
 
     default:
-      fprintf(stderr, "INVALID RENDERER ARG align=%d (8bpp)\n", align);
+      fprintf(mzxerr, "INVALID RENDERER ARG align=%d (8bpp)\n", align);
       exit(1);
       break;
   }
@@ -134,7 +135,7 @@ inline void render_layer_func<Uint16>(void * RESTRICT pixels, Uint32 pitch,
       break;
 
     default:
-      fprintf(stderr, "INVALID RENDERER ARG align=%d (16bpp)\n", align);
+      fprintf(mzxerr, "INVALID RENDERER ARG align=%d (16bpp)\n", align);
       exit(1);
       break;
   }
@@ -164,7 +165,7 @@ inline void render_layer_func<Uint32>(void * RESTRICT pixels, Uint32 pitch,
       break;
 
     default:
-      fprintf(stderr, "INVALID RENDERER ARG align=%d (32bpp)\n", align);
+      fprintf(mzxerr, "INVALID RENDERER ARG align=%d (32bpp)\n", align);
       exit(1);
       break;
   }
@@ -201,7 +202,7 @@ static inline void render_layer_func(void * RESTRICT pixels, Uint32 pitch,
       break;
 #endif
     default:
-      fprintf(stderr, "INVALID RENDERER ARG bpp=%d\n"
+      fprintf(mzxerr, "INVALID RENDERER ARG bpp=%d\n"
        "(is this bpp enabled for this platform?)\n", bpp);
       exit(1);
       break;
@@ -231,7 +232,7 @@ static inline void render_layer_func(void * RESTRICT pixels, Uint32 pitch,
       break;
 
     default:
-      fprintf(stderr, "INVALID RENDERER ARG smzx=%d\n", smzx);
+      fprintf(mzxerr, "INVALID RENDERER ARG smzx=%d\n", smzx);
       exit(1);
       break;
   }
@@ -273,7 +274,7 @@ static void render_layer_func(void * RESTRICT pixels, Uint32 pitch,
     /* fall-through */
 
     default:
-      fprintf(stderr, "INVALID RENDERER ARG ppal=%d (smzx=%d)\n", ppal, SMZX);
+      fprintf(mzxerr, "INVALID RENDERER ARG ppal=%d (smzx=%d)\n", ppal, SMZX);
       exit(1);
       break;
   }
@@ -300,7 +301,7 @@ static inline void render_layer_func(void * RESTRICT pixels, Uint32 pitch,
       break;
 
     default:
-      fprintf(stderr, "INVALID RENDERER ARG trans=%d\n", trans);
+      fprintf(mzxerr, "INVALID RENDERER ARG trans=%d\n", trans);
       exit(1);
       break;
   }
@@ -325,7 +326,7 @@ static inline void render_layer_func(void * RESTRICT pixels, Uint32 pitch,
       break;
 
     default:
-      fprintf(stderr, "INVALID RENDERER ARG clip=%d\n", clip);
+      fprintf(mzxerr, "INVALID RENDERER ARG clip=%d\n", clip);
       exit(1);
       break;
   }
@@ -525,8 +526,8 @@ static inline void render_layer_func(void * RESTRICT pixels, Uint32 pitch,
   static boolean printed = false;
   if(!printed)
   {
-    fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
-    fflush(stderr);
+    fprintf(mzxerr, "%s\n", __PRETTY_FUNCTION__);
+    fflush(mzxerr);
     printed = true;
   }
 #endif

--- a/src/str.c
+++ b/src/str.c
@@ -1499,8 +1499,8 @@ static boolean wildcard_char_is_escapable(unsigned char c)
 #if 0
 #define WILDCARD_PRINT() do { \
     for(size_t k = 0; k <= str_len; k++) \
-      fprintf(stderr, "%c ", (k+1 < left ? ' ' : str_matched[k] ? 'Y' : 'n')); \
-    fprintf(stderr, "\n"); \
+      fprintf(mzxerr, "%c ", (k+1 < left ? ' ' : str_matched[k] ? 'Y' : 'n')); \
+    fprintf(mzxerr, "\n"); \
 } while(0)
 #endif
 

--- a/src/util.c
+++ b/src/util.c
@@ -385,8 +385,12 @@ FILE *mzxerr_h = NULL;
 
 /**
  * Some platforms may not be able to display console output without extra work.
- * On these platforms redirect STDIO to files so the console output is easier
- * to read. NOTE: this needs to use stdio, don't use vfile here.
+ * On these platforms, open stdout/stderr replacement files instead. The log
+ * macros and any other references to `mzxout` and `mzxerr` will use these
+ * files instead of stdio.
+ *
+ * Previously, this was implemented using `freopen` on stdout/stderr, but
+ * doing this in some console SDKs does not work correctly (NDS, PS Vita).
  */
 boolean redirect_stdio_init(const char *base_path, boolean require_conf)
 {
@@ -433,7 +437,7 @@ boolean redirect_stdio_init(const char *base_path, boolean require_conf)
   fprintf(mzxout, "MegaZeux: Logging to '%s' (%" PRIu64 ")\n", dest_path, t);
   fflush(mzxout);
 
-  // Redirect stderr to stderr.txt.
+  // Redirect mzxerr to stderr.txt.
   dest_path[dest_len] = '\0';
   path_append(dest_path, MAX_PATH, "stderr.txt");
   fp_wr = fopen_unsafe(dest_path, "w");

--- a/src/util.c
+++ b/src/util.c
@@ -378,12 +378,17 @@ const char *mzx_res_get_by_id(enum resource_id id)
   return mzx_res[id].path;
 }
 
+#ifdef CONFIG_STDIO_REDIRECT
+
+FILE *mzxout_h = NULL;
+FILE *mzxerr_h = NULL;
+
 /**
  * Some platforms may not be able to display console output without extra work.
  * On these platforms redirect STDIO to files so the console output is easier
  * to read. NOTE: this needs to use stdio, don't use vfile here.
  */
-boolean redirect_stdio(const char *base_path, boolean require_conf)
+boolean redirect_stdio_init(const char *base_path, boolean require_conf)
 {
   char dest_path[MAX_PATH];
   size_t dest_len;
@@ -406,36 +411,64 @@ boolean redirect_stdio(const char *base_path, boolean require_conf)
     dest_path[dest_len] = '\0';
   }
 
+  // Clean up existing handles from a previous attempt.
+  redirect_stdio_exit();
+
   // Test directory for write access.
   path_append(dest_path, MAX_PATH, "stdout.txt");
   fp_wr = fopen_unsafe(dest_path, "w");
-  if(fp_wr)
+  if(!fp_wr)
   {
-    t = (uint64_t)time(NULL);
-
-    // Redirect stdout to stdout.txt.
-    fclose(fp_wr);
-    fprintf(stdout, "Redirecting logs to '%s'...\n", dest_path);
-    if(freopen(dest_path, "w", stdout))
-      fprintf(stdout, "MegaZeux: Logging to '%s' (%" PRIu64 ")\n", dest_path, t);
-    else
-      fprintf(stdout, "Failed to redirect stdout\n");
+    fprintf(stdout, "Failed to redirect stdout\n");
     fflush(stdout);
-
-    // Redirect stderr to stderr.txt.
-    dest_path[dest_len] = '\0';
-    path_append(dest_path, MAX_PATH, "stderr.txt");
-    fprintf(stderr, "Redirecting logs to '%s'...\n", dest_path);
-    if(freopen(dest_path, "w", stderr))
-      fprintf(stderr, "MegaZeux: Logging to '%s' (%" PRIu64 ")\n", dest_path, t);
-    else
-      fprintf(stderr, "Failed to redirect stderr\n");
-    fflush(stderr);
-
-    return true;
+    return false;
   }
-  return false;
+
+  t = (uint64_t)time(NULL);
+
+  // Redirect mzxout to stdout.txt.
+  fprintf(stdout, "Redirecting logs to '%s'...\n", dest_path);
+  fflush(stdout);
+  mzxout_h = fp_wr;
+  fprintf(mzxout, "MegaZeux: Logging to '%s' (%" PRIu64 ")\n", dest_path, t);
+  fflush(mzxout);
+
+  // Redirect stderr to stderr.txt.
+  dest_path[dest_len] = '\0';
+  path_append(dest_path, MAX_PATH, "stderr.txt");
+  fp_wr = fopen_unsafe(dest_path, "w");
+  if(!fp_wr)
+  {
+    fprintf(stderr, "Failed to redirect stderr\n");
+    fflush(stderr);
+    return false;
+  }
+
+  fprintf(stderr, "Redirecting logs to '%s'...\n", dest_path);
+  fflush(stderr);
+  mzxerr_h = fp_wr;
+  fprintf(mzxerr, "MegaZeux: Logging to '%s' (%" PRIu64 ")\n", dest_path, t);
+  fflush(mzxerr);
+
+  return true;
 }
+
+void redirect_stdio_exit(void)
+{
+  if(mzxout_h)
+  {
+    fclose(mzxout_h);
+    mzxout_h = NULL;
+  }
+
+  if(mzxerr_h)
+  {
+    fclose(mzxerr_h);
+    mzxerr_h = NULL;
+  }
+}
+
+#endif /* CONFIG_STDIO_REDIRECT */
 
 // Get 2 bytes, little endian
 

--- a/src/util.h
+++ b/src/util.h
@@ -43,6 +43,16 @@ __M_BEGIN_DECLS
 
 #define SGN(x) ((x > 0) - (x < 0))
 
+#ifdef CONFIG_STDIO_REDIRECT
+CORE_LIBSPEC extern FILE *mzxout_h;
+CORE_LIBSPEC extern FILE *mzxerr_h;
+#define mzxout (mzxout_h ? mzxout_h : stdout)
+#define mzxerr (mzxerr_h ? mzxerr_h : stderr)
+#else
+#define mzxout stdout
+#define mzxerr stderr
+#endif
+
 enum resource_id
 {
   MZX_EXECUTABLE_DIR = 0,
@@ -87,7 +97,10 @@ CORE_LIBSPEC int mzx_res_init(const char *argv0, boolean editor);
 CORE_LIBSPEC void mzx_res_free(void);
 CORE_LIBSPEC const char *mzx_res_get_by_id(enum resource_id id);
 
-CORE_LIBSPEC boolean redirect_stdio(const char *base_path, boolean require_conf);
+#ifdef CONFIG_STDIO_REDIRECT
+CORE_LIBSPEC boolean redirect_stdio_init(const char *base_path, boolean require_conf);
+CORE_LIBSPEC void redirect_stdio_exit(void);
+#endif
 
 // Code to load multi-byte ints from little endian file
 int fgetw(FILE *fp);
@@ -159,21 +172,21 @@ CORE_LIBSPEC void __stack_chk_fail(void);
 
 #define info(...) \
  do { \
-   fprintf(stdout, "INFO: " __VA_ARGS__); \
-   fflush(stdout); \
+   fprintf(mzxout, "INFO: " __VA_ARGS__); \
+   fflush(mzxout); \
  } while(0)
 
 #define warn(...) \
  do { \
-   fprintf(stderr, "WARNING: " __VA_ARGS__); \
-   fflush(stderr); \
+   fprintf(mzxerr, "WARNING: " __VA_ARGS__); \
+   fflush(mzxerr); \
  } while(0)
 
 #ifdef DEBUG
 #define debug(...) \
  do { \
-   fprintf(stderr, "DEBUG: " __VA_ARGS__); \
-   fflush(stderr); \
+   fprintf(mzxerr, "DEBUG: " __VA_ARGS__); \
+   fflush(mzxerr); \
  } while(0)
 #else
 #define debug(...) do { } while(0)
@@ -181,8 +194,8 @@ CORE_LIBSPEC void __stack_chk_fail(void);
 #if defined(DEBUG) && defined(DEBUG_TRACE)
 #define trace(...) \
  do { \
-    fprintf(stderr, "TRACE: " __VA_ARGS__); \
-    fflush(stderr); \
+    fprintf(mzxerr, "TRACE: " __VA_ARGS__); \
+    fflush(mzxerr); \
  } while(0)
 #else
 #define trace(...) do { } while(0)

--- a/src/utils/checkres.c
+++ b/src/utils/checkres.c
@@ -2243,7 +2243,7 @@ static void _decrypt_legacy_world(struct memfile *mf, char *password,
   ALIGN_TYPE xor_w = ALIGN_XOR(xor);
   unsigned char *pos = mf->current;
 
-  debug("xor=%u, password: %s\n", (unsigned int)xor, password);
+  fprintf(stderr, "xor=%u, password: %s\n", (unsigned int)xor, password);
 
   while(pos < mf->end && ((size_t)pos) % sizeof(ALIGN_TYPE))
     *(pos++) ^= xor;
@@ -2297,7 +2297,7 @@ static enum status parse_legacy_robot(struct memfile *mf,
     // This includes the global robots in Slave Pit and Wes.
     if(ret && !used)
     {
-      warn("Unused robot with corruption detected (this is safe to ignore).\n");
+      warnhere("Unused robot with corruption detected (this is safe to ignore).\n");
       ret = SUCCESS;
     }
   }
@@ -3054,7 +3054,7 @@ static enum status parse_file(const char *file_name,
         buffer = ccalloc(1, actual_size);
         if(ZIP_SUCCESS != zip_read_file(zp, buffer, actual_size, &actual_size))
         {
-          warn("Error processing '%s': %s\n\n", name_buffer,
+          warnhere("Error processing '%s': %s\n\n", name_buffer,
            decode_status(ZIP_FAILED));
           free(buffer);
           continue;
@@ -3076,7 +3076,7 @@ static enum status parse_file(const char *file_name,
         if(ret != SUCCESS)
         {
           // Keep going; other files in the archive may not be corrupt.
-          warn("Error processing '%s': %s\n\n", name_buffer, decode_status(ret));
+          warnhere("Error processing '%s': %s\n\n", name_buffer, decode_status(ret));
           ret = SUCCESS;
         }
         free(buffer);
@@ -3134,13 +3134,13 @@ static enum status parse_file(const char *file_name,
         if(ret != SUCCESS)
         {
           // Keep going; other files in the path may not be corrupt.
-          warn("Error processing '%s': %s\n", current_file->file_name,
+          warnhere("Error processing '%s': %s\n", current_file->file_name,
            decode_status(ret));
           ret = SUCCESS;
         }
       }
       else
-        warn("Failed to open '%s' for reading\n", current_file->file_name);
+        warnhere("Failed to open '%s' for reading\n", current_file->file_name);
     }
   }
 

--- a/src/utils/utils_alloc.h
+++ b/src/utils/utils_alloc.h
@@ -30,6 +30,10 @@
 
 __M_BEGIN_DECLS
 
+/* Workaround for linking zip.o */
+FILE *mzxout_h = NULL;
+FILE *mzxerr_h = NULL;
+
 #ifdef CONFIG_CHECK_ALLOC
 
 #include <stdlib.h>

--- a/src/world.c
+++ b/src/world.c
@@ -535,10 +535,10 @@ static inline enum val_result validate_world_info(struct world *mzx_world,
   return VAL_SUCCESS;
 
 err_free:
-  fprintf(stderr,
+  fprintf(mzxerr,
    "load_world_info: expected ID %xh not found (found %xh, last %xh)\n",
    missing_ident, ident, last_ident);
-  fflush(stderr);
+  fflush(mzxerr);
 
   free(buffer);
   mzx_world->raw_world_info = NULL;
@@ -2138,8 +2138,8 @@ static int load_world_zip(struct world *mzx_world, struct zip_archive *zp,
     if(err != ZIP_SUCCESS)
     {
       zip_skip_file(zp);
-      fprintf(stderr, "ERROR - Read error @ file ID %u\n", file_id);
-      fflush(stderr);
+      fprintf(mzxerr, "ERROR - Read error @ file ID %u\n", file_id);
+      fflush(mzxerr);
     }
   }
 
@@ -2262,10 +2262,10 @@ int save_world(struct world *mzx_world, const char *file, boolean savegame,
 
   else
   {
-    fprintf(stderr,
+    fprintf(mzxerr,
      "ERROR: Attempted to save incompatible world version %d.%d! Aborting!\n",
      (world_version >> 8) & 0xFF, world_version & 0xFF);
-    fflush(stderr);
+    fflush(mzxerr);
 
     return -1;
   }


### PR DESCRIPTION
Probably (but maybe doesn't) fixes stdio redirect bugs for the NDS and potentially other consoles with sketchy SDKs by using different file handles for redirected `stdout` and `stderr` (instead of modifying `stdout` and `stderr` directly with `freopen`). This also means vio.c doesn't need to support `freopen` in the future.

- [x] Actually test on the NDS or something idk