### PR TITLE
Fix intake INTK_BACKSPACE_WORDS cursor behavior.

### DIFF
--- a/src/intake.c
+++ b/src/intake.c
@@ -723,6 +723,7 @@ boolean intake_apply_event_fixed(subcontext *sub, enum intake_event_type type,
           intake_skip_back(intk);
           value--;
         }
+        new_pos = intk->pos;
         if(intk->pos < old_pos)
         {
           memmove(intk->dest + intk->pos, intk->dest + old_pos,

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -298,19 +298,19 @@ void TEST_STRING(const char *setting_name, char (&setting)[S],
 
     setting[0] = '\0';
     load_arg(arg);
-    ASSERTXNCMP(setting, data[i].expected, len, arg);
-    ASSERTEQX(setting[len], '\0', arg);
+    ASSERTNCMP(setting, data[i].expected, len, "%s", arg);
+    ASSERTEQ(setting[len], '\0', "%s", arg);
 
     setting[0] = '\0';
     load_arg_file(arg, game_allowed);
-    ASSERTXNCMP(setting, data[i].expected, len, arg);
-    ASSERTEQX(setting[len], '\0', arg);
+    ASSERTNCMP(setting, data[i].expected, len, "%s", arg);
+    ASSERTEQ(setting[len], '\0', "%s", arg);
 
     if(!game_allowed)
     {
       setting[0] = '\0';
       load_arg_file(arg, true);
-      ASSERTEQX(setting[0], '\0', arg);
+      ASSERTEQ(setting[0], '\0', "%s", arg);
     }
   }
 }


### PR DESCRIPTION
The `INTK_BACKSPACE_WORDS` event default implementation failed to actually move the cursor back to the start of the erased token, causing Ctrl+Backspace in the robot editor to be buggy.

Additionally, cleans up some of the duplicate `ASSERTx` macros in Unit.hpp by making the regular versions allow a variadic message format to pass to `vsnprintf`. The `ASSERTXx` macros in most places still haven't been replaced yet. Since there wasn't a non-message version of `ASSERTXNCMP`, I just replaced that one entirely.