### PR TITLE
Unit test cleanup, remove ASSERTX macros, fix warnings.

### DIFF
--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -87,7 +87,7 @@ DEBUG_CFLAGS ?= -O0
 # build without -DNDEBUG to allow assert().
 #
 unit_cflags ?= ${DEBUG_CFLAGS} -g \
- -Wall -Wextra -pedantic -Wno-unused-parameter -funsigned-char -std=gnu++11
+ -Wall -Wextra -pedantic -Wno-unused-parameter -funsigned-char -fno-rtti -std=gnu++11
 
 unit_cflags += ${SDL_CFLAGS} -Umain
 unit_ldflags +=

--- a/unit/Unit.hpp
+++ b/unit/Unit.hpp
@@ -199,16 +199,6 @@ public:
     } \
   } while(0)
 
-// TODO: use ASSERT instead.
-#define ASSERTX(test, reason) \
-  do\
-  {\
-    if(!(test)) \
-    {\
-      throw Unit::exception(__LINE__, #test, reason); \
-    }\
-  } while(0)
-
 #define ASSERTEQ(a, b, ...) \
   do\
   {\
@@ -218,33 +208,12 @@ public:
     } \
   } while(0)
 
-// TODO: use ASSERTEQ instead.
-#define ASSERTEQX(a, b, reason) \
-  do\
-  {\
-    if(!((a) == (b)))\
-    {\
-      throw Unit::exception(__LINE__, #a " == " #b, (a), (b), reason); \
-    }\
-  } while(0)
-
 #define ASSERTCMP(a, b, ...) \
   do\
   {\
     if(strcmp(a,b)) \
     {\
       throw Unit::exception(__LINE__, "strcmp(" #a ", " #b ")", (a), (b), "" __VA_ARGS__); \
-    }\
-  } while(0)
-
-
-// TODO: use ASSERTCMP instead.
-#define ASSERTXCMP(a, b, reason) \
-  do\
-  {\
-    if(strcmp(a,b)) \
-    {\
-      throw Unit::exception(__LINE__, "strcmp(" #a ", " #b ")", (a), (b), reason); \
     }\
   } while(0)
 
@@ -263,16 +232,6 @@ public:
     if(memcmp(a,b,l)) \
     {\
       throw Unit::exception(__LINE__, "memcmp(" #a ", " #b ", " #l ")", (a), (b), (l), "" __VA_ARGS__); \
-    }\
-  } while(0)
-
-// TODO: use ASSERTMEM instead.
-#define ASSERTXMEM(a, b, l, reason) \
-  do\
-  {\
-    if(memcmp(a,b,l)) \
-    {\
-      throw Unit::exception(__LINE__, "memcmp(" #a ", " #b ", " #l ")", (a), (b), (l), reason); \
     }\
   } while(0)
 
@@ -324,15 +283,10 @@ namespace Unit
      line(_line), test(coalesce(_test)), reason(""), has_reason(false),
      left(coalesce(nullptr)), right(coalesce(nullptr)), has_values(false) {}
 
-    exception(int _line, const char *_test, const char *_reason):
-     line(_line), test(coalesce(_test)), reason(coalesce(_reason)), has_reason(!!_reason),
-     left(coalesce(nullptr)), right(coalesce(nullptr)), has_values(false) {}
-
-    template<class T, class S>
-    exception(int _line, const char *_test, T _left, S _right, const char *_reason_fmt, ...):
-     line(_line), test(coalesce(_test)), has_reason(false), has_values(false)
+    exception(int _line, const char *_test, const char *_reason_fmt, ...):
+     line(_line), test(coalesce(_test)), has_reason(false),
+     left(coalesce(nullptr)), right(coalesce(nullptr)), has_values(false)
     {
-      printf("%s\n", __PRETTY_FUNCTION__);
       if(_reason_fmt && _reason_fmt[0])
       {
         va_list vl;
@@ -341,7 +295,22 @@ namespace Unit
         va_end(vl);
       }
       else
-        reason = "NULL";
+        reason = coalesce(nullptr);
+    }
+
+    template<class T, class S>
+    exception(int _line, const char *_test, T _left, S _right, const char *_reason_fmt, ...):
+     line(_line), test(coalesce(_test)), has_reason(false), has_values(false)
+    {
+      if(_reason_fmt && _reason_fmt[0])
+      {
+        va_list vl;
+        va_start(vl, _reason_fmt);
+        set_reason_fmt(_reason_fmt, vl);
+        va_end(vl);
+      }
+      else
+        reason = coalesce(nullptr);
 
       set_operand(left, _left);
       set_operand(right, _right);
@@ -360,7 +329,7 @@ namespace Unit
         va_end(vl);
       }
       else
-        reason = "NULL";
+        reason = coalesce(nullptr);
 
       has_values = (_left || _right);
       length /= sizeof(T);

--- a/unit/Unit.hpp
+++ b/unit/Unit.hpp
@@ -84,6 +84,7 @@
 #include <csignal>
 #include <iostream>
 #include <sstream>
+#include <string>
 #include <type_traits>
 #include <vector>
 

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -208,17 +208,17 @@ void TEST_INT(const char *setting_name, T &setting, ssize_t min, ssize_t max)
 
     setting = default_value;
     load_arg(arg);
-    ASSERTEQX((ssize_t)setting, expected, arg);
+    ASSERTEQ((ssize_t)setting, expected, "%s", arg);
 
     setting = default_value;
     load_arg_file(arg, game_allowed);
-    ASSERTEQX((ssize_t)setting, expected, arg);
+    ASSERTEQ((ssize_t)setting, expected, "%s", arg);
 
     if(!game_allowed)
     {
       setting = default_value;
       load_arg_file(arg, true);
-      ASSERTEQX(setting, default_value, arg);
+      ASSERTEQ(setting, default_value, "%s", arg);
     }
   }
 }
@@ -236,17 +236,17 @@ void TEST_ENUM(const char *setting_name, T &setting,
 
     setting = default_value;
     load_arg(arg);
-    ASSERTEQX((int)setting, data[i].expected, arg);
+    ASSERTEQ((int)setting, data[i].expected, "%s", arg);
 
     setting = default_value;
     load_arg_file(arg, game_allowed);
-    ASSERTEQX((int)setting, data[i].expected, arg);
+    ASSERTEQ((int)setting, data[i].expected, "%s", arg);
 
     if(!game_allowed)
     {
       setting = default_value;
       load_arg_file(arg, true);
-      ASSERTEQX(setting, default_value, arg);
+      ASSERTEQ(setting, default_value, "%s", arg);
     }
   }
 }
@@ -265,22 +265,22 @@ void TEST_PAIR(const char *setting_name, T &setting_a, T &setting_b,
     setting_a = default_value;
     setting_b = default_value;
     load_arg(arg);
-    ASSERTEQX((int)setting_a, data[i].expected_a, arg);
-    ASSERTEQX((int)setting_b, data[i].expected_b, arg);
+    ASSERTEQ((int)setting_a, data[i].expected_a, "%s", arg);
+    ASSERTEQ((int)setting_b, data[i].expected_b, "%s", arg);
 
     setting_a = default_value;
     setting_b = default_value;
     load_arg_file(arg, game_allowed);
-    ASSERTEQX((int)setting_a, data[i].expected_a, arg);
-    ASSERTEQX((int)setting_b, data[i].expected_b, arg);
+    ASSERTEQ((int)setting_a, data[i].expected_a, "%s", arg);
+    ASSERTEQ((int)setting_b, data[i].expected_b, "%s", arg);
 
     if(!game_allowed)
     {
       setting_a = default_value;
       setting_b = default_value;
       load_arg_file(arg, true);
-      ASSERTEQX(setting_a, default_value, arg);
-      ASSERTEQX(setting_b, default_value, arg);
+      ASSERTEQ(setting_a, default_value, "%s", arg);
+      ASSERTEQ(setting_b, default_value, "%s", arg);
     }
   }
 }
@@ -787,9 +787,9 @@ UNITTEST(Settings)
       snprintf(buffer, sizeof(buffer), "%s=%s", option, hosts[i]);
       load_arg(buffer);
 
-      ASSERTEQ(conf->update_host_count, i+1);
+      ASSERTEQ(conf->update_host_count, i+1, "");
       for(int j = 0; j <= i; j++)
-        ASSERTCMP(conf->update_hosts[j], hosts[j]);
+        ASSERTCMP(conf->update_hosts[j], hosts[j], "");
     }
     free_config();
   }
@@ -937,17 +937,17 @@ UNITTEST(Settings)
       load_arg(buffer);
 
       if(current.width != IGNORE)
-        ASSERTEQX(econf->board_width, current.width, buffer);
+        ASSERTEQ(econf->board_width, current.width, "%s", buffer);
       if(current.height != IGNORE)
-        ASSERTEQX(econf->board_height, current.height, buffer);
+        ASSERTEQ(econf->board_height, current.height, "%s", buffer);
       if(current.viewport_x != IGNORE)
-        ASSERTEQX(econf->viewport_x, current.viewport_x, buffer);
+        ASSERTEQ(econf->viewport_x, current.viewport_x, "%s", buffer);
       if(current.viewport_y != IGNORE)
-        ASSERTEQX(econf->viewport_y, current.viewport_y, buffer);
+        ASSERTEQ(econf->viewport_y, current.viewport_y, "%s", buffer);
       if(current.viewport_w != IGNORE)
-        ASSERTEQX(econf->viewport_w, current.viewport_w, buffer);
+        ASSERTEQ(econf->viewport_w, current.viewport_w, "%s", buffer);
       if(current.viewport_h != IGNORE)
-        ASSERTEQX(econf->viewport_h, current.viewport_h, buffer);
+        ASSERTEQ(econf->viewport_h, current.viewport_h, "%s", buffer);
     }
   }
 
@@ -1279,17 +1279,17 @@ UNITTEST(Settings)
       expected = &(data[i].expected);
 
       if(expected->board_id != IGNORE)
-        ASSERTEQX(dest->board_id, expected->board_id, buffer);
+        ASSERTEQ(dest->board_id, expected->board_id, "%s", buffer);
       if(expected->cursor_x != IGNORE)
-        ASSERTEQX(dest->cursor_x, expected->cursor_x, buffer);
+        ASSERTEQ(dest->cursor_x, expected->cursor_x, "%s", buffer);
       if(expected->cursor_y != IGNORE)
-        ASSERTEQX(dest->cursor_y, expected->cursor_y, buffer);
+        ASSERTEQ(dest->cursor_y, expected->cursor_y, "%s", buffer);
       if(expected->scroll_x != IGNORE)
-        ASSERTEQX(dest->scroll_x, expected->scroll_x, buffer);
+        ASSERTEQ(dest->scroll_x, expected->scroll_x, "%s", buffer);
       if(expected->scroll_y != IGNORE)
-        ASSERTEQX(dest->scroll_y, expected->scroll_y, buffer);
+        ASSERTEQ(dest->scroll_y, expected->scroll_y, "%s", buffer);
       if(expected->debug_x != IGNORE)
-        ASSERTEQX(dest->debug_x, expected->debug_x, buffer);
+        ASSERTEQ(dest->debug_x, expected->debug_x, "%s", buffer);
     }
   }
 
@@ -1316,14 +1316,14 @@ void TEST_JOY_ALIAS(const config_test_single (&data)[NUM_TESTS])
   constexpr int16_t DEFAULT = INVALID<int16_t>();
   char arg[512];
 
-  ASSERT(joy_global_map);
+  ASSERT(joy_global_map, "");
   for(int i = 0; i < NUM_TESTS; i++)
   {
     joy_global_map->button[0][0] = DEFAULT;
     snprintf(arg, arraysize(arg), "joy1button1=%s", data[i].value);
     load_arg(arg);
 
-    ASSERTEQX(joy_global_map->button[0][0], data[i].expected, arg);
+    ASSERTEQ(joy_global_map->button[0][0], data[i].expected, "%s", arg);
   }
 }
 
@@ -1334,7 +1334,7 @@ void TEST_JOY_BUTTON(const config_test_joystick (&data)[NUM_TESTS])
   constexpr int16_t DEFAULT = INVALID<int16_t>();
   char arg[512];
 
-  ASSERT(joy_global_map);
+  ASSERT(joy_global_map, "");
   for(int i = 0; i < NUM_TESTS; i++)
   {
     const config_test_joystick &t = data[i];
@@ -1350,9 +1350,9 @@ void TEST_JOY_BUTTON(const config_test_joystick (&data)[NUM_TESTS])
     for(int j = 0; j < MAX_JOYSTICKS; j++)
     {
       if(j >= t.first - 1 && j <= t.last - 1)
-        ASSERTEQX(joy_global_map->button[j][t.which - 1], t.expected[0], arg);
+        ASSERTEQ(joy_global_map->button[j][t.which - 1], t.expected[0], "%s", arg);
       else
-        ASSERTEQX(joy_global_map->button[j][t.which - 1], DEFAULT, arg);
+        ASSERTEQ(joy_global_map->button[j][t.which - 1], DEFAULT, "%s", arg);
     }
   }
 }
@@ -1364,7 +1364,7 @@ void TEST_JOY_AXIS(const config_test_joystick (&data)[NUM_TESTS])
   constexpr int16_t DEFAULT = INVALID<int16_t>();
   char arg[512];
 
-  ASSERT(joy_global_map);
+  ASSERT(joy_global_map, "");
   for(int i = 0; i < NUM_TESTS; i++)
   {
     const config_test_joystick &t = data[i];
@@ -1384,13 +1384,13 @@ void TEST_JOY_AXIS(const config_test_joystick (&data)[NUM_TESTS])
     {
       if(j >= t.first - 1 && j <= t.last - 1)
       {
-        ASSERTEQX(joy_global_map->axis[j][t.which - 1][0], t.expected[0], arg);
-        ASSERTEQX(joy_global_map->axis[j][t.which - 1][1], t.expected[1], arg);
+        ASSERTEQ(joy_global_map->axis[j][t.which - 1][0], t.expected[0], "%s", arg);
+        ASSERTEQ(joy_global_map->axis[j][t.which - 1][1], t.expected[1], "%s", arg);
       }
       else
       {
-        ASSERTEQX(joy_global_map->axis[j][t.which - 1][0], DEFAULT, arg);
-        ASSERTEQX(joy_global_map->axis[j][t.which - 1][1], DEFAULT, arg);
+        ASSERTEQ(joy_global_map->axis[j][t.which - 1][0], DEFAULT, "%s", arg);
+        ASSERTEQ(joy_global_map->axis[j][t.which - 1][1], DEFAULT, "%s", arg);
       }
     }
   }
@@ -1403,7 +1403,7 @@ void TEST_JOY_HAT(const config_test_joystick (&data)[NUM_TESTS])
   constexpr int16_t DEFAULT = INVALID<int16_t>();
   char arg[512];
 
-  ASSERT(joy_global_map);
+  ASSERT(joy_global_map, "");
   for(int i = 0; i < NUM_TESTS; i++)
   {
     const config_test_joystick &t = data[i];
@@ -1423,17 +1423,17 @@ void TEST_JOY_HAT(const config_test_joystick (&data)[NUM_TESTS])
     {
       if(j >= t.first - 1 && j <= t.last - 1)
       {
-        ASSERTEQX(joy_global_map->hat[j][JOYHAT_UP], t.expected[JOYHAT_UP], arg);
-        ASSERTEQX(joy_global_map->hat[j][JOYHAT_DOWN], t.expected[JOYHAT_DOWN], arg);
-        ASSERTEQX(joy_global_map->hat[j][JOYHAT_LEFT], t.expected[JOYHAT_LEFT], arg);
-        ASSERTEQX(joy_global_map->hat[j][JOYHAT_RIGHT], t.expected[JOYHAT_RIGHT], arg);
+        ASSERTEQ(joy_global_map->hat[j][JOYHAT_UP], t.expected[JOYHAT_UP], "%s", arg);
+        ASSERTEQ(joy_global_map->hat[j][JOYHAT_DOWN], t.expected[JOYHAT_DOWN], "%s", arg);
+        ASSERTEQ(joy_global_map->hat[j][JOYHAT_LEFT], t.expected[JOYHAT_LEFT], "%s", arg);
+        ASSERTEQ(joy_global_map->hat[j][JOYHAT_RIGHT], t.expected[JOYHAT_RIGHT], "%s", arg);
       }
       else
       {
-        ASSERTEQX(joy_global_map->hat[j][JOYHAT_UP], DEFAULT, arg);
-        ASSERTEQX(joy_global_map->hat[j][JOYHAT_DOWN], DEFAULT, arg);
-        ASSERTEQX(joy_global_map->hat[j][JOYHAT_LEFT], DEFAULT, arg);
-        ASSERTEQX(joy_global_map->hat[j][JOYHAT_RIGHT], DEFAULT, arg);
+        ASSERTEQ(joy_global_map->hat[j][JOYHAT_UP], DEFAULT, "%s", arg);
+        ASSERTEQ(joy_global_map->hat[j][JOYHAT_DOWN], DEFAULT, "%s", arg);
+        ASSERTEQ(joy_global_map->hat[j][JOYHAT_LEFT], DEFAULT, "%s", arg);
+        ASSERTEQ(joy_global_map->hat[j][JOYHAT_RIGHT], DEFAULT, "%s", arg);
       }
     }
   }
@@ -1446,7 +1446,7 @@ void TEST_JOY_ACTION(const config_test_joystick (&data)[NUM_TESTS])
   constexpr int16_t DEFAULT = INVALID<int16_t>();
   char arg[512];
 
-  ASSERT(joy_global_map);
+  ASSERT(joy_global_map, "");
   for(int i = 0; i < NUM_TESTS; i++)
   {
     const config_test_joystick &t = data[i];
@@ -1462,9 +1462,9 @@ void TEST_JOY_ACTION(const config_test_joystick (&data)[NUM_TESTS])
     for(int j = 0; j < MAX_JOYSTICKS; j++)
     {
       if(j >= t.first - 1 && j <= t.last - 1)
-        ASSERTEQX(joy_global_map->action[j][t.which], t.expected[0], arg);
+        ASSERTEQ(joy_global_map->action[j][t.which], t.expected[0], "%s", arg);
       else
-        ASSERTEQX(joy_global_map->action[j][t.which], DEFAULT, arg);
+        ASSERTEQ(joy_global_map->action[j][t.which], DEFAULT, "%s", arg);
     }
   }
 }
@@ -1725,12 +1725,12 @@ UNITTEST(Include)
     // This version only works from a config file.
     boolean ret = write_config("a.cnf", "include b.cnf");
     ret &= write_config("b.cnf", "mzx_speed = 4");
-    ASSERTEQ(ret, true);
+    ASSERTEQ(ret, true, "");
 
     conf->mzx_speed = 2;
 
     set_config_from_file(SYSTEM_CNF, "a.cnf");
-    ASSERTEQ(conf->mzx_speed, 4);
+    ASSERTEQ(conf->mzx_speed, 4, "");
   }
 
   SECTION(IncludeEquals)
@@ -1738,17 +1738,17 @@ UNITTEST(Include)
     // This version works from both the config file and the command line.
     char include_conf[] = "include=c.cnf";
     boolean ret = write_config("c.cnf", "mzx_speed = 6");
-    ASSERTEQ(ret, true);
+    ASSERTEQ(ret, true, "");
 
     conf->mzx_speed = 1;
 
     load_arg(include_conf);
-    ASSERTEQX(conf->mzx_speed, 6, include_conf);
+    ASSERTEQ(conf->mzx_speed, 6, "%s", include_conf);
 
     conf->mzx_speed = 2;
 
     load_arg_file(include_conf, false);
-    ASSERTEQX(conf->mzx_speed, 6, include_conf);
+    ASSERTEQ(conf->mzx_speed, 6, "%s", include_conf);
   }
 
   SECTION(Recursion)
@@ -1758,7 +1758,7 @@ UNITTEST(Include)
     boolean ret = write_config("a.cnf", "include b.cnf");
     ret &= write_config("b.cnf", "include c.cnf");
     ret &= write_config("c.cnf", "mzx_speed=5\nboard_editor_hide_help=1");
-    ASSERTEQ(ret, true);
+    ASSERTEQ(ret, true, "");
 
     conf->mzx_speed = 1;
 #ifdef CONFIG_EDITOR
@@ -1766,9 +1766,9 @@ UNITTEST(Include)
 #endif
 
     load_arg((char *)"include=a.cnf");
-    ASSERTEQ(conf->mzx_speed, 5);
+    ASSERTEQ(conf->mzx_speed, 5, "");
 #ifdef CONFIG_EDITOR
-    ASSERTEQ(econf->board_editor_hide_help, true);
+    ASSERTEQ(econf->board_editor_hide_help, true, "");
 #endif
   }
 
@@ -1779,7 +1779,7 @@ UNITTEST(Include)
     // of file descriptors prior to running out of stack. This is pretty much
     // a freebie, it just needs to not crash or run out of memory.
     boolean ret = write_config("a.cnf", "include a.cnf");
-    ASSERTEQ(ret, true);
+    ASSERTEQ(ret, true, "");
 
     set_config_from_file(SYSTEM_CNF, "a.cnf");
   }

