### PR TITLE
Add experimental libmodplug GDM loader to replace gdm2s3m.

### DIFF
--- a/contrib/libmodplug/src/Makefile.in
+++ b/contrib/libmodplug/src/Makefile.in
@@ -21,17 +21,29 @@ libmodplug_cflags += -Wno-implicit-fallthrough
 endif
 
 libmodplug_objs = \
-    ${libmodplug_obj}/fastmix.o ${libmodplug_obj}/load_669.o \
-    ${libmodplug_obj}/load_amf.o ${libmodplug_obj}/load_dsm.o \
-    ${libmodplug_obj}/load_far.o ${libmodplug_obj}/load_it.o \
-    ${libmodplug_obj}/load_med.o ${libmodplug_obj}/load_mod.o \
-    ${libmodplug_obj}/load_mtm.o ${libmodplug_obj}/load_okt.o \
-    ${libmodplug_obj}/load_s3m.o ${libmodplug_obj}/load_stm.o \
-    ${libmodplug_obj}/load_ult.o ${libmodplug_obj}/load_wav.o \
-    ${libmodplug_obj}/load_xm.o ${libmodplug_obj}/mmcmp.o \
-    ${libmodplug_obj}/modplug.o ${libmodplug_obj}/snd_dsp.o \
-    ${libmodplug_obj}/sndfile.o ${libmodplug_obj}/snd_flt.o \
-    ${libmodplug_obj}/snd_fx.o ${libmodplug_obj}/sndmix.o
+    ${libmodplug_obj}/fastmix.o \
+    ${libmodplug_obj}/load_669.o \
+    ${libmodplug_obj}/load_amf.o \
+    ${libmodplug_obj}/load_dsm.o \
+    ${libmodplug_obj}/load_far.o \
+    ${libmodplug_obj}/load_gdm.o \
+    ${libmodplug_obj}/load_it.o \
+    ${libmodplug_obj}/load_med.o \
+    ${libmodplug_obj}/load_mod.o \
+    ${libmodplug_obj}/load_mtm.o \
+    ${libmodplug_obj}/load_okt.o \
+    ${libmodplug_obj}/load_s3m.o \
+    ${libmodplug_obj}/load_stm.o \
+    ${libmodplug_obj}/load_ult.o \
+    ${libmodplug_obj}/load_wav.o \
+    ${libmodplug_obj}/load_xm.o \
+    ${libmodplug_obj}/mmcmp.o \
+    ${libmodplug_obj}/modplug.o \
+    ${libmodplug_obj}/snd_dsp.o \
+    ${libmodplug_obj}/sndfile.o \
+    ${libmodplug_obj}/snd_flt.o \
+    ${libmodplug_obj}/snd_fx.o \
+    ${libmodplug_obj}/sndmix.o
 
 ${libmodplug_obj}/%.o: ${libmodplug_src}/%.cpp src/config.h
 	$(if ${V},,@echo "  CXX     " $<)

--- a/contrib/libmodplug/src/libmodplug/sndfile.h
+++ b/contrib/libmodplug/src/libmodplug/sndfile.h
@@ -71,6 +71,7 @@ typedef const BYTE * LPCBYTE;
 #define MOD_TYPE_J2B		0x800000
 #define MOD_TYPE_ABC		0x1000000
 #define MOD_TYPE_PAT		0x2000000
+#define MOD_TYPE_GDM		0x40000000 // Fake type
 #define MOD_TYPE_UMX		0x80000000 // Fake type
 #define MAX_MODTYPE		24
 
@@ -652,6 +653,7 @@ public:
 	BOOL ReadMT2(LPCBYTE lpStream, DWORD dwMemLength);
 	BOOL ReadPSM(LPCBYTE lpStream, DWORD dwMemLength);
 	BOOL ReadJ2B(LPCBYTE lpStream, DWORD dwMemLength);
+	BOOL ReadGDM(LPCBYTE lpStream, DWORD dwMemLength);
 	BOOL ReadUMX(LPCBYTE lpStream, DWORD dwMemLength);
 	BOOL ReadABC(LPCBYTE lpStream, DWORD dwMemLength);
 	BOOL TestABC(LPCBYTE lpStream, DWORD dwMemLength);

--- a/contrib/libmodplug/src/load_gdm.cpp
+++ b/contrib/libmodplug/src/load_gdm.cpp
@@ -246,11 +246,11 @@ BOOL CSoundFile::ReadGDM(const BYTE *lpStream, DWORD dwMemLength)
 	if (nOrders > MAX_ORDERS) nOrders = MAX_ORDERS;
 	if (nSamples >= MAX_SAMPLES) nSamples = MAX_SAMPLES - 1;
 
-	if ((ordersPos < sizeof(FILEHEADERGDM)) || (ordersPos + nOrders > dwMemLength) ||
-	 (patternsPos < sizeof(FILEHEADERGDM)) || (patternsPos > dwMemLength) ||
-	 (samplesPos < sizeof(FILEHEADERGDM)) || (samplesPos > dwMemLength) ||
+	if ((ordersPos < sizeof(FILEHEADERGDM)) || (ordersPos >= dwMemLength) || (ordersPos + nOrders > dwMemLength) ||
+	 (patternsPos < sizeof(FILEHEADERGDM)) || (patternsPos >= dwMemLength) ||
+	 (samplesPos < sizeof(FILEHEADERGDM)) || (samplesPos >= dwMemLength) ||
 	 (samplesPos + sizeof(SAMPLEGDM) * pfh->nSamples > dwMemLength) ||
-	 (sampleDataPos < sizeof(FILEHEADERGDM)) || (sampleDataPos > dwMemLength))
+	 (sampleDataPos < sizeof(FILEHEADERGDM)) || (sampleDataPos >= dwMemLength))
 		return FALSE;
 
 	// Most GDMs were converted from S3M and BWSB generally behaves like an S3M

