### PR TITLE
Move misc. warnings from core_flags to global CFLAGS/CXXFLAGS.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,7 +184,6 @@ jobs:
     env:
       CC: clang
       CXX: clang++
-      LINK_CC: clang++
     steps:
       - name: Install dependencies
         run: sudo apt update && sudo apt install -y --no-install-recommends $MZXDEPS_DEBIAN_SDL2
@@ -201,7 +200,6 @@ jobs:
     env:
       CC: clang
       CXX: clang++
-      LINK_CC: "@clang++"
       UBSAN_OPTIONS: print_stacktrace=1
     steps:
       - name: Install dependencies

--- a/Makefile
+++ b/Makefile
@@ -229,8 +229,8 @@ CFLAGS   += ${OPTIMIZE_CFLAGS} -DNDEBUG
 CXXFLAGS += ${OPTIMIZE_CFLAGS} -DNDEBUG
 endif
 
-CFLAGS   += -Wundef -Wunused-macros
-CXXFLAGS += -Wundef -Wunused-macros
+CFLAGS   += -Wundef -Wunused-macros -Wpointer-arith -Wwrite-strings -Wmissing-declarations
+CXXFLAGS += -Wundef -Wunused-macros -Wpointer-arith -Wwrite-strings -Wmissing-declarations
 
 #
 # Enable C++11 for compilers that support it.

--- a/contrib/libmodplug/src/Makefile.in
+++ b/contrib/libmodplug/src/Makefile.in
@@ -17,7 +17,7 @@ libmodplug_cflags = -DHAVE_INTTYPES_H -I${libmodplug_src} \
 # Rather than bloat the patches to fix these warnings, just disable them.
 #
 ifneq (${HAS_W_NO_IMPLICIT_FALLTHROUGH},)
-libmodplug_cflags += -Wno-implicit-fallthrough
+libmodplug_cflags += -Wno-implicit-fallthrough -Wno-missing-declarations
 endif
 
 libmodplug_objs = \

--- a/contrib/libmodplug/src/Makefile.in
+++ b/contrib/libmodplug/src/Makefile.in
@@ -13,11 +13,13 @@ libmodplug_cflags = -DHAVE_INTTYPES_H -I${libmodplug_src} \
                     -I${libmodplug_src}/libmodplug \
                     -include src/platform_endian.h
 
+libmodplug_cflags += -Wno-missing-declarations
+
 #
 # Rather than bloat the patches to fix these warnings, just disable them.
 #
 ifneq (${HAS_W_NO_IMPLICIT_FALLTHROUGH},)
-libmodplug_cflags += -Wno-implicit-fallthrough -Wno-missing-declarations
+libmodplug_cflags += -Wno-implicit-fallthrough
 endif
 
 libmodplug_objs = \

--- a/contrib/libxmp/Makefile.megazeux
+++ b/contrib/libxmp/Makefile.megazeux
@@ -24,7 +24,7 @@ libxmp_cflags := \
 #
 libxmp_cflags += \
  -Wno-missing-prototypes -Wno-unused-macros -Wno-sign-compare \
- -Wno-missing-field-initializers
+ -Wno-missing-field-initializers -Wno-missing-declarations
 
 ifeq (${HAS_W_NO_UNUSED_BUT_SET_VARIABLE},1)
 libxmp_cflags += -Wno-unused-but-set-variable

--- a/contrib/rad/validate20.cpp
+++ b/contrib/rad/validate20.cpp
@@ -16,6 +16,10 @@
 
 
 
+const char *RADValidate(const void *data, size_t data_size);
+
+
+
 //==================================================================================================
 // The error strings are all supplied here in case you want to translate them to another language
 // (or supply your own more descriptive error messages).

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -29,8 +29,7 @@ network_src = src/network
 network_obj = src/network/.build
 
 core_flags   += -ffast-math -funsigned-char
-core_flags   += -Wmissing-format-attribute -Wpointer-arith
-core_flags   += -Wwrite-strings
+core_flags   += -Wmissing-format-attribute
 core_cflags  += ${CFLAGS} -Wmissing-prototypes
 core_cxxflags = ${CXXFLAGS} -DHAVE_INTTYPES_H
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -415,6 +415,10 @@ endif
 # external libraries for MinGW and (particularly) Android builds.
 #
 ifneq (${core_cxxobjs},)
+# Exception: force C++ linking when building against sanitizers.
+ifneq (${SANITIZER},)
+LINK_CC := ${CXX}
+endif
 ifneq (${LINK_CC},${CXX})
 core_cxxobjs := ${core_obj}/nostdc++.o ${core_cxxobjs}
 endif

--- a/src/network/Socket.cpp
+++ b/src/network/Socket.cpp
@@ -458,7 +458,7 @@ boolean Socket::is_last_error_fatal(void)
  * as a workaround, use Win32 functions instead (these should be safe back to
  * Windows 95).
  */