--- a/unit/editor/stringsearch.cpp
+++ b/unit/editor/stringsearch.cpp
@@ -127,86 +127,86 @@ UNITTEST(Search)
 
   SECTION(OneOff)
   {
-    for(int i = 0; i < arraysize(haystack_none); i++)
+    for(const string_pair &d : haystack_none)
     {
-      A = haystack_none[i].haystack;
-      B = haystack_none[i].needle;
+      A = d.haystack;
+      B = d.needle;
 
-      ASSERTX(!string_search(A, strlen(A), B, strlen(B), nullptr, false), A);
+      ASSERT(!string_search(A, strlen(A), B, strlen(B), nullptr, false), "%s", A);
     }
 
-    for(int i = 0; i < arraysize(haystack_once); i++)
+    for(const string_pair_idx &d : haystack_once)
     {
-      A = haystack_once[i].haystack;
-      B = haystack_once[i].needle;
-      ssize_t where = haystack_once[i].where;
+      A = d.haystack;
+      B = d.needle;
+      ssize_t where = d.where;
 
       dest = string_search(A, strlen(A), B, strlen(B), nullptr, false);
-      ASSERTX(dest, A);
-      ASSERT(dest >= A && dest < A + strlen(A));
-      ASSERTEQX((const char *)dest - A, where, A);
+      ASSERT(dest, "%s", A);
+      ASSERT(dest >= A && dest < A + strlen(A), "%s", A);
+      ASSERTEQ((const char *)dest - A, where, "%s", A);
     }
 
-    for(int i = 0; i < arraysize(haystack_twice); i++)
+    for(const string_pair &d : haystack_twice)
     {
-      A = haystack_twice[i].haystack;
-      B = haystack_twice[i].needle;
+      A = d.haystack;
+      B = d.needle;
 
       dest = string_search(A, strlen(A), B, strlen(B), nullptr, false);
-      ASSERTX(dest, A);
-      ASSERT(dest >= A && dest < A + strlen(A));
+      ASSERT(dest, "%s", A);
+      ASSERT(dest >= A && dest < A + strlen(A), "%s", A);
     }
   }
 
   SECTION(Repeating)
   {
-    for(int i = 0; i < arraysize(haystack_once); i++)
+    for(const string_pair_idx &d : haystack_once)
     {
       const char *dest;
-      A = haystack_once[i].haystack;
-      B = haystack_once[i].needle;
-      ssize_t where = haystack_once[i].where;
+      A = d.haystack;
+      B = d.needle;
+      ssize_t where = d.where;
       ssize_t a_len = strlen(A);
       ssize_t b_len = strlen(B);
 
       string_search_index(B, b_len, &data, false);
 
       dest = (const char *)string_search(A, a_len, B, b_len, &data, false);
-      ASSERTX(dest, A);
-      ASSERT(dest >= A && dest < A + a_len);
-      ASSERTEQX((const char *)dest - A, where, A);
+      ASSERT(dest, "%s", A);
+      ASSERT(dest >= A && dest < A + a_len, "%s", A);
+      ASSERTEQ((const char *)dest - A, where, "%s", A);
       dest++;
       a_len -= dest - A;
       A = dest;
 
-      ASSERTX(!string_search(A, a_len, B, b_len, &data, false), A);
+      ASSERT(!string_search(A, a_len, B, b_len, &data, false), "%s", A);
     }
 
-    for(int i = 0; i < arraysize(haystack_twice); i++)
+    for(const string_pair &d : haystack_twice)
     {
       const char *dest;
-      A = haystack_twice[i].haystack;
-      B = haystack_twice[i].needle;
+      A = d.haystack;
+      B = d.needle;
       ssize_t a_len = strlen(A);
       ssize_t b_len = strlen(B);
 
       string_search_index(B, b_len, &data, false);
 
       dest = (const char *)string_search(A, a_len, B, b_len, &data, false);
-      ASSERTX(dest, A);
-      ASSERT(dest >= A && dest < A + a_len);
+      ASSERT(dest, "%s", A);
+      ASSERT(dest >= A && dest < A + a_len, "%s", A);
       dest++;
       a_len -= dest - A;
       A = dest;
 
       dest = (const char *)string_search(A, a_len, B, b_len, &data, false);
-      ASSERTX(dest, A);
-      ASSERT(dest >= A && dest < A + a_len);
+      ASSERT(dest, "%s", A);
+      ASSERT(dest >= A && dest < A + a_len, "%s", A);
       dest++;
       a_len -= dest - A;
       A = dest;
 
-      ASSERTX(!string_search(A, a_len, B, b_len, &data, false), A);
+      ASSERT(!string_search(A, a_len, B, b_len, &data, false), "%s", A);
     }
   }
 }
@@ -283,82 +283,82 @@ UNITTEST(SearchCaseInsensitive)
 
   SECTION(OneOff)
   {
-    for(int i = 0; i < arraysize(haystack_none); i++)
+    for(const string_pair &d : haystack_none)
     {
-      A = haystack_none[i].haystack;
-      B = haystack_none[i].needle;
+      A = d.haystack;
+      B = d.needle;
 
-      ASSERTX(!string_search(A, strlen(A), B, strlen(B), NULL, true), A);
+      ASSERT(!string_search(A, strlen(A), B, strlen(B), NULL, true), "%s", A);
     }
 
-    for(int i = 0; i < arraysize(haystack_once); i++)
+    for(const string_pair &d : haystack_once)
     {
-      A = haystack_once[i].haystack;
-      B = haystack_once[i].needle;
+      A = d.haystack;
+      B = d.needle;
 
       dest = string_search(A, strlen(A), B, strlen(B), NULL, true);
-      ASSERTX(dest, A);
-      ASSERT(dest >= A && dest < A + strlen(A));
+      ASSERT(dest, "%s", A);
+      ASSERT(dest >= A && dest < A + strlen(A), "%s", A);
     }
 
-    for(int i = 0; i < arraysize(haystack_twice); i++)
+    for(const string_pair &d : haystack_twice)
     {
-      A = haystack_twice[i].haystack;
-      B = haystack_twice[i].needle;
+      A = d.haystack;
+      B = d.needle;
 
       dest = string_search(A, strlen(A), B, strlen(B), NULL, true);
-      ASSERTX(dest, A);
-      ASSERT(dest >= A && dest < A + strlen(A));
+      ASSERT(dest, "%s", A);
+      ASSERT(dest >= A && dest < A + strlen(A), "%s", A);
     }
   }
 
   SECTION(Repeating)
   {
-    for(int i = 0; i < arraysize(haystack_once); i++)
+    for(const string_pair &d : haystack_once)
     {
       const char *dest;
-      A = haystack_once[i].haystack;
-      B = haystack_once[i].needle;
+      A = d.haystack;
+      B = d.needle;
       ssize_t a_len = strlen(A);
       ssize_t b_len = strlen(B);
 
       string_search_index(B, b_len, &data, true);
 
       dest = (const char *)string_search(A, a_len, B, b_len, &data, true);
-      ASSERTX(dest, A);
-      ASSERT(dest >= A && dest < A + a_len);
+      ASSERT(dest, "%s", A);
+      ASSERT(dest >= A && dest < A + a_len, "%s", A);
       dest++;
       a_len -= dest - A;
       A = dest;
 
-      ASSERTX(!string_search(A, a_len, B, b_len, &data, true), A);
+      ASSERT(!string_search(A, a_len, B, b_len, &data, true), "%s", A);
     }
 
-    for(int i = 0; i < arraysize(haystack_twice); i++)
+    for(const string_pair &d : haystack_twice)
     {
       const char *dest;
-      A = haystack_twice[i].haystack;
-      B = haystack_twice[i].needle;
+      A = d.haystack;
+      B = d.needle;
       ssize_t a_len = strlen(A);
       ssize_t b_len = strlen(B);
 
       string_search_index(B, b_len, &data, true);
 
       dest = (const char *)string_search(A, a_len, B, b_len, &data, true);
-      ASSERTX(dest, A);
-      ASSERT(dest >= A && dest < A + a_len);
+      ASSERT(dest, "%s", A);
+      ASSERT(dest >= A && dest < A + a_len, "%s", A);
       dest++;
       a_len -= dest - A;
       A = dest;
 
       dest = (const char *)string_search(A, a_len, B, b_len, &data, true);
-      ASSERTX(dest, A);
-      ASSERT(dest >= A && dest < A + a_len);
+      ASSERT(dest, "%s", A);
+      ASSERT(dest >= A && dest < A + a_len, "%s", A);
       dest++;
       a_len -= dest - A;
       A = dest;
 
-      ASSERTX(!string_search(A, a_len, B, b_len, &data, true), A);
+      ASSERT(!string_search(A, a_len, B, b_len, &data, true), "%s", A);
     }
   }
 }

--- a/unit/expr.cpp
+++ b/unit/expr.cpp
@@ -56,34 +56,30 @@ static const tr_int_data data[] =
 
 UNITTEST(tr_int_to_string)
 {
-  char sprintf_buf[12];
   char tr_buf[12];
   char *tmp;
   size_t len;
 
-  for(int i = 0; i < arraysize(data); i++)
+  for(const tr_int_data &d : data)
   {
-    sprintf(sprintf_buf, "%d", data[i].value);
-    tmp = tr_int_to_string(tr_buf, data[i].value, &len);
+    tmp = tr_int_to_string(tr_buf, d.value, &len);
 
-    ASSERTEQX(len, strlen(data[i].dec), data[i].dec);
-    ASSERTCMP(tmp, data[i].dec);
+    ASSERTEQ(len, strlen(d.dec), "%s", d.dec);
+    ASSERTCMP(tmp, d.dec, "");
   }
 }
 
 UNITTEST(tr_int_to_hex_string)
 {
-  char sprintf_buf[9];
   char tr_buf[9];
   char *tmp;
   size_t len;
 
-  for(int i = 0; i < arraysize(data); i++)
+  for(const tr_int_data &d : data)
   {
-    sprintf(sprintf_buf, "%x", data[i].value);
-    tmp = tr_int_to_hex_string(tr_buf, data[i].value, &len);
+    tmp = tr_int_to_hex_string(tr_buf, d.value, &len);
 
-    ASSERTEQX(len, strlen(data[i].hex), data[i].hex);
-    ASSERTCMP(tmp, data[i].hex);
+    ASSERTEQ(len, strlen(d.hex), "%s", d.hex);
+    ASSERTCMP(tmp, d.hex, "");
   }
 }

--- a/unit/intake.cpp
+++ b/unit/intake.cpp
@@ -157,7 +157,6 @@ UNITTEST(PosLength)
 {
   struct intake_subcontext intk{};
   char dest[256];
-  char buf[80];
   int ext = 0;
 
   intk.current_length = 100;
@@ -170,9 +169,8 @@ UNITTEST(PosLength)
   {
     for(const int_pair &d : pos_data)
     {
-      snprintf(buf, arraysize(buf), "%d -> %d", d.input, d.expected);
       intake_set_pos(&intk, d.input);
-      ASSERTEQX(intk.pos, d.expected, buf);
+      ASSERTEQ(intk.pos, d.expected, "%d -> %d", d.input, d.expected);
     }
   }
 
@@ -182,10 +180,9 @@ UNITTEST(PosLength)
 
     for(const int_pair &d : pos_data)
     {
-      snprintf(buf, arraysize(buf), "%d -> %d", d.input, d.expected);
       intake_set_pos(&intk, d.input);
-      ASSERTEQX(intk.pos, d.expected, buf);
-      ASSERTEQX(ext, d.expected, buf);
+      ASSERTEQ(intk.pos, d.expected, "%d -> %d", d.input, d.expected);
+      ASSERTEQ(ext, d.expected, "%d -> %d", d.input, d.expected);
     }
   }
 
@@ -193,9 +190,8 @@ UNITTEST(PosLength)
   {
     for(const int_pair &d : length_data)
     {
-      snprintf(buf, arraysize(buf), "%d -> %d", d.input, d.expected);
       intake_set_length(&intk, d.input);
-      ASSERTEQX(intk.current_length, d.expected, buf);
+      ASSERTEQ(intk.current_length, d.expected, "%d -> %d", d.input, d.expected);
     }
   }
 
@@ -205,10 +201,9 @@ UNITTEST(PosLength)
 
     for(const int_pair &d : length_data)
     {
-      snprintf(buf, arraysize(buf), "%d -> %d", d.input, d.expected);
       intake_set_length(&intk, d.input);
-      ASSERTEQX(intk.current_length, d.expected, buf);
-      ASSERTEQX(ext, d.expected, buf);
+      ASSERTEQ(intk.current_length, d.expected, "%d -> %d", d.input, d.expected);
+      ASSERTEQ(ext, d.expected, "%d -> %d", d.input, d.expected);
     }
   }
 
@@ -226,18 +221,16 @@ UNITTEST(PosLength)
   {
     for(const int_pair &d : pos_data)
     {
-      snprintf(buf, arraysize(buf), "%d -> %d", d.input, d.expected);
       intake_set_pos(&intk, d.input);
       intake_sync((subcontext *)&intk);
-      ASSERTEQX(intk.pos, d.expected, buf);
+      ASSERTEQ(intk.pos, d.expected, "%d -> %d", d.input, d.expected);
     }
 
     for(const int_pair &d : length_data)
     {
-      snprintf(buf, arraysize(buf), "%d -> %d", d.input, d.expected);
       intake_set_length(&intk, d.input);
       intake_sync((subcontext *)&intk);
-      ASSERTEQX(intk.current_length, d.expected, buf);
+      ASSERTEQ(intk.current_length, d.expected, "%d -> %d", d.input, d.expected);
     }
   }
 
@@ -252,11 +245,10 @@ UNITTEST(PosLength)
 
     for(const int_pair &d : pos_data)
     {
-      snprintf(buf, arraysize(buf), "%d -> %d", d.input, d.expected);
       ext = d.input;
       intake_sync((subcontext *)&intk);
-      ASSERTEQX(intk.pos, d.expected, buf);
-      ASSERTEQX(ext, d.expected, buf);
+      ASSERTEQ(intk.pos, d.expected, "%d -> %d", d.input, d.expected);
+      ASSERTEQ(ext, d.expected, "%d -> %d", d.input, d.expected);
     }
   }
 
@@ -274,11 +266,10 @@ UNITTEST(PosLength)
     for(const int_pair &d : length_data)
     {
       dest_len = std::max(0, std::min(dest_len, d.input));
-      snprintf(buf, arraysize(buf), "%d -> %d", d.input, dest_len);
       intake_set_length(&intk, d.input);
       intake_sync((subcontext *)&intk);
-      ASSERTEQX(intk.current_length, dest_len, buf);
-      ASSERTEQX(intk.pos, 97, buf);
+      ASSERTEQ(intk.current_length, dest_len, "%d -> %d", d.input, dest_len);
+      ASSERTEQ(intk.pos, 97, "%d -> %d", d.input, dest_len);
     }
   }
 
@@ -293,11 +284,10 @@ UNITTEST(PosLength)
 
     for(const int_pair &d : length_data)
     {
-      snprintf(buf, arraysize(buf), "%d -> %d", d.input, d.expected);
       ext = d.input;
       intake_sync((subcontext *)&intk);
-      ASSERTEQX(intk.current_length, d.expected, buf);
-      ASSERTEQX(ext, d.expected, buf);
+      ASSERTEQ(intk.current_length, d.expected, "%d -> %d", d.input, d.expected);
+      ASSERTEQ(ext, d.expected, "%d -> %d", d.input, d.expected);
     }
   }
 
@@ -313,11 +303,10 @@ UNITTEST(PosLength)
 
     for(const int_pair &d : length_data)
     {
-      snprintf(buf, arraysize(buf), "%d -> %d", d.input, dest_len);
       ext = d.input;
       intake_sync((subcontext *)&intk);
-      ASSERTEQX(intk.current_length, dest_len, buf);
-      ASSERTEQX(ext, dest_len, buf);
+      ASSERTEQ(intk.current_length, dest_len, "%d -> %d", d.input, dest_len);
+      ASSERTEQ(ext, dest_len, "%d -> %d", d.input, dest_len);
     }
   }
 }
@@ -351,7 +340,6 @@ UNITTEST(EventFixed)
   struct intake_subcontext intk{};
   subcontext *sub = reinterpret_cast<subcontext *>(&intk);
   char dest[256];
-  char buf[80];
   boolean result;
 
   intk.dest = dest;
@@ -370,9 +358,8 @@ UNITTEST(EventFixed)
 
     for(int i : skip_backward_positions)
     {
-      snprintf(buf, arraysize(buf), "%d", i);
-      ASSERTEQX(intk.pos, i, buf);
-      ASSERTEQX(ext, i, buf);
+      ASSERTEQ(intk.pos, i, "%d", i);
+      ASSERTEQ(ext, i, "%d", i);
       intake_skip_back(&intk);
     }
   }
@@ -384,9 +371,8 @@ UNITTEST(EventFixed)
 
     for(int i : skip_forward_positions)
     {
-      snprintf(buf, arraysize(buf), "%d", i);
-      ASSERTEQX(intk.pos, i, buf);
-      ASSERTEQX(ext, i, buf);
+      ASSERTEQ(intk.pos, i, "%d", i);
+      ASSERTEQ(ext, i, "%d", i);
       intake_skip_forward(&intk);
     }
   }
@@ -395,12 +381,12 @@ UNITTEST(EventFixed)
   {
     // Should not crash with a null intake.
     result = intake_apply_event_fixed(nullptr, INTK_MOVE, 0, 0, nullptr);
-    ASSERTEQ(result, false);
+    ASSERTEQ(result, false, "");
 
     // Should not crash with a null dest.
     intk.dest = nullptr;
     result = intake_apply_event_fixed(sub, INTK_MOVE, 0, 0, nullptr);
-    ASSERTEQ(result, false);
+    ASSERTEQ(result, false, "");
     intk.dest = dest;
 
     // Should not crash if intk->pos is somehow invalid.
@@ -409,7 +395,7 @@ UNITTEST(EventFixed)
     {
       intk.pos = i;
       result = intake_apply_event_fixed(sub, INTK_MOVE, 0, 0, nullptr);
-      ASSERTEQ(result, false);
+      ASSERTEQ(result, false, "");
     }
   }
 
@@ -417,7 +403,7 @@ UNITTEST(EventFixed)
   {
     // Nothing should ever actually send this event (if it does, it's a bug).
     result = intake_apply_event_fixed(sub, INTK_NO_EVENT, 0, 0, nullptr);
-    ASSERTEQ(result, false);
+    ASSERTEQ(result, false, "");
   }
 
   SECTION(INTK_MOVE)
@@ -425,11 +411,10 @@ UNITTEST(EventFixed)
     // Applying this moves the cursor, that's it.
     for(const int_pair &d : pos_data)
     {
-      snprintf(buf, arraysize(buf), "%d -> %d", d.input, d.expected);
       intk.pos = 25;
       result = intake_apply_event_fixed(sub, INTK_MOVE, d.input, 0, nullptr);
-      ASSERTEQX(result, true, buf);
-      ASSERTEQX(intk.pos, d.expected, buf);
+      ASSERTEQ(result, true, "%d -> %d", d.input, d.expected);
+      ASSERTEQ(intk.pos, d.expected, "%d -> %d", d.input, d.expected);
     }
   }
 
@@ -441,22 +426,20 @@ UNITTEST(EventFixed)
 
     for(int i : skip_forward_positions)
     {
-      snprintf(buf, arraysize(buf), "%d (forward)", i);
-      ASSERTEQX(intk.pos, i, buf);
-      ASSERTEQX(ext, i, buf);
+      ASSERTEQ(intk.pos, i, "%d (forward)", i);
+      ASSERTEQ(ext, i, "%d (forward)", i);
       result = intake_apply_event_fixed(sub, INTK_MOVE_WORDS, intk.pos, 1, nullptr);
-      ASSERTEQX(result, true, buf);
+      ASSERTEQ(result, true, "%d (forward)", i);
     }
 
     ext = 100;
     intk.pos = 100;
     for(int i : skip_backward_positions)
     {
-      snprintf(buf, arraysize(buf), "%d (backward)", i);
-      ASSERTEQX(intk.pos, i, buf);
-      ASSERTEQX(ext, i, buf);
+      ASSERTEQ(intk.pos, i, "%d (backward)", i);
+      ASSERTEQ(ext, i, "%d (backward)", i);
       result = intake_apply_event_fixed(sub, INTK_MOVE_WORDS, intk.pos, -1, nullptr);
-      ASSERTEQX(result, true, buf);
+      ASSERTEQ(result, true, "%d (backward)", i);
     }
   }
 
@@ -475,7 +458,7 @@ UNITTEST(EventFixed)
         result = intake_apply_event_fixed(sub, INTK_INSERT, intk.pos + 1, d.input[i], nullptr);
         ASSERTEQ(result, true, "%s", d.expected);
       }
-      ASSERTCMP(dest, d.expected);
+      ASSERTCMP(dest, d.expected, "");
       ASSERTEQ(intk.current_length, expected_len, "%s", d.expected);
       ASSERTEQ(intk.pos, d.new_pos, "%s", d.expected);
     }
@@ -487,14 +470,14 @@ UNITTEST(EventFixed)
 
     intk.pos = 7;
     result = intake_apply_event_fixed(sub, INTK_INSERT, intk.pos + 1, 'h', nullptr);
-    ASSERTEQ(result, true);
+    ASSERTEQ(result, true, "");
     result = intake_apply_event_fixed(sub, INTK_INSERT, intk.pos + 1, 'i', nullptr);
-    ASSERTEQ(result, false);
-    ASSERTEQ(intk.pos, 8);
+    ASSERTEQ(result, false, "");
+    ASSERTEQ(intk.pos, 8, "");
     intk.pos = 0;
     result = intake_apply_event_fixed(sub, INTK_INSERT, intk.pos + 1, 'i', nullptr);
-    ASSERTEQ(result, false);
-    ASSERTEQ(intk.pos, 0);
+    ASSERTEQ(result, false, "");
+    ASSERTEQ(intk.pos, 0, "");
   }
 
   SECTION(INTK_OVERWRITE)
@@ -510,10 +493,10 @@ UNITTEST(EventFixed)
       for(size_t i = 0, len = strlen(d.input); i < len; i++)
       {
         result = intake_apply_event_fixed(sub, INTK_OVERWRITE, intk.pos + 1, d.input[i], nullptr);
-        ASSERTEQX(result, true, d.expected);
+        ASSERTEQ(result, true, "%s", d.expected);
       }
-      ASSERTCMP(dest, d.expected);
-      ASSERTEQ(intk.current_length, expected_len);
+      ASSERTCMP(dest, d.expected, "");
+      ASSERTEQ(intk.current_length, expected_len, "");
     }
 
     // Special: prevent inserting beyond the maximum length.
@@ -523,15 +506,15 @@ UNITTEST(EventFixed)
 
     intk.pos = 7;
     result = intake_apply_event_fixed(sub, INTK_OVERWRITE, intk.pos + 1, 'h', nullptr);
-    ASSERTEQ(result, true);
+    ASSERTEQ(result, true, "");
     result = intake_apply_event_fixed(sub, INTK_OVERWRITE, intk.pos + 1, 'i', nullptr);
-    ASSERTEQ(result, false);
-    ASSERTEQ(intk.pos, 8);
+    ASSERTEQ(result, false, "");
+    ASSERTEQ(intk.pos, 8, "");
     // This should work, though.
     intk.pos = 0;
     result = intake_apply_event_fixed(sub, INTK_OVERWRITE, intk.pos + 1, 'i', nullptr);
-    ASSERTEQ(result, true);
-    ASSERTCMP(dest, "ibcdefgh");
+    ASSERTEQ(result, true, "");
+    ASSERTCMP(dest, "ibcdefgh", "");
   }
 
   SECTION(INTK_DELETE)