--- a/contrib/libmodplug/src/load_gdm.cpp
+++ b/contrib/libmodplug/src/load_gdm.cpp
@@ -252,7 +252,7 @@ BOOL CSoundFile::ReadGDM(const BYTE *lpStream, DWORD dwMemLength)
 	if ((ordersPos < sizeof(FILEHEADERGDM)) || (ordersPos >= dwMemLength) || (ordersPos + nOrders > dwMemLength) ||
 	    (patternsPos < sizeof(FILEHEADERGDM)) || (patternsPos >= dwMemLength) ||
 	    (samplesPos < sizeof(FILEHEADERGDM)) || (samplesPos >= dwMemLength) ||
-	    (samplesPos + sizeof(SAMPLEGDM) * pfh->nSamples > dwMemLength) ||
+	    (samplesPos + sizeof(SAMPLEGDM) * nSamples > dwMemLength) ||
 	    (sampleDataPos < sizeof(FILEHEADERGDM)) || (sampleDataPos >= dwMemLength))
 		return FALSE;
 

--- a/contrib/libmodplug/src/load_gdm.cpp
+++ b/contrib/libmodplug/src/load_gdm.cpp
@@ -30,7 +30,7 @@ typedef struct tagFILEHEADERGDM
 	BYTE tracker_ver_minor;
 	BYTE panning[32];
 	BYTE globalvol;
-	BYTE default_tempo;
+	BYTE default_speed;
 	BYTE default_bpm;
 	BYTE origfmt[2];
 	BYTE ordersPos[4];
@@ -254,8 +254,8 @@ BOOL CSoundFile::ReadGDM(const BYTE *lpStream, DWORD dwMemLength)
 	m_nMinPeriod = 64;
 	m_nMaxPeriod = 32767;
 	m_nDefaultGlobalVolume = pfh->globalvol << 2;
-	m_nDefaultTempo = pfh->default_tempo;
-	m_nDefaultSpeed = pfh->default_bpm;
+	m_nDefaultTempo = pfh->default_bpm;
+	m_nDefaultSpeed = pfh->default_speed;
 	m_nChannels = 0;
 	m_nSamples = pfh->nSamples + 1;
 

--- a/contrib/libmodplug/src/load_gdm.cpp
+++ b/contrib/libmodplug/src/load_gdm.cpp
@@ -300,22 +300,20 @@ BOOL CSoundFile::ReadGDM(const BYTE *lpStream, DWORD dwMemLength)
 
 		UINT flags = smp.flags;
 
-		if (len > MAX_SAMPLE_LENGTH) len = MAX_SAMPLE_LENGTH;
-		if (loopend > len) loopend = len;
-		if (loopstart > loopend) loopstart = loopend = 0;
-
-		sflags[nins] = 0;
+		// Note: BWSB and 2GDM don't support LZW, stereo samples, sample panning.
 		if (flags & SAMPLEGDM::S_16BIT)
 		{
-			sflags[nins] |= RS_PCM16U;
+			sflags[nins] = RS_PCM16U;
 			// Due to a 2GDM bug, the sample size is halved.
 			// (Note BWSB doesn't even check for these anyway.)
 			len /= 2;
 		}
 		else
-			sflags[nins] |= RS_PCM8U;
+			sflags[nins] = RS_PCM8U;
 
-		// Note: BWSB and 2GDM don't support LZW, stereo samples, sample panning.
+		if (len > MAX_SAMPLE_LENGTH) len = MAX_SAMPLE_LENGTH;
+		if (loopend > len) loopend = len;
+		if (loopstart > loopend) loopstart = loopend = 0;
 
 		ins.nLength = len;
 		ins.nLoopStart = loopstart;
@@ -452,8 +450,11 @@ BOOL CSoundFile::ReadGDM(const BYTE *lpStream, DWORD dwMemLength)
 		UINT len = ins.nLength;
 
 		if (pos >= dwMemLength) break;
-		if (len) ReadSample(&ins, sflags[n], (LPSTR)(lpStream + pos), dwMemLength - pos);
-		pos += len;
+		if (len)
+		{
+			len = ReadSample(&ins, sflags[n], (LPSTR)(lpStream + pos), dwMemLength - pos);
+			pos += len;
+		}
 	}
 
 	return TRUE;

--- a/contrib/libmodplug/src/load_gdm.cpp
+++ b/contrib/libmodplug/src/load_gdm.cpp
@@ -230,6 +230,7 @@ BOOL CSoundFile::ReadGDM(const BYTE *lpStream, DWORD dwMemLength)
 	const SAMPLEGDM *psmp;
 	BYTE sflags[256];
 	DWORD pos;
+	UINT npat;
 
 	if ((!lpStream) || (dwMemLength < sizeof(FILEHEADERGDM))) return FALSE;
 	if ((fixu32(pfh->sig) != GDM_SIG) || (fixu32(pfh->sig2) != GMFS_SIG)) return FALSE;
