### PR TITLE
Add a force_bpp setting for automatic BPP selection.

### DIFF
--- a/arch/3ds/render.cpp
+++ b/arch/3ds/render.cpp
@@ -520,12 +520,6 @@ static void ctr_free_video(struct graphics_data *graphics)
   C3D_Fini();
 }
 
-static boolean ctr_check_video_mode(struct graphics_data *graphics, int width,
- int height, int depth, boolean fullscreen, boolean resize)
-{
-  return true;
-}
-
 static boolean ctr_set_video_mode(struct graphics_data *graphics, int width,
  int height, int depth, boolean fullscreen, boolean resize)
 {
@@ -1205,7 +1199,6 @@ void render_ctr_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = ctr_init_video;
   renderer->free_video = ctr_free_video;
-  renderer->check_video_mode = ctr_check_video_mode;
   renderer->set_video_mode = ctr_set_video_mode;
   renderer->update_colors = ctr_update_colors;
   renderer->resize_screen = resize_screen_standard;

--- a/arch/3ds/render.cpp
+++ b/arch/3ds/render.cpp
@@ -376,6 +376,7 @@ static boolean ctr_init_video(struct graphics_data *graphics,
  struct config_info *conf)
 {
   static struct ctr_render_data render_data;
+  Uint32 bits_per_pixel = 16;
 
 #ifdef RDR_DEBUG
   consoleInit(GFX_TOP, NULL);
@@ -391,8 +392,11 @@ static boolean ctr_init_video(struct graphics_data *graphics,
   render_data.rendering_frame = false;
   render_data.checked_frame = false;
 
+  if(conf->force_bpp == 32)
+    bits_per_pixel = conf->force_bpp;
+
   // 1024x512 is the smallest power of two texture which can fit a 640x350 playfield
-  if (conf->force_bpp == 32)
+  if(bits_per_pixel == 32)
     C3D_TexInitVRAM(&render_data.playfield_tex, 1024, 512, GPU_RGBA8);
   else
     C3D_TexInitVRAM(&render_data.playfield_tex, 1024, 512, GPU_RGB565);
@@ -484,7 +488,7 @@ static boolean ctr_init_video(struct graphics_data *graphics,
   C3D_DepthTest(false, GPU_GEQUAL, GPU_WRITE_ALL);
 
   graphics->allow_resize = 0;
-  graphics->bits_per_pixel = 32;
+  graphics->bits_per_pixel = bits_per_pixel;
 
   graphics->resolution_width = 640;
   graphics->resolution_height = 350;

--- a/arch/nds/render.c
+++ b/arch/nds/render.c
@@ -433,12 +433,6 @@ static boolean nds_init_video(struct graphics_data *graphics,
   return true;
 }
 
-static boolean nds_check_video_mode(struct graphics_data *graphics,
- int width, int height, int depth, boolean fullscreen, boolean resize)
-{
-  return true;  // stub
-}
-
 static boolean nds_set_video_mode(struct graphics_data *graphics,
  int width, int height, int depth, boolean fullscreen, boolean resize)
 {
@@ -834,7 +828,6 @@ void render_nds_register(struct renderer *renderer)
 {
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = nds_init_video;
-  renderer->check_video_mode = nds_check_video_mode;
   renderer->set_video_mode = nds_set_video_mode;
   renderer->update_colors = nds_update_colors;
   renderer->resize_screen = nds_resize_screen;

--- a/arch/nds/render.c
+++ b/arch/nds/render.c
@@ -429,6 +429,7 @@ static boolean nds_init_video(struct graphics_data *graphics,
   // Now that we're initialized, install the vblank handler.
   irqSet(IRQ_VBLANK, nds_on_vblank);
 
+  graphics->bits_per_pixel = 8;
   return true;
 }
 

--- a/arch/wii/render_gx.c
+++ b/arch/wii/render_gx.c
@@ -379,12 +379,6 @@ static void gx_free_video(struct graphics_data *graphics)
   graphics->render_data = NULL;
 }
 
-static boolean gx_check_video_mode(struct graphics_data *graphics,
- int width, int height, int depth, boolean fullscreen, boolean resize)
-{
-  return true;
-}
-
 static boolean gx_set_video_mode(struct graphics_data *graphics,
  int width, int height, int depth, boolean fullscreen, boolean resize)
 {
@@ -965,7 +959,6 @@ void render_gx_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = gx_init_video;
   renderer->free_video = gx_free_video;
-  renderer->check_video_mode = gx_check_video_mode;
   renderer->set_video_mode = gx_set_video_mode;
   renderer->update_colors = gx_update_colors;
   renderer->resize_screen = resize_screen_standard;

--- a/arch/wii/render_gx.c
+++ b/arch/wii/render_gx.c
@@ -276,6 +276,7 @@ static boolean gx_init_video(struct graphics_data *graphics,
   graphics->render_data = render_data;
   graphics->ratio = conf->video_ratio;
   graphics->gl_vsync = conf->gl_vsync;
+  graphics->bits_per_pixel = 16;
 
   VIDEO_Init();
 

--- a/arch/wii/render_xfb.c
+++ b/arch/wii/render_xfb.c
@@ -81,6 +81,7 @@ static boolean xfb_init_video(struct graphics_data *graphics,
   render_data = cmalloc(sizeof(struct xfb_render_data));
   graphics->render_data = render_data;
   graphics->ratio = conf->video_ratio;
+  graphics->bits_per_pixel = 16;
 
   VIDEO_Init();
 

--- a/arch/wii/render_xfb.c
+++ b/arch/wii/render_xfb.c
@@ -128,12 +128,6 @@ static void xfb_free_video(struct graphics_data *graphics)
   graphics->render_data = NULL;
 }
 
-static boolean xfb_check_video_mode(struct graphics_data *graphics,
- int width, int height, int depth, boolean fullscreen, boolean resize)
-{
-  return true;
-}
-
 static boolean xfb_set_video_mode(struct graphics_data *graphics,
  int width, int height, int depth, boolean fullscreen, boolean resize)
 {
@@ -371,7 +365,6 @@ void render_xfb_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = xfb_init_video;
   renderer->free_video = xfb_free_video;
-  renderer->check_video_mode = xfb_check_video_mode;
   renderer->set_video_mode = xfb_set_video_mode;
   renderer->update_colors = xfb_update_colors;
   renderer->resize_screen = resize_screen_standard;

--- a/config.txt
+++ b/config.txt
@@ -173,11 +173,18 @@
 # MZX is limited internally to 8bit colour, but it can upmix its
 # rendering to 32bit if your video card has difficulty with 8bit
 # resolutions. Using 32bit colour is slower, but not by much.
-# NOTE: This option may be ignored by one or more of the above
-# renderers, but it is guaranteed to apply to "software". Valid
-# settings are usually '8', '16', or '32'. Default is '32'.
+#
+# NOTE: This option may be ignored by one or more of the above renderers.
+# force_bpp is guaranteed to apply to "software". This might not always be
+# useful, however; SDL 2 picks a native window pixel format automatically
+# and non-native BPPs are handled with an extra surface blit. The "softscale"
+# renderer can use this setting to select different native pixel formats.
+#
+# Valid settings are usually '8', '16', or '32'; a value of '0' or 'auto'
+# will instruct the renderer to automatically pick the best available
+# BPP (if applicable). Default is 'auto'.
 
-# force_bpp = 32
+# force_bpp = auto
 
 # Whether MZX should start up in fullscreen or not.
 # Press ctrl-alt-enter to toggle fullscreen as MZX runs.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -137,6 +137,9 @@ USERS
   mediump has inadequate precision, MZX will print a warning.
 + Enabled the GLSL renderer for the Android port. The Android
   port now uses the GLSL scaled software renderer by default.
++ Fixed software renderer display issues caused by relying on
+  SDL_PixelFormat::BitsPerPixel instead of BytesPerPixel on
+  platforms with native 15 BPP display modes.
 - Removed GL4ES from the GLSL blacklist.
 - Removed 3DS CIA support. (asie)
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -8,6 +8,10 @@ USERS
   and embedded devices and is the new default renderer selected
   by auto_glsl. (Hardware rendered GLSL is still available for
   users with graphics cards by selecting the "glsl" renderer.)
++ Added an "auto" mode for the force_bpp config option. Modern
+  SDL automatically selects a native window pixel format and a
+  fixed value can make the software renderer slower. Detecting
+  the BPP from the created window is more in line with reality.
 + Added robot editor undo (Ctrl+Z) and redo (Ctrl+Y). Like with
   board/vlayer/charset editing, the size of the undo stack is
   defined by the config setting "undo_history_size". Note that

--- a/src/configure.c
+++ b/src/configure.c
@@ -71,7 +71,8 @@
 #define VIDEO_OUTPUT_DEFAULT "software"
 #define FULLSCREEN_WIDTH_DEFAULT 640
 #define FULLSCREEN_HEIGHT_DEFAULT 480
-#endif
+#define FORCE_BPP_DEFAULT 16
+#endif /* CONFIG_SDL */
 #endif
 
 #ifdef CONFIG_3DS

--- a/src/configure.c
+++ b/src/configure.c
@@ -71,12 +71,10 @@
 #define VIDEO_OUTPUT_DEFAULT "software"
 #define FULLSCREEN_WIDTH_DEFAULT 640
 #define FULLSCREEN_HEIGHT_DEFAULT 480
-#define FORCE_BPP_DEFAULT 16
 #endif
 #endif
 
 #ifdef CONFIG_3DS
-#define FORCE_BPP_DEFAULT 16
 #define VIDEO_RATIO_DEFAULT RATIO_CLASSIC_4_3
 #endif
 
@@ -98,7 +96,7 @@
 // End arch-specific config.
 
 #ifndef FORCE_BPP_DEFAULT
-#define FORCE_BPP_DEFAULT 32
+#define FORCE_BPP_DEFAULT BPP_AUTO
 #endif
 
 #ifndef GL_VSYNC_DEFAULT
@@ -282,9 +280,11 @@ static const struct config_enum allow_cheats_values[] =
 
 static const struct config_enum force_bpp_values[] =
 {
+  { "0", BPP_AUTO },
   { "8", 8 },
   { "16", 16 },
-  { "32", 32 }
+  { "32", 32 },
+  { "auto", BPP_AUTO },
 };
 
 static const struct config_enum gl_filter_method_values[] =

--- a/src/configure.h
+++ b/src/configure.h
@@ -34,6 +34,11 @@ enum config_type
   NUM_CONFIG_TYPES
 };
 
+enum force_bpp_special
+{
+  BPP_AUTO = 0,
+};
+
 enum ratio_type
 {
   RATIO_CLASSIC_4_3,

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1801,6 +1801,13 @@ boolean set_video_mode(void)
     set_window_caption(graphics.default_caption);
     set_window_grab(graphics.grab_mouse);
     set_window_icon();
+
+    // Make sure a BPP was selected by the renderer (if applicable).
+    if(graphics.bits_per_pixel == BPP_AUTO)
+    {
+      warn("renderer.check_video_mode or renderer.set_video_mode must "
+       "auto-select BPP! Report this!\n");
+    }
   }
 
   return ret;

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -105,8 +105,6 @@ struct renderer
 {
   boolean (*init_video)       (struct graphics_data *, struct config_info *);
   void    (*free_video)       (struct graphics_data *);
-  boolean (*check_video_mode) (struct graphics_data *, int width, int height,
-                                int depth, boolean fullscreen, boolean resize);
   boolean (*set_video_mode)   (struct graphics_data *, int width, int height,
                                 int depth, boolean fullscreen, boolean resize);
   void    (*update_colors)    (struct graphics_data *, struct rgb_color *palette,

--- a/src/old/render_sdl2accel.c
+++ b/src/old/render_sdl2accel.c
@@ -567,7 +567,6 @@ void render_sdl2accel_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = sdl2_init_video;
   renderer->free_video = sdl2_free_video;
-  renderer->check_video_mode = sdl_check_video_mode;
   renderer->set_video_mode = sdl2_set_video_mode;
   renderer->update_colors = sdl2_update_colors;
   renderer->resize_screen = resize_screen_standard;

--- a/src/render_egl.c
+++ b/src/render_egl.c
@@ -136,7 +136,7 @@ boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
   if(egl_render_data->native_display == NULL)
   {
     warn("XOpenDisplay failed\n");
-    return
+    return false;
   }
 
   window = XCreateSimpleWindow(egl_render_data->native_display,

--- a/src/render_egl.c
+++ b/src/render_egl.c
@@ -126,11 +126,19 @@ boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
   struct egl_render_data *egl_render_data = graphics->render_data;
   const EGLint *attribs = gles_v1_attribs;
   EGLNativeWindowType window = 0;
+  EGLint num_configs;
   EGLint w, h;
 
   assert(egl_render_data != NULL);
 
 #ifdef CONFIG_X11
+  egl_render_data->native_display = XOpenDisplay(NULL);
+  if(egl_render_data->native_display == NULL)
+  {
+    warn("XOpenDisplay failed\n");
+    return
+  }
+
   window = XCreateSimpleWindow(egl_render_data->native_display,
                                RootWindow(egl_render_data->native_display, 0),
                                0, 0, 640, 350, 0,
@@ -139,6 +147,27 @@ boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
   XMapWindow(egl_render_data->native_display, window);
   XFlush(egl_render_data->native_display);
 #endif
+
+  egl_render_data->display = eglGetDisplay(egl_render_data->native_display);
+  if(egl_render_data->display == EGL_NO_DISPLAY)
+  {
+    warn("eglGetDisplay failed\n");
+    return false;
+  }
+
+  if(!eglInitialize(egl_render_data->display, NULL, NULL))
+  {
+    warn("eglInitialize failed\n");
+    return false;
+  }
+
+  if(!eglChooseConfig(egl_render_data->display,
+                      get_current_config(depth),
+                      &egl_render_data->config, 1, &num_configs))
+  {
+    warn("eglChooseConfig failed\n");
+    return false;
+  }
 
   egl_render_data->surface = eglCreateWindowSurface(egl_render_data->display,
                                                     egl_render_data->config,
@@ -207,42 +236,6 @@ err_cleanup:
   return false;
 }
 
-boolean gl_check_video_mode(struct graphics_data *graphics, int width,
- int height, int depth, boolean fullscreen, boolean resize)
-{
-  struct egl_render_data *egl_render_data = graphics->render_data;
-  EGLint num_configs;
-
-  assert(egl_render_data != NULL);
-
-#ifdef CONFIG_X11
-  egl_render_data->native_display = XOpenDisplay(NULL);
-#endif
-
-  egl_render_data->display = eglGetDisplay(egl_render_data->native_display);
-  if(egl_render_data->display == EGL_NO_DISPLAY)
-  {
-    warn("eglGetDisplay failed\n");
-    return false;
-  }
-
-  if(!eglInitialize(egl_render_data->display, NULL, NULL))
-  {
-    warn("eglInitialize failed\n");
-    return false;
-  }
-
-  if(!eglChooseConfig(egl_render_data->display,
-                      get_current_config(depth),
-                      &egl_render_data->config, 1, &num_configs))
-  {
-    warn("eglChooseConfig failed\n");
-    return false;
-  }
-
-  return true;
-}
-
 void gl_set_attributes(struct graphics_data *graphics)
 {
   // Note that this function is called twice- both before and after
@@ -297,7 +290,10 @@ void gl_cleanup(struct graphics_data *graphics)
   }
 
 #ifdef CONFIG_X11
-  XCloseDisplay(egl_render_data->native_display);
-  egl_render_data->native_display = 0;
+  if(egl_render_data->native_display)
+  {
+    XCloseDisplay(egl_render_data->native_display);
+    egl_render_data->native_display = NULL;
+  }
 #endif
 }

--- a/src/render_egl.h
+++ b/src/render_egl.h
@@ -30,8 +30,6 @@ __M_BEGIN_DECLS
 
 boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
  int depth, boolean fullscreen, boolean resize, struct gl_version req_ver);
-boolean gl_check_video_mode(struct graphics_data *graphics, int width,
- int height, int depth, boolean fullscreen, boolean resize);
 void gl_set_attributes(struct graphics_data *graphics);
 boolean gl_swap_buffers(struct graphics_data *graphics);
 void gl_cleanup(struct graphics_data *graphics);

--- a/src/render_gl1.c
+++ b/src/render_gl1.c
@@ -357,7 +357,6 @@ void render_gl1_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = gl1_init_video;
   renderer->free_video = gl1_free_video;
-  renderer->check_video_mode = gl_check_video_mode;
   renderer->set_video_mode = gl1_set_video_mode;
   renderer->update_colors = gl1_update_colors;
   renderer->resize_screen = gl1_resize_screen;

--- a/src/render_gl2.c
+++ b/src/render_gl2.c
@@ -1018,7 +1018,6 @@ void render_gl2_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = gl2_init_video;
   renderer->free_video = gl2_free_video;
-  renderer->check_video_mode = gl_check_video_mode;
   renderer->set_video_mode = gl2_set_video_mode;
   renderer->update_colors = gl2_update_colors;
   renderer->resize_screen = resize_screen_standard;

--- a/src/render_glsl.c
+++ b/src/render_glsl.c
@@ -1557,7 +1557,6 @@ void render_glsl_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = glsl_init_video;
   renderer->free_video = glsl_free_video;
-  renderer->check_video_mode = gl_check_video_mode;
   renderer->set_video_mode = glsl_set_video_mode;
   renderer->update_colors = glsl_update_colors;
   renderer->resize_screen = resize_screen_standard;

--- a/src/render_glsl.c
+++ b/src/render_glsl.c
@@ -1317,8 +1317,6 @@ static void glsl_render_cursor(struct graphics_data *graphics,
     return;
   }
 
-  glsl.glDisable(GL_TEXTURE_2D);
-
   glsl.glUseProgram(render_data->cursor_program);
   gl_check_error();
 
@@ -1420,6 +1418,8 @@ static void glsl_sync_screen(struct graphics_data *graphics)
     // Stream it to the screen texture.
     glsl.glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, SCREEN_PIX_W, SCREEN_PIX_H,
      GL_RGBA, GL_UNSIGNED_BYTE, render_data->pixels);
+    width = SCREEN_PIX_W;
+    height = SCREEN_PIX_H;
     gl_check_error();
   }
   else

--- a/src/render_gp2x.c
+++ b/src/render_gp2x.c
@@ -366,7 +366,6 @@ void render_gp2x_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = gp2x_init_video;
   renderer->free_video = gp2x_free_video;
-  renderer->check_video_mode = sdl_check_video_mode;
   renderer->set_video_mode = gp2x_set_video_mode;
   renderer->update_colors = gp2x_update_colors;
   renderer->resize_screen = resize_screen_standard;

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -141,8 +141,10 @@ Uint32 sdl_pixel_format_priority(Uint32 pixel_format, Uint32 bits_per_pixel,
       break;
     }
 
-    case SDL_PIXELFORMAT_RGB444:
+#if SDL_VERSION_ATLEAST(2,0,12)
     case SDL_PIXELFORMAT_BGR444:
+#endif
+    case SDL_PIXELFORMAT_RGB444:
     case SDL_PIXELFORMAT_ARGB4444:
     case SDL_PIXELFORMAT_RGBA4444:
     case SDL_PIXELFORMAT_ABGR4444:

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -430,7 +430,10 @@ boolean sdl_check_video_mode(struct graphics_data *graphics, int width,
    sdl_flags(depth, fullscreen, false, resize));
 
   if(depth == BPP_AUTO && out_depth > 0)
+  {
+    debug("SDL_VideoModeOK recommends BPP=%d\n", out_depth);
     graphics->bits_per_pixel = out_depth;
+  }
 
   return !!out_depth;
 #endif

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -326,7 +326,7 @@ boolean sdl_set_video_mode(struct graphics_data *graphics, int width,
    */
 
   fmt = SDL_GetWindowPixelFormat(render_data->window);
-  debug("Window pixel format is: %s\n", SDL_GetPixelFormatName(fmt));
+  debug("Window pixel format: %s\n", SDL_GetPixelFormatName(fmt));
 
   if(!sdl_pixel_format_priority(fmt, depth, true))
   {
@@ -346,6 +346,8 @@ boolean sdl_set_video_mode(struct graphics_data *graphics, int width,
   }
   else
     matched = true;
+
+  debug("Using pixel format: %s\n", SDL_GetPixelFormatName(fmt));
 
   if(depth == BPP_AUTO)
     graphics->bits_per_pixel = SDL_BYTESPERPIXEL(fmt) * 8;

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -394,10 +394,6 @@ boolean sdl_set_video_mode(struct graphics_data *graphics, int width,
 
 #else // !SDL_VERSION_ATLEAST(2,0,0)
 
-  // If SDL_VideoModeOK failed to select a BPP, just force 32-bit.
-  if(depth == BPP_AUTO)
-    graphics->bits_per_pixel = depth = 32;
-
   render_data->screen = SDL_SetVideoMode(width, height, depth,
    sdl_flags(depth, fullscreen, false, resize));
 
@@ -429,10 +425,20 @@ boolean sdl_check_video_mode(struct graphics_data *graphics, int width,
   out_depth = SDL_VideoModeOK(width, height, in_depth,
    sdl_flags(depth, fullscreen, false, resize));
 
-  if(depth == BPP_AUTO && out_depth > 0)
+  if(depth == BPP_AUTO)
   {
-    debug("SDL_VideoModeOK recommends BPP=%d\n", out_depth);
-    graphics->bits_per_pixel = out_depth;
+    if(out_depth == 8 || out_depth == 16 || out_depth == 32)
+    {
+      debug("SDL_VideoModeOK recommends BPP=%d\n", out_depth);
+      graphics->bits_per_pixel = out_depth;
+    }
+    else
+
+    if(out_depth > 0)
+    {
+      debug("SDL_VideoModeOK recommends unsupported BPP=%d; using 32bpp\n", out_depth);
+      graphics->bits_per_pixel = 32;
+    }
   }
 
   return !!out_depth;

--- a/src/render_sdl.h
+++ b/src/render_sdl.h
@@ -63,9 +63,6 @@ void sdl_destruct_window(struct graphics_data *graphics);
 boolean sdl_set_video_mode(struct graphics_data *graphics, int width,
  int height, int depth, boolean fullscreen, boolean resize);
 
-boolean sdl_check_video_mode(struct graphics_data *graphics, int width,
- int height, int depth, boolean fullscreen, boolean resize);
-
 #if defined(CONFIG_RENDER_GL_FIXED) || defined(CONFIG_RENDER_GL_PROGRAM)
 
 #include "render_gl.h"
@@ -82,8 +79,6 @@ boolean sdl_check_video_mode(struct graphics_data *graphics, int width,
 
 boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
  int depth, boolean fullscreen, boolean resize, struct gl_version req_ver);
-boolean gl_check_video_mode(struct graphics_data *graphics, int width,
- int height, int depth, boolean fullscreen, boolean resize);
 void gl_set_attributes(struct graphics_data *graphics);
 boolean gl_swap_buffers(struct graphics_data *graphics);
 

--- a/src/render_sdl.h
+++ b/src/render_sdl.h
@@ -63,6 +63,12 @@ void sdl_destruct_window(struct graphics_data *graphics);
 boolean sdl_set_video_mode(struct graphics_data *graphics, int width,
  int height, int depth, boolean fullscreen, boolean resize);
 
+#if !SDL_VERSION_ATLEAST(2,0,0)
+// Used internally only.
+boolean sdl_check_video_mode(struct graphics_data *graphics, int width,
+ int height, int *depth, int flags);
+#endif
+
 #if defined(CONFIG_RENDER_GL_FIXED) || defined(CONFIG_RENDER_GL_PROGRAM)
 
 #include "render_gl.h"

--- a/src/render_sdl.h
+++ b/src/render_sdl.h
@@ -43,11 +43,21 @@ struct sdl_render_data
   SDL_Surface *shadow;
 };
 
+#ifdef __MACOSX__
+// Mac OS X has a special OpenGL YCbCr native texture mode which is
+// faster than RGB for older machines.
+#define YUV_PRIORITY 1000000
+#else
+#define YUV_PRIORITY 422
+#endif
+
 extern CORE_LIBSPEC Uint32 sdl_window_id;
 
 int sdl_flags(int depth, boolean fullscreen, boolean fullscreen_windowed,
  boolean resize);
 boolean sdl_get_fullscreen_resolution(int *width, int *height, boolean scaling);
+Uint32 sdl_pixel_format_priority(Uint32 pixel_format,  Uint32 bits_per_pixel,
+ boolean force_rgb);
 void sdl_destruct_window(struct graphics_data *graphics);
 
 boolean sdl_set_video_mode(struct graphics_data *graphics, int width,

--- a/src/render_soft.c
+++ b/src/render_soft.c
@@ -257,7 +257,6 @@ void render_soft_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = soft_init_video;
   renderer->free_video = soft_free_video;
-  renderer->check_video_mode = sdl_check_video_mode;
   renderer->set_video_mode = sdl_set_video_mode;
   renderer->update_colors = soft_update_colors;
   renderer->resize_screen = resize_screen_standard;

--- a/src/render_soft.c
+++ b/src/render_soft.c
@@ -114,7 +114,7 @@ static void soft_render_graph(struct graphics_data *graphics)
 
   Uint32 *pixels = (Uint32 *)screen->pixels;
   Uint32 pitch = screen->pitch;
-  Uint32 bpp = screen->format->BitsPerPixel;
+  Uint32 bpp = screen->format->BytesPerPixel * 8;
   Uint32 mode = graphics->screen_mode;
 
   pixels += pitch * ((screen->h - 350) / 8);
@@ -166,7 +166,7 @@ static void soft_render_cursor(struct graphics_data *graphics,
 
   Uint32 *pixels = (Uint32 *)screen->pixels;
   Uint32 pitch = screen->pitch;
-  Uint32 bpp = screen->format->BitsPerPixel;
+  Uint32 bpp = screen->format->BytesPerPixel * 8;
   Uint32 flatcolor;
 
   pixels += pitch * ((screen->h - 350) / 8);
@@ -198,7 +198,7 @@ static void soft_render_mouse(struct graphics_data *graphics,
 
   Uint32 *pixels = (Uint32 *)screen->pixels;
   Uint32 pitch = screen->pitch;
-  Uint32 bpp = screen->format->BitsPerPixel;
+  Uint32 bpp = screen->format->BytesPerPixel * 8;
   Uint32 mask, amask;
 
   pixels += pitch * ((screen->h - 350) / 8);
@@ -242,7 +242,7 @@ static void soft_render_layer(struct graphics_data *graphics,
 
   Uint32 *pixels = (Uint32 *)screen->pixels;
   Uint32 pitch = screen->pitch;
-  Uint32 bpp = screen->format->BitsPerPixel;
+  Uint32 bpp = screen->format->BytesPerPixel * 8;
 
   pixels += pitch * ((screen->h - 350) / 8);
   pixels += (screen->w - 640) * bpp / 64;

--- a/src/render_soft.c
+++ b/src/render_soft.c
@@ -57,7 +57,8 @@ static boolean soft_init_video(struct graphics_data *graphics,
     graphics->window_height = 350;
 
   // We have 8-bit, 16-bit, and 32-bit software renderers
-  if(conf->force_bpp == 8 || conf->force_bpp == 16 || conf->force_bpp == 32)
+  if(conf->force_bpp == BPP_AUTO || conf->force_bpp == 8 ||
+   conf->force_bpp == 16 || conf->force_bpp == 32)
     graphics->bits_per_pixel = conf->force_bpp;
 
   return set_video_mode();
@@ -121,10 +122,18 @@ static void soft_render_graph(struct graphics_data *graphics)
 
   SDL_LockSurface(screen);
   if(bpp == 8)
+  {
     render_graph8((Uint8 *)pixels, pitch, graphics, set_colors8[mode]);
-  else if(bpp == 16)
+  }
+  else
+
+  if(bpp == 16)
+  {
     render_graph16((Uint16 *)pixels, pitch, graphics, set_colors16[mode]);
-  else if(bpp == 32)
+  }
+  else
+
+  if(bpp == 32)
   {
     if(!mode)
       render_graph32(pixels, pitch, graphics);
@@ -224,7 +233,6 @@ static void soft_sync_screen(struct graphics_data *graphics)
   SDL_Flip(render_data->screen);
 #endif
 }
-
 
 static void soft_render_layer(struct graphics_data *graphics,
  struct video_layer *layer)

--- a/src/render_softscale.c
+++ b/src/render_softscale.c
@@ -527,7 +527,6 @@ void render_softscale_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = softscale_init_video;
   renderer->free_video = softscale_free_video;
-  renderer->check_video_mode = sdl_check_video_mode;
   renderer->set_video_mode = softscale_set_video_mode;
   renderer->update_colors = softscale_update_colors;
   renderer->resize_screen = resize_screen_standard;

--- a/src/render_yuv.c
+++ b/src/render_yuv.c
@@ -55,6 +55,10 @@ static boolean yuv_set_video_mode_size(struct graphics_data *graphics,
 {
   struct yuv_render_data *render_data = graphics->render_data;
 
+  if(SDL_VideoModeOK(width, height, 32,
+   sdl_flags(depth, fullscreen, false, resize) | SDL_ANYFORMAT) <= 0)
+    return false;
+
   // the YUV renderer _requires_ 32bit colour
   render_data->sdl.screen = SDL_SetVideoMode(width, height, 32,
    sdl_flags(depth, fullscreen, false, resize) | SDL_ANYFORMAT);
@@ -148,13 +152,6 @@ static void yuv_free_video(struct graphics_data *graphics)
 
   free(graphics->render_data);
   graphics->render_data = NULL;
-}
-
-static boolean yuv_check_video_mode(struct graphics_data *graphics,
- int width, int height, int depth, boolean fullscreen, boolean resize)
-{
-  return SDL_VideoModeOK(width, height, 32,
-   sdl_flags(depth, fullscreen, false, resize) | SDL_ANYFORMAT);
 }
 
 static void yuv_update_colors(struct graphics_data *graphics,
@@ -283,7 +280,6 @@ void render_yuv1_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = yuv_init_video;
   renderer->free_video = yuv_free_video;
-  renderer->check_video_mode = yuv_check_video_mode;
   renderer->set_video_mode = yuv1_set_video_mode;
   renderer->update_colors = yuv_update_colors;
   renderer->resize_screen = resize_screen_standard;

--- a/src/render_yuv.c
+++ b/src/render_yuv.c
@@ -55,8 +55,8 @@ static boolean yuv_set_video_mode_size(struct graphics_data *graphics,
 {
   struct yuv_render_data *render_data = graphics->render_data;
 
-  if(SDL_VideoModeOK(width, height, 32,
-   sdl_flags(depth, fullscreen, false, resize) | SDL_ANYFORMAT) <= 0)
+  if(!sdl_check_video_mode(graphics, width, height, &depth,
+   sdl_flags(depth, fullscreen, false, resize) | SDL_ANYFORMAT))
     return false;
 
   // the YUV renderer _requires_ 32bit colour
@@ -132,6 +132,7 @@ static boolean yuv_init_video(struct graphics_data *graphics,
 
   memset(render_data, 0, sizeof(struct yuv_render_data));
 
+  graphics->bits_per_pixel = 32;
   graphics->render_data = render_data;
   graphics->allow_resize = conf->allow_resize;
   graphics->ratio = conf->video_ratio;

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -374,13 +374,15 @@ UNITTEST(Settings)
   {
     static const config_test_single data[] =
     {
+      { "0", BPP_AUTO },
       { "8", 8 },
       { "16", 16 },
       { "32", 32 },
+      { "auto", BPP_AUTO },
       { "-1", DEFAULT },
       { "231", DEFAULT },
-      { "0", DEFAULT },
       { "asdfsdf", DEFAULT },
+      { "autou", DEFAULT },
     };
     TEST_ENUM("force_bpp", conf->force_bpp, data);
   }


### PR DESCRIPTION
The `force_bpp` config setting doesn't really reflect the reality of the SDL 2 version of MZX's software renderer, which is that SDL picks a native window format internally and this can't really be changed. This branch adds an "auto" setting for `force_bpp` which makes MZX select the BPP value that SDL picked instead of the other way around. This should fix issues involving blitting being selected by default on platforms where the native pixel format is not RGB888 (encountered in m68k Linux via QEMU with a 16-bit display).

SDL 1.2 can also support the "auto" setting by using the `SDL_VideoModeOK` return value instead of ignoring it.

The nature of the way this is implemented means a renderer `init_video`, `check_video_mode`, or `set_video_mode` function should now always initialize `graphics->bits_per_pixel`. If `init_video` passes `BPP_AUTO` through to `graphics->bits_per_pixel`, this needs to be replaced with an actual BPP in `set_video_mode`.

- [x] More testing (SDL 2).
- [x] More testing (SDL 1.2).
- [x] More testing (EGL).
- [x] Testing (QEMU: m68k VM).
- [x] Testing (QEMU: other VMs that support <32-bit display modes).