@@ -556,10 +539,10 @@ UNITTEST(EventFixed)
       for(int i = 0; i < d.repeat_times; i++)
       {
         result = intake_apply_event_fixed(sub, INTK_DELETE, intk.pos, 0, nullptr);
-        ASSERTEQX(result, true, d.expected);
+        ASSERTEQ(result, true, "%s", d.expected);
       }
-      ASSERTCMP(dest, d.expected);
-      ASSERTEQ(intk.current_length, expected_len);
+      ASSERTCMP(dest, d.expected, "");
+      ASSERTEQ(intk.current_length, expected_len, "");
     }
   }
 
@@ -587,7 +570,7 @@ UNITTEST(EventFixed)
         result = intake_apply_event_fixed(sub, INTK_BACKSPACE, intk.pos - 1, 0, nullptr);
         ASSERTEQ(result, true, "%s", d.expected);
       }
-      ASSERTCMP(dest, d.expected);
+      ASSERTCMP(dest, d.expected, "");
       ASSERTEQ(intk.current_length, expected_len, "%s", d.expected);
       ASSERTEQ(intk.pos, d.new_pos, "%s", d.expected);
     }
@@ -622,7 +605,7 @@ UNITTEST(EventFixed)
 
       result = intake_apply_event_fixed(sub, INTK_BACKSPACE_WORDS, intk.pos, d.repeat_times, nullptr);
       ASSERTEQ(result, true, "%s", d.expected);
-      ASSERTCMP(dest, d.expected);
+      ASSERTCMP(dest, d.expected, "");
       ASSERTEQ(intk.current_length, expected_len, "%s", d.expected);
       ASSERTEQ(intk.pos, d.new_pos, "%s", d.expected);
     }
@@ -643,16 +626,15 @@ UNITTEST(EventFixed)
 
     for(const event_repeat_data &d : data)
     {
-      snprintf(buf, arraysize(buf), "%s @ %d", d.base, d.start_pos);
       strcpy(dest, d.base);
       intake_set_length(&intk, strlen(dest));
       intake_set_pos(&intk, d.start_pos);
 
       result = intake_apply_event_fixed(sub, INTK_CLEAR, 0, 0, nullptr);
-      ASSERTEQ(result, true, "%s", buf);
-      ASSERTCMP(dest, "", "%s", buf);
-      ASSERTEQ(intk.current_length, 0, "%s", buf);
-      ASSERTEQ(intk.pos, d.new_pos, "%s", buf);
+      ASSERTEQ(result, true, "%s", "%s @ %d", d.base, d.start_pos);
+      ASSERTCMP(dest, "", "%s", "%s @ %d", d.base, d.start_pos);
+      ASSERTEQ(intk.current_length, 0, "%s", "%s @ %d", d.base, d.start_pos);
+      ASSERTEQ(intk.pos, d.new_pos, "%s", "%s @ %d", d.base, d.start_pos);
     }
   }
 
@@ -666,12 +648,12 @@ UNITTEST(EventFixed)
 
       int len = strlen(d.input);
       result = intake_apply_event_fixed(sub, INTK_INSERT_BLOCK, intk.pos + len, len, d.input);
-      ASSERTEQX(result, true, d.expected);
-      ASSERTCMP(dest, d.expected);
+      ASSERTEQ(result, true, "%s", d.expected);
+      ASSERTCMP(dest, d.expected, "");
     }
     // Reject null data...
     result = intake_apply_event_fixed(sub, INTK_INSERT_BLOCK, intk.pos, 0, nullptr);
-    ASSERTEQ(result, false);
+    ASSERTEQ(result, false, "");
   }
 
   SECTION(INTK_OVERWRITE_BLOCK)
@@ -684,12 +666,12 @@ UNITTEST(EventFixed)
 
       int len = strlen(d.input);
       result = intake_apply_event_fixed(sub, INTK_OVERWRITE_BLOCK, intk.pos + len, len, d.input);
-      ASSERTEQX(result, true, d.expected);
-      ASSERTCMP(dest, d.expected);
+      ASSERTEQ(result, true, "%s", d.expected);
+      ASSERTCMP(dest, d.expected, "");
     }
     // Reject null data...
     result = intake_apply_event_fixed(sub, INTK_OVERWRITE_BLOCK, intk.pos, 0, nullptr);
-    ASSERTEQ(result, false);
+    ASSERTEQ(result, false, "");
   }
 
   SECTION(intake_input_string)
@@ -708,13 +690,13 @@ UNITTEST(EventFixed)
       const char *ret = intake_input_string(sub, d.input, d.linebreak_char);
       if(d.retval >= 0)
       {
-        ASSERTX(ret != nullptr, d.expected);
-        ASSERTEQX((ssize_t)(ret - d.input), d.retval, d.expected);
+        ASSERT(ret != nullptr, "%s", d.expected);
+        ASSERTEQ((ssize_t)(ret - d.input), d.retval, "%s", d.expected);
       }
       else
-        ASSERTEQX(ret, nullptr, d.expected);
+        ASSERTEQ(ret, nullptr, "%s", d.expected);
 
-      ASSERTCMP(dest, d.expected);
+      ASSERTCMP(dest, d.expected, "");
     }
   }
 }
@@ -732,9 +714,9 @@ boolean event_callback(void *priv, subcontext *sub, enum intake_event_type type,
   struct intake_subcontext *intk = reinterpret_cast<struct intake_subcontext *>(sub);
   event_cb_data *d = reinterpret_cast<event_cb_data *>(priv);
 
-  ASSERTEQX(old_pos, intk->pos, d->expected);
+  ASSERTEQ(old_pos, intk->pos, "%s", d->expected);
   if(intk->dest)
-    ASSERTCMP(intk->dest, d->expected);
+    ASSERTCMP(intk->dest, d->expected, "");
 
   if(d->pos_external)
     *(d->pos_external) = new_pos;
@@ -796,8 +778,8 @@ UNITTEST(EventCallback)
       intk.event_priv = &priv;
       intk.pos = d.old_pos;
       intake_event_ext(&intk, d.type, d.old_pos, d.new_pos, d.value, dummy_data);
-      ASSERTEQX(priv.call_count, 1, d.base);
-      ASSERTEQX(intk.pos, d.new_pos, d.base);
+      ASSERTEQ(priv.call_count, 1, "%s", d.base);
+      ASSERTEQ(intk.pos, d.new_pos, "%s", d.base);
     }
   }
 
@@ -817,8 +799,8 @@ UNITTEST(EventCallback)
       intk.pos = d.old_pos;
       strcpy(dest, d.base);
       intake_event_ext(&intk, d.type, d.old_pos, d.new_pos, d.value, dummy_data);
-      ASSERTEQX(priv.call_count, 1, d.base);
-      ASSERTEQX(intk.pos, d.new_pos, d.base);
+      ASSERTEQ(priv.call_count, 1, "%s", d.base);
+      ASSERTEQ(intk.pos, d.new_pos, "%s", d.base);
     }
   }
 
@@ -840,15 +822,15 @@ UNITTEST(EventCallback)
 
       const char *ret = intake_input_string(sub, d.input, d.linebreak_char);
       if(strlen(d.input))
-        ASSERTEQX(priv.call_count, 1, d.base);
+        ASSERTEQ(priv.call_count, 1, "%s", d.base);
 
       if(d.retval >= 0)
       {
-        ASSERTX(ret != nullptr, d.expected);
-        ASSERTEQX((ssize_t)(ret - d.input), d.retval, d.expected);
+        ASSERT(ret != nullptr, "%s", d.expected);
+        ASSERTEQ((ssize_t)(ret - d.input), d.retval, "%s", d.expected);
       }
       else
-        ASSERTEQX(ret, nullptr, d.expected);
+        ASSERTEQ(ret, nullptr, "%s", d.expected);
     }
   }
 }

--- a/unit/io/bitstream.cpp
+++ b/unit/io/bitstream.cpp
@@ -68,7 +68,6 @@ UNITTEST(UnShrinkLike)
     43497, 256, 1, 60659,
   };
 
-  char mesg[80];
   struct bitstream b{};
   int out;
   int i;
@@ -79,30 +78,27 @@ UNITTEST(UnShrinkLike)
   for(i = 0; i < arraysize(expected9); i++)
   {
     out = BS_READ(&b, 9);
-    snprintf(mesg, arraysize(mesg), "code size 9, position %u", (unsigned)i);
-    ASSERTEQX(out, expected9[i], mesg);
+    ASSERTEQ(out, expected9[i], "code size 9, position %d", i);
   }
 
   for(i = 0; i < arraysize(expected12); i++)
   {
     out = BS_READ(&b, 12);
-    snprintf(mesg, arraysize(mesg), "code size 12, position %u", (unsigned)i);
-    ASSERTEQX(out, expected12[i], mesg);
+    ASSERTEQ(out, expected12[i], "code size 12, position %d", i);
   }
 
   for(i = 0; i < arraysize(expected16); i++)
   {
     out = BS_READ(&b, 16);
-    snprintf(mesg, arraysize(mesg), "code size 16, position %u", (unsigned)i);
-    ASSERTEQX(out, expected16[i], mesg);
+    ASSERTEQ(out, expected16[i], "code size 16, position %d", i);
   }
 
-  ASSERTEQ(b.input, nullptr);
-  ASSERTEQ(b.input_left, 0);
+  ASSERTEQ(b.input, nullptr, "");
+  ASSERTEQ(b.input_left, 0, "");
 
   // NOTE: this won't always be true as streams are byte-aligned, but this
   // test data has been designed so that this should be true.