@@ -338,7 +339,7 @@ BOOL CSoundFile::ReadGDM(const BYTE *lpStream, DWORD dwMemLength)
 	// Scan patterns to get pattern row counts and the real module channel count.
 	// Also do bounds checks to make sure the patterns can be safely loaded.
 	pos = patternsPos;
-	for (UINT npat = 0; npat < nPatterns && pos + 2 <= dwMemLength; npat++)
+	for (npat = 0; npat < nPatterns && pos + 2 <= dwMemLength; npat++)
 	{
 		UINT patLen = fixu16(lpStream + pos);
 		DWORD patEnd = pos + patLen;
@@ -387,7 +388,7 @@ BOOL CSoundFile::ReadGDM(const BYTE *lpStream, DWORD dwMemLength)
 
 	// Load patterns.
 	pos = patternsPos;
-	for (UINT npat = 0; npat < nPatterns && pos + 2 <= dwMemLength; npat++)
+	for (npat = 0; npat < nPatterns && pos + 2 <= dwMemLength; npat++)
 	{
 		UINT patLen = fixu16(lpStream + pos);
 		DWORD patEnd = pos + patLen;

--- a/contrib/libmodplug/src/load_gdm.cpp
+++ b/contrib/libmodplug/src/load_gdm.cpp
@@ -308,6 +308,8 @@ BOOL CSoundFile::ReadGDM(const BYTE *lpStream, DWORD dwMemLength)
 			// Due to a 2GDM bug, the sample size is halved.
 			// (Note BWSB doesn't even check for these anyway.)
 			len /= 2;
+			loopstart /= 2;
+			loopend /= 2;
 		}
 		else
 			sflags[nins] = RS_PCM8U;

--- a/contrib/libmodplug/src/load_gdm.cpp
+++ b/contrib/libmodplug/src/load_gdm.cpp
@@ -134,7 +134,7 @@ static void GDM_TranslateEffect(const FILEHEADERGDM *pfh, MODCOMMAND &ev, UINT c
 		} else
 		{
 			ev.command = CMD_VOLUME;
-			ev.param = param;
+			ev.param = (param > 64) ? 64 : param;
 		}
 		break;
 
@@ -206,11 +206,11 @@ static void GDM_TranslateEffect(const FILEHEADERGDM *pfh, MODCOMMAND &ev, UINT c
 			if (!ev.volcmd && channel == 0)
 			{
 				ev.volcmd = VOLCMD_PANNING;
-				ev.vol = (param << 2) + 2;
+				ev.vol = ((param & 0x0f) << 2) + 2;
 			} else
 			{
 				ev.command = CMD_PANNING8;
-				ev.param = (param << 3) + 4;
+				ev.param = ((param & 0x0f) << 3) + 4;
 			}
 			break;
 		}

--- a/contrib/libmodplug/src/load_gdm.cpp
+++ b/contrib/libmodplug/src/load_gdm.cpp
@@ -1,0 +1,452 @@
+/*
+ * This source code is public domain.
+ *
+ * Authors: Alice Rowan <petrifiedrowan@gmail.com>
+*/
+
+////////////////////////////////////////////////////////////
+// General Digital Music module loader
+////////////////////////////////////////////////////////////
+
+#include "stdafx.h"
+#include "sndfile.h"
+
+//#pragma warning(disable:4244)
+
+static const DWORD GDM_SIG = 0xfe4d4447; // GDM\xFE
+static const DWORD GMFS_SIG = 0x53464d47; // GMFS
+
+typedef struct tagFILEHEADERGDM
+{
+	BYTE sig[4];		// GDM\xFE
+	char name[32];
+	char author[32];
+	BYTE eof[3];		// \x0D\x0A\x1A
+	BYTE sig2[4];		// GMFS
+	BYTE gdm_ver_major;
+	BYTE gdm_ver_minor;
+	BYTE tracker_id[2];
+	BYTE tracker_ver_major;
+	BYTE tracker_ver_minor;
+	BYTE panning[32];
+	BYTE globalvol;
+	BYTE default_tempo;
+	BYTE default_bpm;
+	BYTE origfmt[2];
+	BYTE ordersPos[4];
+	BYTE nOrders;
+	BYTE patternsPos[4];
+	BYTE nPatterns;
+	BYTE samplesPos[4];
+	BYTE sampleDataPos[4];
+	BYTE nSamples;
+	BYTE messagePos[4];
+	BYTE messageLength[4];
+	BYTE ignore[16];
+} FILEHEADERGDM;
+
+typedef struct tagSAMPLEGDM
+{
+	enum SAMPLEGDMFLAGS
+	{
+		S_LOOP = (1<<0),
+		S_16BIT = (1<<1),
+		S_VOLUME = (1<<2),
+		S_PAN = (1<<3),
+		S_LZW = (1<<4),
+		S_STEREO = (1<<5)
+	};
+
+	char name[32];
+	char dosname[12];
+	BYTE ignore;
+	BYTE length[4];
+	BYTE loopstart[4];
+	BYTE loopend[4];
+	BYTE flags;
+	BYTE c4rate[2];
+	BYTE volume;
+	BYTE panning;
+} SAMPLEGDM;
+
+static WORD fixu16(const BYTE *val)
+{
+	return (val[1] << 8) | val[0];
+}
+
+static DWORD fixu32(const BYTE (&val)[4])
+{
+	return (val[3] << 24) | (val[2] << 16) | (val[1] << 8) | val[0];
+}
+
+static void GDM_TranslateEffect(const FILEHEADERGDM *pfh, MODCOMMAND &ev, UINT channel, UINT effect, UINT param)
+//--------------------------------------------------------------------------------------------------------------
+{
+	// Note due to the limitations of libmodplug's volume commands,
+	// anything that relied on multiple simultaneous non-volume effects
+	// is not going to work. Only UltraTracker GDMs should really cause
+	// this, and it's likely that none exist in the wild.
+	static const BYTE translate_effects[32] =
+	{
+		CMD_NONE,
+		CMD_PORTAMENTOUP,
+		CMD_PORTAMENTODOWN,
+		CMD_TONEPORTAMENTO,
+		CMD_VIBRATO,
+		CMD_TONEPORTAVOL,
+		CMD_VIBRATOVOL,
+		CMD_TREMOLO,
+		CMD_TREMOR,
+		CMD_OFFSET,
+		CMD_VOLUMESLIDE,
+		CMD_POSITIONJUMP,
+		CMD_VOLUME,
+		CMD_PATTERNBREAK,
+		CMD_MODCMDEX,
+		CMD_SPEED,
+
+		CMD_ARPEGGIO,
+		CMD_NONE, // Set Internal Flag
+		CMD_RETRIG,
+		CMD_GLOBALVOLUME,
+		CMD_FINEVIBRATO,
+		CMD_NONE,
+		CMD_NONE,
+		CMD_NONE,
+		CMD_NONE,
+		CMD_NONE,
+		CMD_NONE,
+		CMD_NONE,
+		CMD_NONE,
+		CMD_NONE,
+		CMD_NONE, // Special-- default to nothing.
+		CMD_TEMPO
+	};
+
+	switch (effect)
+	{
+	case 0x0c: // Volume
+		// Prefer volume command over regular command.
+		if (!ev.volcmd)
+		{
+			ev.volcmd = VOLCMD_VOLUME;
+			ev.vol = (param > 64) ? 64 : param;
+		} else
+		{
+			ev.command = CMD_VOLUME;
+			ev.param = param;
+		}
+		break;
+
+	case 0x0e: // Extended
+		// Most of these are effectively MOD extended commands, but
+		// the fine volslide and portamento commands need to be
+		// converted back to their S3M equivalents.
+		switch ((param & 0xf0) >> 4)
+		{
+		case 0x01: // Fine porta up.
+			ev.command = CMD_PORTAMENTOUP;
+			ev.param = 0xf0 | (param & 0x0f);
+			break;
+
+		case 0x02: // Fine porta down.
+			ev.command = CMD_PORTAMENTODOWN;
+			ev.param = 0xf0 | (param & 0x0f);
+			break;
+
+		case 0x08: // Extra fine porta up.
+			ev.command = CMD_PORTAMENTOUP;
+			ev.param = 0xe0 | (param & 0x0f);
+			break;
+
+		case 0x09: // Extra fine porta down.
+			ev.command = CMD_PORTAMENTODOWN;
+			ev.param = 0xe0 | (param & 0x0f);
+			break;
+
+		case 0x0a: // Fine volslide up.
+			if (param & 0x0f)
+			{
+				ev.command = CMD_VOLUMESLIDE;
+				ev.param = 0x0f | ((param & 0x0f) << 4);
+			}
+			break;
+
+		case 0x0b: // Fine volslide down.
+			if (param & 0x0f)
+			{
+				ev.command = CMD_VOLUMESLIDE;
+				ev.param = 0xf0 | (param & 0x0f);
+			}
+			break;
+
+		default:
+			ev.command = CMD_MODCMDEX;
+			ev.param = param;
+			break;
+		}
+		break;
+
+	case 0x1e: // Special
+		switch ((param & 0xf0) >> 4)
+		{
+		case 0x00: // Sample control.
+			// Only surround on is emitted by 2GDM.
+			// This comes from XA4, so convert it back.
+			if ((param & 0x0f) == 1)
+			{
+				ev.command = CMD_PANNING8;
+				ev.param = 0xA4;
+			}
+			break;
+
+		case 0x08: // Set Pan Position
+			// Prefer volume command over regular command if this
+			// this comes from effect channel 0.
+			if (!ev.volcmd && channel == 0)
+			{
+				ev.volcmd = VOLCMD_PANNING;
+				ev.vol = (param << 2) + 2;
+			} else
+			{
+				ev.command = CMD_PANNING8;
+				ev.param = (param << 3) + 4;
+			}
+			break;
+		}
+		break;
+
+	default:
+		ev.command = translate_effects[effect];
+		ev.param = param;
+		break;
+	}
+}
+
+BOOL CSoundFile::ReadGDM(const BYTE *lpStream, DWORD dwMemLength)
+//---------------------------------------------------------------
+{
+	const FILEHEADERGDM *pfh = (const FILEHEADERGDM *)lpStream;
+	const SAMPLEGDM *psmp;
+	BYTE sflags[256];
+	DWORD pos;
+
+	if ((!lpStream) || (dwMemLength < sizeof(FILEHEADERGDM))) return FALSE;
+	if ((fixu32(pfh->sig) != GDM_SIG) || (fixu32(pfh->sig2) != GMFS_SIG)) return FALSE;
+
+	DWORD ordersPos = fixu32(pfh->ordersPos);
+	DWORD patternsPos = fixu32(pfh->patternsPos);
+	DWORD samplesPos = fixu32(pfh->samplesPos);
+	DWORD sampleDataPos = fixu32(pfh->sampleDataPos);
+	DWORD messagePos = fixu32(pfh->messagePos);
+	DWORD messageLen = fixu32(pfh->messageLength);
+
+	if ((!ordersPos) || (ordersPos > dwMemLength) ||
+	 (!patternsPos) || (patternsPos > dwMemLength) || (pfh->nPatterns >= 240) ||
+	 (!samplesPos) || (samplesPos > dwMemLength) ||
+	 (samplesPos + sizeof(SAMPLEGDM) * pfh->nSamples > dwMemLength) ||
+	 (!sampleDataPos) || (sampleDataPos > dwMemLength))
+		return FALSE;
+
+	// Most GDMs were converted from S3M and BWSB generally behaves like an S3M
+	// player, so assuming S3M behavior and quirks is a fairly safe bet.
+	m_nType = MOD_TYPE_GDM | MOD_TYPE_S3M;
+	m_nMinPeriod = 64;
+	m_nMaxPeriod = 32767;
+	m_nDefaultGlobalVolume = pfh->globalvol << 2;
+	m_nDefaultTempo = pfh->default_tempo;
+	m_nDefaultSpeed = pfh->default_bpm;
+	m_nChannels = 0;
+	m_nSamples = pfh->nSamples + 1;
+
+	// Get initial panning.
+	for (UINT i = 0; i < 32; i++)
+	{
+		if (pfh->panning[i] < 16)
+		{
+			ChnSettings[i].nPan = (pfh->panning[i] << 4) + 8;
+		}
+		// TODO 16=surround
+	}
+
+	// Title and message.
+	memcpy(m_szNames[0], pfh->name, 32);
+	m_szNames[0][31] = '\0';
+
+	if ((messagePos < dwMemLength) && (messagePos + messageLen < dwMemLength))
+	{
+		m_lpszSongComments = new char[messageLen + 1];
+		memcpy(m_lpszSongComments, lpStream + messagePos, messageLen);
+		m_lpszSongComments[messageLen] = '\0';
+	}
+
+	// Samples.
+	psmp = (const SAMPLEGDM *)(lpStream + samplesPos);
+	for (UINT nins = 0; nins < m_nSamples; nins++)
+	{
+		const SAMPLEGDM &smp = psmp[nins];
+		MODINSTRUMENT &ins = Ins[nins + 1];
+
+		DWORD len = fixu32(smp.length);
+		DWORD loopstart = fixu32(smp.loopstart);
+		DWORD loopend = fixu32(smp.loopend);
+
+		UINT flags = smp.flags;
+
+		if (len > MAX_SAMPLE_LENGTH) len = MAX_SAMPLE_LENGTH;
+		if (loopend > len) loopend = len;
+		if (loopstart > loopend) loopstart = loopend = 0;
+
+		sflags[nins] = 0;
+		if (flags & SAMPLEGDM::S_16BIT)
+		{
+			sflags[nins] |= RS_PCM16U;
+			// Due to a 2GDM bug, the sample size is halved.
+			// (Note BWSB doesn't even check for these anyway.)
+			len /= 2;
+		}
+		else
+			sflags[nins] |= RS_PCM8U;
+
+		// Note: BWSB and 2GDM don't support LZW, stereo samples, sample panning.
+
+		ins.nLength = len;
+		ins.nLoopStart = loopstart;
+		ins.nLoopEnd = loopend;
+		if (loopend && (flags & SAMPLEGDM::S_LOOP)) ins.uFlags |= CHN_LOOP;
+
+		ins.nC4Speed = fixu16(smp.c4rate);
+		ins.nVolume = (flags & SAMPLEGDM::S_VOLUME) && (smp.volume <= 64) ? (smp.volume << 2) : 256;
+		ins.nGlobalVol = 64;
+		ins.nPan = 128;
+
+		memcpy(m_szNames[nins], smp.name, 32);
+		m_szNames[nins][31] = '\0';
+
+		memcpy(ins.name, smp.dosname, 12);
+		ins.name[13] = '\0';
+	}
+
+	// Order table.
+	memcpy(Order, lpStream + ordersPos, pfh->nOrders + 1);
+
+	// Scan patterns to get pattern row counts and the real module channel count.
+	pos = patternsPos;
+	for (UINT npat = 0; npat <= pfh->nPatterns && pos + 2 < dwMemLength; npat++)
+	{
+		UINT patLen = fixu16(lpStream + pos);
+		DWORD patEnd = pos + patLen;
+		UINT rows = 0;
+		UINT channel;
+
+		if (patEnd > dwMemLength) return FALSE;
+
+		pos += 2;
+		while (pos < patEnd)
+		{
+			rows++;
+
+			while (pos < patEnd)
+			{
+				BYTE dat = lpStream[pos++];
+				if (!dat)
+					break;
+
+				channel = dat & 0x1f;
+				if (channel >= m_nChannels)
+					m_nChannels = channel + 1;
+
+				// Note and sample.
+				if (dat & 0x20)
+					pos += 2;
+
+				// Effects.
+				if (dat & 0x40)
+				{
+					do
+					{
+						dat = lpStream[pos];
+						pos += 2;
+					} while (dat & 0x20);
+				}
+			}
+		}
+
+		if (rows < 64)
+			rows = 64;
+
+		PatternSize[npat] = rows;
+	}
+
+	// Load patterns.
+	pos = patternsPos;
+	for (UINT npat = 0; npat <= pfh->nPatterns && pos + 2 < dwMemLength; npat++)
+	{
+		UINT patLen = fixu16(lpStream + pos);
+		DWORD patEnd = pos + patLen;
+		UINT row = 0;
+
+		pos += 2;
+
+		Patterns[npat] = AllocatePattern(PatternSize[npat], m_nChannels);
+		if (!Patterns[npat]) break;
+
+		// Load the pattern.
+		MODCOMMAND *m = Patterns[npat];
+		while (pos < patEnd)
+		{
+			while (pos < patEnd)
+			{
+				BYTE dat = lpStream[pos++];
+				if (!dat)
+					break;
+
+				BYTE channel = dat & 0x1f;
+				MODCOMMAND &ev = m[row * m_nChannels + channel];
+
+				if (dat & 0x20)
+				{
+					BYTE note = lpStream[pos++];
+					BYTE smpl = lpStream[pos++];
+
+					if (note) // This can be blank (see STARDSTM.GDM).
+					{
+						BYTE octave = (note & 0x70) >> 4;
+						note = octave * 12 + (note & 0x0f) + 12;
+					}
+
+					ev.note = note;
+					ev.instr = smpl;
+				}
+
+				if (dat & 0x40)
+				{
+					BYTE cmd, param;
+					do
+					{
+						cmd = lpStream[pos++];
+						param = lpStream[pos++];
+						GDM_TranslateEffect(pfh, ev, (cmd & 0xc0) >> 6, (cmd & 0x01f), param);
+
+					} while (cmd & 0x20);
+				}
+			}
+
+			row++;
+		}
+	}
+
+	// Reading Samples
+	pos = sampleDataPos;
+	for (UINT n = 0; n < m_nSamples; n++)
+	{
+		MODINSTRUMENT &ins = Ins[n + 1];
+		UINT len = ins.nLength;
+
+		if (pos >= dwMemLength) break;
+		if (len) ReadSample(&ins, sflags[n], (LPSTR)(lpStream + pos), dwMemLength - pos);
+		pos += len;
+	}
+
+	return TRUE;
+}

--- a/contrib/libmodplug/src/load_gdm.cpp
+++ b/contrib/libmodplug/src/load_gdm.cpp
@@ -72,7 +72,7 @@ static WORD fixu16(const BYTE *val)
 	return (val[1] << 8) | val[0];
 }
 
