### PR TITLE
More compiler warning flags cleanup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,13 +253,20 @@ LDFLAGS  += ${ARCH_LDFLAGS}
 # Note: -Wstrict-prototypes was previously turned off for Android/NDS/Wii/PSP.
 #
 warnings := -Wall -Wextra -Wno-unused-parameter -Wwrite-strings
-warnings += -Wundef -Wunused-macros -Wpointer-arith -Wmissing-declarations
+warnings += -Wundef -Wunused-macros -Wpointer-arith
 CFLAGS   += ${warnings} -Wdeclaration-after-statement -Wmissing-prototypes -Wstrict-prototypes
 CXXFLAGS += ${warnings}
 
 #
 # Optional compile flags.
 #
+
+#
+# Warn against global functions defined without a previous declaration (C++).
+#
+ifeq (${HAS_W_MISSING_DECLARATIONS_CXX},1)
+CXXFLAGS += -Wmissing-declarations
+endif
 
 #
 # Warn against variable-length array (VLA) usage, which is technically valid

--- a/Makefile
+++ b/Makefile
@@ -229,9 +229,6 @@ CFLAGS   += ${OPTIMIZE_CFLAGS} -DNDEBUG
 CXXFLAGS += ${OPTIMIZE_CFLAGS} -DNDEBUG
 endif
 
-CFLAGS   += -Wundef -Wunused-macros -Wpointer-arith -Wwrite-strings -Wmissing-declarations
-CXXFLAGS += -Wundef -Wunused-macros -Wpointer-arith -Wwrite-strings -Wmissing-declarations
-
 #
 # Enable C++11 for compilers that support it.
 # Anything actually using C++11 should be optional or platform-specific,
@@ -247,11 +244,18 @@ endif
 # Always generate debug information; this may end up being
 # stripped (on embedded platforms) or objcopy'ed out.
 #
-CFLAGS   += -g -W -Wall -Wno-unused-parameter -std=gnu99
-CFLAGS   += -Wdeclaration-after-statement ${ARCH_CFLAGS}
-CXXFLAGS += -g -W -Wall -Wno-unused-parameter ${CXX_STD}
-CXXFLAGS += -fno-exceptions -fno-rtti ${ARCH_CXXFLAGS}
+CFLAGS   += -std=gnu99 -g ${ARCH_CFLAGS}
+CXXFLAGS += ${CXX_STD} -g -fno-exceptions -fno-rtti ${ARCH_CXXFLAGS}
 LDFLAGS  += ${ARCH_LDFLAGS}
+
+#
+# Default warnings.
+# Note: -Wstrict-prototypes was previously turned off for Android/NDS/Wii/PSP.
+#
+warnings := -Wall -Wextra -Wno-unused-parameter -Wwrite-strings
+warnings += -Wundef -Wunused-macros -Wpointer-arith -Wmissing-declarations
+CFLAGS   += ${warnings} -Wdeclaration-after-statement -Wmissing-prototypes -Wstrict-prototypes
+CXXFLAGS += ${warnings}
 
 #
 # Optional compile flags.

--- a/arch/compat.inc
+++ b/arch/compat.inc
@@ -77,6 +77,7 @@ endif
 
 GCC_VER_GE_4_3   := ${shell test ${GCC_VER} -ge 40300; echo $$?}
 ifeq (${GCC_VER_GE_4_3},0)
+HAS_W_MISSING_DECLARATIONS_CXX ?= 1
 HAS_W_VLA ?= 1
 endif
 endif

--- a/arch/nds/extmem.c
+++ b/arch/nds/extmem.c
@@ -110,13 +110,13 @@ static void nds_ext_free(void *mem)
       mspace_free(nds_mspace[i], mem);
 }
 
-static void nds_ext_unlock()
+static void nds_ext_unlock(void)
 {
   if(nds_mspace_def[MSPACE_SLOT_2].start != 0)
     ram_unlock();
 }
 