-  ASSERTEQ(b.buf_left, 0);
+  ASSERTEQ(b.buf_left, 0, "");
 }
 
 /**
@@ -144,7 +140,6 @@ UNITTEST(ExplodeLike)
     { 1, 1 }, { 8, 0x4F }, { 1, 1 }, { 1, 0 }, { 1, 1 },
   };
 
-  char mesg[80];
   struct bitstream b{};
   int out;
   int i;
@@ -154,19 +149,17 @@ UNITTEST(ExplodeLike)
 
   for(i = 0; i < arraysize(sequence); i++)
   {
-    snprintf(mesg, arraysize(mesg), "position %d, %u bit(s)", i,
-     sequence[i].length);
-
     out = BS_READ(&b, sequence[i].length);
-    ASSERTEQX(out, sequence[i].expected_value, mesg);
+    ASSERTEQ(out, sequence[i].expected_value, "position %d, %u bit(s)", i,
+     sequence[i].length);
   }
 
-  ASSERTEQ(b.input, nullptr);
-  ASSERTEQ(b.input_left, 0);
+  ASSERTEQ(b.input, nullptr, "");
+  ASSERTEQ(b.input_left, 0, "");
 
   // NOTE: this won't always be true as streams are byte-aligned, but this
   // test data has been designed so that this should be true.
-  ASSERTEQ(b.buf_left, 0);
+  ASSERTEQ(b.buf_left, 0, "");
 }
 
 /**
@@ -238,7 +231,6 @@ UNITTEST(OutOfBounds)
   };
   samesize(data, sequence);
 
-  char mesg[80];
   int out;
   int i;
   int j;
@@ -252,15 +244,13 @@ UNITTEST(OutOfBounds)
 
     for(j = 0; i < arraysize(sequence[i]) && sequence[i][j].length; j++)
     {
-      snprintf(mesg, arraysize(mesg), "array %d, position %d, %u bit(s)", i, j,
-       sequence[i][j].length);
-
       out = BS_READ(&b, sequence[i][j].length);
-      ASSERTEQX(out, sequence[i][j].expected_value, mesg);
+      ASSERTEQ(out, sequence[i][j].expected_value,
+       "array %d, position %d, %u bit(s)", i, j, sequence[i][j].length);
     }
 
-    ASSERTEQ(b.input, nullptr);
-    ASSERTEQ(b.input_left, 0);
+    ASSERTEQ(b.input, nullptr, "");
+    ASSERTEQ(b.input_left, 0, "");
 
     // NOTE: may be bits left in this test, so don't try to test it...
   }

--- a/unit/io/memfile.cpp
+++ b/unit/io/memfile.cpp
@@ -32,10 +32,10 @@ UNITTEST(mfopen)
     struct memfile mf;
 
     mfopen(buffer, arraysize(buffer), &mf);
-    ASSERTEQ(mf.start, buffer);
-    ASSERTEQ(mf.current, buffer);
-    ASSERTEQ(mf.end, mf.start + arraysize(buffer));
-    ASSERTEQ(mf.alloc, false);
+    ASSERTEQ(mf.start, buffer, "");
+    ASSERTEQ(mf.current, buffer, "");
+    ASSERTEQ(mf.end, mf.start + arraysize(buffer), "");
+    ASSERTEQ(mf.alloc, false, "");
   }
 
   SECTION(mfopen_alloc)
@@ -43,14 +43,14 @@ UNITTEST(mfopen)
     struct memfile *mf;
 
     mf = mfopen_alloc(buffer, arraysize(buffer));
-    ASSERT(mf);
-    ASSERTEQ(mf->start, buffer);
-    ASSERTEQ(mf->current, buffer);
-    ASSERTEQ(mf->end, buffer + arraysize(buffer));
-    ASSERTEQ(mf->alloc, true);
+    ASSERT(mf, "");
+    ASSERTEQ(mf->start, buffer, "");
+    ASSERTEQ(mf->current, buffer, "");
+    ASSERTEQ(mf->end, buffer + arraysize(buffer), "");
+    ASSERTEQ(mf->alloc, true, "");
 
     int ret = mf_alloc_free(mf);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
   }
 
   SECTION(mf_alloc_free_on_static_memfile)
@@ -59,10 +59,10 @@ UNITTEST(mfopen)
     mfopen(buffer, arraysize(buffer), &mf);
 
     int ret = mf_alloc_free(&mf);
-    ASSERTEQ(ret, -1);
-    ASSERTEQ(mf.start, buffer);
-    ASSERTEQ(mf.current, buffer);
-    ASSERTEQ(mf.end, buffer + arraysize(buffer));
+    ASSERTEQ(ret, -1, "");
+    ASSERTEQ(mf.start, buffer, "");
+    ASSERTEQ(mf.current, buffer, "");
+    ASSERTEQ(mf.end, buffer + arraysize(buffer), "");
   }
 }
 
@@ -78,18 +78,18 @@ UNITTEST(mfsync)
   for(i = 0; i < arraysize(buffers); i++)
   {
     mfopen(buffers[i], arraysize(buffers[i]), &mf);
-    ASSERTEQ(mf.start, buffers[i]);
-    ASSERTEQ(mf.end, buffers[i] + arraysize(buffers[i]));
+    ASSERTEQ(mf.start, buffers[i], "%d", i);
+    ASSERTEQ(mf.end, buffers[i] + arraysize(buffers[i]), "%d", i);
 
     mfsync(&buf, &len, &mf);
-    ASSERTEQ(buf, (void *)buffers[i]);
-    ASSERTEQ((int)len, arraysize(buffers[i]));
+    ASSERTEQ(buf, (void *)buffers[i], "%d", i);
+    ASSERTEQ((int)len, arraysize(buffers[i]), "%d", i);
 
     mfsync(&buf, nullptr, &mf);
-    ASSERTEQ(buf, (void *)buffers[i]);
+    ASSERTEQ(buf, (void *)buffers[i], "%d", i);
 
     mfsync(nullptr, &len, &mf);
-    ASSERTEQ((int)len, arraysize(buffers[i]));
+    ASSERTEQ((int)len, arraysize(buffers[i]), "%d", i);
 
     mfsync(nullptr, nullptr, &mf);
   }
@@ -129,17 +129,17 @@ UNITTEST(mfhasspace)
   for(i = 0; i < arraysize(pairs); i++)
   {
     mfopen(pairs[i].buffer, pairs[i].buffer_len, &mf);
-    ASSERTEQ(pairs[i].has8,   mfhasspace(8, &mf));
-    ASSERTEQ(pairs[i].has16,  mfhasspace(16, &mf));
-    ASSERTEQ(pairs[i].has32,  mfhasspace(32, &mf));
-    ASSERTEQ(pairs[i].has64,  mfhasspace(64, &mf));
-    ASSERTEQ(pairs[i].has128, mfhasspace(128, &mf));
+    ASSERTEQ(pairs[i].has8,   mfhasspace(8, &mf), "%d", i);
+    ASSERTEQ(pairs[i].has16,  mfhasspace(16, &mf), "%d", i);
+    ASSERTEQ(pairs[i].has32,  mfhasspace(32, &mf), "%d", i);
+    ASSERTEQ(pairs[i].has64,  mfhasspace(64, &mf), "%d", i);
+    ASSERTEQ(pairs[i].has128, mfhasspace(128, &mf), "%d", i);
 
     mf.current = (mf.end - mf.start)/2 + mf.start;
-    ASSERTEQ(pairs[i].has16,  mfhasspace(8, &mf));
-    ASSERTEQ(pairs[i].has32,  mfhasspace(16, &mf));
-    ASSERTEQ(pairs[i].has64,  mfhasspace(32, &mf));
-    ASSERTEQ(pairs[i].has128, mfhasspace(64, &mf));
+    ASSERTEQ(pairs[i].has16,  mfhasspace(8, &mf), "%d", i);
+    ASSERTEQ(pairs[i].has32,  mfhasspace(16, &mf), "%d", i);
+    ASSERTEQ(pairs[i].has64,  mfhasspace(32, &mf), "%d", i);
+    ASSERTEQ(pairs[i].has128, mfhasspace(64, &mf), "%d", i);
   }
 }
 
@@ -156,17 +156,17 @@ UNITTEST(mfmove)
 
   mfopen(buffera, arraysize(buffera), &mf);
   mf.current = mf.start + 96;
-  ASSERTEQ(mf.current, buffera + 96);
+  ASSERTEQ(mf.current, buffera + 96, "");
 
   mfmove(bufferb, arraysize(bufferb), &mf);
-  ASSERTEQ(mf.start, bufferb);
-  ASSERTEQ(mf.end, bufferb + arraysize(bufferb));
-  ASSERTEQ(mf.current, bufferb + 96);
+  ASSERTEQ(mf.start, bufferb, "");
+  ASSERTEQ(mf.end, bufferb + arraysize(bufferb), "");
+  ASSERTEQ(mf.current, bufferb + 96, "");
 
   mfmove(bufferc, arraysize(bufferc), &mf);
-  ASSERTEQ(mf.start, bufferc);
-  ASSERTEQ(mf.end, bufferc + arraysize(bufferc));
-  ASSERTEQ(mf.current, bufferc + arraysize(bufferc));
+  ASSERTEQ(mf.start, bufferc, "");
+  ASSERTEQ(mf.end, bufferc + arraysize(bufferc), "");
+  ASSERTEQ(mf.current, bufferc + arraysize(bufferc), "");
 }
 
 UNITTEST(mfresize)
@@ -177,15 +177,15 @@ UNITTEST(mfresize)
   struct memfile mf;
   size_t size;
 
-  ASSERT(buf);
+  ASSERT(buf, "");
   mfopen(buf, BUFSIZE, &mf);
   mfresize(NEWSIZE, &mf);
   mfsync(&buf, &size, &mf);
-  ASSERTEQ(size, NEWSIZE);
+  ASSERTEQ(size, NEWSIZE, "");
 
   mfresize(BUFSIZE, &mf);
   mfsync(&buf, &size, &mf);
-  ASSERTEQ(size, BUFSIZE);
+  ASSERTEQ(size, BUFSIZE, "");
 
   free(buf);
 }
@@ -200,7 +200,6 @@ struct seq
 UNITTEST(mfseek_mftell)
 {
   unsigned char buffer[256];
-  char msg[64];
   struct memfile mf;
   static const int offs_safe[] =
   {
@@ -227,46 +226,41 @@ UNITTEST(mfseek_mftell)
     9999,
   };
   int ret;
-  int i;
 
   mfopen(buffer, arraysize(buffer), &mf);
 
   SECTION(mftell)
   {
-    for(i = 0; i < arraysize(offs_safe); i++)
+    for(int pos : offs_safe)
     {
-      snprintf(msg, arraysize(msg), "mftell safe %d", i);
-      mf.current = mf.start + offs_safe[i];
-      ASSERTEQX(mftell(&mf), offs_safe[i], msg);
+      mf.current = mf.start + pos;
+      ASSERTEQ(mftell(&mf), pos, "mftell safe %d", pos);
     }
   }
 
   SECTION(seek_set)
   {
-    for(i = 0; i < arraysize(offs_safe); i++)
+    for(int pos : offs_safe)
     {
-      snprintf(msg, arraysize(msg), "seek_set safe %d", i);
-      ret = mfseek(&mf, offs_safe[i], SEEK_SET);
-      ASSERTEQX(ret, 0, msg);
-      ASSERTEQX(mftell(&mf), offs_safe[i], msg);
+      ret = mfseek(&mf, pos, SEEK_SET);
+      ASSERTEQ(ret, 0, "seek_set safe %d", pos);
+      ASSERTEQ(mftell(&mf), pos, "seek_set safe %d", pos);
     }
 
-    ASSERT(!mfseek(&mf, 129, SEEK_SET));
+    ASSERT(!mfseek(&mf, 129, SEEK_SET), "");
 
-    for(i = 0; i < arraysize(offs_unsafe); i++)
+    for(int pos : offs_unsafe)
     {
-      snprintf(msg, arraysize(msg), "seek_set unsafe %d", i);
-      ret = mfseek(&mf, offs_unsafe[i], SEEK_SET);
-      ASSERTEQX(ret, -1, msg);
-      ASSERTEQX(mftell(&mf), 129, msg);
+      ret = mfseek(&mf, pos, SEEK_SET);
+      ASSERTEQ(ret, -1, "seek_set unsafe %d", pos);
+      ASSERTEQ(mftell(&mf), 129, "seek_set unsafe %d", pos);
     }
 
-    for(i = 0; i < arraysize(offs_maybe_safe); i++)
+    for(int pos : offs_maybe_safe)
     {
-      snprintf(msg, arraysize(msg), "seek_set unsafe2 %d", i);
-      ret = mfseek(&mf, offs_maybe_safe[i], SEEK_SET);
-      ASSERTEQX(ret, -1, msg);
-      ASSERTEQX(mftell(&mf), 129, msg);
+      ret = mfseek(&mf, pos, SEEK_SET);
+      ASSERTEQ(ret, -1, "seek_set unsafe2 %d", pos);
+      ASSERTEQ(mftell(&mf), 129, "seek_set unsafe2 %d", pos);
     }
   }
 
@@ -284,39 +278,37 @@ UNITTEST(mfseek_mftell)
       { 197,    0,  0 }
     };
 
-    for(i = 0; i < arraysize(sequence); i++)
+    for(const seq seq : sequence)
     {
-      snprintf(msg, arraysize(msg), "seek_cur sequence %d", i);
-      ASSERTEQX(mftell(&mf), sequence[i].position, msg);
-      ret = mfseek(&mf, sequence[i].next, SEEK_CUR);
-      ASSERTEQX(ret, sequence[i].retval, msg);
+      ASSERTEQ(mftell(&mf), seq.position, "seek_cur sequence %d->%d", seq.position, seq.next);
+      ret = mfseek(&mf, seq.next, SEEK_CUR);
+      ASSERTEQ(ret, seq.retval, "seek_cur sequence %d->%d", seq.position, seq.next);
     }
   }
 
   SECTION(seek_end)
   {
     mfseek(&mf, 0, SEEK_END);
-    ASSERTEQX(mftell(&mf), arraysize(buffer), "seek_end");
+    ASSERTEQ(mftell(&mf), arraysize(buffer), "seek_end");
   }
 
   SECTION(seek_past_end)
   {
     mf.seek_past_end = true;
 
-    for(i = 0; i < arraysize(offs_maybe_safe); i++)
+    for(int pos : offs_maybe_safe)
     {
-      snprintf(msg, arraysize(msg), "seek_set past end %d", i);
-      ret = mfseek(&mf, offs_maybe_safe[i], SEEK_SET);
-      ASSERTEQX(ret, 0, msg);
-      ASSERTEQX(mftell(&mf), offs_maybe_safe[i], msg);
-      ASSERTEQX(mfhasspace(1, &mf), false, msg);
+      ret = mfseek(&mf, pos, SEEK_SET);
+      ASSERTEQ(ret, 0, "seek_set past end %d", pos);
+      ASSERTEQ(mftell(&mf), pos, "seek_set past end %d", pos);
+      ASSERTEQ(mfhasspace(1, &mf), false, "seek_set past end %d", pos);
     }
   }
 }
 
 UNITTEST(read_write)
 {
-  static const unsigned char data8[] =
+  static const uint8_t data8[] =
   {
     0x00, 0x01, 0xFF, 0xFE, 0x7F, 0x53, 0xA3, 0xD8,
     0xFF, 0x00, 0x12, 0x34, 0x45, 0x67, 0x89, 0xAB,
@@ -338,7 +330,7 @@ UNITTEST(read_write)
   };
 
   const int SIZE = arraysize(data8);
-  unsigned char dest[SIZE * 2];
+  uint8_t dest[SIZE * 2];
   struct memfile mf;
   int res;
   int res2;
@@ -359,10 +351,10 @@ UNITTEST(read_write)
 
     // NOTE: this function does not perform bounds checks since when using it
     // it is assumed these have already been performed.
-    for(i = 0; i < arraysize(data8); i++)
+    for(uint8_t value : data8)
     {
       uint8_t tmp = mfgetc(&mf);
-      ASSERTEQ(tmp, data8[i]);
+      ASSERTEQ(tmp, value, "");
     }
   }
 
@@ -372,10 +364,10 @@ UNITTEST(read_write)
     // it is assumed these have already been performed.
     mfopen(data8, SIZE, &mf);
 
-    for(i = 0; i < arraysize(data16); i++)
+    for(uint16_t value : data16)
     {
       uint16_t tmp = mfgetw(&mf);
-      ASSERTEQ(tmp, data16[i]);
+      ASSERTEQ(tmp, value, "");
     }
   }
 
@@ -385,10 +377,10 @@ UNITTEST(read_write)
     // it is assumed these have already been performed.
     mfopen(data8, SIZE, &mf);
 
-    for(i = 0; i < arraysize(data32s); i++)
+    for(int32_t value : data32s)
     {
       int tmp = mfgetd(&mf);
-      ASSERTEQ(tmp, data32s[i]);
+      ASSERTEQ(tmp, value, "");
     }
   }
 
@@ -398,10 +390,10 @@ UNITTEST(read_write)
     // it is assumed these have already been performed.
     mfopen(data8, SIZE, &mf);
 
-    for(i = 0; i < arraysize(data32u); i++)
+    for(uint32_t value : data32u)
     {
       uint32_t tmp = mfgetud(&mf);
-      ASSERTEQ(tmp, data32u[i]);
+      ASSERTEQ(tmp, value);
     }
   }
 
@@ -410,37 +402,34 @@ UNITTEST(read_write)
     mfopen(data8, SIZE, &mf);
 
     res = mfread(dest, SIZE, 1, &mf);
-    ASSERTEQ(res, 1);
-    res = memcmp(data8, dest, SIZE);
-    ASSERTEQ(res, 0);
+    ASSERTEQ(res, 1, "read SIZE x 1");
+    ASSERTMEM(data8, dest, SIZE, "read SIZE x 1");
 
     mf.current = mf.start;
     res = mfread(dest, 1, SIZE, &mf);
-    ASSERTEQ(res, SIZE);
-    res = memcmp(data8, dest, SIZE);
-    ASSERTEQ(res, 0);
+    ASSERTEQ(res, SIZE, "read 1 x SIZE");
+    ASSERTMEM(data8, dest, SIZE, "read 1 x SIZE");
 
     mf.current = mf.start;
     res = mfread(dest, SIZE/2, 1, &mf);
     res2 = mfread(dest + SIZE/2, 1, SIZE/2, &mf);
-    ASSERTEQ(res, 1);
-    ASSERTEQ(res2, SIZE/2);
-    res = memcmp(data8, dest, SIZE);
-    ASSERTEQ(res, 0);
+    ASSERTEQ(res, 1, "read SIZE/2");
+    ASSERTEQ(res2, SIZE/2, "read SIZE/2");
+    ASSERTMEM(data8, dest, SIZE, "read SIZE/2");
 
     mf.current = mf.start;
     res = mfread(dest, SIZE, 2, &mf);
-    ASSERTEQ(res, 1);
+    ASSERTEQ(res, 1, "read SIZE x 2");
 
     mf.current = mf.start;
     res = mfread(dest, 3, SIZE*2/3, &mf);
-    ASSERTEQ(res, SIZE/3);
+    ASSERTEQ(res, SIZE/3, "read 3 x (SIZE * 2/3), past end");
 
     res = mfread(dest, 1, SIZE - SIZE/3*3 + 1, &mf);
-    ASSERTEQ(res, SIZE - SIZE/3*3);
+    ASSERTEQ(res, SIZE - SIZE/3*3, "read 1 x 2, past end");
 
     res = mfread(dest, 1, 1, &mf);
-    ASSERTEQ(res, 0);
+    ASSERTEQ(res, 0, "read 1, past end");
   }
 
   SECTION(mfputc)
@@ -452,8 +441,8 @@ UNITTEST(read_write)
     for(i = 0; i < arraysize(data8); i++)
     {
       res = mfputc(data8[i], &mf);
-      ASSERTEQ((unsigned)res, data8[i]);
-      ASSERTEQ((unsigned)res, dest[i]);
+      ASSERTEQ((unsigned)res, data8[i], "");
+      ASSERTEQ((unsigned)res, dest[i], "");
     }
   }
 
@@ -466,8 +455,8 @@ UNITTEST(read_write)
     for(i = 0; i < arraysize(data16); i++)
     {
       mfputw(data16[i], &mf);
-      ASSERTEQ((uint16_t)dest[i * 2 + 0], data16[i] & 0xFF);
-      ASSERTEQ((uint16_t)dest[i * 2 + 1], (data16[i] >> 8) & 0xFF);
+      ASSERTEQ((uint16_t)dest[i * 2 + 0], data16[i] & 0xFF, "");
+      ASSERTEQ((uint16_t)dest[i * 2 + 1], (data16[i] >> 8) & 0xFF, "");
     }
   }
 
@@ -480,10 +469,10 @@ UNITTEST(read_write)
     for(i = 0; i < arraysize(data32s); i++)
     {
       mfputd(data32s[i], &mf);
-      ASSERTEQ((int)dest[i * 4 + 0], data32s[i] & 0xFF);
-      ASSERTEQ((int)dest[i * 4 + 1], (data32s[i] >> 8) & 0xFF);
-      ASSERTEQ((int)dest[i * 4 + 2], (data32s[i] >> 16) & 0xFF);
-      ASSERTEQ((int)dest[i * 4 + 3], (data32s[i] >> 24) & 0xFF);
+      ASSERTEQ((int)dest[i * 4 + 0], data32s[i] & 0xFF, "");
+      ASSERTEQ((int)dest[i * 4 + 1], (data32s[i] >> 8) & 0xFF, "");
+      ASSERTEQ((int)dest[i * 4 + 2], (data32s[i] >> 16) & 0xFF, "");
+      ASSERTEQ((int)dest[i * 4 + 3], (data32s[i] >> 24) & 0xFF, "");
     }
   }
 
@@ -496,10 +485,10 @@ UNITTEST(read_write)
     for(i = 0; i < arraysize(data32u); i++)
     {
       mfputud(data32u[i], &mf);
-      ASSERTEQ((uint32_t)dest[i * 4 + 0], data32u[i] & 0xFF);
-      ASSERTEQ((uint32_t)dest[i * 4 + 1], (data32u[i] >> 8) & 0xFF);
-      ASSERTEQ((uint32_t)dest[i * 4 + 2], (data32u[i] >> 16) & 0xFF);
-      ASSERTEQ((uint32_t)dest[i * 4 + 3], (data32u[i] >> 24) & 0xFF);
+      ASSERTEQ((uint32_t)dest[i * 4 + 0], data32u[i] & 0xFF, "");
+      ASSERTEQ((uint32_t)dest[i * 4 + 1], (data32u[i] >> 8) & 0xFF, "");
+      ASSERTEQ((uint32_t)dest[i * 4 + 2], (data32u[i] >> 16) & 0xFF, "");
+      ASSERTEQ((uint32_t)dest[i * 4 + 3], (data32u[i] >> 24) & 0xFF, "");
     }
   }
 
@@ -508,23 +497,20 @@ UNITTEST(read_write)
     mfopen(dest, SIZE, &mf);
 
     res = mfwrite(data8, SIZE, 1, &mf);
-    ASSERTEQ(res, 1);
-    res = memcmp(data8, dest, SIZE);
-    ASSERTEQ(res, 0);
+    ASSERTEQ(res, 1, "write SIZE x 1");
+    ASSERTMEM(data8, dest, SIZE, "write SIZE x 1");
 
     mf.current = mf.start;
     res = mfwrite(data8, 1, SIZE, &mf);
-    ASSERTEQ(res, SIZE);
-    res = memcmp(data8, dest, SIZE);
-    ASSERTEQ(res, 0);
+    ASSERTEQ(res, SIZE, "write 1 x SIZE");
+    ASSERTMEM(data8, dest, SIZE, "write 1 x SIZE");
 
     mf.current = mf.start;
     res = mfwrite(data8, SIZE/2, 1, &mf);
     res2 = mfwrite(data8 + SIZE/2, 1, SIZE/2, &mf);
-    ASSERTEQ(res, 1);
-    ASSERTEQ(res2, SIZE/2);
-    res = memcmp(data8, dest, SIZE);
-    ASSERTEQ(res, 0);
+    ASSERTEQ(res, 1, "write SIZE/2");
+    ASSERTEQ(res2, SIZE/2, "write SIZE/2");
+    ASSERTMEM(data8, dest, SIZE, "write SIZE/2");
 
     mf.current = mf.start;
     res = mfwrite(data8, SIZE, 2, &mf);
@@ -532,13 +518,13 @@ UNITTEST(read_write)
 
     mf.current = mf.start;
     res = mfwrite(data8, 3, SIZE*2/3, &mf);
-    ASSERTEQ(res, SIZE/3);
+    ASSERTEQ(res, SIZE/3, "write 3 * (SIZE*2/3), past end");
 
     res = mfwrite(data8, 1, SIZE - SIZE/3*3 + 1, &mf);
-    ASSERTEQ(res, SIZE - SIZE/3*3);
+    ASSERTEQ(res, SIZE - SIZE/3*3, "write 1 x 2, past end");
 
     res = mfwrite(data8, 1, 1, &mf);
-    ASSERTEQ(res, 0);
+    ASSERTEQ(res, 0, "write 1, past end");
   }
 }
 
@@ -641,10 +627,10 @@ UNITTEST(mfsafegets)
         char *result = mfsafegets(buffer, arraysize(buffer), &mf);
         if(result && data[i].output[j])
         {
-          ASSERTCMP(result, data[i].output[j]);
+          ASSERTCMP(result, data[i].output[j], "%d %d", i, j);
         }
         else
-          ASSERTEQ(result, data[i].output[j]);
+          ASSERTEQ(result, data[i].output[j], "%d %d", i, j);
       }
     }
   }
@@ -660,10 +646,10 @@ UNITTEST(mfsafegets)
         char *result = mfsafegets(buffer, SHORT_BUF_LEN, &mf);
         if(result && short_data[i].output[j])
         {
-          ASSERTCMP(result, short_data[i].output[j]);
+          ASSERTCMP(result, short_data[i].output[j], "%d %d", i, j);
         }
         else
-          ASSERTEQ(result, short_data[i].output[j]);
+          ASSERTEQ(result, short_data[i].output[j], "%d %d", i, j);
       }
     }
   }

--- a/unit/io/memfile.cpp
+++ b/unit/io/memfile.cpp
@@ -393,7 +393,7 @@ UNITTEST(read_write)
     for(uint32_t value : data32u)
     {
       uint32_t tmp = mfgetud(&mf);
-      ASSERTEQ(tmp, value);
+      ASSERTEQ(tmp, value, "");
     }
   }
 
@@ -514,7 +514,7 @@ UNITTEST(read_write)
 
     mf.current = mf.start;
     res = mfwrite(data8, SIZE, 2, &mf);
-    ASSERTEQ(res, 1);
+    ASSERTEQ(res, 1, "");
 
     mf.current = mf.start;
     res = mfwrite(data8, 3, SIZE*2/3, &mf);

--- a/unit/io/path.cpp
+++ b/unit/io/path.cpp
@@ -1239,9 +1239,8 @@ template<size_t N>
 static void test_mkdir(const path_mkdir_data (&data)[N],
  enum path_create_error expected)
 {
-  for(size_t i = 0; i < N; i++)
+  for(const path_mkdir_data &cur : data)
   {
-    const path_mkdir_data &cur = data[i];
     enum path_create_error ret = path_create_parent_recursively(cur.path);
     ASSERTEQ(ret, expected, "%s", cur.path);
   }

--- a/unit/io/path.cpp
+++ b/unit/io/path.cpp
@@ -139,29 +139,28 @@ UNITTEST(path_force_ext)
   };
   char buffer[MAX_PATH];
   boolean result;
-  int i;
 
   SECTION(NormalCases)
   {
-    for(i = 0; i < arraysize(data); i++)
+    for(const path_ext_result &d : data)
     {
-      snprintf(buffer, MAX_PATH, "%s", data[i].path);
-      result = path_force_ext(buffer, MAX_PATH, data[i].ext);
+      snprintf(buffer, MAX_PATH, "%s", d.path);
+      result = path_force_ext(buffer, MAX_PATH, d.ext);
 
-      ASSERTX(result, data[i].path);
-      ASSERTCMP(buffer, data[i].result);
+      ASSERT(result, "%s", d.path);
+      ASSERTCMP(buffer, d.result, "%s", d.path);
     }
   }
 
   SECTION(FailureCases)
   {
-    for(i = 0; i < arraysize(bad_data); i++)
+    for(const path_ext_result &d : bad_data)
     {
-      snprintf(buffer, MAX_PATH, "%s", bad_data[i].path);
-      result = path_force_ext(buffer, 32, bad_data[i].ext);
+      snprintf(buffer, MAX_PATH, "%s", d.path);
+      result = path_force_ext(buffer, 32, d.ext);
 
-      ASSERTX(!result, bad_data[i].path);
-      ASSERTCMP(buffer, bad_data[i].result);
+      ASSERT(!result, "%s", d.path);
+      ASSERTCMP(buffer, d.result, "%s", d.path);
     }
   }
 }
@@ -236,19 +235,19 @@ UNITTEST(path_is_absolute)
 
   SECTION(path_is_absolute)
   {
-    for(int i = 0; i < arraysize(data); i++)
+    for(const path_is_abs_result &d : data)
     {
-      ssize_t len = path_is_absolute(data[i].path);
-      ASSERTEQX(len, data[i].root_len, data[i].path);
+      ssize_t len = path_is_absolute(d.path);
+      ASSERTEQ(len, d.root_len, "%s", d.path);
     }
   }
 
   SECTION(path_is_root)
   {
-    for(int i = 0; i < arraysize(data); i++)
+    for(const path_is_abs_result &d : data)
     {
-      boolean is_root = path_is_root(data[i].path);
-      ASSERTEQX(is_root, data[i].is_root, data[i].path);
+      boolean is_root = path_is_root(d.path);
+      ASSERTEQ(is_root, d.is_root, "%s", d.path);
     }
   }
 }
@@ -341,14 +340,13 @@ UNITTEST(path_get_ext_offset)
     },
   };
   ssize_t result;
-  int i;
 
-  for(i = 0; i < arraysize(data); i++)
+  for(const path_output_pair &d : data)
   {
-    result = path_get_ext_offset(data[i].path);
-    ASSERTEQX(result, data[i].return_value, data[i].path);
-    if(result >= 0 && data[i].expected)
-      ASSERTCMP(data[i].path + result, data[i].expected);
+    result = path_get_ext_offset(d.path);
+    ASSERTEQ(result, d.return_value, "%s", d.path);
+    if(result >= 0 && d.expected)
+      ASSERTCMP(d.path + result, d.expected, "%s", d.path);
   }
 }
 
@@ -442,38 +440,36 @@ UNITTEST(path_clean_slashes)
   };
 
   char buffer[MAX_PATH];
-  size_t result;
-  int i;
 
   SECTION(path_clean_slashes)
   {
-    for(i = 0; i < arraysize(data); i++)
+    for(const path_clean_output &d : data)
     {
-      snprintf(buffer, MAX_PATH, "%s", data[i].path);
+      snprintf(buffer, MAX_PATH, "%s", d.path);
       buffer[MAX_PATH - 1] = '\0';
 
       path_clean_slashes(buffer, MAX_PATH);
-      ASSERTCMP(buffer, data[i].PATH_CLEAN_RESULT);
+      ASSERTCMP(buffer, d.PATH_CLEAN_RESULT, "%s", d.path);
     }
   }
 
   SECTION(path_clean_slashes_copy)
   {
-    for(i = 0; i < arraysize(data); i++)
+    for(const path_clean_output &d : data)
     {
-      result = path_clean_slashes_copy(buffer, MAX_PATH, data[i].path);
-      ASSERTEQ(result, strlen(data[i].PATH_CLEAN_RESULT));
-      ASSERTCMP(buffer, data[i].PATH_CLEAN_RESULT);
+      size_t result = path_clean_slashes_copy(buffer, MAX_PATH, d.path);
+      ASSERTEQ(result, strlen(d.PATH_CLEAN_RESULT), "%s", d.path);
+      ASSERTCMP(buffer, d.PATH_CLEAN_RESULT, "%s", d.path);
     }
   }
 
   SECTION(path_clean_slashes_copy_truncation)
   {
-    for(i = 0; i < arraysize(truncate_data); i++)
+    for(const path_clean_output &d : truncate_data)
     {
-      result = path_clean_slashes_copy(buffer, 32, truncate_data[i].path);
-      ASSERTEQ(result, strlen(truncate_data[i].PATH_CLEAN_RESULT));
-      ASSERTCMP(buffer, truncate_data[i].PATH_CLEAN_RESULT);
+      size_t result = path_clean_slashes_copy(buffer, 32, d.path);
+      ASSERTEQ(result, strlen(d.PATH_CLEAN_RESULT), "%s", d.path);
+      ASSERTCMP(buffer, d.PATH_CLEAN_RESULT, "%s", d.path);
     }
   }
 }
@@ -627,120 +623,119 @@ UNITTEST(path_split_functions)
   char dir_buffer[MAX_PATH];
   char file_buffer[MAX_PATH];
   ssize_t result;
-  int i;
 
   stat_result_type = STAT_FAIL;
 
   SECTION(path_has_directory)
   {
-    for(i = 0; i < arraysize(data); i++)
+    for(const path_split_data &d : data)
     {
-      boolean result = path_has_directory(data[i].path);
-      ASSERTEQX(result, data[i].dir_return_value > 0, data[i].path);
+      boolean result = path_has_directory(d.path);
+      ASSERTEQ(result, d.dir_return_value > 0, "%s", d.path);
     }
 
     stat_result_type = STAT_DIR;
 
-    for(i = 0; i < arraysize(data_stat); i++)
+    for(const path_split_data &d : data_stat)
     {
-      boolean result = path_has_directory(data_stat[i].path);
-      ASSERTEQX(result, data_stat[i].dir_return_value > 0, data_stat[i].path);
+      boolean result = path_has_directory(d.path);
+      ASSERTEQ(result, d.dir_return_value > 0, "%s", d.path);
     }
   }
 
   SECTION(path_to_directory)
   {
-    for(i = 0; i < arraysize(data); i++)
+    for(const path_split_data &d : data)
     {
-      snprintf(dir_buffer, MAX_PATH, "%s", data[i].path);
+      snprintf(dir_buffer, MAX_PATH, "%s", d.path);
       dir_buffer[MAX_PATH - 1] = '\0';
 
       result = path_to_directory(dir_buffer, MAX_PATH);
-      ASSERTEQX(result, data[i].dir_return_value, data[i].path);
-      if(result >= 0 && data[i].SPLIT_DIRECTORY)
-        ASSERTCMP(dir_buffer, data[i].SPLIT_DIRECTORY);
+      ASSERTEQ(result, d.dir_return_value, "%s", d.path);
+      if(result >= 0 && d.SPLIT_DIRECTORY)
+        ASSERTCMP(dir_buffer, d.SPLIT_DIRECTORY, "%s", d.path);
     }
 
     stat_result_type = STAT_DIR;
 
-    for(i = 0; i < arraysize(data_stat); i++)
+    for(const path_split_data &d : data_stat)
     {
-      snprintf(dir_buffer, MAX_PATH, "%s", data_stat[i].path);
+      snprintf(dir_buffer, MAX_PATH, "%s", d.path);
       dir_buffer[MAX_PATH - 1] = '\0';
 
       result = path_to_directory(dir_buffer, MAX_PATH);
-      ASSERTEQX(result, data_stat[i].dir_return_value, data_stat[i].path);
-      if(result >= 0 && data_stat[i].SPLIT_DIRECTORY)
-        ASSERTCMP(dir_buffer, data_stat[i].SPLIT_DIRECTORY);
+      ASSERTEQ(result, d.dir_return_value, "%s", d.path);
+      if(result >= 0 && d.SPLIT_DIRECTORY)
+        ASSERTCMP(dir_buffer, d.SPLIT_DIRECTORY, "%s", d.path);
     }
   }
 
   SECTION(path_get_directory)
   {
-    for(i = 0; i < arraysize(data); i++)
+    for(const path_split_data &d : data)
     {
-      result = path_get_directory(dir_buffer, MAX_PATH, data[i].path);
-      ASSERTEQX(result, data[i].dir_return_value, data[i].path);
-      if(result >= 0 && data[i].SPLIT_DIRECTORY)
-        ASSERTCMP(dir_buffer, data[i].SPLIT_DIRECTORY);
+      result = path_get_directory(dir_buffer, MAX_PATH, d.path);
+      ASSERTEQ(result, d.dir_return_value, "%s", d.path);
+      if(result >= 0 && d.SPLIT_DIRECTORY)
+        ASSERTCMP(dir_buffer, d.SPLIT_DIRECTORY, "%s", d.path);
     }
 
     stat_result_type = STAT_DIR;
 
-    for(i = 0; i < arraysize(data_stat); i++)
+    for(const path_split_data &d : data_stat)
     {
-      result = path_get_directory(dir_buffer, MAX_PATH, data_stat[i].path);
-      ASSERTEQX(result, data_stat[i].dir_return_value, data_stat[i].path);
-      if(result >= 0 && data_stat[i].SPLIT_DIRECTORY)
-        ASSERTCMP(dir_buffer, data_stat[i].SPLIT_DIRECTORY);
+      result = path_get_directory(dir_buffer, MAX_PATH, d.path);
+      ASSERTEQ(result, d.dir_return_value, "%s", d.path);
+      if(result >= 0 && d.SPLIT_DIRECTORY)
+        ASSERTCMP(dir_buffer, d.SPLIT_DIRECTORY, "%s", d.path);
     }
   }
 
   SECTION(path_to_filename)
   {
-    for(i = 0; i < arraysize(data); i++)
+    for(const path_split_data &d : data)
     {
-      snprintf(file_buffer, MAX_PATH, "%s", data[i].path);
+      snprintf(file_buffer, MAX_PATH, "%s", d.path);
       file_buffer[MAX_PATH - 1] = '\0';
 
       result = path_to_filename(file_buffer, MAX_PATH);
-      ASSERTEQX(result, data[i].file_return_value, data[i].path);
-      if(result >= 0 && data[i].filename)
-        ASSERTCMP(file_buffer, data[i].filename);
+      ASSERTEQ(result, d.file_return_value, "%s", d.path);
+      if(result >= 0 && d.filename)
+        ASSERTCMP(file_buffer, d.filename, "%s", d.path);
     }
 
     stat_result_type = STAT_DIR;
 
-    for(i = 0; i < arraysize(data_stat); i++)
+    for(const path_split_data &d : data_stat)
     {
-      snprintf(file_buffer, MAX_PATH, "%s", data_stat[i].path);
+      snprintf(file_buffer, MAX_PATH, "%s", d.path);
       file_buffer[MAX_PATH - 1] = '\0';
 
       result = path_to_filename(file_buffer, MAX_PATH);
-      ASSERTEQX(result, data_stat[i].file_return_value, data_stat[i].path);
-      if(result >= 0 && data_stat[i].filename)
-        ASSERTCMP(file_buffer, data_stat[i].filename);
+      ASSERTEQ(result, d.file_return_value, "%s", d.path);
+      if(result >= 0 && d.filename)
+        ASSERTCMP(file_buffer, d.filename, "%s", d.path);
     }
   }
 
   SECTION(path_get_filename)
   {
-    for(i = 0; i < arraysize(data); i++)
+    for(const path_split_data &d : data)
     {
-      result = path_get_filename(file_buffer, MAX_PATH, data[i].path);
-      ASSERTEQX(result, data[i].file_return_value, data[i].path);
-      if(result >= 0 && data[i].filename)
-        ASSERTCMP(file_buffer, data[i].filename);
+      result = path_get_filename(file_buffer, MAX_PATH, d.path);
+      ASSERTEQ(result, d.file_return_value, "%s", d.path);
+      if(result >= 0 && d.filename)
+        ASSERTCMP(file_buffer, d.filename, "%s", d.path);
     }
 
     stat_result_type = STAT_DIR;
 
-    for(i = 0; i < arraysize(data_stat); i++)
+    for(const path_split_data &d : data_stat)
     {
-      result = path_get_filename(file_buffer, MAX_PATH, data_stat[i].path);
-      ASSERTEQX(result, data_stat[i].file_return_value, data_stat[i].path);
-      if(result >= 0 && data_stat[i].filename)
-        ASSERTCMP(file_buffer, data_stat[i].filename);
+      result = path_get_filename(file_buffer, MAX_PATH, d.path);
+      ASSERTEQ(result, d.file_return_value, "%s", d.path);
+      if(result >= 0 && d.filename)
+        ASSERTCMP(file_buffer, d.filename, "%s", d.path);
     }
   }
 
@@ -748,35 +743,35 @@ UNITTEST(path_split_functions)
   {
     boolean result;
 
-    for(i = 0; i < arraysize(data); i++)
+    for(const path_split_data &d : data)
     {
       result = path_get_directory_and_filename(
-        dir_buffer, MAX_PATH, file_buffer, MAX_PATH, data[i].path);
-      ASSERTEQX(result, data[i].dir_and_file_return_value, data[i].path);
+       dir_buffer, MAX_PATH, file_buffer, MAX_PATH, d.path);
+      ASSERTEQ(result, d.dir_and_file_return_value, "%s", d.path);
       if(result)
       {
-        if(data[i].SPLIT_DIRECTORY)
-          ASSERTCMP(dir_buffer, data[i].SPLIT_DIRECTORY);
+        if(d.SPLIT_DIRECTORY)
+          ASSERTCMP(dir_buffer, d.SPLIT_DIRECTORY, "%s", d.path);
 
-        if(data[i].filename)
-          ASSERTCMP(file_buffer, data[i].filename);
+        if(d.filename)
+          ASSERTCMP(file_buffer, d.filename, "%s", d.path);
       }
     }
 
     stat_result_type = STAT_DIR;
 
-    for(i = 0; i < arraysize(data_stat); i++)
+    for(const path_split_data &d : data_stat)
     {
       result = path_get_directory_and_filename(
-        dir_buffer, MAX_PATH, file_buffer, MAX_PATH, data_stat[i].path);
-      ASSERTEQX(result, data_stat[i].dir_and_file_return_value, data_stat[i].path);
+       dir_buffer, MAX_PATH, file_buffer, MAX_PATH, d.path);
+      ASSERTEQ(result, d.dir_and_file_return_value, "%s", d.path);
       if(result)
       {
-        if(data_stat[i].SPLIT_DIRECTORY)
-          ASSERTCMP(dir_buffer, data_stat[i].SPLIT_DIRECTORY);
+        if(d.SPLIT_DIRECTORY)
+          ASSERTCMP(dir_buffer, d.SPLIT_DIRECTORY, "%s", d.path);
 
-        if(data_stat[i].filename)
-          ASSERTCMP(file_buffer, data_stat[i].filename);
+        if(d.filename)
+          ASSERTCMP(file_buffer, d.filename, "%s", d.path);
       }
     }
   }
@@ -887,66 +882,65 @@ UNITTEST(path_append_and_path_join)
 
   char buffer[MAX_PATH];
   ssize_t result;
-  int i;
 
   SECTION(path_append_NormalCases)
   {
-    for(i = 0; i < arraysize(data); i++)
+    for(const path_target_output &d : data)
     {
-      snprintf(buffer, MAX_PATH, "%s", data[i].path);
+      snprintf(buffer, MAX_PATH, "%s", d.path);
       buffer[MAX_PATH - 1] = '\0';
 
-      result = path_append(buffer, MAX_PATH, data[i].target);
-      ASSERTEQX(result, data[i].return_value, data[i].path);
-      if(result && data[i].PATH_CLEAN_RESULT)
-        ASSERTCMP(buffer, data[i].PATH_CLEAN_RESULT);
+      result = path_append(buffer, MAX_PATH, d.target);
+      ASSERTEQ(result, d.return_value, "%s", d.path);
+      if(result && d.PATH_CLEAN_RESULT)
+        ASSERTCMP(buffer, d.PATH_CLEAN_RESULT, "%s", d.path);
     }
   }
 
   SECTION(path_append_SmallBufferCases)
   {
-    for(i = 0; i < arraysize(small_data); i++)
+    for(const path_target_output &d : small_data)
     {
-      snprintf(buffer, MAX_PATH, "%s", small_data[i].path);
+      snprintf(buffer, MAX_PATH, "%s", d.path);
       buffer[MAX_PATH - 1] = '\0';
 
-      result = path_append(buffer, 32, small_data[i].target);
-      ASSERTEQX(result, small_data[i].return_value, small_data[i].path);
-      if(result && small_data[i].PATH_CLEAN_RESULT)
+      result = path_append(buffer, 32, d.target);
+      ASSERTEQ(result, d.return_value, "%s", d.path);
+      if(result && d.PATH_CLEAN_RESULT)
       {
-        ASSERTCMP(buffer, small_data[i].PATH_CLEAN_RESULT);
+        ASSERTCMP(buffer, d.PATH_CLEAN_RESULT, "%s", d.path);
       }
       else
-        ASSERTCMP(buffer, small_data[i].path);
+        ASSERTCMP(buffer, d.path, "");
     }
   }
 
   SECTION(path_join_NormalCases)
   {
-    for(i = 0; i < arraysize(data); i++)
+    for(const path_target_output &d : data)
     {
-      result = path_join(buffer, MAX_PATH, data[i].path, data[i].target);
-      ASSERTEQX(result, data[i].return_value, data[i].path);
-      if(result && data[i].PATH_CLEAN_RESULT)
-        ASSERTCMP(buffer, data[i].PATH_CLEAN_RESULT);
+      result = path_join(buffer, MAX_PATH, d.path, d.target);
+      ASSERTEQ(result, d.return_value, "%s", d.path);
+      if(result && d.PATH_CLEAN_RESULT)
+        ASSERTCMP(buffer, d.PATH_CLEAN_RESULT, "%s", d.path);
     }
   }
 
   SECTION(path_join_SmallBufferCases)
   {
-    for(i = 0; i < arraysize(small_data); i++)
+    for(const path_target_output &d : small_data)
     {
       static const char *def = "DO NOT MODIFY";
       snprintf(buffer, MAX_PATH, "%s", def);
 
-      result = path_join(buffer, 32, small_data[i].path, small_data[i].target);
-      ASSERTEQX(result, small_data[i].return_value, small_data[i].path);
-      if(result && small_data[i].PATH_CLEAN_RESULT)
+      result = path_join(buffer, 32, d.path, d.target);
+      ASSERTEQ(result, d.return_value, "%s", d.path);
+      if(result && d.PATH_CLEAN_RESULT)
       {
-        ASSERTCMP(buffer, small_data[i].PATH_CLEAN_RESULT);
+        ASSERTCMP(buffer, d.PATH_CLEAN_RESULT, "%s", d.path);
       }
       else
-        ASSERTCMP(buffer, def);
+        ASSERTCMP(buffer, def, "%s", d.path);
     }
   }
 }
@@ -1049,38 +1043,37 @@ UNITTEST(path_remove_prefix)
   };
   char buffer[MAX_PATH];
   ssize_t result;
-  int i;
 
   SECTION(NoPrefixLength)
   {
-    for(i = 0; i < arraysize(data); i++)
+    for(const path_target_output &d : data)
     {
-      snprintf(buffer, MAX_PATH, "%s", data[i].path);
+      snprintf(buffer, MAX_PATH, "%s", d.path);
       buffer[MAX_PATH - 1] = '\0';
 
-      result = path_remove_prefix(buffer, MAX_PATH, data[i].target, 0);
-      ASSERTEQX(result, data[i].return_value, data[i].path);
+      result = path_remove_prefix(buffer, MAX_PATH, d.target, 0);
+      ASSERTEQ(result, d.return_value, "%s", d.path);
       if(result >= 0)
-        ASSERTCMP(buffer, data[i].PATH_CLEAN_RESULT);
+        ASSERTCMP(buffer, d.PATH_CLEAN_RESULT, "%s", d.path);
       else
-        ASSERTCMP(buffer, data[i].path);
+        ASSERTCMP(buffer, d.path, "");
     }
   }
 
   SECTION(PrefixLength)
   {
-    for(i = 0; i < arraysize(data); i++)
+    for(const path_target_output &d : data)
     {
-      snprintf(buffer, MAX_PATH, "%s", data[i].path);
+      snprintf(buffer, MAX_PATH, "%s", d.path);
       buffer[MAX_PATH - 1] = '\0';
 
-      result = path_remove_prefix(buffer, MAX_PATH, data[i].target,
-       strlen(data[i].target));
-      ASSERTEQX(result, data[i].return_value, data[i].path);
+      result = path_remove_prefix(buffer, MAX_PATH, d.target,
+       strlen(d.target));
+      ASSERTEQ(result, d.return_value, "%s", d.path);
       if(result >= 0)
-        ASSERTCMP(buffer, data[i].PATH_CLEAN_RESULT);
+        ASSERTCMP(buffer, d.PATH_CLEAN_RESULT, "%s", d.path);
       else
-        ASSERTCMP(buffer, data[i].path);
+        ASSERTCMP(buffer, d.path, "");
     }
   }
 }
@@ -1204,21 +1197,20 @@ UNITTEST(path_navigate)
   };
   char buffer[MAX_PATH];
   ssize_t result;
-  int i;
 
   SECTION(Success)
   {
     stat_result_type = STAT_DIR;
 
-    for(i = 0; i < arraysize(data); i++)
+    for(const path_target_output &d : data)
     {
-      snprintf(buffer, MAX_PATH, "%s", data[i].path);
+      snprintf(buffer, MAX_PATH, "%s", d.path);
       buffer[MAX_PATH - 1] = '\0';
 
-      result = path_navigate(buffer, MAX_PATH, data[i].target);
-      ASSERTEQX(result, data[i].return_value, data[i].path);
-      if(result && data[i].PATH_CLEAN_RESULT)
-        ASSERTCMP(buffer, data[i].PATH_CLEAN_RESULT);
+      result = path_navigate(buffer, MAX_PATH, d.target);
+      ASSERTEQ(result, d.return_value, "%s", d.path);
+      if(result && d.PATH_CLEAN_RESULT)
+        ASSERTCMP(buffer, d.PATH_CLEAN_RESULT, "%s", d.path);
     }
   }
 
@@ -1226,14 +1218,14 @@ UNITTEST(path_navigate)
   {
     stat_result_type = STAT_FAIL;
 
-    for(i = 0; i < arraysize(data); i++)
+    for(const path_target_output &d : data)
     {
-      snprintf(buffer, MAX_PATH, "%s", data[i].path);
+      snprintf(buffer, MAX_PATH, "%s", d.path);
       buffer[MAX_PATH - 1] = '\0';
 
-      result = path_navigate(buffer, MAX_PATH, data[i].target);
-      ASSERTEQX(result, -1, data[i].path);
-      ASSERTCMP(buffer, data[i].path);
+      result = path_navigate(buffer, MAX_PATH, d.target);
+      ASSERTEQ(result, -1, "%s", d.path);
+      ASSERTCMP(buffer, d.path, "");
     }
   }
 }
@@ -1251,7 +1243,7 @@ static void test_mkdir(const path_mkdir_data (&data)[N],
   {
     const path_mkdir_data &cur = data[i];
     enum path_create_error ret = path_create_parent_recursively(cur.path);
-    ASSERTEQX(ret, expected, cur.path);
+    ASSERTEQ(ret, expected, "%s", cur.path);
   }
 }
 

--- a/unit/io/vio.cpp
+++ b/unit/io/vio.cpp
@@ -104,75 +104,67 @@ static const char * const vfsafegets_output[][MAX_LINES] =
   static_assert(bytes_from_end < 0, "invalid bytes from end value :("); \
   vfseek(vf, arraysize(test_data) + bytes_from_end - 1, SEEK_SET); \
   int c = vfgetc(vf); \
-  ASSERTEQX(c, test_data[arraysize(test_data) + bytes_from_end - 1], "not eof"); \
+  ASSERTEQ(c, test_data[arraysize(test_data) + bytes_from_end - 1], "not eof"); \
 }
 
 static void test_vfgetc(vfile *vf)
 {
-  char buf[64];
   for(int i = 0; i < arraysize(test_data); i++)
   {
-    snprintf(buf, arraysize(buf), "vfgetc offset=%d", i);
     int c = vfgetc(vf);
-    ASSERTEQX(c, test_data[i], buf);
+    ASSERTEQ(c, test_data[i], "vfgetc offset=%d", i);
   }
   int c = vfgetc(vf);
-  ASSERTEQX(c, EOF, "eof");
+  ASSERTEQ(c, EOF, "eof");
 }
 
 static void test_vfgetw(vfile *vf)
 {
-  char buf[64];
   int expected;
   int c;
 
   for(int i = 0; i < arraysize(test_data); i += 2)
   {
-    snprintf(buf, arraysize(buf), "vfgetw offset=%d", i);
-
     c = vfgetw(vf);
     expected = test_data[i] | (test_data[i + 1] << 8);
-    ASSERTEQX(c, expected, buf);
+    ASSERTEQ(c, expected, "vfgetw offset=%d", i);
   }
   // Both bytes should cause EOF.
   c = vfgetw(vf);
-  ASSERTEQX(c, EOF, "eof (byte 0)");
+  ASSERTEQ(c, EOF, "eof (byte 0)");
 
   back_up(-1, vf);
   c = vfgetw(vf);
-  ASSERTEQX(c, EOF, "eof (byte 1)");
+  ASSERTEQ(c, EOF, "eof (byte 1)");
 }
 
 static void test_vfgetd(vfile *vf)
 {
-  char buf[64];
   int expected;
   int c;
 
   for(int i = 0; i < arraysize(test_data); i += 4)
   {
-    snprintf(buf, arraysize(buf), "vfgetd offset=%d", i);
-
     c = vfgetd(vf);
     expected = static_cast<int>(test_data[i] | (test_data[i + 1] << 8) |
      (test_data[i + 2] << 16) | (test_data[i + 3] << 24));
-    ASSERTEQX(c, expected, buf);
+    ASSERTEQ(c, expected, "vfgetd offset=%d", i);
   }
   // All four bytes should cause EOF.
   c = vfgetd(vf);
-  ASSERTEQX(c, EOF, "eof (byte 0)");
+  ASSERTEQ(c, EOF, "eof (byte 0)");
 
   back_up(-1, vf);
   c = vfgetd(vf);
-  ASSERTEQX(c, EOF, "eof (byte 1)");
+  ASSERTEQ(c, EOF, "eof (byte 1)");
 
   back_up(-2, vf);
   c = vfgetd(vf);
-  ASSERTEQX(c, EOF, "eof (byte 2)");
+  ASSERTEQ(c, EOF, "eof (byte 2)");
 
   back_up(-3, vf);
   c = vfgetd(vf);
-  ASSERTEQX(c, EOF, "eof (byte 3)");
+  ASSERTEQ(c, EOF, "eof (byte 3)");
 }
 
 static void test_vfread(vfile *vf)
@@ -183,25 +175,25 @@ static void test_vfread(vfile *vf)
 
   // One read >length should be refused.
   ret = vfread(buffer, len * 2, 1, vf);
-  ASSERTEQX(ret, 0, "vfread too much data");
+  ASSERTEQ(ret, 0, "vfread too much data");
   vrewind(vf);
 
   // Two reads =length should read exactly length once.
   ret = vfread(buffer, len, 2, vf);
-  ASSERTEQX(ret, 1, "vfread 2x len");
+  ASSERTEQ(ret, 1, "vfread 2x len");
   vrewind(vf);
 
   // More reads...
   ret = vfread(buffer, len / 2, 3, vf);
-  ASSERTEQX(ret, 2, "vfread 1.5x len");
+  ASSERTEQ(ret, 2, "vfread 1.5x len");
   vrewind(vf);
 
   ret = vfread(buffer, len / 4, 5, vf);
-  ASSERTEQX(ret, 4, "vfread 1.25x len");
+  ASSERTEQ(ret, 4, "vfread 1.25x len");
   vrewind(vf);
 
   ret = vfread(buffer, 3, len, vf);
-  ASSERTEQX(ret, len / 3, "vfread len x 3");
+  ASSERTEQ(ret, len / 3, "vfread len x 3");
   // NOTE: seems to be implementation-defined whether this ends up
   // at 255 or 256, so don't bother testing that.
 }
@@ -210,57 +202,57 @@ static void test_write_check(vfile *vf)
 {
   uint8_t tmp[arraysize(test_data)];
   int r = vfread(tmp, arraysize(test_data), 1, vf);
-  ASSERTEQX(r, 1, "test_write_check vfread");
-  ASSERTXMEM(test_data, tmp, arraysize(test_data), "test_write_check memcmp");
+  ASSERTEQ(r, 1, "test_write_check vfread");
+  ASSERTMEM(test_data, tmp, arraysize(test_data), "test_write_check memcmp");
   r = vfgetc(vf);
-  ASSERTEQX(r, EOF, "test_write_check eof");
+  ASSERTEQ(r, EOF, "test_write_check eof");
 }
 
 static void test_vfputc(vfile *vf)
 {
-  char buf[64];
+  //char buf[64];
   long pos = vftell(vf);
 
   for(int i = 0; i < arraysize(test_data); i++)
   {
-    snprintf(buf, arraysize(buf), "vfputc offset=%d", i);
+    //snprintf(buf, arraysize(buf), "vfputc offset=%d", i);
     vfputc(test_data[i], vf);
   }
   int r = vfseek(vf, pos, SEEK_SET);
-  ASSERTEQX(r, 0, "vfseek");
+  ASSERTEQ(r, 0, "vfseek");
   test_write_check(vf);
 }
 
 static void test_vfputw(vfile *vf)
 {
-  char buf[64];
+  //char buf[64];
   long pos = vftell(vf);
 
   for(int i = 0; i < arraysize(test_data); i += 2)
   {
     int d = test_data[i] | (test_data[i + 1] << 8);
-    snprintf(buf, arraysize(buf), "vfputw offset=%d", i);
+    //snprintf(buf, arraysize(buf), "vfputw offset=%d", i);
     vfputw(d, vf);
   }
   int r = vfseek(vf, pos, SEEK_SET);
-  ASSERTEQX(r, 0, "vfseek");
+  ASSERTEQ(r, 0, "vfseek");
   test_write_check(vf);
 }
 
 static void test_vfputd(vfile *vf)
 {
-  char buf[64];
+  //char buf[64];
   long pos = vftell(vf);
 
   for(int i = 0; i < arraysize(test_data); i += 4)
   {
     int d = test_data[i] | (test_data[i + 1] << 8) |
      (test_data[i + 2] << 16) | (test_data[i + 3] << 24);
-    snprintf(buf, arraysize(buf), "vfputw offset=%d", i);
+    //snprintf(buf, arraysize(buf), "vfputw offset=%d", i);
     vfputd(d, vf);
   }
   int r = vfseek(vf, pos, SEEK_SET);
-  ASSERTEQX(r, 0, "vfseek");
+  ASSERTEQ(r, 0, "vfseek");
   test_write_check(vf);
 }
 
@@ -269,10 +261,10 @@ static void test_vfwrite(vfile *vf)
   long pos = vftell(vf);
 
   int r = vfwrite(test_data, 1, arraysize(test_data), vf);
-  ASSERTEQX(r, arraysize(test_data), "vfwrite");
+  ASSERTEQ(r, arraysize(test_data), "vfwrite");
 
   r = vfseek(vf, pos, SEEK_SET);
-  ASSERTEQX(r, 0, "vfseek");
+  ASSERTEQ(r, 0, "vfseek");
   test_write_check(vf);
 }
 
@@ -281,13 +273,13 @@ static void test_vfputs(vfile *vf)
   long pos = vftell(vf);
 
   int r = vfputs(reinterpret_cast<const char *>(test_data), vf);
-  ASSERTEQX(r, 0, "vfputs");
+  ASSERTEQ(r, 0, "vfputs");
 
   r = vfputc(0, vf);
-  ASSERTEQX(r, 0, "vfputc");
+  ASSERTEQ(r, 0, "vfputc");
 
   r = vfseek(vf, pos, SEEK_SET);
-  ASSERTEQX(r, 0, "vfseek");
+  ASSERTEQ(r, 0, "vfseek");
   test_write_check(vf);
 }
 
@@ -300,79 +292,72 @@ static void test_vfseek_vftell_vrewind_read(vfile *vf)
   static constexpr int end_invalid[] = { -257, -2000, -127848, -2391231 };
   static constexpr int len = arraysize(test_data);
 
-  char buf[64];
   long expected;
   long pos;
   int ret;
 
   // SEEK_SET (valid).
-  for(int i = 0; i < arraysize(set_valid); i++)
+  for(int value : set_valid)
   {
-    snprintf(buf, arraysize(buf), "SEEK_SET valid %d", i);
-    ret = vfseek(vf, set_valid[i], SEEK_SET);
+    ret = vfseek(vf, value, SEEK_SET);
     pos = vftell(vf);
-    ASSERTEQX(ret, 0, buf);
-    ASSERTEQX(pos, set_valid[i], buf);
+    ASSERTEQ(ret, 0, "SEEK_SET valid: %d", value);
+    ASSERTEQ(pos, value, "SEEK_SET valid: %d", value);
   }
   vrewind(vf);
   pos = vftell(vf);
-  ASSERTEQX(pos, 0, "vrewind after SEEK_SET");
+  ASSERTEQ(pos, 0, "vrewind after SEEK_SET");
 
   // SEEK_CUR (valid).
   expected = 0;
-  for(int i = 0; i < arraysize(cur_valid); i++)
+  for(int value : cur_valid)
   {
-    snprintf(buf, arraysize(buf), "SEEK_CUR valid %d", i);
-    expected += cur_valid[i];
-    ret = vfseek(vf, cur_valid[i], SEEK_CUR);
+    expected += value;
+    ret = vfseek(vf, value, SEEK_CUR);
     pos = vftell(vf);
-    ASSERTEQX(ret, 0, buf);
-    ASSERTEQX(pos, expected, buf);
+    ASSERTEQ(ret, 0, "SEEK_CUR valid: %d", value);
+    ASSERTEQ(pos, expected, "SEEK_CUR valid: %d", value);
   }
   vrewind(vf);
   pos = vftell(vf);
-  ASSERTEQX(pos, 0, "vrewind after SEEK_CUR");
+  ASSERTEQ(pos, 0, "vrewind after SEEK_CUR");
 
   // SEEK_SET and SEEK_CUR (invalid).
-  for(int i = 0; i < arraysize(set_cur_invalid); i++)
+  for(int value : set_cur_invalid)
   {
-    snprintf(buf, arraysize(buf), "SEEK_SET invalid %d", i);
-    ret = vfseek(vf, set_cur_invalid[i], SEEK_SET);
-    ASSERTX(ret != 0, buf);
+    ret = vfseek(vf, value, SEEK_SET);
+    ASSERT(ret != 0, "SEEK_SET invalid: %d", value);
     vrewind(vf);
     pos = vftell(vf);
-    ASSERTEQX(pos, 0, buf);
+    ASSERTEQ(pos, 0, "SEEK_SET invalid: %d", value);
 
-    snprintf(buf, arraysize(buf), "SEEK_CUR invalid %d", i);
-    ret = vfseek(vf, set_cur_invalid[i], SEEK_CUR);
-    ASSERTX(ret != 0, buf);
+    ret = vfseek(vf, value, SEEK_CUR);
+    ASSERT(ret != 0, "SEEK_CUR invalid: %d", value);
     vrewind(vf);
     pos = vftell(vf);
-    ASSERTEQX(pos, 0, buf);
+    ASSERTEQ(pos, 0, "SEEK_CUR invalid: %d", value);
   }
 
   // SEEK_END (valid).
-  for(int i = 0; i < arraysize(end_valid); i++)
+  for(int value : end_valid)
   {
-    snprintf(buf, arraysize(buf), "SEEK_END valid %d", i);
-    ret = vfseek(vf, end_valid[i], SEEK_END);
+    ret = vfseek(vf, value, SEEK_END);
     pos = vftell(vf);
-    ASSERTEQX(ret, 0, buf);
-    ASSERTEQX(pos, len + end_valid[i], buf);
+    ASSERTEQ(ret, 0, "SEEK_END valid: %d", value);
+    ASSERTEQ(pos, len + value, "SEEK_END valid: %d", value);
   }
   vrewind(vf);
   pos = vftell(vf);
-  ASSERTEQX(pos, 0, "vrewind after SEEK_END");
+  ASSERTEQ(pos, 0, "vrewind after SEEK_END");
 
   // SEEK_END (invalid).
-  for(int i = 0; i < arraysize(end_invalid); i++)
+  for(int value : end_invalid)
   {
-    snprintf(buf, arraysize(buf), "SEEK_END invalid %d", i);
-    ret = vfseek(vf, end_invalid[i], SEEK_END);
-    ASSERTX(ret != 0, buf);
+    ret = vfseek(vf, value, SEEK_END);
+    ASSERT(ret != 0, "SEEK_END invalid: %d", value);
     vrewind(vf);
     pos = vftell(vf);
-    ASSERTEQX(pos, 0, buf);
+    ASSERTEQ(pos, 0, "SEEK_END invalid: %d", value);
   }
 }
 
@@ -382,8 +367,8 @@ static void test_filelength(long expected_len, vfile *vf)
   long len = vfilelength(vf, false);
   long newpos = vftell(vf);
 
-  ASSERTEQX(len, expected_len, "vfilelength");
-  ASSERTEQX(pos, newpos, "vfilelength with no rewind");
+  ASSERTEQ(len, expected_len, "vfilelength");
+  ASSERTEQ(pos, newpos, "vfilelength with no rewind");
 
   if(len >> 1)
   {
@@ -391,8 +376,8 @@ static void test_filelength(long expected_len, vfile *vf)
     len = vfilelength(vf, true);
     newpos = vftell(vf);
 
-    ASSERTEQX(len, expected_len, "vfilelength 2");
-    ASSERTEQX(newpos, 0, "vfilelength with rewind");
+    ASSERTEQ(len, expected_len, "vfilelength 2");
+    ASSERTEQ(newpos, 0, "vfilelength with rewind");
   }
 }
 
@@ -416,115 +401,113 @@ static void test_vungetc(vfile *vf)
   // vungetc should fail if EOF or some other junk is provided.
   // Note: MSVCRT stdio &255s non-EOF values (?).
   ret = vungetc(EOF, vf);
-  ASSERTEQ(ret, EOF);
+  ASSERTEQ(ret, EOF, "vungetc EOF");
   ret = vungetc(-128141, vf);
-  ASSERTEQ(ret, EOF);
+  ASSERTEQ(ret, EOF, "vungetc -128141");
   ret = vungetc(256, vf);
-  ASSERTEQ(ret, EOF);
+  ASSERTEQ(ret, EOF, "vungetc 256");
 
   // vfgetc should read the buffered char.
   ret = vungetc(0xAB, vf);
-  ASSERTEQ(ret, 0xAB);
+  ASSERTEQ(ret, 0xAB, "vungetc 0xAB");
   value = vfgetc(vf);
-  ASSERTEQ(value, 0xAB);
+  ASSERTEQ(value, 0xAB, "vfgetc 0xAB");
 
   // vfgetw should read the buffered char + one char from the data.
   ret = vungetc(0xCD, vf);
-  ASSERTEQ(ret, 0xCD);
+  ASSERTEQ(ret, 0xCD, "vungetc 0xCD");
   value = vfgetw(vf);
-  ASSERTEQ(value, 0xCD | ((first_dword & 0xFF) << 8));
+  ASSERTEQ(value, 0xCD | ((first_dword & 0xFF) << 8), "vfgetw 0xCD ...");
 
   // vfgetd should read the buffered char + three chars from the data.
   ret = vungetc(0xEF, vf);
-  ASSERTEQ(ret, 0xEF);
+  ASSERTEQ(ret, 0xEF, "vungetc 0xEF");
   value = vfgetd(vf);
-  ASSERTEQ(value, 0xEF | (first_dword & ~0xFF));
+  ASSERTEQ(value, 0xEF | (first_dword & ~0xFF), "vfgetd 0xEF ...");
 
   // vfread should read the buffered char + n-1 chars from the data.
   ret = vungetc(0x12, vf);
-  ASSERTEQ(ret, 0x12);
+  ASSERTEQ(ret, 0x12, "vungetc 0x12");
   value = vfread(tmp, 64, 1, vf);
-  ASSERTEQ(value, 1);
-  ASSERTEQ(tmp[0], 0x12);
-  ASSERTMEM(tmp + 1, next_64, 63);
+  ASSERTEQ(value, 1, "vfread 0x12 ...");
+  ASSERTEQ(tmp[0], 0x12, "vfread 0x12 ...");
+  ASSERTMEM(tmp + 1, next_64, 63, "vfread 0x12 ...");
 
   // vfsafegets should read the buffered char + n-1 chars from the data.
   vfseek(vf, arraysize(test_data) - 5, SEEK_SET);
   ret = vungetc(0xFF, vf);
-  ASSERTEQ(ret, 0xFF);
+  ASSERTEQ(ret, 0xFF, "vungetc 0xFF");
   retstr = vfsafegets(tmp, arraysize(tmp), vf);
-  ASSERT(retstr);
-  ASSERTEQ(tmp[0], 0xFF);
-  ASSERTMEM(tmp + 1, last_5, 5);
+  ASSERT(retstr, "vfsafegets 0xFF ...");
+  ASSERTEQ(tmp[0], 0xFF, "vfsafegets 0xFF ...");
+  ASSERTMEM(tmp + 1, last_5, 5, "vfsafegets 0xFF ...");
 
   // If the buffer char is \r and the next char in the stream is \n, consume both.
   vfseek(vf, 0, SEEK_SET);
   ret = vungetc(0x0D, vf);
-  ASSERTEQ(ret, 0x0D);
+  ASSERTEQ(ret, 0x0D, "vungetc 0x0D");
   retstr = vfsafegets(tmp, arraysize(tmp), vf);
-  ASSERT(retstr);
-  ASSERTEQ((int)tmp[0], 0);
+  ASSERT(retstr, "vfsafegets 0x0D ...");
+  ASSERTEQ((int)tmp[0], 0, "vfsafegets 0x0D ...");
   pos = vftell(vf);
-  ASSERTEQ(pos, 1);
+  ASSERTEQ(pos, 1, "vfsafegets 0x0D ...");
 
   // Reading a buffer char from the end of the file should not return NULL.
   vfseek(vf, 0, SEEK_END);
   ret = vungetc('a', vf);
-  ASSERTEQ(ret, 'a');
+  ASSERTEQ(ret, 'a', "vungetc 'a'");
   retstr = vfsafegets(tmp, arraysize(tmp), vf);
-  ASSERT(retstr);
-  ASSERTCMP(retstr, "a");
+  ASSERT(retstr, "vsafegets 'a'");
+  ASSERTCMP(retstr, "a", "vsafegets 'a'");
   pos = vftell(vf);
-  ASSERTEQ(pos, arraysize(test_data));
+  ASSERTEQ(pos, arraysize(test_data), "vsafegets 'a'");
 
   // vseek should discard the buffered char.
   ret = vungetc(0x34, vf);
-  ASSERTEQ(ret, 0x34);
+  ASSERTEQ(ret, 0x34, "vungetc 0x34");
   vfseek(vf, 128, SEEK_SET);
   value = vfgetc(vf);
-  ASSERTEQ(value, test_data[128]);
+  ASSERTEQ(value, test_data[128], "vfgetc NOT 0x34");
 
   // vrewind should discard the buffered char.
   ret = vungetc(0x56, vf);
-  ASSERTEQ(ret, 0x56);
+  ASSERTEQ(ret, 0x56, "vungetc 0x56");
   vrewind(vf);
   value = vfgetd(vf);
-  ASSERTEQ(value, first_dword);
+  ASSERTEQ(value, first_dword, "vfgetd NOT 0x56 ...");
 
   // vfilelength with rewind should discard the buffered char.
   ret = vungetc(0x78, vf);
-  ASSERTEQ(ret, 0x78);
+  ASSERTEQ(ret, 0x78, "vungetc 0x78");
   long len = vfilelength(vf, true);
-  ASSERTEQ(len, arraysize(test_data));
+  ASSERTEQ(len, arraysize(test_data), "vfgetd NOT 0x78");
   value = vfgetd(vf);
-  ASSERTEQ(value, first_dword);
+  ASSERTEQ(value, first_dword, "vfgetd NOT 0x78");
 
   // ftell should subtract the buffered char count from the cursor for binary
   // streams. Calling ftell when (cursor - buffered char count)<0 is undefined.
   ret = vfseek(vf, 128, SEEK_SET);
-  ASSERTEQ(ret, 0);
+  ASSERTEQ(ret, 0, "vfseek");
   ret = vungetc(0x9A, vf);
-  ASSERTEQ(ret, 0x9A);
+  ASSERTEQ(ret, 0x9A, "vungetc 0x9A");
   pos = vftell(vf);
-  ASSERTEQ(pos, 127);
+  ASSERTEQ(pos, 127, "vftell after vungetc");
 }
 
 static void test_vfsafegets(vfile *vf, int i, const char * const (&output)[MAX_LINES])
 {
   char buffer[VFSAFEGETS_BUFFER];
-  char msg[64];
   char *cursor;
   int line = 0;
 
   while((cursor = vfsafegets(buffer, VFSAFEGETS_BUFFER, vf)))
   {
-    snprintf(msg, arraysize(msg), "test=%d, line=%d", i, line);
-    ASSERTX(line < MAX_LINES - 1, msg);
-    ASSERTX(output[line], msg);
-    ASSERTXCMP(buffer, output[line], msg);
+    ASSERT(line < MAX_LINES - 1, "test=%d, line=%d", i, line);
+    ASSERT(output[line], "test=%d, line=%d", i, line);
+    ASSERTCMP(buffer, output[line], "%s", "test=%d, line=%d", i, line);
     line++;
   }
-  ASSERT(!output[line]);
+  ASSERT(!output[line], "");
 }
 
 #define READ_TESTS(vf) do { \
@@ -549,13 +532,13 @@ static void test_vfsafegets(vfile *vf, int i, const char * const (&output)[MAX_L
 UNITTEST(Init)
 {
   FILE *fp = fopen_unsafe(TEST_READ_FILENAME, "wb");
-  ASSERTX(fp, "fopen_unsafe");
+  ASSERT(fp, "fopen_unsafe");
 
   int r = fwrite(test_data, sizeof(test_data), 1, fp);
-  ASSERTEQX(r, 1, "fwrite");
+  ASSERTEQ(r, 1, "fwrite");
 
   r = fclose(fp);
-  ASSERTEQX(r, 0, "fclose");
+  ASSERTEQ(r, 0, "fclose");
 
   samesize(TEST_READ_TEXT_FILENAME, vfsafegets_data);
   samesize(TEST_READ_TEXT_FILENAME, vfsafegets_output);
@@ -563,13 +546,13 @@ UNITTEST(Init)
   for(int i = 0; i < arraysize(TEST_READ_TEXT_FILENAME); i++)
   {
     fp = fopen_unsafe(TEST_READ_TEXT_FILENAME[i], "wb");
-    ASSERTX(fp, "fopen_unsafe");
+    ASSERT(fp, "fopen_unsafe");
 
     r = fwrite(vfsafegets_data[i], strlen(vfsafegets_data[i]), 1, fp);
-    ASSERTEQX(r, 1, "fwrite");
+    ASSERTEQ(r, 1, "fwrite");
 
     r = fclose(fp);
-    ASSERTEQX(r, 0, "fclose");
+    ASSERTEQ(r, 0, "fclose");
   }
 }
 
@@ -577,21 +560,21 @@ UNITTEST(FileRead)
 {
   ScopedFile<vfile, vfclose> vf_in =
    vfopen_unsafe_ext(TEST_READ_FILENAME, "rb", V_SMALL_BUFFER);
-  ASSERT(vf_in);
+  ASSERT(vf_in, "");
   READ_TESTS(vf_in);
 }
 
 UNITTEST(FileWrite)
 {
   ScopedFile<vfile, vfclose> vf_out = vfopen_unsafe(TEST_WRITE_FILENAME, "w+b");
-  ASSERT(vf_out);
+  ASSERT(vf_out, "");
   WRITE_TESTS(vf_out, false);
 }
 
 UNITTEST(FileAppend)
 {
   ScopedFile<vfile, vfclose> vf_out = vfopen_unsafe(TEST_WRITE_FILENAME, "a+b");
-  ASSERT(vf_out);
+  ASSERT(vf_out, "");
   // Align the read cursor with the write cursor.
   vfseek(vf_out, 0, SEEK_END);
   WRITE_TESTS(vf_out, true);
@@ -602,7 +585,7 @@ UNITTEST(MemoryRead)
   char buffer[arraysize(test_data)];
   memcpy(buffer, test_data, arraysize(test_data));
   ScopedFile<vfile, vfclose> vf_in = vfile_init_mem(buffer, arraysize(buffer), "rb");
-  ASSERT(vf_in);
+  ASSERT(vf_in, "");
   READ_TESTS(vf_in);
 }
 
@@ -613,7 +596,7 @@ UNITTEST(MemoryWrite)
   int ret;
 
   ScopedFile<vfile, vfclose> vf_out = vfile_init_mem(buffer, len, "w+b");
-  ASSERT(vf_out);
+  ASSERT(vf_out, "");
   WRITE_TESTS(vf_out, false);
 
   SECTION(NoWritePastEnd)
@@ -621,24 +604,24 @@ UNITTEST(MemoryWrite)
     /* Make sure writes that would exceed a fixed size buffer are refused. */
     vfseek(vf_out, len, SEEK_SET);
     ret = vfputc(0xAB, vf_out);