-static DWORD fixu32(const BYTE (&val)[4])
+static DWORD fixu32(const BYTE val[4])
 {
 	return (val[3] << 24) | (val[2] << 16) | (val[1] << 8) | val[0];
 }

--- a/contrib/libmodplug/src/load_gdm.cpp
+++ b/contrib/libmodplug/src/load_gdm.cpp
@@ -121,6 +121,8 @@ static void GDM_TranslateEffect(const FILEHEADERGDM *pfh, MODCOMMAND &ev, UINT c
 		CMD_TEMPO
 	};
 
+	if (effect >= 32) return;
+
 	switch (effect)
 	{
 	case 0x0c: // Volume
@@ -247,10 +249,10 @@ BOOL CSoundFile::ReadGDM(const BYTE *lpStream, DWORD dwMemLength)
 	if (nSamples >= MAX_SAMPLES) nSamples = MAX_SAMPLES - 1;
 
 	if ((ordersPos < sizeof(FILEHEADERGDM)) || (ordersPos >= dwMemLength) || (ordersPos + nOrders > dwMemLength) ||
-	 (patternsPos < sizeof(FILEHEADERGDM)) || (patternsPos >= dwMemLength) ||
-	 (samplesPos < sizeof(FILEHEADERGDM)) || (samplesPos >= dwMemLength) ||
-	 (samplesPos + sizeof(SAMPLEGDM) * pfh->nSamples > dwMemLength) ||
-	 (sampleDataPos < sizeof(FILEHEADERGDM)) || (sampleDataPos >= dwMemLength))
+	    (patternsPos < sizeof(FILEHEADERGDM)) || (patternsPos >= dwMemLength) ||
+	    (samplesPos < sizeof(FILEHEADERGDM)) || (samplesPos >= dwMemLength) ||
+	    (samplesPos + sizeof(SAMPLEGDM) * pfh->nSamples > dwMemLength) ||
+	    (sampleDataPos < sizeof(FILEHEADERGDM)) || (sampleDataPos >= dwMemLength))
 		return FALSE;
 
 	// Most GDMs were converted from S3M and BWSB generally behaves like an S3M