-void winsock_perror(const char *message, int code)
+static void winsock_perror(const char *message, int code)
 {
   LPSTR err_message = NULL;
 

--- a/src/nostdc++.cpp
+++ b/src/nostdc++.cpp
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <new>
 
+extern "C" CORE_LIBSPEC void __cxa_pure_virtual();
 extern "C" CORE_LIBSPEC void __cxa_pure_virtual()
 {
   fprintf(mzxerr, "Attempted to call pure virtual function! Aborting!\n");
@@ -37,6 +38,7 @@ extern "C" CORE_LIBSPEC void __cxa_pure_virtual()
   exit(1);
 }
 
+extern "C" CORE_LIBSPEC void __cxa_deleted_virtual();
 extern "C" CORE_LIBSPEC void __cxa_deleted_virtual()
 {
   fprintf(mzxerr, "Attempted to call deleted virtual function! Aborting!\n");

--- a/src/pngops.c
+++ b/src/pngops.c
@@ -26,6 +26,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef NEED_PNG_WRITE_SCREEN
+
 int png_write_screen(uint8_t *pixels, struct rgb_color *pal, int count,
  const char *name)
 {
@@ -162,6 +164,8 @@ exit_close:
 exit_out:
   return ret;
 }
+
+#endif /* NEED_PNG_WRITE_SCREEN */
 
 #ifdef NEED_PNG_READ_FILE
 

--- a/src/pngops.h
+++ b/src/pngops.h
@@ -33,9 +33,9 @@ __M_BEGIN_DECLS
 
 #ifdef NEED_PNG_WRITE_SCREEN
 
-#include "graphics.h"
 #include <stdint.h>
-#include <stdio.h>
+
+struct rgb_color;
 
 int png_write_screen(uint8_t *pixels, struct rgb_color *pal, int count,
  const char *name);
@@ -44,6 +44,8 @@ int png_write_screen_32bpp(uint32_t *pixels, const char *name);
 #endif // NEED_PNG_WRITE_SCREEN
 
 #ifdef NEED_PNG_READ_FILE
+
+#include <stdio.h>
 
 typedef boolean (*check_w_h_constraint_t)(png_uint_32 w, png_uint_32 h);
 typedef void *(*rgba_surface_allocator_t)(png_uint_32 w, png_uint_32 h,

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -208,7 +208,7 @@ static const char *ui_new_version_available(context *ctx,
  * Either way, the update can't be performed, so explain why and possibly
  * offer some other useful options.
  */
-enum new_version_opts ui_new_version_error(context *ctx,
+static enum new_version_opts ui_new_version_error(context *ctx,
  const char *new_ver, boolean platform_has_remote_manifest)
 {
   char reason[LINE_BUF_LEN];

--- a/src/utils/ccv.c
+++ b/src/utils/ccv.c
@@ -163,13 +163,13 @@ static const char USAGE_EXAMPLES[] =
 "    intensities >=160 as white.\n"
 "\n";
 
-void Usage()
+static void Usage()
 {
   fprintf(stderr, USAGE);
   fprintf(stderr, "Type \"ccv -help\" for extended options information\n");
 }
 
-void Help()
+static void Help()
 {
   fprintf(stderr, USAGE);
   fprintf(stderr, USAGE_DESC);
@@ -178,7 +178,7 @@ void Help()
   fprintf(stderr, USAGE_EXAMPLES);
 }
 
-void Error(const char *string, ...)
+static void Error(const char *string, ...)
 {
   va_list vaList;
   va_start(vaList, string);
@@ -189,7 +189,7 @@ void Error(const char *string, ...)
   exit(1);
 }
 
-inline static int lc_strcmp(const char *A, const char *B)
+static inline int lc_strcmp(const char *A, const char *B)
 {
   const char *a = A;
   const char *b = B;
@@ -204,7 +204,7 @@ inline static int lc_strcmp(const char *A, const char *B)
     b++;
   }
 }
-inline static int lc_strncmp(const char *A, const char *B, int n)
+static inline int lc_strncmp(const char *A, const char *B, int n)
 {
   const char *a = A;
   const char *b = B;
@@ -223,7 +223,7 @@ inline static int lc_strncmp(const char *A, const char *B, int n)
   }
 }
 
-inline static void file_write32(int val, FILE *fp)
+static inline void file_write32(int val, FILE *fp)
 {
   fputc((val >> 0) & 0xFF, fp);
   fputc((val >> 8) & 0xFF, fp);
@@ -231,7 +231,7 @@ inline static void file_write32(int val, FILE *fp)
   fputc((val >> 24) & 0xFF, fp);
 }
 
-inline static int file_read32(FILE *fp)
+static inline int file_read32(FILE *fp)
 {
   unsigned int r = 0;
   r |= fgetc(fp);
@@ -241,13 +241,13 @@ inline static int file_read32(FILE *fp)
   return r;
 }
 
-inline static void file_write16(int val, FILE *fp)
+static inline void file_write16(int val, FILE *fp)
 {
   fputc((val >> 0) & 0xFF, fp);
   fputc((val >> 8) & 0xFF, fp);
 }
 
-inline static int file_read16(FILE *fp)
+static inline int file_read16(FILE *fp)
 {
   unsigned int r = 0;
   r |= fgetc(fp);
@@ -255,12 +255,14 @@ inline static int file_read16(FILE *fp)
   return r;
 }
 
-typedef struct {
+typedef struct
+{
   char path[MAX_PATH+1];
   UT_hash_handle hh;
 } InputFile;
 
-typedef struct {
+typedef struct
+{
   InputFile *files;
 
   int w;
@@ -284,7 +286,7 @@ typedef struct {
   char dither[256];
 } Config;
 
-Config *DefaultConfig()
+static Config *DefaultConfig()
 {
   Config *cfg = cmalloc(sizeof(Config));
   cfg->files = NULL;
@@ -313,93 +315,106 @@ Config *DefaultConfig()
   return cfg;
 }
 
-int Option(const char *option_name, int arguments, char *argument, int args_left)
+static int Option(const char *option_name, int arguments, char *argument, int args_left)
 {
-  if (strcmp(argument, option_name) != 0) return 0;
-  if (args_left < arguments) {
+  if(strcmp(argument, option_name) != 0)
+    return 0;
+
+  if(args_left < arguments)
     Error("Insufficient arguments for %s", option_name);
-  }
+
   return 1;
 }
 
-Config *LoadConfig(int argc, char **argv)
+static Config *LoadConfig(int argc, char **argv)
 {
   Config *cfg = DefaultConfig();
-
-  char arg_used[argc];
   int i;
 
-  memset(arg_used, 0, argc);
-
-  if (argc >= 1 && strcmp(argv[0], "-help") == 0) {
+  if(argc >= 1 && strcmp(argv[0], "-help") == 0)
+  {
     Help();
     exit(0);
   }
 
-  for (i = 0; i < argc; i++) {
-    if (arg_used[i]) continue;
-    if (argv[i][0] == '-' && argv[i][1] != '\0') { // Argument
+  for(i = 0; i < argc; i++)
+  {
+    if(argv[i][0] == '-' && argv[i][1] != '\0') // Argument
+    {
       int args_left = argc - i - 1;
-      if (Option("-q", 0, argv[i], args_left)) {
+      if(Option("-q", 0, argv[i], args_left))
+      {
         cfg->quiet = 1;
         continue;
       }
-      if (Option("-w", 1, argv[i], args_left)) {
+      if(Option("-w", 1, argv[i], args_left))
+      {
         cfg->w = atoi(argv[i+1]);
-        arg_used[i+1] = 1;
+        i++;
         continue;
       }
-      if (Option("-h", 1, argv[i], args_left)) {
+      if(Option("-h", 1, argv[i], args_left))
+      {
         cfg->h = atoi(argv[i+1]);
-        arg_used[i+1] = 1;
+        i++;
         continue;
       }
-      if (Option("-mzm", 0, argv[i], args_left)) {
+      if(Option("-mzm", 0, argv[i], args_left))
+      {
         cfg->mzm = 1;
         cfg->reuse = 1;
         continue;
       }
-      if (Option("-reuse", 0, argv[i], args_left)) {
+      if(Option("-reuse", 0, argv[i], args_left))
+      {
         cfg->reuse = 1;
         continue;
       }
-      if (Option("-noreuse", 0, argv[i], args_left)) {
+      if(Option("-noreuse", 0, argv[i], args_left))
+      {
         cfg->noreuse = 1;
         continue;
       }
-      if (Option("-output", 1, argv[i], args_left)) {
+      if(Option("-output", 1, argv[i], args_left))
+      {
         snprintf(cfg->output, MAX_PATH - 4, "%s", argv[i+1]);
         cfg->output[MAX_PATH-4] = '\0';
-        arg_used[i+1] = 1;
+        i++;
         continue;
       }
-      if (Option("-c", 1, argv[i], args_left)) {
+      if(Option("-c", 1, argv[i], args_left))
+      {
         cfg->c = atoi(argv[i+1]);
-        arg_used[i+1] = 1;
+        i++;
         continue;
       }
-      if (Option("-dither", 1, argv[i], args_left)) {
+      if(Option("-dither", 1, argv[i], args_left))
+      {
         snprintf(cfg->dither, sizeof(cfg->dither), "%s", argv[i+1]);
         cfg->dither[255] = '\0';
-        arg_used[i+1] = 1;
+        i++;
         continue;
       }
-      if (Option("-threshold", 1, argv[i], args_left)) {
+      if(Option("-threshold", 1, argv[i], args_left))
+      {
         cfg->threshold = atoi(argv[i+1]);
-        arg_used[i+1] = 1;
+        i++;
         continue;
       }
-      if (Option("-offset", 1, argv[i], args_left)) {
+      if(Option("-offset", 1, argv[i], args_left))
+      {
         cfg->offset = atoi(argv[i+1]);
-        arg_used[i+1] = 1;
+        i++;
         continue;
       }
-      if (Option("-blank", 1, argv[i], args_left)) {
+      if(Option("-blank", 1, argv[i], args_left))
+      {
         cfg->blank = atoi(argv[i+1]);
-        arg_used[i+1] = 1;
+        i++;
         continue;
       }
-      if (Option("-exclude", 1, argv[i], args_left)) {
+      if(Option("-exclude", 1, argv[i], args_left))
+      {
         char *s = argv[i+1];
         char tok[256];
         char op;
@@ -409,33 +424,40 @@ Config *LoadConfig(int argc, char **argv)
 
         cfg->exclude_on = 1;
 
-        while (*s) {
-          if (sscanf(s, "%[0-9]", tok) == 0) break;
+        while(*s)
+        {
+          if(sscanf(s, "%[0-9]", tok) == 0)
+            break;
           s += strlen(tok);
 
           cfg->exclude[atoi(tok)] = 1;
 
-          if (curr == 1) {
+          if(curr == 1)
+          {
             curr = 0;
             range_ed = atoi(tok);
 
-            for (int ch = range_st; range_st <= range_ed ? ch <= range_ed : ch >= range_ed; range_st <= range_ed ? ch++ : ch--) {
+            for(int ch = range_st; range_st <= range_ed ? ch <= range_ed : ch >= range_ed; range_st <= range_ed ? ch++ : ch--)
               cfg->exclude[ch] = 1;
-            }
           }
 
           op = s[0];
-          if (op) s++;
-          if (op == '-') {
+          if(op)
+            s++;
+
+          if(op == '-')
+          {
             range_st = atoi(tok);
             curr = 1;
           }
         }
 
-        arg_used[i+1] = 1;
+        i++;
         continue;
       }
-    } else { // Filename
+    }
+    else // Filename
+    {
       InputFile *file = cmalloc(sizeof(InputFile));
       snprintf(file->path, MAX_PATH + 1, "%s", argv[i]);
       file->path[MAX_PATH] = 0;
@@ -443,7 +465,8 @@ Config *LoadConfig(int argc, char **argv)
     }
   }
 
-  if (cfg->files == NULL) {
+  if(cfg->files == NULL)
+  {
     Usage();
     exit(1);
   }
@@ -451,13 +474,14 @@ Config *LoadConfig(int argc, char **argv)
   return cfg;
 }
 
-typedef struct {
+typedef struct
+{
   int w, h;
   int channels;
   unsigned char *pixels;
 } Image;
 
-Image *CreateImage(int w, int h, int channels)
+static Image *CreateImage(int w, int h, int channels)
 {
   Image *image = cmalloc(sizeof(Image));
   image->pixels = cmalloc(w * h * channels);
@@ -467,7 +491,7 @@ Image *CreateImage(int w, int h, int channels)
   return image;
 }
 
-void LoadImage(struct image_file *dest, Config *cfg, const char *path)
+static void LoadImage(struct image_file *dest, Config *cfg, const char *path)
 {
   struct image_raw_format format;
   struct image_raw_format *use_format = NULL;
@@ -484,25 +508,26 @@ void LoadImage(struct image_file *dest, Config *cfg, const char *path)
     Error("Failed to load file '%s'", path);
 }
 
-void FreeImage(Image *img)
+static void FreeImage(Image *img)
 {
   free(img->pixels);
   free(img);
 }
 
-int Brightness(const struct image_file *img, uint32_t x, uint32_t y)
+static int Brightness(const struct image_file *img, uint32_t x, uint32_t y)
 {
   const struct rgba_color *color = &(img->data[y * img->width + x]);
   return (color->r * 30 + color->g * 59 + color->b * 11) / 100;
 }
 
-typedef struct {
+typedef struct
+{
   char method[256];
   int diffuse[1024];
   unsigned w, h, div;
 } Diffuse;
 
-Diffuse diffmethods[] = {
+static const Diffuse diffmethods[] = {
 {"Floyd-Steinberg", {0, -1, 7,
                     3, 5, 1}, 3, 2, 16},
 
@@ -527,7 +552,7 @@ Diffuse diffmethods[] = {
                     5,  0,  12, 0,  12, 0,  5}, 7, 4, 200}
 };
 
-void QuantiseDiffuse(struct image_file *img, Image *qimg, int threshold, const char *method)
+static void QuantiseDiffuse(struct image_file *img, Image *qimg, int threshold, const char *method)
 {
   int *err = cmalloc(img->width * img->height * sizeof(int));
   int method_i = -1;
@@ -538,27 +563,32 @@ void QuantiseDiffuse(struct image_file *img, Image *qimg, int threshold, const c
   int v_noerr, v, wr;
   memset(err, 0, img->width * img->height * sizeof(int));
 
-  for (i = 0; i < sizeof(diffmethods) / sizeof(diffmethods[0]); i++) {
-    if (lc_strncmp(method, diffmethods[i].method, strlen(method)) == 0) method_i = i;
+  for(i = 0; i < sizeof(diffmethods) / sizeof(diffmethods[0]); i++)
+  {
+    if(lc_strncmp(method, diffmethods[i].method, strlen(method)) == 0)
+      method_i = i;
   }
-  if (method_i == -1) {
+  if(method_i == -1)
     Error("-dither method '%s' not found. Try another setting", method);
-  }
 
   D = diffmethods[method_i];
   mx = 0;
   my = 0;
-  for (i = 0; i < D.w * D.h; i++) {
+  for(i = 0; i < D.w * D.h; i++)
+  {
     x = i % D.w;
     y = i / D.w;
-    if (D.diffuse[i] == -1) {
+    if(D.diffuse[i] == -1)
+    {
       mx = x;
       my = y;
       D.diffuse[i] = 0;
     }
   }
-  for (y = 0; y < img->height; y++) {
-    for (x = 0; x < img->width; x++) {
+  for(y = 0; y < img->height; y++)
+  {
+    for(x = 0; x < img->width; x++)
+    {
       v_noerr = Brightness(img, x, y);
       v = v_noerr + err[y * img->width + x] / D.div;
       if (v > 255) v = 255;
@@ -566,9 +596,10 @@ void QuantiseDiffuse(struct image_file *img, Image *qimg, int threshold, const c
       wr = v >= threshold ? 255 : 0;
       qimg->pixels[y * img->width + x] = v >= threshold ? 1 : 0;
 
-      if ((v_noerr - wr) != 0) {
-
-        for (i = 0; i < D.w * D.h; i++) {
+      if((v_noerr - wr) != 0)
+      {
+        for(i = 0; i < D.w * D.h; i++)
+        {
           int ox = (i % D.w) - mx + x;
           int oy = (i / D.w) - my + y;
           if((D.diffuse[i] > 0) && (ox >= 0) && (oy >= 0) &&
@@ -583,7 +614,7 @@ void QuantiseDiffuse(struct image_file *img, Image *qimg, int threshold, const c
   free(err);
 }
 
-void QuantiseTheshold(struct image_file *img, Image *qimg, int threshold)
+static void QuantiseTheshold(struct image_file *img, Image *qimg, int threshold)
 {
   unsigned int i, x, y;
 
@@ -597,24 +628,27 @@ void QuantiseTheshold(struct image_file *img, Image *qimg, int threshold)
   }
 }
 
-Image *Quantise(Config *cfg, struct image_file *img)
+static Image *Quantise(Config *cfg, struct image_file *img)
 {
   Image *qimg = CreateImage(img->width, img->height, 1);
 
-  if (cfg->dither[0] == '\0') {
+  if(cfg->dither[0] == '\0')
+  {
     QuantiseTheshold(img, qimg, cfg->threshold);
-  } else {
-    QuantiseDiffuse(img, qimg, cfg->threshold, cfg->dither);
   }
+  else
+    QuantiseDiffuse(img, qimg, cfg->threshold, cfg->dither);
+
   return qimg;
 }
 
-typedef struct {
+typedef struct
+{
   int chars;
   unsigned char *data;
 } Charset;
 
-Charset *CreateCharset(Image *img)
+static Charset *CreateCharset(Image *img)
 {
   Charset *cset = cmalloc(sizeof(Charset));
   int cset_size = (img->w / 8) * (img->h / 14);
@@ -625,10 +659,14 @@ Charset *CreateCharset(Image *img)
   cset->chars = cset_size;
 
   chr = 0;
-  for (cy = 0; cy < img->h / 14; cy++) {
-    for (cx = 0; cx < img->w / 8; cx++) {
-      for (py = 0; py < 14; py++) {
-        for (px = 0; px < 8; px++) {
+  for(cy = 0; cy < img->h / 14; cy++)
+  {
+    for(cx = 0; cx < img->w / 8; cx++)
+    {
+      for(py = 0; py < 14; py++)
+      {
+        for(px = 0; px < 8; px++)
+        {
           cset->data[chr * 14 + py] |= img->pixels[(cy * 14 + py) * img->w + (cx * 8 + px)] ? 128 >> px : 0;
         }
       }
@@ -639,78 +677,87 @@ Charset *CreateCharset(Image *img)
   return cset;
 }
 
-typedef struct {
+typedef struct
+{
   int w, h;
   int *data;
 } Mzm;
 
-Mzm *CreateMzm(int w, int h)
+static Mzm *CreateMzm(int w, int h)
 {
   Mzm *mzm = cmalloc(sizeof(Mzm));
   int i;
   mzm->w = w;
   mzm->h = h;
   mzm->data = cmalloc(w * h * sizeof(int));
-  for (i = 0; i < w * h; i++) {
+
+  for(i = 0; i < w * h; i++)
     mzm->data[i] = i;
-  }
+
   return mzm;
 }
 
-void FreeMzm(Mzm *mzm)
+static void FreeMzm(Mzm *mzm)
 {
   free(mzm->data);
   free(mzm);
 }
 
-typedef struct {
+typedef struct
+{
   unsigned char data[14];
   int i;
   UT_hash_handle hh;
 } Char;
 
-void Reuse(Charset *cset, Mzm *mzm)
+static void Reuse(Charset *cset, Mzm *mzm)
 {
   Char *clist = NULL;
   Char *c, *tmp;
   int out_chars = 0;
   int i;
   unsigned char *cdata;
-  for (i = 0; i < cset->chars; i++) {
+  for(i = 0; i < cset->chars; i++)
+  {
     cdata = cset->data + i * 14;
 
     HASH_FIND(hh, clist, cdata, sizeof(clist->data), c);
-    if (!c) {
+    if(!c)
+    {
       c = cmalloc(sizeof(Char));
       memcpy(c->data, cdata, 14);
-      if (mzm) {
+
+      if(mzm)
         c->i = mzm->data[i] = out_chars;
-      }
+
       memmove(cset->data + out_chars * 14, cset->data + i * 14, 14);
       HASH_ADD(hh, clist, data, sizeof(clist->data), c);
       out_chars++;
-    } else {
-      if (mzm) {
+    }
+    else
+    {
+      if(mzm)
         mzm->data[i] = c->i;
-      }
     }
   }
   cset->chars = out_chars;
   cset->data = realloc(cset->data, cset->chars * 14);
 
-  HASH_ITER(hh, clist, c, tmp) {
+  HASH_ITER(hh, clist, c, tmp)
+  {
     HASH_DEL(clist, c);
     free(c);
   }
 }
 
-char *OutputPath(const char *input, Config *cfg, const char *ext)
+static char *OutputPath(const char *input, Config *cfg, const char *ext)
 {
   char *output_path = NULL;
   char buf[MAX_PATH+1];
   char *buf_e;
   size_t output_len;
-  if (cfg->output[0] == '\0') {
+  if(cfg->output[0] == '\0')
+  {
     if(strcmp(input, "-"))
       snprintf(buf, MAX_PATH, "%s", input);
     else
@@ -724,7 +771,9 @@ char *OutputPath(const char *input, Config *cfg, const char *ext)
     output_path = cmalloc(output_len);
     snprintf(output_path, output_len, "%s%s", buf, ext);
     output_path[output_len - 1] = '\0';
-  } else {
+  }
+  else
+  {
     output_len = strlen(cfg->output) + strlen(ext) + 1;
     output_path = cmalloc(output_len);
     snprintf(output_path, output_len, "%s%s", cfg->output, ext);
@@ -733,14 +782,14 @@ char *OutputPath(const char *input, Config *cfg, const char *ext)
   return output_path;
 }
 
-void WriteCharset(const char *path, Charset *cset)
+static void WriteCharset(const char *path, Charset *cset)
 {
   FILE *fp = fopen_unsafe(path, "wb");
   fwrite(cset->data, 14, cset->chars, fp);
   fclose(fp);
 }
 
-void WriteMzm(const char *path, Mzm *mzm)
+static void WriteMzm(const char *path, Mzm *mzm)
 {
   FILE *fp = fopen_unsafe(path, "wb");
   int i;
@@ -754,7 +803,8 @@ void WriteMzm(const char *path, Mzm *mzm)
   fputc(0, fp); // robot storage mode
   fputc(0, fp); // reserved
 
-  for (i = 0; i < mzm->w * mzm->h; i++) {
+  for(i = 0; i < mzm->w * mzm->h; i++)
+  {
     fputc(mzm->data[i] & 0xFF, fp);
     fputc(15, fp);
   }
@@ -768,11 +818,13 @@ static inline int CountBits(const unsigned char *A)
   unsigned int v;
   unsigned int count;
   unsigned char val;
-  if (sizeof(unsigned int) == 4) {
+  if(sizeof(unsigned int) == 4)
+  {
     c = 0;
 
     a = (const unsigned int*)A;
-    for (i = 0; i < 3; i++) {
+    for(i = 0; i < 3; i++)
+    {
       v = *a;
       v = v - ((v >> 1) & 0x55555555);
       v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
@@ -785,14 +837,15 @@ static inline int CountBits(const unsigned char *A)
     c += (((v + (v >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24;
 
     return c;
-  } else {
+  }
+  else
+  {
     count = 0;
-    for (int i = 0; i < 14; i++) {
+    for(int i = 0; i < 14; i++)
+    {
       val = A[i];
-      for (; val; count++)
-      {
+      for(; val; count++)
         val &= val - 1; // clear the least significant bit set
-      }
     }
     return count;
   }
@@ -803,33 +856,36 @@ static inline int CharDist(const unsigned char *A, const unsigned char *B)
 {
   unsigned char v[14];
   int i;
-  for (i = 0; i < 14; i++) {
+  for(i = 0; i < 14; i++)
     v[i] = A[i] ^ B[i];
-  }
+
   return CountBits(v);
 }
 
 // Simple quantisation- combine the two closest pairs of chars until the right number of chars are available
-void Reduce_Simple(Charset *cset, int chars)
+static void Reduce_Simple(Charset *cset, int chars)
 {
   int pair_i, pair_j, pair_dist, data_dist;
   int i, j;
   unsigned char *data_i, *data_j;
   int bits;
 
-  while (cset->chars > chars)
+  while(cset->chars > chars)
   {
     pair_i = -1;
     pair_j = -1;
     pair_dist = INT_MAX;
 
-    for (i = 0; i < cset->chars; i++) {
+    for(i = 0; i < cset->chars; i++)
+    {
       data_i = cset->data + i * 14;
-      for (j = i + 1; j < cset->chars; j++) {
+      for(j = i + 1; j < cset->chars; j++)
+      {
         data_j = cset->data + j * 14;
 
         data_dist = CharDist(data_i, data_j);
-        if (data_dist < pair_dist) {
+        if(data_dist < pair_dist)
+        {
           pair_dist = data_dist;
           pair_i = i;
           pair_j = j;
@@ -840,15 +896,18 @@ void Reduce_Simple(Charset *cset, int chars)
     data_i = cset->data + pair_i * 14;
     data_j = cset->data + pair_j * 14;
     bits = CountBits(data_i) + CountBits(data_j);
-    if (bits >= 112) {
-      for (i = 0; i < 14; i++) {
+    if(bits >= 112)
+    {
+      for(i = 0; i < 14; i++)
+      {
         //data_i[i] = data_i[i] > data_j[i] ? data_i[i] : data_j[i];
         data_i[i] = data_i[i] | data_j[i];
       }
-    } else {
-      for (i = 0; i < 14; i++) {
+    }
+    else
+    {
+      for(i = 0; i < 14; i++)
         data_i[i] = ~(~data_i[i] | ~data_j[i]);
-      }
     }
 
     memmove(data_j, data_j + 14, (cset->chars - pair_j - 1) * 14);
@@ -858,12 +917,14 @@ void Reduce_Simple(Charset *cset, int chars)
   cset->data = realloc(cset->data, cset->chars * 14);
 }
 
-int ChrImageDist(const unsigned char *cdata, Image *img, int xoff, int yoff)
+static int ChrImageDist(const unsigned char *cdata, Image *img, int xoff, int yoff)
 {
   int tdist = 0;
   int x, y, px, py, chr_lightness, img_lightness;
-  for (y = 0; y < 14; y++) {
-    for (x = 0; x < 8; x++) {
+  for(y = 0; y < 14; y++)
+  {
+    for(x = 0; x < 8; x++)
+    {
       px = xoff + x;
       py = yoff + y;
       chr_lightness = cdata[y] & (128 >> x) ? 1 : 0;
@@ -874,7 +935,7 @@ int ChrImageDist(const unsigned char *cdata, Image *img, int xoff, int yoff)
   return tdist;
 }
 
-void RemapMzm(Charset *cset, Mzm *mzm, Image *qimage)
+static void RemapMzm(Charset *cset, Mzm *mzm, Image *qimage)
 {
   // Remap the MZM to the charset to create the closest approximation of the quantised image.
   int x, y, c;
@@ -895,33 +956,36 @@ void RemapMzm(Charset *cset, Mzm *mzm, Image *qimage)
   }
 }
 
-void Reduce(Charset *cset, Mzm *mzm, Image *original, int chars, Config *cfg)
+static void Reduce(Charset *cset, Mzm *mzm, Image *original, int chars, Config *cfg)
 {
-  if (cset->chars <= chars) return;
+  if(cset->chars <= chars)
+    return;
 
   Reduce_Simple(cset, chars);
   RemapMzm(cset, mzm, original);
 }
 
-void OffsetMzm(Mzm *mzm, int offset)
+static void OffsetMzm(Mzm *mzm, int offset)
 {
   int i;
-  if (mzm) {
-    for (i = 0; i < mzm->w * mzm->h; i++) {
+  if(mzm)
+  {
+    for(i = 0; i < mzm->w * mzm->h; i++)
       mzm->data[i] += offset;
-    }
   }
 }
 
-void ExcludeChars(Charset *cset, Mzm *mzm, char *exclude, int offset)
+static void ExcludeChars(Charset *cset, Mzm *mzm, char *exclude, int offset)
 {
   int remap[256];
   int remap_offset = 0;
   int ci, i;
-  for (i = 0; i < cset->chars && i < 256; i++) {
+  for(i = 0; i < cset->chars && i < 256; i++)
+  {
     remap[i] = i;
     ci = i + remap_offset + offset;
-    if ((ci >= 0) && (ci < 256) && (exclude[ci])) {
+    if((ci >= 0) && (ci < 256) && (exclude[ci]))
+    {
       cset->data = realloc(cset->data, (cset->chars + 1) * 14);
       remap[i] = cset->chars;
       memmove(cset->data + (remap[i])*14, cset->data + i * 14, 14);
@@ -931,42 +995,55 @@ void ExcludeChars(Charset *cset, Mzm *mzm, char *exclude, int offset)
     }
   }
 
-  if (mzm) {
-    for (i = 0; i < mzm->w * mzm->h; i++) {
-      while ((mzm->data[i] != remap[mzm->data[i]])) {
+  if(mzm)
+  {
+    for(i = 0; i < mzm->w * mzm->h; i++)
+    {
+      while((mzm->data[i] != remap[mzm->data[i]]))
         mzm->data[i] = remap[mzm->data[i]];
-      }
     }
   }
 }
 
-void SwapBlank(Charset *cset, Mzm *mzm, int blank)
+static void SwapBlank(Charset *cset, Mzm *mzm, int blank)
 {
   int current_blank = -1;
   int i, j, isblank;
   unsigned char tmp[14];
-  for (i = 0; i < cset->chars; i++) {
+  for(i = 0; i < cset->chars; i++)
+  {
     isblank = 1;
-    for (j = 0; j < 14; j++) {
-      if (cset->data[i * 14 + j] != 0) {
+    for(j = 0; j < 14; j++)
+    {
+      if(cset->data[i * 14 + j] != 0)
+      {
         isblank = 0;
         break;
       }
     }
 
-    if (isblank) current_blank = i;
+    if(isblank)
+      current_blank = i;
     break;
   }
-  if (current_blank != -1) {
+  if(current_blank != -1)
+  {
     memcpy(tmp, cset->data + current_blank*14, 14);
     memcpy(cset->data + current_blank*14, cset->data + blank*14, 14);
     memcpy(cset->data + blank*14, tmp, 14);
 
-    if (mzm) {
-      for (i = 0; i < mzm->w * mzm->h; i++) {
-        if (mzm->data[i] == current_blank) {
+    if(mzm)
+    {
+      for(i = 0; i < mzm->w * mzm->h; i++)
+      {
+        if(mzm->data[i] == current_blank)
+        {
           mzm->data[i] = blank;
-        } else if (mzm->data[i] == blank) {
+        }
+        else
+
+        if(mzm->data[i] == blank)
+        {
           mzm->data[i] = current_blank;
         }
       }
@@ -996,37 +1073,31 @@ int main(int argc, char **argv)
     struct image_file image;
     LoadImage(&image, cfg, file->path);
 
-    if (((image.width % 8) != 0) || ((image.height % 14) != 0)) {
+    if(((image.width % 8) != 0) || ((image.height % 14) != 0))
       Error("Image dimensions are not divisible by 8x14");
-    }
+
     qimage = Quantise(cfg, &image);
 
     cset = CreateCharset(qimage);
 
     mzm = NULL;
-    if (cfg->mzm) {
+    if(cfg->mzm)
       mzm = CreateMzm(qimage->w / 8, qimage->h / 14);
-    }
 
-    if (cfg->reuse && !cfg->noreuse) {
+    if(cfg->reuse && !cfg->noreuse)
       Reuse(cset, mzm);
-    }
 
-    if (cfg->c) {
+    if(cfg->c)
       Reduce(cset, mzm, qimage, cfg->c, cfg);
-    }
 
-    if (cfg->blank != -1) {
+    if(cfg->blank != -1)
       SwapBlank(cset, mzm, cfg->blank);
-    }
 
-    if (cfg->exclude_on) {
+    if(cfg->exclude_on)
       ExcludeChars(cset, mzm, cfg->exclude, cfg->offset);
-    }
 
-    if (cfg->offset) {
+    if(cfg->offset)
       OffsetMzm(mzm, cfg->offset);
-    }
 
     image_free(&image);
     FreeImage(qimage);
@@ -1043,19 +1114,20 @@ int main(int argc, char **argv)
       free(filename_chr);
     }
 
-    if (cfg->mzm) { // Output MZM
+    if(cfg->mzm)
+    { // Output MZM
       char *filename_mzm = OutputPath(file->path, cfg, ".mzm");
       WriteMzm(filename_mzm, mzm);
       FreeMzm(mzm);
 
-      if (!cfg->quiet) {
+      if(!cfg->quiet)
         printf(", %s", filename_mzm);
-      }
 
       free(filename_mzm);
     }
 
-    if (!cfg->quiet) printf("\n");
+    if(!cfg->quiet)
+      printf("\n");
   }
 
   return 0;

--- a/src/utils/ccv.c
+++ b/src/utils/ccv.c
@@ -189,6 +189,7 @@ static void Error(const char *string, ...)
   exit(1);
 }
 
+/*
 static inline int lc_strcmp(const char *A, const char *B)
 {
   const char *a = A;
@@ -204,6 +205,8 @@ static inline int lc_strcmp(const char *A, const char *B)
     b++;
   }
 }
+*/
+
 static inline int lc_strncmp(const char *A, const char *B, int n)
 {
   const char *a = A;
@@ -231,6 +234,7 @@ static inline void file_write32(int val, FILE *fp)
   fputc((val >> 24) & 0xFF, fp);
 }
 
+/*
 static inline int file_read32(FILE *fp)
 {
   unsigned int r = 0;
@@ -240,6 +244,7 @@ static inline int file_read32(FILE *fp)
   r |= fgetc(fp) << 24;
   return r;
 }
+*/
 
 static inline void file_write16(int val, FILE *fp)
 {
@@ -247,6 +252,7 @@ static inline void file_write16(int val, FILE *fp)
   fputc((val >> 8) & 0xFF, fp);
 }
 
+/*
 static inline int file_read16(FILE *fp)
 {
   unsigned int r = 0;
@@ -254,6 +260,7 @@ static inline int file_read16(FILE *fp)
   r |= fgetc(fp) << 8;
   return r;
 }
+*/
 
 typedef struct
 {

--- a/src/utils/png2smzx.c
+++ b/src/utils/png2smzx.c
@@ -35,13 +35,6 @@
 #define MAX_PATH 512
 #endif
 
-// FIXME: Fix this better
-int error(const char *string, unsigned int type, unsigned int options,
- unsigned int code)
-{
-  return 0;
-}
-
 int main(int argc, char **argv)
 {
   FILE *fp;

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -83,11 +83,13 @@ endif
 DEBUG_CFLAGS ?= -O0
 
 #
+# Use DEBUG_CFLAGS to override any optimization flags in the global flags.
 # Build without -DDEBUG to suppress debug messages,
 # build without -DNDEBUG to allow assert().
+# Turn on exceptions explicitly, since the global CXXFLAGS turn them off.
 #
-unit_cflags ?= ${DEBUG_CFLAGS} -g \
- -Wall -Wextra -pedantic -Wno-unused-parameter -funsigned-char -fno-rtti -std=gnu++11
+unit_cflags ?= ${CXXFLAGS} ${DEBUG_CFLAGS} -UDEBUG -UNDEBUG
+unit_cflags += -fexceptions -funsigned-char -std=gnu++11
 
 unit_cflags += ${SDL_CFLAGS} -Umain
 unit_ldflags +=

--- a/unit/Unit.hpp
+++ b/unit/Unit.hpp
@@ -697,7 +697,7 @@ namespace Unit
   }
 }
 
-void sigabrt_handler(int signal)
+static void sigabrt_handler(int signal)
 {
   if(signal == SIGABRT)
   {

--- a/unit/intake.cpp
+++ b/unit/intake.cpp
@@ -708,7 +708,7 @@ struct event_cb_data
   int call_count;
 };
 
-boolean event_callback(void *priv, subcontext *sub, enum intake_event_type type,
+static boolean event_callback(void *priv, subcontext *sub, enum intake_event_type type,
  int old_pos, int new_pos, int value, const char *data)
 {
   struct intake_subcontext *intk = reinterpret_cast<struct intake_subcontext *>(sub);

--- a/unit/io/vio.cpp
+++ b/unit/io/vio.cpp
@@ -767,7 +767,7 @@ UNITTEST(Filesystem)
     t = getcwd(buffer2, arraysize(buffer2));
     ASSERTEQ(t, buffer2, "");
     size_t len = strlen(buffer2);
-    ASSERT(len < arraysize(buffer), "");
+    ASSERT(len < sizeof(buffer), "");
     ASSERTMEM(buffer, buffer2, len, "");
   }
 

--- a/unit/network/Manifest.cpp
+++ b/unit/network/Manifest.cpp
@@ -192,7 +192,7 @@ UNITTEST(ManifestEntry)
   }
 }
 
-void test_manifest(const Manifest &m, const char *comment)
+static void test_manifest(const Manifest &m, const char *comment)
 {
   const ManifestEntry *e = m.first();
   for(const manifestdata &f : filedata)


### PR DESCRIPTION
Moves the usage of `-Wpointer-arith` and `-Wwrite-strings` to the global `CFLAGS` and adds `-Wmissing-declarations` to the global `CFLAGS`. Includes warning fixes for these changes, and also fixes ccv.c's style and the -Wvla warning in ccv.c.