-    ASSERTEQ(ret, EOF);
+    ASSERTEQ(ret, EOF, "");
 
     vfseek(vf_out, len - 1, SEEK_SET);
     ret = vfputw(0xCD, vf_out);
-    ASSERTEQ(ret, EOF);
+    ASSERTEQ(ret, EOF, "");
 
     vfseek(vf_out, len - 3, SEEK_SET);
     ret = vfputd(0xEF, vf_out);
-    ASSERTEQ(ret, EOF);
+    ASSERTEQ(ret, EOF, "");
 
     static constexpr char tmp[] = "abcdefghij";
     vfseek(vf_out, len - 7, SEEK_SET);
     ret = vfputs(tmp, vf_out);
-    ASSERTEQ(ret, EOF);
+    ASSERTEQ(ret, EOF, "");
 
     vfseek(vf_out, 128, SEEK_SET);
     ret = vfwrite(test_data, len, 1, vf_out);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
   }
 }
 
@@ -649,7 +632,7 @@ UNITTEST(MemoryWriteExt)
   size_t size = 0;
 
   ScopedFile<vfile, vfclose> vf_out = vfile_init_mem_ext(&buffer, &size, "w+b");
-  ASSERT(vf_out);
+  ASSERT(vf_out, "");
   WRITE_TESTS(vf_out, false);
   free(buffer);
 }