-static void nds_ext_lock()
+static void nds_ext_lock(void)
 {
   if(nds_mspace_def[MSPACE_SLOT_2].start != 0)
     ram_lock();

--- a/arch/nds/platform.c
+++ b/arch/nds/platform.c
@@ -112,7 +112,7 @@ void profile_end(void)
 // graphics changes
 extern void guruMeditationDump(void);
 
-static void mzxExceptionHandler()
+static void mzxExceptionHandler(void)
 {
   // stop vblank handler
   irqClear(IRQ_VBLANK);

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -30,8 +30,8 @@ network_obj = src/network/.build
 
 core_flags   += -ffast-math -funsigned-char
 core_flags   += -Wmissing-format-attribute
-core_cflags  += ${CFLAGS} -Wmissing-prototypes
-core_cxxflags = ${CXXFLAGS} -DHAVE_INTTYPES_H
+core_cflags  += ${CFLAGS}
+core_cxxflags = ${CXXFLAGS}
 
 ifneq (${PLATFORM},emscripten)
 core_flags   += -I${PREFIX}/include
@@ -135,20 +135,6 @@ core_cobjs := \
 # to build the main binary. Currently there are only optional sources.
 #
 core_cxxobjs :=
-
-#
-# Hack to avoid silly warnings from devkitPro headers
-#
-ifeq ($(or ${BUILD_WII},${BUILD_NDS},${BUILD_PSP}),)
-core_cflags += -Wstrict-prototypes
-endif
-
-#
-# Hack to avoid silly warnings from Android headers
-#
-ifeq (${PLATFORM},android)
-core_cflags += -Wno-strict-prototypes
-endif
 
 #
 # These are really just hacks and should be moved elsewhere
@@ -277,7 +263,7 @@ core_cobjs := ${core_obj}/render_layer.o ${core_cobjs}
 endif
 
 ifeq (${BUILD_MODPLUG},1)
-core_flags += -I${libmodplug_src} -I${libmodplug_src}/libmodplug
+core_flags += -I${libmodplug_src} -I${libmodplug_src}/libmodplug -DHAVE_INTTYPES_H
 core_cxxobjs += ${audio_obj}/audio_modplug.o ${libmodplug_objs}
 endif
 

--- a/src/io/vio.h
+++ b/src/io/vio.h
@@ -33,7 +33,7 @@ __M_BEGIN_DECLS
 enum vfileflags
 {
   V_SMALL_BUFFER = (1<<29), // setvbuf <= 256 for real files in binary mode.
-  V_LARGE_BUFFER = (1<<30), // setvbuf >= 8192 for real files in binary mode.
+  V_LARGE_BUFFER = (1<<30)  // setvbuf >= 8192 for real files in binary mode.
 };
 
 UTILS_LIBSPEC vfile *vfopen_unsafe_ext(const char *filename, const char *mode,

--- a/src/utils/ccv.c
+++ b/src/utils/ccv.c
@@ -163,13 +163,13 @@ static const char USAGE_EXAMPLES[] =
 "    intensities >=160 as white.\n"
 "\n";
 
-static void Usage()
+static void Usage(void)
 {
   fprintf(stderr, USAGE);
   fprintf(stderr, "Type \"ccv -help\" for extended options information\n");
 }
 
-static void Help()
+static void Help(void)
 {
   fprintf(stderr, USAGE);
   fprintf(stderr, USAGE_DESC);
@@ -293,7 +293,7 @@ typedef struct
   char dither[256];
 } Config;
 
-static Config *DefaultConfig()
+static Config *DefaultConfig(void)
 {
   Config *cfg = cmalloc(sizeof(Config));
   cfg->files = NULL;

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -94,19 +94,6 @@ unit_cflags += -fexceptions -funsigned-char -std=gnu++11
 unit_cflags += ${SDL_CFLAGS} -Umain
 unit_ldflags +=
 
-#
-# Old GCC versions emit false positive warnings for C++11 value initializers.
-#
-ifeq (${HAS_BROKEN_W_MISSING_FIELD_INITIALIZERS},1)
-unit_cflags += -Wno-missing-field-initializers
-endif
-
-ifeq (${BUILD_F_ANALYZER},1)
-ifeq (${HAS_F_ANALYZER},1)
-unit_cflags += -fanalyzer
-endif
-endif
-
 # Required for image_file test.
 ifneq (${LIBPNG},)
 unit_cflags  += ${LIBPNG_CFLAGS}


### PR DESCRIPTION
Moves some more of the questionable warning handling in `src/Makefile.in` to the main `Makefile`, groups warning flags together, replaces `-W` with `-Wextra`, and gets rid of some obsolete duplicate warning flags in `unit/Makfile.in`.