--- a/contrib/libmodplug/src/load_gdm.cpp
+++ b/contrib/libmodplug/src/load_gdm.cpp
@@ -281,7 +281,7 @@ BOOL CSoundFile::ReadGDM(const BYTE *lpStream, DWORD dwMemLength)
 	memcpy(m_szNames[0], pfh->name, 32);
 	m_szNames[0][31] = '\0';
 
-	if ((messagePos < dwMemLength) && (messagePos + messageLen < dwMemLength))
+	if ((messagePos < dwMemLength) && (messageLen <= dwMemLength - messagePos))
 	{
 		m_lpszSongComments = new char[messageLen + 1];
 		memcpy(m_lpszSongComments, lpStream + messagePos, messageLen);

--- a/contrib/libmodplug/src/sndfile.cpp
+++ b/contrib/libmodplug/src/sndfile.cpp
@@ -161,11 +161,11 @@ BOOL CSoundFile::Create(LPCBYTE lpStream, DWORD dwMemLength)
 		 && (!ReadUlt(lpStream, dwMemLength))
 		 //&& (!ReadDMF(lpStream, dwMemLength))
 		 && (!ReadDSM(lpStream, dwMemLength))
+		 && (!ReadGDM(lpStream, dwMemLength))
 		 //&& (!ReadUMX(lpStream, dwMemLength))
 		 && (!ReadAMF(lpStream, dwMemLength))
 		 //&& (!ReadPSM(lpStream, dwMemLength))
 		 //&& (!ReadMT2(lpStream, dwMemLength))
-		 && (!ReadGDM(lpStream, dwMemLength))
 #endif // MODPLUG_BASIC_SUPPORT
 		 && (!ReadMod(lpStream, dwMemLength))) m_nType = MOD_TYPE_NONE;
 #ifdef MMCMP_SUPPORT

