### PR TITLE
Clean up misc. world/board/object string fields in saves.

### DIFF
--- a/docs/fileform.html
+++ b/docs/fileform.html
@@ -1974,7 +1974,7 @@ while(i < width * height)
       <div class="markdown">
 | ID       | Property                             | Data Type               | Notes |
 |----------|--------------------------------------|-------------------------|-------|
-| `0x0001` | World name                           | string(25) (with \0)    |
+| `0x0001` | World name                           | string                  | <a href="#world290note1">(1)</a>
 | `0x0002` | World version                        | int(w)                  |
 | `0x0003` | File version                         | int(w)                  |
 | `0x0004` | Save start board #                   | int(b)                  | 255: temporary board
@@ -2048,6 +2048,14 @@ while(i < width * height)
 | `0x8091` | SMZX message enabled in SMZX mode?   | int(b)                  | Save-only, 2.91+
 | `0x8092` | Joystick presses simulate keypresses?| int(b)                  | Save-only, 2.92+
       </div>
+      <ol>
+        <li id="world290note1">
+          World name maximum length is currently 24 characters; extra data
+          will be ignored. Versions prior to 2.92d expect this field to be null
+          terminated, and may leave parts of previous world names in the loaded
+          name if it is not.
+        </li>
+      </ol>
     </section>
 
     <section id="sfx290" class="inner">
@@ -2225,14 +2233,14 @@ while(i < width * height)
       <div class="markdown">
 | ID       | Property               | Data Type             | Notes |
 |----------|------------------------|-----------------------|-------|
-| `0x0001` | Board name             | string(25) (with \0)  | Strict<a href="#board290note1">(1)</a>
+| `0x0001` | Board name             | string                | Strict<a href="#board290note1">(1)</a><a href="#board290note2">(2)</a>
 | `0x0002` | Board width            | int(w)                | Strict
 | `0x0003` | Board height           | int(w)                | Strict
 | `0x0004` | Overlay mode           | int(b)                | Strict
 | `0x0005` | Robot count            | int(b)                | Strict
 | `0x0006` | Scroll count           | int(b)                | Strict
 | `0x0007` | Sensor count           | int(b)                | Strict
-| `0x0008` | File version           | int(w)                | Strict<a href="#board290note2">(2)</a>
+| `0x0008` | File version           | int(w)                | Strict<a href="#board290note3">(3)</a>
 | `0x0010` | Mod playing            | string
 | `0x0011` | Viewport X             | int(b)
 | `0x0012` | Viewport Y             | int(b)
@@ -2287,6 +2295,11 @@ while(i < width * height)
           out.
         </li>
         <li id="board290note2">
+          Board name maximum length is currently 24 characters; extra data
+          will be ignored. Versions prior to 2.93 expect this field to be null
+          terminated and may append garbage to the name if it is not.
+        </li>
+        <li id="board290note3">
           This field exists mainly to provide redundancy for the
           <a href="#mzb">.MZB</a> file header. In world and save files, this
           field should be redundant with the file version field derived from
@@ -2313,7 +2326,7 @@ while(i < width * height)
       <div class="markdown">
 | ID       | Property                     | Data Type             | Notes |
 |----------|------------------------------|-----------------------|-------|
-| `0x0001` | Robot name                   | string(15) (with \0)  | Strict<a href="#robot290note1">(1)</a>
+| `0x0001` | Robot name                   | string                | Strict<a href="#robot290note1">(1)</a><a href="#robot290note1">(2)</a>
 | `0x0002` | Robot char                   | int(b)                | Strict
 | `0x0003` | X position                   | int(ws)               | Strict
 | `0x0004` | Y position                   | int(ws)               | Strict
@@ -2340,6 +2353,12 @@ while(i < width * height)
           Properties marked "strict" must be present and in the order specified
           in the table for the robot data to be considered valid.
         </li>
