### PR TITLE
Remove memfile.h includes from more headers.

### DIFF
--- a/src/io/vfile.h
+++ b/src/io/vfile.h
@@ -18,7 +18,8 @@
  */
 
 /**
- * Types for vio.h (so it doesn't have to be included in world_struct.h).
+ * Types for vio.h and memfile.h so they don't have to be included in
+ * world_struct.h and other high-traffic headers.
  */
 
 #ifndef __IO_VFILE_H
@@ -29,6 +30,7 @@
 __M_BEGIN_DECLS
 
 typedef struct vfile vfile;
+struct memfile;
 struct stat;
 
 __M_END_DECLS

--- a/src/io/vio.h
+++ b/src/io/vio.h
@@ -45,7 +45,6 @@ vfile *vfile_init_mem_ext(void **external_buffer, size_t *external_buffer_size,
 UTILS_LIBSPEC vfile *vtempfile(size_t initial_size);
 UTILS_LIBSPEC int vfclose(vfile *vf);
 
-struct memfile;
 struct memfile *vfile_get_memfile(vfile *vf);
 
 UTILS_LIBSPEC int vchdir(const char *path);

--- a/src/io/zip.h
+++ b/src/io/zip.h
@@ -29,7 +29,6 @@ __M_BEGIN_DECLS
 // This needs to stay self-sufficient.
 // Don't use core features, don't extern anything.
 
-#include "memfile.h"
 #include "vfile.h"
 
 /**

--- a/src/io/zip_deflate.h
+++ b/src/io/zip_deflate.h
@@ -29,6 +29,7 @@
 __M_BEGIN_DECLS
 
 #include <assert.h>
+#include <stdlib.h>
 #include <zlib.h>
 
 #include "zip.h"

--- a/src/io/zip_deflate64.h
+++ b/src/io/zip_deflate64.h
@@ -25,6 +25,7 @@
 __M_BEGIN_DECLS
 
 #include <assert.h>
+#include <stdlib.h>
 #include <zlib.h>
 
 // Not really how you're supposed to do this, oh well... :(

--- a/src/legacy_robot.c
+++ b/src/legacy_robot.c
@@ -33,6 +33,7 @@
 #include "util.h"
 #include "world.h"
 #include "world_struct.h"
+#include "io/memfile.h"
 #include "io/vio.h"
 
 struct robot *legacy_load_robot_allocate(struct world *mzx_world, vfile *vf,

--- a/src/legacy_robot.h
+++ b/src/legacy_robot.h
@@ -27,7 +27,6 @@ __M_BEGIN_DECLS
 
 #include "const.h"
 #include "world_struct.h"
-#include "io/memfile.h"
 #include "io/vfile.h"
 
 struct robot *legacy_load_robot_allocate(struct world *mzx_world, vfile *vf,

--- a/unit/io/zip.cpp
+++ b/unit/io/zip.cpp
@@ -22,6 +22,7 @@
 #include "../Unit.hpp"
 
 #include "../../src/util.h"
+#include "../../src/io/memfile.h"
 #include "../../src/io/path.h"
 #include "../../src/io/zip.h"
 #include "../../src/io/zip_stream.h"


### PR DESCRIPTION
The `memfile` header defines a bunch of inline functions that need to be parsed every time it's included, so I've removed includes of it in other headers.