--- a/contrib/libmodplug/src/sndfile.cpp
+++ b/contrib/libmodplug/src/sndfile.cpp
@@ -165,6 +165,7 @@ BOOL CSoundFile::Create(LPCBYTE lpStream, DWORD dwMemLength)
 		 && (!ReadAMF(lpStream, dwMemLength))
 		 //&& (!ReadPSM(lpStream, dwMemLength))
 		 //&& (!ReadMT2(lpStream, dwMemLength))
+		 && (!ReadGDM(lpStream, dwMemLength))
 #endif // MODPLUG_BASIC_SUPPORT
 		 && (!ReadMod(lpStream, dwMemLength))) m_nType = MOD_TYPE_NONE;
 #ifdef MMCMP_SUPPORT

--- a/contrib/patches/libmodplug/14-libmodplug-0.8.9.0-add-gdm-loader.diff
+++ b/contrib/patches/libmodplug/14-libmodplug-0.8.9.0-add-gdm-loader.diff
@@ -1,0 +1,32 @@
+diff --git a/src/libmodplug/sndfile.h b/src/libmodplug/sndfile.h
+index 091e25fd..2a3c3147 100644
+--- a/src/libmodplug/sndfile.h
++++ b/src/libmodplug/sndfile.h
+@@ -71,6 +71,7 @@ typedef const BYTE * LPCBYTE;
+ #define MOD_TYPE_J2B		0x800000
+ #define MOD_TYPE_ABC		0x1000000
+ #define MOD_TYPE_PAT		0x2000000
++#define MOD_TYPE_GDM		0x40000000 // Fake type
+ #define MOD_TYPE_UMX		0x80000000 // Fake type
+ #define MAX_MODTYPE		24
+ 
+@@ -652,6 +653,7 @@ public:
+ 	BOOL ReadMT2(LPCBYTE lpStream, DWORD dwMemLength);
+ 	BOOL ReadPSM(LPCBYTE lpStream, DWORD dwMemLength);
+ 	BOOL ReadJ2B(LPCBYTE lpStream, DWORD dwMemLength);
++	BOOL ReadGDM(LPCBYTE lpStream, DWORD dwMemLength);
+ 	BOOL ReadUMX(LPCBYTE lpStream, DWORD dwMemLength);
+ 	BOOL ReadABC(LPCBYTE lpStream, DWORD dwMemLength);
+ 	BOOL TestABC(LPCBYTE lpStream, DWORD dwMemLength);
+diff --git a/src/sndfile.cpp b/src/sndfile.cpp
+index cc84dee6..684f1fcd 100644
+--- a/src/sndfile.cpp
++++ b/src/sndfile.cpp
+@@ -165,6 +165,7 @@ BOOL CSoundFile::Create(LPCBYTE lpStream, DWORD dwMemLength)
+ 		 && (!ReadAMF(lpStream, dwMemLength))
+ 		 //&& (!ReadPSM(lpStream, dwMemLength))
+ 		 //&& (!ReadMT2(lpStream, dwMemLength))
++		 && (!ReadGDM(lpStream, dwMemLength))
+ #endif // MODPLUG_BASIC_SUPPORT
+ 		 && (!ReadMod(lpStream, dwMemLength))) m_nType = MOD_TYPE_NONE;
+ #ifdef MMCMP_SUPPORT