+        <li id="robot290note2">
+          Robot name maximum length is currently 14 characters; extra data
+          will be ignored. Versions prior to 2.92d expect this field to be
+          exactly 15 bytes long and to contain a null terminator, and may behave
+          unexpectedly if it does not.
+        </li>
       </ol>
     </section>
 
@@ -2362,12 +2381,20 @@ while(i < width * height)
         Sensor data is stored in a properties file with the following properties:
       </p>
       <div class="markdown">
-| ID       | Property         | Data Type |
-|----------|------------------|-----------|
-| `0x0001` | Sensor name      | string(15) (with \0)
+| ID       | Property         | Data Type | Notes |
+|----------|------------------|-----------|-------|
+| `0x0001` | Sensor name      | string    | <a href="#sensor290note1">(1)</a>
 | `0x0002` | Sensor char      | int(b)
-| `0x0003` | Robot to message | string(15) (with \0)
+| `0x0003` | Robot to message | string    | <a href="#sensor290note1">(1)</a>
       </div>
+      <ol>
+        <li id="sensor290note1">
+          Robot/sensor name maximum length is currently 14 characters; extra data
+          will be ignored. Versions prior to 2.92d expect these fields to be
+          exactly 15 bytes long and to contain a null terminator, and may behave
+          unexpectedly if they do not.
+        </li>
+      </ol>
     </section>
   </section>
 

