### PR TITLE
Add GLSL scaled software renderer 'glslscale'.

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -38,9 +38,9 @@
 # A much faster option for almost anything with a graphics card is the
 # "softscale" renderer. This renderer uses SDL2's built-in rendering API
 # to stream the output of the software renderer to a hardware-accelerated
-# texture (if available) for extremely fast scaling and display. This is
-# usually the fastest scaling renderer for devices using integrated graphics
-# (Intel HD, phones, tablets, Raspberry Pi).
+# texture (if available) for extremely fast scaling and display. This (or
+# "glslscale", see below) is usually the fastest scaling renderer for devices
+# using integrated graphics e.g. Intel HD, phones, tablets, Raspberry Pi.
 #
 # Either 32 bit or 16 bit rendering can be enabled (see force_bpp), but
 # 32 bit is recommended. Nearest neighbor or linear scaling will be chosen
@@ -87,13 +87,19 @@
 # This renderer uses GLSL shaders to render and scale the screen, and several
 # different scaling shaders can be selected at runtime using the settings menu.
 # This renderer is called "glsl". It is the highest quality and best performing
-# renderer for most PCs and games, and is enabled by default.
+# renderer for most PCs with a dedicated video card.
+#
+# A variant of the GLSL renderer called "glslscale" is available that uses the
+# software renderer internally with GLSL shader scaling. This performs better
+# than the original GLSL renderer on PCs and other devices that don't have a
+# video card, and is currently the default renderer for most platforms.
 #
 # Uncomment ONE of the lines below:
 
 # video_output = opengl1
 # video_output = opengl2
 # video_output = glsl
+# video_output = glslscale
 
 # The scaling renderers can be configured to preserve aspect ratio where
 # possible in window and fullscreen modes. The supported ratios are

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -2,6 +2,12 @@ GIT
 
 USERS
 
++ Added the "glslscale" renderer. This is the same as the GLSL
+  renderer, but uses software rendering with scaling shaders
+  instead of hardware rendering. This is faster on low end PCs
+  and embedded devices and is the new default renderer selected
+  by auto_glsl. (Hardware rendered GLSL is still available for
+  users with graphics cards by selecting the "glsl" renderer.)
 + Added robot editor undo (Ctrl+Z) and redo (Ctrl+Y). Like with
   board/vlayer/charset editing, the size of the undo stack is
   defined by the config setting "undo_history_size". Note that
@@ -126,7 +132,7 @@ USERS
   provided by the OpenGL ES driver. If highp is unavailable and
   mediump has inadequate precision, MZX will print a warning.
 + Enabled the GLSL renderer for the Android port. The Android
-  port will still use the softscale renderer by default.
+  port now uses the GLSL scaled software renderer by default.
 - Removed GL4ES from the GLSL blacklist.
 - Removed 3DS CIA support. (asie)
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -238,6 +238,7 @@ endif
 # Shader renderers (OGL>=2, OGLES=2)
 ifeq (${BUILD_RENDER_GL_PROGRAM},1)
 core_cobjs += ${core_obj}/render_glsl.o
+render_layer_software = 1
 endif
 
 #

--- a/src/configure.c
+++ b/src/configure.c
@@ -89,7 +89,6 @@
 
 #ifdef ANDROID
 #define FULLSCREEN_DEFAULT 1
-#define VIDEO_OUTPUT_DEFAULT "softscale"
 #endif
 
 #ifdef __EMSCRIPTEN__

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -75,6 +75,7 @@ static const struct renderer_data renderers[] =
 #endif
 #if defined(CONFIG_RENDER_GL_PROGRAM)
   { "glsl", render_glsl_register },
+  { "glslscale", render_glsl_software_register },
   { "auto_glsl", render_auto_glsl_register },
 #endif
 #if defined(CONFIG_RENDER_YUV)