@@ -660,18 +643,18 @@ UNITTEST(MemoryAppendExt)
   static constexpr size_t BUF_SIZE = 256;
   void *buffer = malloc(BUF_SIZE);
   size_t size = BUF_SIZE;
-  ASSERT(buffer);
+  ASSERT(buffer, "");
 
   {
     ScopedFile<vfile, vfclose> vf_out = vfile_init_mem_ext(&buffer, &size, "a+b");
-    ASSERT(vf_out);
+    ASSERT(vf_out, "");
     // Align the read cursor with the write cursor.
     vfseek(vf_out, 0, SEEK_END);
     WRITE_TESTS(vf_out, true);
   }
   free(buffer);
   if(this->expected_section)
-    ASSERTEQ(size, arraysize(test_data) + BUF_SIZE);
+    ASSERTEQ(size, arraysize(test_data) + BUF_SIZE, "");
 }
 
 UNITTEST(vfsafegets)
@@ -682,7 +665,7 @@ UNITTEST(vfsafegets)
     {
       ScopedFile<vfile, vfclose> vf =
        vfopen_unsafe_ext(TEST_READ_TEXT_FILENAME[i], "rb", V_SMALL_BUFFER);
-      ASSERT(vf);
+      ASSERT(vf, "");
       test_vfsafegets(vf, i, vfsafegets_output[i]);
     }
   }