--- a/contrib/patches/libmodplug/14-libmodplug-0.8.9.0-add-gdm-loader.diff
+++ b/contrib/patches/libmodplug/14-libmodplug-0.8.9.0-add-gdm-loader.diff
@@ -19,14 +19,14 @@ index 091e25fd..2a3c3147 100644
  	BOOL ReadABC(LPCBYTE lpStream, DWORD dwMemLength);
  	BOOL TestABC(LPCBYTE lpStream, DWORD dwMemLength);
 diff --git a/src/sndfile.cpp b/src/sndfile.cpp
-index cc84dee6..684f1fcd 100644
---- a/src/sndfile.cpp
-+++ b/src/sndfile.cpp
-@@ -165,6 +165,7 @@ BOOL CSoundFile::Create(LPCBYTE lpStream, DWORD dwMemLength)
+index cc84dee6..d1730910 100644
+--- a/contrib/libmodplug/src/sndfile.cpp
++++ b/contrib/libmodplug/src/sndfile.cpp
+@@ -161,6 +161,7 @@ BOOL CSoundFile::Create(LPCBYTE lpStream, DWORD dwMemLength)
+ 		 && (!ReadUlt(lpStream, dwMemLength))
+ 		 //&& (!ReadDMF(lpStream, dwMemLength))
+ 		 && (!ReadDSM(lpStream, dwMemLength))
++		 && (!ReadGDM(lpStream, dwMemLength))
+ 		 //&& (!ReadUMX(lpStream, dwMemLength))
  		 && (!ReadAMF(lpStream, dwMemLength))
  		 //&& (!ReadPSM(lpStream, dwMemLength))