--- a/src/render_glsl.c
+++ b/src/render_glsl.c
@@ -926,7 +926,7 @@ static boolean glsl_set_video_mode(struct graphics_data *graphics,
       if(range[0] <= 11 || precision <= 10)
       {
         warn("poor medium float precision! "
-         "This renderer may look bad; use \"softscale\" instead.\n");
+         "This renderer may look bad; use \"glslscale\" or \"softscale\" instead.\n");
       }
     }
   }

--- a/src/render_glsl.c
+++ b/src/render_glsl.c
@@ -1419,18 +1419,21 @@ static void glsl_sync_screen(struct graphics_data *graphics)
      GL_RGBA, GL_UNSIGNED_BYTE, render_data->pixels);
     gl_check_error();
   }
+  else
 
-  // If FBOs are enabled, the screen was directly drawn to the screen texture
-  // and the window framebuffer needs to be selected. Otherwise, copy the
-  // screen off of the window framebuffer to the screen texture.
   if(!glsl.has_fbo)
   {
+    // If FBOs are enabled, the screen was rendered to the screen texture
+    // and nothing extra needs to be done here. If FBOs are not enabled, then
+    // the screen needs to be copied to the texture off the window framebuffer.
     glsl.glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 0, 0,
      GL_POWER_2_WIDTH, GL_POWER_2_HEIGHT, 0);
     gl_check_error();
   }
-  else
+
+  if(glsl.has_fbo)
   {
+    // Select the screen framebuffer to draw the scaled screen to.
     glsl.glBindFramebuffer(GL_FRAMEBUFFER, 0);
     gl_check_error();
   }

--- a/src/render_glsl.c
+++ b/src/render_glsl.c
@@ -854,6 +854,9 @@ static void glsl_debug_callback(GLenum source, GLenum type, GLuint id,
 static boolean glsl_set_video_mode(struct graphics_data *graphics,
  int width, int height, int depth, boolean fullscreen, boolean resize)
 {
+#ifdef CONFIG_GLES
+  struct glsl_render_data *render_data = graphics->render_data;
+#endif
   boolean load_fbo_syms = true;
 
   gl_set_attributes(graphics);

--- a/src/render_glsl.c
+++ b/src/render_glsl.c
@@ -829,7 +829,7 @@ static void glsl_resize_screen(struct graphics_data *graphics,
     gl_set_filter_method(CONFIG_GL_FILTER_NEAREST, glsl.glTexParameterf);
 
     glsl.glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, TEX_DATA_WIDTH, TEX_DATA_HEIGHT,
-    0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+     0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
     gl_check_error();
 
     glsl_remap_char_range(graphics, 0, FULL_CHARSET_SIZE);

--- a/src/renderers.h
+++ b/src/renderers.h
@@ -44,6 +44,7 @@ void render_gl2_register(struct renderer *renderer);
 #endif
 #if defined(CONFIG_RENDER_GL_PROGRAM)
 void render_glsl_register(struct renderer *renderer);
+void render_glsl_software_register(struct renderer *renderer);
 void render_auto_glsl_register(struct renderer *renderer);
 #endif
 #if defined(CONFIG_RENDER_YUV)


### PR DESCRIPTION
Adds a GLSL renderer variant that uses software rendering internally instead of hardware rendering and makes it the new default renderer. This variant is better suited to lower end machines and embedded platforms.

- [x] More testing.

### Results (these mostly line up with prior `softscale` testing):

`glsl` performs better than `glslscale` for:
* desktop dedicated video.
* laptop dedicated video.
* Mobile integrated graphics on very simple screens (no or few layers).

`glslscale` performs better than `glsl` for:
* Mobile integrated graphics with more complex screens. `glsl` is extremely slow here but software-based renderers like `glslscale` run great. sai.frag noticeably slower.
* Mac Mini AMD integrated graphics.
* iMac (Core Duo, Snow Leopard) ATI Radeon X1600 gets `glslscale` performance comparable to `softscale` even using sai.frag.
* Laptop Intel HD video in cases where software layer renderer optimizations work well, similar performance otherwise.
* LLVMPipe and likely other Mesa software renderers.
* qemu-system-ppc (took much less time to get a single Software Rasterizer output frame than `glsl` anyway).