@@ -695,7 +678,7 @@ UNITTEST(vfsafegets)
     for(int i = 0; i < arraysize(TEST_READ_TEXT_FILENAME); i++)
     {
       ScopedFile<vfile, vfclose> vf = vfopen_unsafe(TEST_READ_TEXT_FILENAME[i], "r");
-      ASSERT(vf);
+      ASSERT(vf, "");
       test_vfsafegets(vf, i, vfsafegets_output[i]);
     }
   }
@@ -711,7 +694,7 @@ UNITTEST(vfsafegets)
 
       memcpy(tmp.get(), input, len + 1);
       ScopedFile<vfile, vfclose> vf = vfile_init_mem(tmp.get(), len, "rb");
-      ASSERT(vf);
+      ASSERT(vf, "");
       test_vfsafegets(vf, i, vfsafegets_output[i]);
     }
   }
@@ -722,21 +705,21 @@ UNITTEST(vtempfile)
   SECTION(File)
   {
     ScopedFile<vfile, vfclose> vf = vtempfile(0);
-    ASSERT(vf);
+    ASSERT(vf, "");
     test_vfwrite(vf);
   }
 
   SECTION(Memory)
   {
     ScopedFile<vfile, vfclose> vf = vtempfile(arraysize(test_data));
-    ASSERT(vf);
+    ASSERT(vf, "");
     test_vfwrite(vf);
   }
 
   SECTION(MemorySmallInit)
   {
     ScopedFile<vfile, vfclose> vf = vtempfile(1);
-    ASSERT(vf);
+    ASSERT(vf, "");
     test_vfputc(vf);
   }
 }
@@ -746,31 +729,31 @@ UNITTEST(Filesystem)
   static constexpr char TEST_RENAME_FILENAME[] = "VFILE_TEST_dfbdfbshd";
   static constexpr char TEST_RENAME_DIR[] = "VFILE_TEST_DIR_ndfjsdbnfjdfd";
   static char execdir[1024];
-  struct stat stat_info;
+  struct stat stat_info{}; // 0-init to silence MemorySanitizer.
   int ret;
 
   if(!this->expected_section)
   {
     char *t = getcwd(execdir, arraysize(execdir));
-    ASSERTEQ(t, execdir);
+    ASSERTEQ(t, execdir, "");
   }
   else
   {
     ret = vchdir(execdir);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
   }
 
   SECTION(vchdir)
   {
     ret = vchdir("..");
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
     ret = vchdir("data");
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
 
     ScopedFile<vfile, vfclose> vf = vfopen_unsafe("CT_LEVEL.MOD", "rb");
-    ASSERT(vf);
+    ASSERT(vf, "");
     long len = vfilelength(vf, false);
-    ASSERTEQ(len, 111885);
+    ASSERTEQ(len, 111885, "");
   }
 
   SECTION(vgetcwd)
@@ -778,45 +761,45 @@ UNITTEST(Filesystem)
     char buffer[1024];
     char buffer2[1024];
     char *t = getcwd(buffer, arraysize(buffer));
-    ASSERTEQ(t, buffer);
+    ASSERTEQ(t, buffer, "");
     ret = vchdir("..");
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
     t = getcwd(buffer2, arraysize(buffer2));
-    ASSERTEQ(t, buffer2);
+    ASSERTEQ(t, buffer2, "");
     size_t len = strlen(buffer2);
-    ASSERT(len < arraysize(buffer));
-    ASSERTMEM(buffer, buffer2, len);
+    ASSERT(len < arraysize(buffer), "");
+    ASSERTMEM(buffer, buffer2, len, "");
   }
 
   SECTION(vmkdir)
   {
     ret = vmkdir(TEST_DIR, 0777);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
     ret = stat(TEST_DIR, &stat_info);
-    ASSERTEQ(ret, 0);
-    ASSERT(S_ISDIR(stat_info.st_mode));
+    ASSERTEQ(ret, 0, "");
+    ASSERT(S_ISDIR(stat_info.st_mode), "");
   }
 
   SECTION(vunlink)
   {
     ret = stat(TEST_WRITE_FILENAME, &stat_info);
-    ASSERTEQ(ret, 0);
-    ASSERT(S_ISREG(stat_info.st_mode));
+    ASSERTEQ(ret, 0, "");
+    ASSERT(S_ISREG(stat_info.st_mode), "");
     ret = vunlink(TEST_WRITE_FILENAME);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
     ret = stat(TEST_WRITE_FILENAME, &stat_info);
-    ASSERT(ret != 0);
+    ASSERT(ret != 0, "");
   }
 
   SECTION(vrmdir)
   {
     ret = stat(TEST_DIR, &stat_info);
-    ASSERTEQ(ret, 0);
-    ASSERT(S_ISDIR(stat_info.st_mode));
+    ASSERTEQ(ret, 0, "");
+    ASSERT(S_ISDIR(stat_info.st_mode), "");
     ret = vrmdir(TEST_DIR);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
     ret = stat(TEST_DIR, &stat_info);
-    ASSERT(ret != 0);
+    ASSERT(ret != 0, "");
   }
 
   SECTION(vaccess)
@@ -827,40 +810,40 @@ UNITTEST(Filesystem)
     static constexpr int access_flags = R_OK|W_OK;
 #endif
     ret = access(".", access_flags);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
     ret = vaccess(".", R_OK|W_OK|X_OK);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
 
     ret = vchdir("..");
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
     ret = vchdir("data");
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
     ret = access("CT_LEVEL.MOD", R_OK|W_OK);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
     ret = vaccess("CT_LEVEL.MOD", R_OK|W_OK);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
   }
 
   SECTION(vstat)
   {
-    struct stat stat_info2;
+    struct stat stat_info2{};
     ret = stat(".", &stat_info);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
     ret = vstat(".", &stat_info2);
-    ASSERTEQ(ret, 0);
-    ASSERT(S_ISDIR(stat_info.st_mode));
-    ASSERT(S_ISDIR(stat_info2.st_mode));
+    ASSERTEQ(ret, 0, "");
+    ASSERT(S_ISDIR(stat_info.st_mode), "");
+    ASSERT(S_ISDIR(stat_info2.st_mode), "");
 
     ret = vchdir("..");
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
     ret = vchdir("data");
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
     ret = stat("CT_LEVEL.MOD", &stat_info);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
     ret = vstat("CT_LEVEL.MOD", &stat_info2);
-    ASSERTEQ(ret, 0);
-    ASSERT(S_ISREG(stat_info.st_mode));
-    ASSERT(S_ISREG(stat_info2.st_mode));
+    ASSERTEQ(ret, 0, "");
+    ASSERT(S_ISREG(stat_info.st_mode), "");
+    ASSERT(S_ISREG(stat_info2.st_mode), "");
   }
 
   SECTION(vrename)
@@ -876,36 +859,36 @@ UNITTEST(Filesystem)
     vrmdir(TEST_DIR);
 
     ret = vmkdir(TEST_DIR, 0777);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
 
     {
       ScopedFile<vfile, vfclose> vf = vfopen_unsafe(TEST_WRITE_FILENAME, "wb");
-      ASSERT(vf);
+      ASSERT(vf, "");
     }
 
     ret = vstat(TEST_WRITE_FILENAME, &stat_info);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
 
     // Rename file.
     ret = vrename(TEST_WRITE_FILENAME, buffer);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
 
     ret = vstat(buffer, &stat_info);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
 
     // Rename dir.
     ret = vrename(TEST_DIR, TEST_RENAME_DIR);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
 
     ret = vstat(TEST_RENAME_DIR, &stat_info);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
 
     // Renamed filename still in dir?
     ret = vchdir(TEST_RENAME_DIR);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
 
     ret = vstat(TEST_RENAME_FILENAME, &stat_info);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
   }
 
   SECTION(UTF8)
@@ -921,61 +904,61 @@ UNITTEST(Filesystem)
     if(!ret)
     {
       ret = vchdir(UTF8_DIR);
-      ASSERTEQ(ret, 0);
+      ASSERTEQ(ret, 0, "");
       ret = vunlink(UTF8_FILE);
       ret = vunlink(UTF8_FILE2);
       ret = vchdir("..");
-      ASSERTEQ(ret, 0);
+      ASSERTEQ(ret, 0, "");
       ret = vrmdir(UTF8_DIR);
-      ASSERTEQ(ret, 0);
+      ASSERTEQ(ret, 0, "");
     }
 
     ret = vmkdir(UTF8_DIR, 0777);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
 
     ret = vstat(UTF8_DIR, &stat_info);
-    ASSERTEQ(ret, 0);
-    ASSERT(S_ISDIR(stat_info.st_mode));
+    ASSERTEQ(ret, 0, "");
+    ASSERT(S_ISDIR(stat_info.st_mode), "");
 
     ret = vchdir(UTF8_DIR);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
     char buffer[1024];
 
     char *t = vgetcwd(buffer, arraysize(buffer));
-    ASSERTEQ(t, buffer);
+    ASSERTEQ(t, buffer, "");
     size_t len = strlen(buffer);
-    ASSERTCMP(buffer + len - utf8_dir_len, UTF8_DIR);
+    ASSERTCMP(buffer + len - utf8_dir_len, UTF8_DIR, "");
 
     {
       ScopedFile<vfile, vfclose> vf = vfopen_unsafe(UTF8_FILE, "wb");
-      ASSERT(vf);
+      ASSERT(vf, "");
       ret = vfwrite(test_data, arraysize(test_data), 1, vf);
-      ASSERTEQ(ret, 1);
+      ASSERTEQ(ret, 1, "");
     }
 
     ret = vstat(UTF8_FILE, &stat_info);
-    ASSERTEQ(ret, 0);
-    ASSERTEQ(stat_info.st_size, arraysize(test_data));
-    ASSERT(S_ISREG(stat_info.st_mode));
+    ASSERTEQ(ret, 0, "");
+    ASSERTEQ(stat_info.st_size, arraysize(test_data), "");
+    ASSERT(S_ISREG(stat_info.st_mode), "");
 
     ret = vaccess(UTF8_FILE, R_OK|W_OK);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
 
     ret = vrename(UTF8_FILE, UTF8_FILE2);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
 
     ret = vstat(UTF8_FILE2, &stat_info);
-    ASSERTEQ(ret, 0);
-    ASSERTEQ(stat_info.st_size, arraysize(test_data));
-    ASSERT(S_ISREG(stat_info.st_mode));
+    ASSERTEQ(ret, 0, "");
+    ASSERTEQ(stat_info.st_size, arraysize(test_data), "");
+    ASSERT(S_ISREG(stat_info.st_mode), "");
 
     ret = vunlink(UTF8_FILE2);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
 
     ret = vchdir("..");
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
 
     ret = vrmdir(UTF8_DIR);
-    ASSERTEQ(ret, 0);
+    ASSERTEQ(ret, 0, "");
   }
 }

--- a/unit/memcasecmp.cpp
+++ b/unit/memcasecmp.cpp
@@ -55,9 +55,9 @@ UNITTEST(memtolower)
   for(i = 0; i < 256; i++)
   {
     if(i >= 'A' && i <= 'Z')
-      ASSERTEQ(memtolower(i), (i - 'A' + 'a'));
+      ASSERTEQ(memtolower(i), (i - 'A' + 'a'), "");
     else
-      ASSERTEQ(memtolower(i), i);
+      ASSERTEQ(memtolower(i), i, "");
   }
 }
 
@@ -86,49 +86,48 @@ UNITTEST(Matching)
   };
   const char *a;
   const char *b;
-  int i;
 
   SECTION(memcasecmp)
   {
-    for(i = 0; i < arraysize(pairs); i++)
+    for(const string_pair &p : pairs)
     {
-      a = pairs[i].a;
-      b = pairs[i].b;
-      ASSERTEQX(strlen(a), strlen(b), a);
-      ASSERTX(!memcasecmp(a, b, strlen(a)), a);
+      a = p.a;
+      b = p.b;
+      ASSERTEQ(strlen(a), strlen(b), "%s", a);
+      ASSERT(!memcasecmp(a, b, strlen(a)), "%s", a);
     }
 
-    for(i = 0; i < arraysize(pairs64); i++)
+    for(const string_pair_aligned &p : pairs64)
     {
-      a = pairs64[i].a.c_str();
-      b = pairs64[i].b.c_str();
+      a = p.a.c_str();
+      b = p.b.c_str();
 
-      ASSERTEQ((size_t)a & (ALIGN_64_MODULO - 1), 0);
-      ASSERTEQ((size_t)b & (ALIGN_64_MODULO - 1), 0);
-      ASSERTEQX(strlen(a), strlen(b), a);
-      ASSERTX(!memcasecmp(a, b, strlen(a)), a);
+      ASSERTEQ((size_t)a & (ALIGN_64_MODULO - 1), 0, "a not aligned");
+      ASSERTEQ((size_t)b & (ALIGN_64_MODULO - 1), 0, "b not aligned");
+      ASSERTEQ(strlen(a), strlen(b), "%s", a);
+      ASSERT(!memcasecmp(a, b, strlen(a)), "%s", a);
     }
   }
 
   SECTION(memcasecmp32)
   {
-    for(i = 0; i < arraysize(pairs); i++)
+    for(const string_pair &p : pairs)
     {
-      a = pairs[i].a;
-      b = pairs[i].b;
-      ASSERTEQX(strlen(a), strlen(b), a);
-      ASSERTX(!memcasecmp32(a, b, strlen(a)), a);
+      a = p.a;
+      b = p.b;
+      ASSERTEQ(strlen(a), strlen(b), "%s", a);
+      ASSERT(!memcasecmp32(a, b, strlen(a)), "%s", a);
     }
 
-    for(i = 0; i < arraysize(pairs64); i++)
+    for(const string_pair_aligned &p : pairs64)
     {
-      a = pairs64[i].a.c_str();
-      b = pairs64[i].b.c_str();
+      a = p.a.c_str();
+      b = p.b.c_str();
 
-      ASSERTEQ((size_t)a & (ALIGN_32_MODULO - 1), 0);
-      ASSERTEQ((size_t)b & (ALIGN_32_MODULO - 1), 0);
-      ASSERTEQX(strlen(a), strlen(b), a);
-      ASSERTX(!memcasecmp32(a, b, strlen(a)), a);
+      ASSERTEQ((size_t)a & (ALIGN_32_MODULO - 1), 0, "a not aligned");
+      ASSERTEQ((size_t)b & (ALIGN_32_MODULO - 1), 0, "b not aligned");
+      ASSERTEQ(strlen(a), strlen(b), "%s", a);
+      ASSERT(!memcasecmp32(a, b, strlen(a)), "%s", a);
     }
   }
 }
@@ -162,53 +161,52 @@ UNITTEST(NoMatch)
   const char *a;
   const char *b;
   int expected;
-  int i;
 
   SECTION(memcasecmp)
   {
-    for(i = 0; i < arraysize(pairs); i++)
+    for(const bad_string_pair &p : pairs)
     {
-      a = pairs[i].a;
-      b = pairs[i].b;
-      expected = pairs[i].expected;
-      ASSERTEQX(strlen(a), strlen(b), a);
-      ASSERTEQX(memcasecmp(a, b, strlen(a)), expected, a);
+      a = p.a;
+      b = p.b;
+      expected = p.expected;
+      ASSERTEQ(strlen(a), strlen(b), "%s", a);
+      ASSERTEQ(memcasecmp(a, b, strlen(a)), expected, "%s", a);
     }
 
-    for(i = 0; i < arraysize(pairs64); i++)
+    for(const bad_string_pair_aligned &p : pairs64)
     {
-      a = pairs64[i].a.c_str();
-      b = pairs64[i].b.c_str();
-      expected = pairs64[i].expected;
+      a = p.a.c_str();
+      b = p.b.c_str();
+      expected = p.expected;
 
-      ASSERTEQ((size_t)a & (ALIGN_64_MODULO - 1), 0);
-      ASSERTEQ((size_t)b & (ALIGN_64_MODULO - 1), 0);
-      ASSERTEQX(strlen(a), strlen(b), a);
-      ASSERTEQX(memcasecmp(a, b, strlen(a)), expected, a);
+      ASSERTEQ((size_t)a & (ALIGN_64_MODULO - 1), 0, "a not aligned");
+      ASSERTEQ((size_t)b & (ALIGN_64_MODULO - 1), 0, "b not aligned");
+      ASSERTEQ(strlen(a), strlen(b), "%s", a);
+      ASSERTEQ(memcasecmp(a, b, strlen(a)), expected, "%s", a);
     }
   }
 
   SECTION(memcasecmp32)
   {
-    for(i = 0; i < arraysize(pairs); i++)
+    for(const bad_string_pair &p : pairs)
     {
-      a = pairs[i].a;
-      b = pairs[i].b;
-      expected = pairs[i].expected;
-      ASSERTEQX(strlen(a), strlen(b), a);
-      ASSERTEQX(memcasecmp32(a, b, strlen(a)), expected, a);
+      a = p.a;
+      b = p.b;
+      expected = p.expected;
+      ASSERTEQ(strlen(a), strlen(b), "%s", a);
+      ASSERTEQ(memcasecmp32(a, b, strlen(a)), expected, "%s", a);
     }
 
-    for(i = 0; i < arraysize(pairs64); i++)
+    for(const bad_string_pair_aligned &p : pairs64)
     {
-      a = pairs64[i].a.c_str();
-      b = pairs64[i].b.c_str();
-      expected = pairs64[i].expected;
+      a = p.a.c_str();
+      b = p.b.c_str();
+      expected = p.expected;
 
-      ASSERTEQ((size_t)a & (ALIGN_32_MODULO - 1), 0);
-      ASSERTEQ((size_t)b & (ALIGN_32_MODULO - 1), 0);
-      ASSERTEQX(strlen(a), strlen(b), a);
-      ASSERTEQX(memcasecmp32(a, b, strlen(a)), expected, a);
+      ASSERTEQ((size_t)a & (ALIGN_32_MODULO - 1), 0, "a not aligned");
+      ASSERTEQ((size_t)b & (ALIGN_32_MODULO - 1), 0, "b not aligned");
+      ASSERTEQ(strlen(a), strlen(b), "%s", a);
+      ASSERTEQ(memcasecmp32(a, b, strlen(a)), expected, "%s", a);
     }
   }
 }

--- a/unit/network/Manifest.cpp
+++ b/unit/network/Manifest.cpp
@@ -44,6 +44,9 @@ public:
     if(getcwd(prev, MAX_PATH))
       if(!chdir(new_dir))
         success = true;
+
+    if(!success)
+      FAIL("chdir failed");
   }
 
   ~pushd()
@@ -53,11 +56,6 @@ public:
       trace("--UNIT-- attempting to chdir back to %s.\n", prev);
       chdir(prev);
     }
-  }
-
-  explicit operator bool()
-  {
-    return success;
   }
 };
 
@@ -112,50 +110,43 @@ UNITTEST(ManifestEntry)
 {
   SECTION(ManifestEntry)
   {
-    for(int i = 0; i < arraysize(filedata); i++)
+    for(const manifestdata &f : filedata)
     {
-      const manifestdata &f = filedata[i];
-
       ManifestEntry e(f.sha256, f.size, f.filename);
-      ASSERTXMEM(e.sha256, f.sha256, sizeof(f.sha256), f.filename);
-      ASSERTEQX(e.size, f.size, f.filename);
-      ASSERTCMP(e.name, f.filename);
+      ASSERTMEM(e.sha256, f.sha256, sizeof(f.sha256), "%s", f.filename);
+      ASSERTEQ(e.size, f.size, "%s", f.filename);
+      ASSERTCMP(e.name, f.filename, "");
 
       ManifestEntry e2(e);
-      ASSERTXMEM(e2.sha256, f.sha256, sizeof(f.sha256), f.filename);
-      ASSERTEQX(e2.size, f.size, f.filename);
-      ASSERTCMP(e2.name, f.filename);
+      ASSERTMEM(e2.sha256, f.sha256, sizeof(f.sha256), "%s", f.filename);
+      ASSERTEQ(e2.size, f.size, "%s", f.filename);
+      ASSERTCMP(e2.name, f.filename, "");
     }
   }
 
   SECTION(operator=)
   {
-    for(int i = 0; i < arraysize(filedata); i++)
+    for(const manifestdata &f : filedata)
     {
-      const manifestdata &f = filedata[i];
-
       ManifestEntry e(dummy_file.sha256, dummy_file.size, dummy_file.filename);
       ManifestEntry e2(f.sha256, f.size, f.filename);
       e = e2;
 
-      ASSERTXMEM(e.sha256, f.sha256, sizeof(f.sha256), f.filename);
-      ASSERTEQX(e.size, f.size, f.filename);
-      ASSERTCMP(e.name, f.filename);
+      ASSERTMEM(e.sha256, f.sha256, sizeof(f.sha256), "%s", f.filename);
+      ASSERTEQ(e.size, f.size, "%s", f.filename);
+      ASSERTCMP(e.name, f.filename, "");
     }
   }
 
   SECTION(validate)
   {
     pushd ch(DATA_DIR);
-    ASSERT(ch);
 
-    for(int i = 0; i < arraysize(filedata); i++)
+    for(const manifestdata &f : filedata)
     {
-      const manifestdata &f = filedata[i];
-
       ManifestEntry e(f.sha256, f.size, f.filename);
       boolean valid = e.validate();
-      ASSERTX(valid, f.filename);
+      ASSERT(valid, "%s", f.filename);
     }
   }
 
@@ -178,49 +169,42 @@ UNITTEST(ManifestEntry)
       "\\dev",
     };
 
-    for(int i = 0; i < arraysize(valid); i++)
-      ASSERTX(ManifestEntry::validate_filename(valid[i]), valid[i]);
+    for(const char *filename : valid)
+      ASSERT(ManifestEntry::validate_filename(filename), "%s", filename);
 