- 		 //&& (!ReadMT2(lpStream, dwMemLength))
-+		 && (!ReadGDM(lpStream, dwMemLength))
- #endif // MODPLUG_BASIC_SUPPORT
- 		 && (!ReadMod(lpStream, dwMemLength))) m_nType = MOD_TYPE_NONE;
- #ifdef MMCMP_SUPPORT

--- a/contrib/patches/libmodplug/readme.txt
+++ b/contrib/patches/libmodplug/readme.txt
@@ -1,5 +1,6 @@
 Apply the patches in this directory to bring a stock libmodplug-0.8.9.0
-distribution in line with the local copy used by MegaZeux.
+distribution in line with the local copy used by MegaZeux. Additionally,
+load_gdm.cpp needs to be copied from the local MegaZeux libmodplug.
 
 In addition to the patches, the following files should be removed, as
 they are no longer necessary:

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -278,9 +278,6 @@ core_cobjs := ${core_obj}/render_layer.o ${core_cobjs}
 endif
 
 ifeq (${BUILD_MODPLUG},1)
-core_cflags += -I${gdm2s3m_src}
-core_cxxflags += -I${gdm2s3m_src}
-core_cobjs += ${gdm2s3m_objs}
 core_flags += -I${libmodplug_src} -I${libmodplug_src}/libmodplug
 core_cxxobjs += ${audio_obj}/audio_modplug.o ${libmodplug_objs}
 endif

--- a/src/audio/audio_modplug.cpp
+++ b/src/audio/audio_modplug.cpp
@@ -22,7 +22,6 @@
 #include <modplug.h>
 #include <stdafx.h>
 #include <sndfile.h>
-#include <gdm2s3m.h>
 
 #include "audio.h"
 #include "audio_modplug.h"
@@ -242,50 +241,6 @@ static struct audio_stream *construct_modplug_stream(char *filename,
   return ret_val;
 }
 
-static struct audio_stream *modplug_convert_gdm(char *filename,
- Uint32 frequency, Uint32 volume, Uint32 repeat)
-{
-  /* Wrapper for construct_modplug_stream to convert .GDMs to .S3Ms. */
-  char translated_filename_dest[MAX_PATH];
-  char new_file[MAX_PATH];
-  int have_s3m = 0;
-
-  /* We know this file has a .gdm extension. */
-  int ext_pos = (int)strlen(filename) - 4;
-
-  /* Get the name of its .s3m counterpart */
-  snprintf(new_file, MAX_PATH, "%.*s.s3m", ext_pos, filename);
-  new_file[MAX_PATH - 1] = '\0';
-
-  /* If the destination S3M already exists, check its size. If it's
-   * non-zero in size, we can load it.
-   */
-  if(!fsafetranslate(new_file, translated_filename_dest, MAX_PATH))
-  {
-    FILE *f = fopen_unsafe(translated_filename_dest, "r");
-    long file_len = ftell_and_rewind(f);
-
-    fclose(f);
-    if(file_len > 0)
-      have_s3m = 1;
-  }
-
-  /* In the case we need to convert the GDM, we need to find
-   * the real source path for it. Translate accordingly.
-   */
-  if(!have_s3m && !fsafetranslate(filename, translated_filename_dest, MAX_PATH))
-  {
-    if(!convert_gdm_s3m(translated_filename_dest, new_file))
-      have_s3m = 1;
-  }
-
-  /* If we have an S3M, we can now load it. Otherwise, abort.*/
-  if(have_s3m)
-    return construct_modplug_stream(new_file, frequency, volume, repeat);
-
-  return NULL;
-}
-
 void init_modplug(struct config_info *conf)
 {
   if(conf->oversampling_on)
@@ -330,7 +285,7 @@ void init_modplug(struct config_info *conf)
   audio_ext_register("amf", construct_modplug_stream);
   audio_ext_register("dsm", construct_modplug_stream);
   audio_ext_register("far", construct_modplug_stream);
-  audio_ext_register("gdm", modplug_convert_gdm);
+  audio_ext_register("gdm", construct_modplug_stream);
   audio_ext_register("it", construct_modplug_stream);
   audio_ext_register("med", construct_modplug_stream);
   audio_ext_register("mod", construct_modplug_stream);


### PR DESCRIPTION
This patch replaces gdm2s3m with a real libmodplug GDM loader. This should do effectively the same job as gdm2s3m, except without the intermediate file IO step, directory pollution, and filename translation bugs. (Additionally, it can actually be contributed upstream, so theoretically other projects could benefit from it.)

- [x] sq2-over.gdm
- [x] drivin.gdm
- [x] STARDSTM.GDM
- [x] LB2_7.GDM
- [x] GBAT8.GDM
- [x] JUPITER.GDM
- [x] More testing.
- [x] Upstream patch.