--- a/src/board.c
+++ b/src/board.c
@@ -44,7 +44,7 @@ static int save_board_info(struct board *cur_board, struct zip_archive *zp,
   int result;
 
   size_t size = BOARD_PROPS_SIZE;
-  int length;
+  size_t length;
 
   if(savegame)
     size += BOARD_SAVE_PROPS_SIZE;
@@ -53,7 +53,10 @@ static int save_board_info(struct board *cur_board, struct zip_archive *zp,
 
   mfopen(buffer, size, &mf);
 
-  save_prop_s(BPROP_BOARD_NAME, cur_board->board_name, BOARD_NAME_SIZE, 1, &mf);
+  // Note: hack to save null terminator while GIT worlds are still technically
+  // compatible with 2.92f. Remove at world version inc.
+  length = strlen(cur_board->board_name) /* FIXME */ + 1 /* FIXME */;
+  save_prop_s(BPROP_BOARD_NAME, cur_board->board_name, length, 1, &mf);
   save_prop_w(BPROP_BOARD_WIDTH, cur_board->board_width, &mf);
   save_prop_w(BPROP_BOARD_HEIGHT, cur_board->board_height, &mf);
   save_prop_c(BPROP_OVERLAY_MODE, cur_board->overlay_mode, &mf);
@@ -431,9 +434,9 @@ static int load_board_info(struct board *cur_board, struct zip_archive *zp,
 
       // Essential
       case BPROP_BOARD_NAME:
-        size = MIN(size, BOARD_NAME_SIZE);
+        size = MIN(size, BOARD_NAME_SIZE - 1);
         mfread(cur_board->board_name, size, 1, &prop);
-        cur_board->board_name[BOARD_NAME_SIZE - 1] = 0;
+        cur_board->board_name[size] = 0;
         break;
 
       case BPROP_BOARD_WIDTH:

--- a/src/robot.c
+++ b/src/robot.c
@@ -615,8 +615,9 @@ static void save_robot_to_memory(struct robot *cur_robot,
  struct memfile *mf, int savegame, int file_version)
 {
   struct memfile prop;
+  size_t len = strlen(cur_robot->robot_name);
 
-  save_prop_s(RPROP_ROBOT_NAME, cur_robot->robot_name, ROBOT_NAME_SIZE, 1, mf);
+  save_prop_s(RPROP_ROBOT_NAME, cur_robot->robot_name, len, 1, mf);
   save_prop_c(RPROP_ROBOT_CHAR, cur_robot->robot_char, mf);
   save_prop_w(RPROP_XPOS, cur_robot->xpos, mf);
   save_prop_w(RPROP_YPOS, cur_robot->ypos, mf);
@@ -792,16 +793,17 @@ void save_sensor(struct sensor *cur_sensor, struct zip_archive *zp,
 {
   char buffer[SENSOR_PROPS_SIZE];
   struct memfile mf;
+  size_t len;
 
   if(cur_sensor->used)
   {
     mfopen(buffer, SENSOR_PROPS_SIZE, &mf);
 
-    save_prop_s(SENPROP_SENSOR_NAME, cur_sensor->sensor_name,
-     ROBOT_NAME_SIZE, 1, &mf);
+    len = strlen(cur_sensor->sensor_name);
+    save_prop_s(SENPROP_SENSOR_NAME, cur_sensor->sensor_name, len, 1, &mf);
     save_prop_c(SENPROP_SENSOR_CHAR, cur_sensor->sensor_char, &mf);
-    save_prop_s(SENPROP_ROBOT_TO_MESG, cur_sensor->robot_to_mesg,
-     ROBOT_NAME_SIZE, 1, &mf);
+    len = strlen(cur_sensor->robot_to_mesg);
+    save_prop_s(SENPROP_ROBOT_TO_MESG, cur_sensor->robot_to_mesg, len, 1, &mf);
     save_prop_eof(&mf);
 
     zip_write_file(zp, name, buffer, SENSOR_PROPS_SIZE, ZIP_M_NONE);

--- a/src/utils/downver.c
+++ b/src/utils/downver.c
@@ -61,6 +61,34 @@
 #include "../io/vio.h"
 #include "../io/zip.h"
 
+/**
+ * 2.93 downver TODO:
+ */
+
+/**
+ * Removal of explicit null terminators and junk data in some string fields.
+ *
+ * + Strings that need to be expanded to BOARD_NAME_SIZE and terminated:
+ *    WPROP_WORLD_NAME (NO loading termination pre-2.92d)
+ *    BPROP_BOARD_NAME (loading termination expects BOARD_NAME_SIZE input pre-2.93)
+ *    (FIXME: remove len+1 board name save hack when the version incs.)
+ *
+ * + Strings that need to be expanded to ROBOT_NAME_SIZE and terminated:
+ *    RPROP_ROBOT_NAME (NO loading termination pre-2.92d)
+ *    SENPROP_SENSOR_NAME (NO loading termination pre-2.92d)
+ *    SENPROP_ROBOT_TO_MESG (NO loading termination pre-2.92d)
+ *
+ * + Strings that, unbelievably, were safely terminated as far back as 2.90:
+ *    WPROP_REAL_MOD_PLAYING (loaded safely; saved with unneeded \0 pre-2.93)
+ *    WPROP_INPUT_FILE_NAME (loaded safely; saved with unneeded \0 pre-2.93)
+ *    WPROP_OUTPUT_FILE_NAME (loaded safely; saved with unneeded \0 pre-2.93)
+ *    BPROP_MOD_PLAYING (loaded safely)
+ *    BPROP_CHARSET_PATH (loaded safely)
+ *    BPROP_PALETTE_PATH (loaded safely)
+ *    BPROP_INPUT_STRING (loaded safely)
+ *    BPROP_BOTTOM_MESG (loaded safely)
+ */
+
 #define DOWNVER_VERSION "2.92"
 #define DOWNVER_EXT ".291"
 


### PR DESCRIPTION
Cleans up some issues of varying degree in the ZIP world format:

* World names were saved as a null-terminated array instead of as non-terminated string. (Loading of non-array cases was fixed in 2.92d.)
* World name junk data beyond the terminator could still be saved in some cases.
* World module name, input filename, output filename fields were saved with an unecessary terminator.
* Board name loading used sketchy termination that, when combined with boards names that are too short, could leave uninitialized data at the end of the name before the terminator.
* Board names were saved as a null-terminated array instead of as a non-terminated string. Terminator is currently saved for 2.92X compatibility (see above), but this will be removed.
* Robot names, sensor names, and sensor message robots were saved as null-terminated arrays instead of as non-terminated strings. (Loading of non-array cases was fixed in 2.92d.)