### PR TITLE
Reuse zstreams between files when reading/writing ZIP archives.

### DIFF
--- a/src/io/zip.c
+++ b/src/io/zip.c
@@ -2376,7 +2376,6 @@ static void zip_init_for_write(struct zip_archive *zp, int num_files)
 static struct zip_archive *zip_new_archive(void)
 {
   struct zip_archive *zp = cmalloc(sizeof(struct zip_archive));
-  size_t i;
   zp->is_memory = false;
 
   zp->files = NULL;
@@ -2400,8 +2399,7 @@ static struct zip_archive *zip_new_archive(void)
 
   zp->stream = NULL;
   zp->stream_data = NULL;
-  for(i = 0; i < ARRAY_SIZE(zp->stream_data_ptrs); i++)
-    zp->stream_data_ptrs[i] = NULL;
+  memset(zp->stream_data_ptrs, 0, sizeof(zp->stream_data_ptrs));
 
   zp->mode = ZIP_S_READ_UNINITIALIZED;
 

--- a/src/io/zip.c
+++ b/src/io/zip.c
@@ -220,7 +220,7 @@ static inline boolean zip_is_ignore_file(const char *filename, size_t len)
  */
 static boolean zip_method_is_supported(uint8_t method)
 {
-  if(method > ZIP_M_NONE && method <= MAX_SUPPORTED_METHOD)
+  if(method > ZIP_M_NONE && method <= ZIP_M_MAX_SUPPORTED)
     return !!zip_method_handlers[method];
 
   return (method == ZIP_M_NONE);
@@ -234,6 +234,7 @@ static enum zip_error zip_get_stream(struct zip_archive *zp, uint8_t method,
  enum zip_internal_state new_mode)
 {
   zp->stream = NULL;
+  zp->stream_data = NULL;
 
   if(method == ZIP_M_NONE)
   {
@@ -241,7 +242,7 @@ static enum zip_error zip_get_stream(struct zip_archive *zp, uint8_t method,
     return ZIP_SUCCESS;
   }
 
-  if(method <= MAX_SUPPORTED_METHOD)
+  if(method <= ZIP_M_MAX_SUPPORTED)
   {
     struct zip_method_handler *result = zip_method_handlers[method];
 
@@ -261,7 +262,11 @@ static enum zip_error zip_get_stream(struct zip_archive *zp, uint8_t method,
       {
         if(result && result->decompress_open)
         {
+          if(!zp->stream_data_ptrs[method])
+            zp->stream_data_ptrs[method] = result->create();
+
           zp->stream = result;
+          zp->stream_data = zp->stream_data_ptrs[method];
           return ZIP_SUCCESS;
         }
         return ZIP_UNSUPPORTED_DECOMPRESSION;
@@ -271,7 +276,11 @@ static enum zip_error zip_get_stream(struct zip_archive *zp, uint8_t method,
       {
         if(result && result->compress_open)
         {
+          if(!zp->stream_data_ptrs[method])
+            zp->stream_data_ptrs[method] = result->create();
+
           zp->stream = result;
+          zp->stream_data = zp->stream_data_ptrs[method];
           return ZIP_SUCCESS;
         }
         return ZIP_UNSUPPORTED_COMPRESSION;
@@ -825,7 +834,7 @@ static void zip_set_stream_buffer_size(struct zip_archive *zp, size_t size)
 static enum zip_error zread_stream(uint8_t *destBuf, size_t readLen,
  size_t *consumed, struct zip_archive *zp)
 {
-  struct zip_stream_data *stream_data = &(zp->stream_data);
+  struct zip_stream_data *stream_data = zp->stream_data;
   boolean direct_write = (readLen == zp->stream_u_left);
   uint8_t *in;
   size_t in_size;
@@ -1180,7 +1189,7 @@ static enum zip_error zip_read_stream_open(struct zip_archive *zp, uint8_t mode)
   zp->stream_crc32 = 0;
 
   if(zp->stream)
-    zp->stream->decompress_open(&(zp->stream_data), method, central_fh->flags);
+    zp->stream->decompress_open(zp->stream_data, method, central_fh->flags);
 
   precalculate_read_errors(zp);
   return ZIP_SUCCESS;
@@ -1276,7 +1285,7 @@ enum zip_error zip_read_close_stream(struct zip_archive *zp)
 
   // TODO maybe check final in/out...
   if(zp->stream)
-    zp->stream->close(&(zp->stream_data), NULL, NULL);
+    zp->stream->close(zp->stream_data, NULL, NULL);
 
   expected_crc32 = zp->streaming_file->crc32;
   stream_crc32 = zp->stream_crc32;
@@ -1472,7 +1481,7 @@ static enum zip_error zwrite_out(const void *buffer, size_t len,
 static enum zip_error zwrite_stream_compress(const void *buffer, size_t len,
  size_t *write_len, struct zip_archive *zp)
 {
-  struct zip_stream_data *stream_data = &(zp->stream_data);
+  struct zip_stream_data *stream_data = zp->stream_data;
   uint8_t *out = zp->stream_buffer + ZIP_STREAM_BUFFER_U_SIZE;
   size_t out_len = ZIP_STREAM_BUFFER_C_SIZE;
   enum zip_error result;
@@ -1761,7 +1770,7 @@ static enum zip_error zip_write_open_stream(struct zip_archive *zp,
 
   if(zp->stream)
   {
-    struct zip_stream_data *stream_data = &(zp->stream_data);
+    struct zip_stream_data *stream_data = zp->stream_data;
     zp->stream->compress_open(stream_data, method, 0);
 
     zip_set_stream_buffer_size(zp, ZIP_STREAM_BUFFER_SIZE);
@@ -1837,7 +1846,7 @@ enum zip_error zip_write_close_stream(struct zip_archive *zp)
 
   if(zp->stream)
   {
-    struct zip_stream_data *stream_data = &(zp->stream_data);
+    struct zip_stream_data *stream_data = zp->stream_data;
     size_t final_in = 0;
     size_t final_out = 0;
     size_t write_len = 0;
@@ -1941,6 +1950,10 @@ enum zip_error zip_write_file(struct zip_archive *zp, const char *name,
   enum zip_error result;
 
   // No need to check mode; the functions used here will
+
+  // Attempting to DEFLATE a small file? Store instead...
+  if(srcLen < 256 && method == ZIP_M_DEFLATE)
+    method = ZIP_M_NONE;
 
   result = zip_write_open_file_stream(zp, name, method);
   if(result)
@@ -2229,7 +2242,7 @@ enum zip_error zip_close(struct zip_archive *zp, size_t *final_length)
 {
   int result = ZIP_SUCCESS;
   int mode;
-  int i;
+  size_t i;
 
   if(!zp)
     return ZIP_NULL;
@@ -2320,6 +2333,10 @@ enum zip_error zip_close(struct zip_archive *zp, size_t *final_length)
       *final_length = zp->end_in_file;
   }
 
+  for(i = 0; i < ARRAY_SIZE(zp->stream_data_ptrs); i++)
+    if(zip_method_handlers[i] && zp->stream_data_ptrs[i])
+      zip_method_handlers[i]->destroy(zp->stream_data_ptrs[i]);
+
   vfclose(zp->vf);
 
   free(zp->header_buffer);
@@ -2359,6 +2376,7 @@ static void zip_init_for_write(struct zip_archive *zp, int num_files)
 static struct zip_archive *zip_new_archive(void)
 {
   struct zip_archive *zp = cmalloc(sizeof(struct zip_archive));
+  size_t i;
   zp->is_memory = false;
 
   zp->files = NULL;
@@ -2379,6 +2397,11 @@ static struct zip_archive *zip_new_archive(void)
 
   zp->external_buffer = NULL;
   zp->external_buffer_size = NULL;
+
+  zp->stream = NULL;
+  zp->stream_data = NULL;
+  for(i = 0; i < ARRAY_SIZE(zp->stream_data_ptrs); i++)
+    zp->stream_data_ptrs[i] = NULL;
 
   zp->mode = ZIP_S_READ_UNINITIALIZED;
 

--- a/src/io/zip.h
+++ b/src/io/zip.h
@@ -57,6 +57,8 @@ enum zip_compression_method
   ZIP_M_PPMD                    = 98,
 };
 
+#define ZIP_M_MAX_SUPPORTED ZIP_M_DEFLATE64
+
 enum zip_general_purpose_flag
 {
   ZIP_F_ENCRYPTED           = (1<<0), // Indicates that a file is encrypted.
@@ -186,12 +188,6 @@ struct zip_stream_data
   boolean is_compression_stream;
 };
 
-// zip_stream_data structs should be allocated with at least this much extra
-// space for specific compression method data.
-#define ZIP_STREAM_DATA_PADDING 128
-#define ZIP_STREAM_DATA_ALLOC_SIZE \
- (sizeof(struct zip_stream_data) + ZIP_STREAM_DATA_PADDING)
-
 struct zip_method_handler;
 
 struct zip_archive
@@ -235,8 +231,8 @@ struct zip_archive
   size_t *external_buffer_size;
 
   struct zip_method_handler *stream;
-  struct zip_stream_data stream_data;
-  uint8_t padding[ZIP_STREAM_DATA_PADDING];
+  struct zip_stream_data *stream_data;
+  struct zip_stream_data *stream_data_ptrs[ZIP_M_MAX_SUPPORTED + 1];
 };
 
 UTILS_LIBSPEC int zip_bound_deflate_usage(size_t length);

--- a/src/io/zip_deflate.h
+++ b/src/io/zip_deflate.h
@@ -42,19 +42,39 @@ struct deflate_stream_data
   boolean should_finish;
 };
 
+static inline struct zip_stream_data *deflate_create(void)
+{
+  return ccalloc(1, sizeof(struct deflate_stream_data));
+}
+
+static inline void deflate_destroy(struct zip_stream_data *zs)
+{
+  struct deflate_stream_data *ds = ((struct deflate_stream_data *)zs);
+
+  if(ds->is_inflate)
+    inflateEnd(&(ds->z));
+
+  if(ds->is_deflate)
+    deflateEnd(&(ds->z));
+
+  free(zs);
+}
+
 static inline void inflate_open(struct zip_stream_data *zs, uint16_t method,
  uint16_t flags)
 {
-  assert(ZIP_STREAM_DATA_ALLOC_SIZE >= sizeof(struct deflate_stream_data));
-  memset(zs, 0, sizeof(struct deflate_stream_data));
+  // Only clear the common portion of the stream data.
+  memset(zs, 0, sizeof(struct zip_stream_data));
 }
 
 static inline void deflate_open(struct zip_stream_data *zs, uint16_t method,
  uint16_t flags)
 {
-  assert(ZIP_STREAM_DATA_ALLOC_SIZE >= sizeof(struct deflate_stream_data));
-  memset(zs, 0, sizeof(struct deflate_stream_data));
+  struct deflate_stream_data *ds = ((struct deflate_stream_data *)zs);
+  // Only clear the common portion of the stream data.
+  memset(zs, 0, sizeof(struct zip_stream_data));
   zs->is_compression_stream = true;
+  ds->should_finish = false;
 }
 
 static inline void deflate_close(struct zip_stream_data *zs,
@@ -63,11 +83,12 @@ static inline void deflate_close(struct zip_stream_data *zs,
   struct deflate_stream_data *ds = ((struct deflate_stream_data *)zs);
   if(!zs->finished)
   {
+    // Reset the stream to be used again.
     if(ds->is_inflate)
-      inflateEnd(&(ds->z));
+      inflateReset(&(ds->z));
 
     if(ds->is_deflate)
-      deflateEnd(&(ds->z));
+      deflateReset(&(ds->z));
 
     zs->finished = true;
   }
@@ -104,12 +125,21 @@ static inline enum zip_error inflate_init(struct zip_stream_data *zs)
   if(zs->is_initialized)
     return ZIP_SUCCESS;
 
+  if(ds->is_deflate)
+  {
+    deflateEnd(&(ds->z));
+    ds->is_deflate = false;
+  }
+
   if(ds->z.avail_in)
   {
     // This is a raw deflate stream, so use -MAX_WBITS.
-    inflateInit2(&(ds->z), -MAX_WBITS);
+    if(!ds->is_inflate)
+    {
+      inflateInit2(&(ds->z), -MAX_WBITS);
+      ds->is_inflate = true;
+    }
     zs->is_initialized = true;
-    ds->is_inflate = true;
     return ZIP_SUCCESS;
   }
   return ZIP_INPUT_EMPTY;
@@ -141,7 +171,7 @@ static inline enum zip_error inflate_block(struct zip_stream_data *zs)
     zs->final_output_length = ds->z.total_out;
     zs->finished = true;
 
-    inflateEnd(&(ds->z));
+    inflateReset(&(ds->z));
     return ZIP_STREAM_FINISHED;
   }
 
@@ -160,15 +190,21 @@ static inline enum zip_error deflate_init(struct zip_stream_data *zs)
 {
   struct deflate_stream_data *ds = ((struct deflate_stream_data *)zs);
 
-  if(!zs->is_initialized)
+  if(ds->is_inflate)
+  {
+    inflateEnd(&(ds->z));
+    ds->is_inflate = false;
+  }
+
+  if(!ds->is_deflate)
   {
     // This is a raw deflate stream, so use -MAX_WBITS.
     // Note: aside from the windowbits, these are all defaults.
     deflateInit2(&(ds->z), Z_DEFAULT_COMPRESSION, Z_DEFLATED, -MAX_WBITS,
      8, Z_DEFAULT_STRATEGY);
-    zs->is_initialized = true;
     ds->is_deflate = true;
   }
+  zs->is_initialized = true;
   return ZIP_SUCCESS;
 }
 
@@ -207,7 +243,7 @@ static inline enum zip_error deflate_block(struct zip_stream_data *zs,
     zs->final_output_length = ds->z.total_out;
     zs->finished = true;
 
-    deflateEnd(&(ds->z));
+    deflateReset(&(ds->z));
     return ZIP_STREAM_FINISHED;
   }
 

--- a/src/io/zip_deflate64.h
+++ b/src/io/zip_deflate64.h
@@ -44,11 +44,18 @@ struct deflate64_stream_data
   void *window;
 };
 
+/**
+ * Allocate an inflate64 stream.
+ */
+static inline struct zip_stream_data *inflate64_create(void)
+{
+  return cmalloc(sizeof(struct deflate64_stream_data));
+}
+
 static inline void inflate64_open(struct zip_stream_data *zs, uint16_t method,
  uint16_t flags)
 {
   struct deflate64_stream_data *d64s = ((struct deflate64_stream_data *)zs);
-  assert(ZIP_STREAM_DATA_ALLOC_SIZE >= sizeof(struct deflate64_stream_data));
   memset(zs, 0, sizeof(struct deflate64_stream_data));
 
   d64s->window = cmalloc(1<<16);

--- a/src/io/zip_implode.h
+++ b/src/io/zip_implode.h
@@ -278,6 +278,14 @@ static inline void expl_SF_free(struct SF_tree *tree)
 }
 
 /**
+ * Allocate an explode stream.
+ */
+static inline struct zip_stream_data *expl_create(void)
+{
+  return cmalloc(sizeof(struct explode_stream_data));
+}
+
+/**
  * Open an explode stream.
  */
 static inline void expl_open(struct zip_stream_data *zs, uint16_t method,
@@ -285,7 +293,6 @@ static inline void expl_open(struct zip_stream_data *zs, uint16_t method,
 {
   struct explode_stream_data *xs = ((struct explode_stream_data *)zs);
 
-  assert(ZIP_STREAM_DATA_ALLOC_SIZE >= sizeof(struct explode_stream_data));
   memset(zs, 0, sizeof(struct explode_stream_data));
   xs->has_8k_dictionary = !!(flags & ZIP_F_COMPRESSION_1);
   xs->has_literal_tree = !!(flags & ZIP_F_COMPRESSION_2);

--- a/src/io/zip_reduce.h
+++ b/src/io/zip_reduce.h
@@ -45,14 +45,20 @@ struct reduce_stream_data
 };
 
 /**
+ * Allocate an expanding stream.
+ */
+static inline struct zip_stream_data *reduce_ex_create(void)
+{
+  return cmalloc(sizeof(struct reduce_stream_data));
+}
+
+/**
  * Open an expanding stream.
  */
 static inline void reduce_ex_open(struct zip_stream_data *zs, uint16_t method,
  uint16_t flags)
 {
   struct reduce_stream_data *rs = ((struct reduce_stream_data *)zs);
-
-  assert(ZIP_STREAM_DATA_ALLOC_SIZE >= sizeof(struct reduce_stream_data));
   memset(zs, 0, sizeof(struct reduce_stream_data));
   rs->factor = CLAMP((method - 2), 0, 3);
 }

--- a/src/io/zip_shrink.h
+++ b/src/io/zip_shrink.h
@@ -290,6 +290,14 @@ static inline enum zip_error LZW_decode(struct LZW_tree *tree, uint16_t code,
 }
 
 /**
+ * Allocate an unshrink stream.
+ */
+static inline struct zip_stream_data *unshrink_create(void)
+{
+  return cmalloc(sizeof(struct shrink_stream_data));
+}
+
+/**
  * Open a unshrink stream.
  */
 static inline void unshrink_open(struct zip_stream_data *zs, uint16_t method,
@@ -299,7 +307,6 @@ static inline void unshrink_open(struct zip_stream_data *zs, uint16_t method,
   struct LZW_tree *tree = &(ss->tree);
   int i;
 
-  assert(ZIP_STREAM_DATA_ALLOC_SIZE >= sizeof(struct shrink_stream_data));
   memset(zs, 0, sizeof(struct shrink_stream_data));
 
   tree->nodes = cmalloc(LZW_TREE_ALLOC_DEFAULT * sizeof(struct LZW_node));

--- a/src/io/zip_stream.c
+++ b/src/io/zip_stream.c
@@ -36,6 +36,11 @@
 #endif
 
 #ifdef ZIP_EXTRA_DECOMPRESSORS
+static void zip_stream_destroy(struct zip_stream_data *zs)
+{
+  free(zs);
+}
+
 static void zip_stream_close(struct zip_stream_data *zs,
  size_t *final_input_length, size_t *final_output_length)
 {
@@ -68,6 +73,8 @@ static boolean zip_stream_output(struct zip_stream_data *zs, void *dest,
 
 static struct zip_method_handler shrink_spec =
 {
+  unshrink_create,
+  zip_stream_destroy,
   unshrink_open,
   NULL,
   unshrink_close,
@@ -80,6 +87,8 @@ static struct zip_method_handler shrink_spec =
 
 static struct zip_method_handler reduce_spec =
 {
+  reduce_ex_create,
+  zip_stream_destroy,
   reduce_ex_open,
   NULL,
   zip_stream_close,
@@ -92,6 +101,8 @@ static struct zip_method_handler reduce_spec =
 
 static struct zip_method_handler implode_spec =
 {
+  expl_create,
+  zip_stream_destroy,
   expl_open,
   NULL,
   expl_close,
@@ -104,6 +115,8 @@ static struct zip_method_handler implode_spec =
 
 static struct zip_method_handler deflate64_spec =
 {
+  inflate64_create,
+  zip_stream_destroy,
   inflate64_open,
   NULL,
   inflate64_close,
@@ -117,6 +130,8 @@ static struct zip_method_handler deflate64_spec =
 
 static struct zip_method_handler deflate_spec =
 {
+  deflate_create,
+  deflate_destroy,
   inflate_open,
   deflate_open,
   deflate_close,

--- a/src/io/zip_stream.h
+++ b/src/io/zip_stream.h
@@ -27,13 +27,18 @@ __M_BEGIN_DECLS
 #include <inttypes.h>
 #include "zip.h"
 
-#define MAX_SUPPORTED_METHOD ZIP_M_DEFLATE64
-
 /**
  * Describes ZIP stream functions for a particular (de)compresson method.
  */
 struct zip_method_handler
 {
+  // Create a stream data structure for this method handler.
+  struct zip_stream_data *(*create)(void);
+
+  // Destroy a stream data structure for this method handler.
+  // This function will free the provided zip_stream_data pointer.
+  void (*destroy)(struct zip_stream_data *);
+
   // Open a decompression stream.
   void (*decompress_open)(struct zip_stream_data *, uint16_t method,
    uint16_t flags);
@@ -42,7 +47,8 @@ struct zip_method_handler
   void (*compress_open)(struct zip_stream_data *, uint16_t method,
    uint16_t flags);
 
-  // Frees any memory allocated by the stream. Does not free the zip_stream.
+  // Frees any memory allocated by the stream and does any work necessary to
+  // reset the zip_stream_data struct for the next file, if applicable.
   void (*close)(struct zip_stream_data *, size_t *final_input_length,
    size_t *final_output_length);
 
@@ -69,7 +75,7 @@ struct zip_method_handler
  * ZIP stream function registry for supported (de)compression methods.
  */
 UTILS_LIBSPEC
-extern struct zip_method_handler *zip_method_handlers[MAX_SUPPORTED_METHOD + 1];
+extern struct zip_method_handler *zip_method_handlers[ZIP_M_MAX_SUPPORTED + 1];
 
 __M_END_DECLS
 


### PR DESCRIPTION
Instead of destroying and reallocating `zstream`s repeatedly when reading and writing ZIP files (particularly worlds/saves), the same `zstream` is now reused for every file in the archive. This should ~~moderately~~ slightly? improve saving and loading speeds for embedded platforms where this is a concern. This also gets rid of a pretty disgusting hack in the `zip_archive` struct.

- [x] More testing.
- [x] do something about that `unit/io/zip.cpp` macro garbage fire before merging