-    for(int i = 0; i < arraysize(invalid); i++)
-      ASSERTX(!ManifestEntry::validate_filename(invalid[i]), invalid[i]);
+    for(const char *filename : invalid)
+      ASSERT(!ManifestEntry::validate_filename(filename), "%s", filename);
   }
 
   SECTION(create_from_file)
   {
     pushd ch(DATA_DIR);
-    ASSERT(ch);
 
-    for(int i = 0; i < arraysize(filedata); i++)
+    for(const manifestdata &f : filedata)
     {
-      const manifestdata &f = filedata[i];
-
       std::unique_ptr<ManifestEntry> e(ManifestEntry::create_from_file(f.filename));
-      ASSERTX(e, f.filename);
+      ASSERT(e, "%s", f.filename);
 
-      ASSERTXMEM(e->sha256, f.sha256, sizeof(f.sha256), f.filename);
-      ASSERTEQX(e->size, f.size, f.filename);
-      ASSERTCMP(e->name, f.filename);
+      ASSERTMEM(e->sha256, f.sha256, sizeof(f.sha256), "%s", f.filename);
+      ASSERTEQ(e->size, f.size, "%s", f.filename);
+      ASSERTCMP(e->name, f.filename, "");
     }
   }
 }
 
 void test_manifest(const Manifest &m, const char *comment)
 {
-  char buffer[256];
   const ManifestEntry *e = m.first();
-  for(int i = 0; i < arraysize(filedata); i++)
+  for(const manifestdata &f : filedata)
   {
-    const manifestdata &f = filedata[i];
-    snprintf(buffer, arraysize(buffer), "%s, %s", f.filename, comment);
-
-    ASSERTX(e, buffer);
-    ASSERTXMEM(e->sha256, f.sha256, sizeof(f.sha256), buffer);
-    ASSERTEQX(e->size, f.size, buffer);
-    ASSERTXCMP(e->name, f.filename, buffer);
-    ASSERTX(e->validate(), buffer);
+    ASSERT(e, "%s, %s", f.filename, comment);
+    ASSERTMEM(e->sha256, f.sha256, sizeof(f.sha256), "%s, %s", f.filename, comment);
+    ASSERTEQ(e->size, f.size, "%s, %s", f.filename, comment);
+    ASSERTCMP(e->name, f.filename, "%s, %s", f.filename, comment);
+    ASSERT(e->validate(), "%s, %s", f.filename, comment);
     e = e->next;
   }
-  ASSERT(!e);
+  ASSERT(!e, "unexpected data at end of Manifest");
 }
 
 UNITTEST(Manifest)
@@ -228,13 +212,12 @@ UNITTEST(Manifest)
   SECTION(create)
   {
     pushd ch(DATA_DIR);
-    ASSERT(ch);
 
     Manifest m;
     m.create("manifest.txt");
     test_manifest(m, "create(filename)");
     m.clear();
-    ASSERT(!m.head);
+    ASSERT(!m.head, "clear failed");
 
     m.create(manifest_str, arraysize(manifest_str));
     test_manifest(m, "create(buffer, size)");
@@ -252,7 +235,7 @@ UNITTEST(Manifest)
 
     // append(Manifest &) consumes the source Manifest's data.
     m1.append(m2);
-    ASSERT(!m2.head);
+    ASSERT(!m2.head, "append failed to clear source Manifest");
 
     ManifestEntry *tmp =
      new ManifestEntry(dummy_file.sha256, dummy_file.size, dummy_file.filename);
@@ -261,31 +244,29 @@ UNITTEST(Manifest)
     const ManifestEntry *e = m1.first();
     for(int j = 0; j < 2; j++)
     {
-      for(int i = 0; i < arraysize(filedata); i++)
+      for(const manifestdata &f : filedata)
       {
-        const manifestdata &f = filedata[i];
-        ASSERTX(e, f.filename);
-        ASSERTCMP(e->name, f.filename);
+        ASSERT(e, "%s", f.filename);
+        ASSERTCMP(e->name, f.filename, "");
         e = e->next;
       }
     }
 
-    ASSERTX(e, dummy_file.filename);
-    ASSERTCMP(e->name, dummy_file.filename);
+    ASSERT(e, "%s", dummy_file.filename);
+    ASSERTCMP(e->name, dummy_file.filename, "");
     e = e->next;
-    ASSERT(!e);
+    ASSERT(!e, "unexpected data at end of Manifest");
   }
 
   SECTION(write_to_file)
   {
     pushd ch(DATA_DIR);
-    ASSERT(ch);
 
     Manifest m;
     m.create(manifest_str, arraysize(manifest_str));
     m.write_to_file(TEMP_FILE);
     m.clear();
-    ASSERT(!m.head);
+    ASSERT(!m.head, "clear failed");
 
     m.create(TEMP_FILE);
     test_manifest(m, "create(filename)");

--- a/unit/network/sha256.cpp
+++ b/unit/network/sha256.cpp
@@ -52,12 +52,12 @@ UNITTEST(SHA256String)
   };
   struct SHA256_ctx ctx;
 
-  for(int i = 0; i < arraysize(data); i++)
+  for(const SHA256_data &d : data)
   {
     SHA256_init(&ctx);
-    SHA256_update(&ctx, data[i].input, strlen(data[i].input));
+    SHA256_update(&ctx, d.input, strlen(d.input));
     SHA256_final(&ctx);
-    ASSERTMEM(ctx.H, data[i].result, sizeof(ctx.H), "%s", data[i].input);
+    ASSERTMEM(ctx.H, d.result, sizeof(ctx.H), "%s", d.input);
   }
 }
 
@@ -111,12 +111,12 @@ UNITTEST(SHA256File)
   struct SHA256_ctx ctx;
   char buffer[8192];
 
-  for(int i = 0; i < arraysize(data); i++)
+  for(const SHA256_data &d : data)
   {
     SHA256_init(&ctx);
 
-    FILE *fp = fopen_unsafe(data[i].input, "rb");
-    ASSERT(fp, "%s", data[i].input);
+    FILE *fp = fopen_unsafe(d.input, "rb");
+    ASSERT(fp, "%s", d.input);
 
     fseek(fp, 0, SEEK_END);
     ssize_t file_len = ftell(fp);
@@ -127,13 +127,13 @@ UNITTEST(SHA256File)
     {
       ssize_t len = std::min(file_len - j, (ssize_t)arraysize(buffer));
       size_t ret = fread(buffer, len, 1, fp);
-      ASSERTEQ(ret, 1, "%s", data[i].input);
+      ASSERTEQ(ret, 1, "%s", d.input);
 
       SHA256_update(&ctx, buffer, len);
       j += len;
     }
     fclose(fp);
     SHA256_final(&ctx);
-    ASSERTMEM(ctx.H, data[i].result, sizeof(ctx.H), "%s", data[i].input);
+    ASSERTMEM(ctx.H, d.result, sizeof(ctx.H), "%s", d.input);
   }
 }

--- a/unit/network/sha256.cpp
+++ b/unit/network/sha256.cpp
@@ -57,7 +57,7 @@ UNITTEST(SHA256String)
     SHA256_init(&ctx);
     SHA256_update(&ctx, data[i].input, strlen(data[i].input));
     SHA256_final(&ctx);
-    ASSERTXMEM(ctx.H, data[i].result, sizeof(ctx.H), data[i].input);
+    ASSERTMEM(ctx.H, data[i].result, sizeof(ctx.H), "%s", data[i].input);
   }
 }
 
@@ -116,7 +116,7 @@ UNITTEST(SHA256File)
     SHA256_init(&ctx);
 
     FILE *fp = fopen_unsafe(data[i].input, "rb");
-    ASSERTX(fp, data[i].input);
+    ASSERT(fp, "%s", data[i].input);
 
     fseek(fp, 0, SEEK_END);
     ssize_t file_len = ftell(fp);
@@ -126,13 +126,14 @@ UNITTEST(SHA256File)
     while(j < file_len)
     {
       ssize_t len = std::min(file_len - j, (ssize_t)arraysize(buffer));
-      ASSERTX(fread(buffer, len, 1, fp), data[i].input);
+      size_t ret = fread(buffer, len, 1, fp);
+      ASSERTEQ(ret, 1, "%s", data[i].input);
 
       SHA256_update(&ctx, buffer, len);
       j += len;
     }
     fclose(fp);
     SHA256_final(&ctx);
-    ASSERTXMEM(ctx.H, data[i].result, sizeof(ctx.H), data[i].input);
+    ASSERTMEM(ctx.H, data[i].result, sizeof(ctx.H), "%s", data[i].input);
   }
 }

--- a/unit/utils/image_file.cpp
+++ b/unit/utils/image_file.cpp
@@ -152,7 +152,7 @@ UNITTEST(PNG)
   boolean ret;
 
   ret = load_image_from_file(DATA_BASEDIR "rgba.png", &img, NULL);
-  ASSERT(ret, "png load failed");
+  ASSERT(ret, "rgba.png: load failed");
   compare_image<compare_rgba>(base_rgba_img, img, "rgba.png");
   image_free(&img);
 

--- a/unit/utils/image_file.cpp
+++ b/unit/utils/image_file.cpp
@@ -124,33 +124,21 @@ static boolean compare_rgba(const rgba_color &base, const rgba_color &in)
 }
 
 template<boolean (*COMPARE_FN)(const rgba_color &a, const rgba_color &b)>
-static boolean compare_image(const struct image_file_const &base,
- const struct image_file &in, char *msgbuf, size_t buf_size)
+static void compare_image(const struct image_file_const &base,
+ const struct image_file &in, const char *filename)
 {
-  if(in.width != base.width)
-  {
-    snprintf(msgbuf, buf_size, "width mismatch");
-    return false;
-  }
-
-  if(in.height != base.height)
-  {
-    snprintf(msgbuf, buf_size, "height mismatch");
-    return false;
-  }
+  ASSERTEQ(in.width, base.width, "%s: width mismatch", filename);
+  ASSERTEQ(in.height, base.height, "%s: height mismatch", filename);
 
   size_t num = base.width * base.height;
   for(size_t i = 0; i < num; i++)
   {
     if(!COMPARE_FN(base.data[i], in.data[i]))
     {
-      snprintf(msgbuf, buf_size, "pixel mismatch @ %zu - %08x %08x", i,
+      FAIL("%s: pixel mismatch @ %zu - %08x %08x", filename, i,
        *(uint32_t *)(base.data + i), *(uint32_t *)(in.data + i));
-      return false;
     }
   }
-
-  return true;
 }
 
 
@@ -161,15 +149,11 @@ UNITTEST(PNG)
 #else
 
   struct image_file img{};
-  char msg[256];
   boolean ret;
 
-  size_t off = snprintf(msg, sizeof(msg), "png: ");
-
   ret = load_image_from_file(DATA_BASEDIR "rgba.png", &img, NULL);
-  ASSERTX(ret, msg);
-  ret = compare_image<compare_rgba>(base_rgba_img, img, msg + off, sizeof(msg) - off);
-  ASSERTX(ret, msg);
+  ASSERT(ret, "png load failed");
+  compare_image<compare_rgba>(base_rgba_img, img, "rgba.png");
   image_free(&img);
 
 #endif /* CONFIG_PNG */
@@ -180,7 +164,6 @@ UNITTEST(BMP)
 {
   struct image_file img{};
   char path[512];
-  char msg[256];
   boolean ret;
 
   static const char *bw_inputs[] =
@@ -220,26 +203,22 @@ UNITTEST(BMP)
   {
     for(const char *filename : rgb_truecolor_inputs)
     {
-      size_t off = snprintf(msg, sizeof(msg), "%s: ", filename);
       snprintf(path, sizeof(path), DATA_BASEDIR "%s", filename);
 
       ret = load_image_from_file(path, &img, NULL);
-      ASSERTX(ret, msg);
-      ret = compare_image<compare_rgb>(base_rgba_img, img, msg + off, sizeof(msg) - off);
-      ASSERTX(ret, msg);
+      ASSERT(ret, "%s: load failed", filename);
+      compare_image<compare_rgb>(base_rgba_img, img, filename);
       image_free(&img);
     }
 
     // 16bpp is lossy, needs a special compare...
     for(const char *filename : rgb_truecolor16_inputs)
     {
-      size_t off = snprintf(msg, sizeof(msg), "%s: ", filename);
       snprintf(path, sizeof(path), DATA_BASEDIR "%s", filename);
 
       ret = load_image_from_file(path, &img, NULL);
-      ASSERTX(ret, msg);
-      ret = compare_image<compare_rgb16>(base_rgba_img, img, msg + off, sizeof(msg) - off);
-      ASSERTX(ret, msg);
+      ASSERT(ret, "%s: load failed", filename);
+      compare_image<compare_rgb16>(base_rgba_img, img, filename);
       image_free(&img);
     }
   }
@@ -248,37 +227,31 @@ UNITTEST(BMP)
   {
     for(const char *filename : rgb_indexed_inputs)
     {
-      size_t off = snprintf(msg, sizeof(msg), "%s: ", filename);
       snprintf(path, sizeof(path), DATA_BASEDIR "%s", filename);
 
       ret = load_image_from_file(path, &img, NULL);
-      ASSERTX(ret, msg);
-      ret = compare_image<compare_rgb>(base_rgba_img, img, msg + off, sizeof(msg) - off);
-      ASSERTX(ret, msg);
+      ASSERT(ret, "%s: load failed", filename);
+      compare_image<compare_rgb>(base_rgba_img, img, filename);
       image_free(&img);
     }
 
     for(const char *filename : bw_inputs)
     {
-      size_t off = snprintf(msg, sizeof(msg), "%s: ", filename);
       snprintf(path, sizeof(path), DATA_BASEDIR "%s", filename);
 
       ret = load_image_from_file(path, &img, NULL);
-      ASSERTX(ret, msg);
-      ret = compare_image<compare_rgb>(base_bw_img, img, msg + off, sizeof(msg) - off);
-      ASSERTX(ret, msg);
+      ASSERT(ret, "%s: load failed", filename);
+      compare_image<compare_rgb>(base_bw_img, img, filename);
       image_free(&img);
     }
 
     for(const char *filename : gs_inputs)
     {
-      size_t off = snprintf(msg, sizeof(msg), "%s: ", filename);
       snprintf(path, sizeof(path), DATA_BASEDIR "%s", filename);
 
       ret = load_image_from_file(path, &img, NULL);
-      ASSERTX(ret, msg);
-      ret = compare_image<compare_rgb>(base_gs_img, img, msg + off, sizeof(msg) - off);
-      ASSERTX(ret, msg);
+      ASSERT(ret, "%s: load failed", filename);
+      compare_image<compare_rgb>(base_gs_img, img, filename);
       image_free(&img);
     }
   }
@@ -287,13 +260,11 @@ UNITTEST(BMP)
   {
     for(const char *filename : rgb_rle_inputs)
     {
-      size_t off = snprintf(msg, sizeof(msg), "%s: ", filename);
       snprintf(path, sizeof(path), DATA_BASEDIR "%s", filename);
 
       ret = load_image_from_file(path, &img, NULL);
-      ASSERTX(ret, msg);
-      ret = compare_image<compare_rgb>(base_rgba_img, img, msg + off, sizeof(msg) - off);
-      ASSERTX(ret, msg);
+      ASSERT(ret, "%s: load failed", filename);
+      compare_image<compare_rgb>(base_rgba_img, img, filename);
       image_free(&img);
     }
   }
@@ -304,7 +275,6 @@ UNITTEST(Netpbm)
 {
   struct image_file img{};
   char path[512];
-  char msg[256];
   boolean ret;
 
   static const char *bw_inputs[] =
@@ -364,13 +334,11 @@ UNITTEST(Netpbm)
   {
     for(const char *filename : bw_inputs)
     {
-      size_t off = snprintf(msg, sizeof(msg), "%s: ", filename);
       snprintf(path, sizeof(path), DATA_BASEDIR "%s", filename);
 
       ret = load_image_from_file(path, &img, NULL);
-      ASSERTX(ret, msg);
-      ret = compare_image<compare_rgb>(base_bw_img, img, msg + off, sizeof(msg) - off);
-      ASSERTX(ret, msg);
+      ASSERT(ret, "%s: load failed", filename);
+      compare_image<compare_rgb>(base_bw_img, img, filename);
       image_free(&img);
     }
   }
@@ -379,13 +347,11 @@ UNITTEST(Netpbm)
   {
     for(const char *filename : grey_inputs)
     {
-      size_t off = snprintf(msg, sizeof(msg), "%s: ", filename);
       snprintf(path, sizeof(path), DATA_BASEDIR "%s", filename);
 
       ret = load_image_from_file(path, &img, NULL);
-      ASSERTX(ret, msg);
-      ret = compare_image<compare_rgb>(base_gs_img, img, msg + off, sizeof(msg) - off);
-      ASSERTX(ret, msg);
+      ASSERT(ret, "%s: load failed", filename);
+      compare_image<compare_rgb>(base_gs_img, img, filename);
       image_free(&img);
     }
   }
@@ -394,13 +360,11 @@ UNITTEST(Netpbm)
   {
     for(const char *filename : rgb_inputs)
     {
-      size_t off = snprintf(msg, sizeof(msg), "%s: ", filename);
       snprintf(path, sizeof(path), DATA_BASEDIR "%s", filename);
 
       ret = load_image_from_file(path, &img, NULL);
-      ASSERTX(ret, msg);
-      ret = compare_image<compare_rgb>(base_rgba_img, img, msg + off, sizeof(msg) - off);
-      ASSERTX(ret, msg);
+      ASSERT(ret, "%s: load failed", filename);
+      compare_image<compare_rgb>(base_rgba_img, img, filename);
       image_free(&img);
     }
   }
@@ -409,25 +373,21 @@ UNITTEST(Netpbm)
   {
     for(const char *filename : greya_inputs)
     {
-      size_t off = snprintf(msg, sizeof(msg), "%s: ", filename);
       snprintf(path, sizeof(path), DATA_BASEDIR "%s", filename);
 
       ret = load_image_from_file(path, &img, NULL);
-      ASSERTX(ret, msg);
-      ret = compare_image<compare_rgba>(base_gs_img, img, msg + off, sizeof(msg) - off);
-      ASSERTX(ret, msg);
+      ASSERT(ret, "%s: load failed", filename);
+      compare_image<compare_rgba>(base_gs_img, img, filename);
       image_free(&img);
     }
 
     for(const char *filename : rgba_inputs)
     {
-      size_t off = snprintf(msg, sizeof(msg), "%s: ", filename);
       snprintf(path, sizeof(path), DATA_BASEDIR "%s", filename);
 
       ret = load_image_from_file(path, &img, NULL);
-      ASSERTX(ret, msg);
-      ret = compare_image<compare_rgba>(base_rgba_img, img, msg + off, sizeof(msg) - off);
-      ASSERTX(ret, msg);
+      ASSERT(ret, "%s: load failed", filename);
+      compare_image<compare_rgba>(base_rgba_img, img, filename);
       image_free(&img);
     }
   }
@@ -437,15 +397,11 @@ UNITTEST(Netpbm)
 UNITTEST(farbfeld)
 {
   struct image_file img{};
-  char msg[256];
   boolean ret;
 
-  size_t off = snprintf(msg, sizeof(msg), "farbfeld: ");
-
   ret = load_image_from_file(DATA_BASEDIR "farbfeld.ff", &img, NULL);
-  ASSERTX(ret, msg);
-  ret = compare_image<compare_rgba>(base_rgba_img, img, msg + off, sizeof(msg) - off);
-  ASSERTX(ret, msg);
+  ASSERT(ret, "farbfeld.ff: load failed");
+  compare_image<compare_rgba>(base_rgba_img, img, "farbfeld.ff");
   image_free(&img);
 }
 
@@ -453,9 +409,7 @@ UNITTEST(farbfeld)
 UNITTEST(raw)
 {
   struct image_file img{};
-  char msg[256];
   boolean ret;
-  size_t off;
 
   static const struct image_raw_format gs_format = { base_gs_img.width, base_gs_img.height, 1 };
   static const struct image_raw_format gsa_format = { base_gs_img.width, base_gs_img.height, 2 };
@@ -464,45 +418,33 @@ UNITTEST(raw)
 
   SECTION(Greyscale)
   {
-    off = snprintf(msg, sizeof(msg), "raw_gs.raw: ");
-
     ret = load_image_from_file(DATA_BASEDIR "raw_gs.raw", &img, &gs_format);
-    ASSERTX(ret, msg);
-    ret = compare_image<compare_rgb>(base_gs_img, img, msg + off, sizeof(msg) - off);
-    ASSERTX(ret, msg);
+    ASSERT(ret, "raw_gs.raw: load failed");
+    compare_image<compare_rgb>(base_gs_img, img, "raw_gs.raw");
     image_free(&img);
   }
 
   SECTION(GreyscaleAlpha)
   {
-    off = snprintf(msg, sizeof(msg), "raw_gsa.raw: ");
-
     ret = load_image_from_file(DATA_BASEDIR "raw_gsa.raw", &img, &gsa_format);
-    ASSERTX(ret, msg);
-    ret = compare_image<compare_rgba>(base_gs_img, img, msg + off, sizeof(msg) - off);
-    ASSERTX(ret, msg);
+    ASSERT(ret, "raw_gsa.raw: load failed");
+    compare_image<compare_rgba>(base_gs_img, img, "raw_gsa.raw");
     image_free(&img);
   }
 
   SECTION(RGB)
   {
-    off = snprintf(msg, sizeof(msg), "raw_rgb.raw: ");
-
     ret = load_image_from_file(DATA_BASEDIR "raw_rgb.raw", &img, &rgb_format);
-    ASSERTX(ret, msg);
-    ret = compare_image<compare_rgb>(base_rgba_img, img, msg + off, sizeof(msg) - off);
-    ASSERTX(ret, msg);
+    ASSERT(ret, "raw_rgb.raw: load failed");
+    compare_image<compare_rgb>(base_rgba_img, img, "raw_rgb.raw");
     image_free(&img);
   }
 
   SECTION(RGBA)
   {
-    off = snprintf(msg, sizeof(msg), "raw_rgba.raw: ");
-
     ret = load_image_from_file(DATA_BASEDIR "raw_rgba.raw", &img, &rgba_format);
-    ASSERTX(ret, msg);
-    ret = compare_image<compare_rgba>(base_rgba_img, img, msg + off, sizeof(msg) - off);
-    ASSERTX(ret, msg);
+    ASSERT(ret, "raw_rgba.raw: load failed");
+    compare_image<compare_rgba>(base_rgba_img, img, "raw_rgba.raw");
     image_free(&img);
   }
 }


### PR DESCRIPTION
Removes the `ASSERTX` series of macros in favor of the new variadic parameters to `ASSERT`. Also fixes a bunch of -pedantic warnings in old GCC versions and clang caused by the variadic macros, switches a lot of standard for loops to range-based for loops, and gets rid of some `snprintf` usage made unnecessary by the updated `ASSERT` macros.