### PR TITLE
Use vio.c functions in most applicable non-gameplay places.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -165,6 +165,8 @@ USERS
   loading PNGs with this configuration.
 + ccv and png2smzx now both support streaming image data from
   stdin using the input filename "-".
++ Fixed bugs caused by missing validation in the Import SFX
+  feature in the editor.
 - Removed GL4ES from the GLSL blacklist.
 - Removed 3DS CIA support. (asie)
 

--- a/src/audio/sfx.c
+++ b/src/audio/sfx.c
@@ -36,7 +36,14 @@
 
 #if defined(CONFIG_AUDIO) || defined(CONFIG_EDITOR)
 
-__editor_maybe_static char sfx_strs[NUM_SFX][SFX_SIZE] =
+/**
+ * The longest built-in SFX is the ring/potion sound, which is 68+1 chars long.
+ *
+ * This is also the legacy maximum SFX length. Custom SFX may potentially be
+ * longer in the future, and/or SFX beyond the 50 built-in SFX may be possible.
+ * Aside from potentially repurposing SFX 49, further built-ins are not likely.
+ */
+__editor_maybe_static char sfx_strs[NUM_BUILTIN_SFX][LEGACY_SFX_SIZE] =
 {
   "5c-gec-gec", // Gem
   "5c-gec-gec", // Magic Gem

--- a/src/audio/sfx.h
+++ b/src/audio/sfx.h
@@ -82,6 +82,7 @@ enum sfx_id
   SFX_SCROLL_SIGN       = 47,
   SFX_GOOP              = 48,
   SFX_UNUSED_49         = 49,
+  NUM_BUILTIN_SFX       = 50,
   NUM_SFX               = 50
 };
 
@@ -89,7 +90,7 @@ enum sfx_id
 struct world;
 
 #ifdef CONFIG_EDITOR
-CORE_LIBSPEC extern char sfx_strs[NUM_SFX][SFX_SIZE];
+CORE_LIBSPEC extern char sfx_strs[NUM_BUILTIN_SFX][LEGACY_SFX_SIZE];
 #endif // CONFIG_EDITOR
 
 #ifdef CONFIG_AUDIO

--- a/src/caption.c
+++ b/src/caption.c
@@ -22,6 +22,7 @@
 
 #include "caption.h"
 #include "graphics.h"
+#include "platform_attribute.h" /* ATTRIBUTE_PRINTF */
 #include "world_struct.h"
 
 // TODO this might benefit from a dirty flag + graphics.c hook and/or
@@ -82,18 +83,7 @@ static boolean strip_caption_string(char *output, const char *input)
 /**
  * Append a string to the caption.
  */
-
-// Make GCC shut up
-#ifdef __GNUC__
-#if __GNUC__ >= 5 || (__GNUC__ == 4 &&  __GNUC_MINOR__ >= 4)
-static inline void caption_append(char caption[MAX_CAPTION_SIZE],
- const char *f, ...) __attribute__((format(gnu_printf, 2, 3)));
-#else
-static inline void caption_append(char caption[MAX_CAPTION_SIZE],
- const char *f, ...) __attribute__((format(printf, 2, 3)));
-#endif
-#endif
-
+ATTRIBUTE_PRINTF(2, 3)
 static inline void caption_append(char caption[MAX_CAPTION_SIZE],
  const char *f, ...)
 {

--- a/src/compat.h
+++ b/src/compat.h
@@ -233,36 +233,6 @@ static inline FILE *check_fopen(const char *path, const char *mode)
 
 #define fopen(path, mode) check_fopen(path, mode)
 
-// These functions have the warn_unused_result attribute but in most cases
-// right now we'd just print a warning. So, wrap them and print a warning.
-
-#include <unistd.h>
-
-static inline char *check_getcwd(char *buf, size_t size)
-{
-  char *ret = getcwd(buf, size);
-  if(!ret)
-  {
-    fprintf(stderr, "WARNING: Failed getcwd from %s\n", buf);
-    fflush(stderr);
-  }
-  return ret;
-}
-
-static inline int check_chdir(const char *path)
-{
-  int ret = chdir(path);
-  if(ret)
-  {
-    fprintf(stderr, "WARNING: failed chdir to %s\n", path);
-    fflush(stderr);
-  }
-  return ret;
-}
-
-#define getcwd(buf, size) check_getcwd(buf, size)
-#define chdir(path) check_chdir(path)
-
 // Also deprecate some notoriously bad string functions.
 // strncpy and strncat are unsafe functions that get cargo cult usage as "safe"
 // versions of strcpy and strcat (which they aren't). strtok is non-reentrant.

--- a/src/editor/char_ed.c
+++ b/src/editor/char_ed.c
@@ -30,6 +30,7 @@
 #include "../window.h"
 #include "../world.h"
 #include "../io/path.h"
+#include "../io/vio.h"
 
 #include "configure.h"
 #include "graphics.h"
@@ -859,19 +860,19 @@ static int select_export_mode(struct world *mzx_world, const char *title)
 static int char_import_tile(const char *name, int char_offset, int charset,
  int highlight_width, int highlight_height)
 {
-  FILE *fp = fopen_unsafe(name, "rb");
-  if(fp)
+  vfile *vf = vfopen_unsafe(name, "rb");
+  if(vf)
   {
     size_t buffer_size = highlight_width * highlight_height * CHAR_SIZE;
     char *buffer = ccalloc(buffer_size, 1);
 
-    size_t data_size = ftell_and_rewind(fp);
+    size_t data_size = vfilelength(vf, true);
 
     if(data_size > buffer_size)
       data_size = buffer_size;
 
-    data_size = fread(buffer, 1, data_size, fp);
-    fclose(fp);
+    data_size = vfread(buffer, 1, data_size, vf);
+    vfclose(vf);
 
     ec_change_block((uint8_t)char_offset, (uint8_t)charset,
      (uint8_t)highlight_width, (uint8_t)highlight_height, buffer);
@@ -885,8 +886,8 @@ static int char_import_tile(const char *name, int char_offset, int charset,
 static void char_export_tile(const char *name, int char_offset, int charset,
  int highlight_width, int highlight_height)
 {
-  FILE *fp = fopen_unsafe(name, "wb");
-  if(fp)
+  vfile *vf = vfopen_unsafe(name, "wb");
+  if(vf)
   {
     size_t buffer_size = highlight_width * highlight_height * CHAR_SIZE;
     char *buffer = ccalloc(buffer_size, 1);
@@ -894,8 +895,8 @@ static void char_export_tile(const char *name, int char_offset, int charset,
     ec_read_block((uint8_t)char_offset, (uint8_t)charset,
      (uint8_t)highlight_width, (uint8_t)highlight_height, buffer);
 
-    fwrite(buffer, 1, buffer_size, fp);
-    fclose(fp);
+    vfwrite(buffer, 1, buffer_size, vf);
+    vfclose(vf);
 
     free(buffer);
   }

--- a/src/editor/debug.c
+++ b/src/editor/debug.c
@@ -40,6 +40,7 @@
 #include "../util.h"
 #include "../window.h"
 #include "../world.h"
+#include "../io/vio.h"
 
 #include "../audio/audio.h"
 
@@ -3240,29 +3241,26 @@ void __debug_counters(context *ctx)
         {
           struct counter_list *counter_list = &(mzx_world->counter_list);
           struct string_list *string_list = &(mzx_world->string_list);
-          FILE *fp;
+          vfile *vf;
           size_t i;
 
-          fp = fopen_unsafe(export_name, "wb");
+          vf = vfopen_unsafe(export_name, "wb");
 
           for(i = 0; i < counter_list->num_counters; i++)
           {
-            fprintf(fp, "set \"%s\" to %"PRId32"\n",
-             counter_list->counters[i]->name, counter_list->counters[i]->value);
+            struct counter *ctr = counter_list->counters[i];
+            vf_printf(vf, "set \"%s\" to %" PRId32 "\n", ctr->name, ctr->value);
           }
 
           for(i = 0; i < string_list->num_strings; i++)
           {
-            fprintf(fp, "set \"%s\" to \"",
-             string_list->strings[i]->name);
-
-            fwrite(string_list->strings[i]->value,
-             string_list->strings[i]->length, 1, fp);
-
-            fprintf(fp, "\"\n");
+            struct string *str = string_list->strings[i];
+            vf_printf(vf, "set \"%s\" to \"", str->name);
+            vfwrite(str->value, str->length, 1, vf);
+            vfputs("\"\n", vf);
           }
 
-          fclose(fp);
+          vfclose(vf);
         }
 
         window_focus = 5;

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -228,7 +228,7 @@ static boolean editor_reload_world(struct editor_context *editor,
   snprintf(config_file_name, MAX_PATH, "%.*s.editor.cnf", file_name_len, file);
   config_file_name[MAX_PATH - 1] = '\0';
 
-  if(stat(config_file_name, &file_info) >= 0)
+  if(vstat(config_file_name, &file_info) >= 0)
     set_config_from_file(GAME_EDITOR_CNF, config_file_name);
 
   edit_menu_show_board_mod(editor->edit_menu);
@@ -248,7 +248,7 @@ static void get_test_world_filename(struct editor_context *editor)
   strcpy(editor->test_reload_file, TEST_WORLD_FILENAME);
 
   // If the regular file exists, attempt numbered names.
-  for(i = 2; !stat(editor->test_reload_file, &file_info); i++)
+  for(i = 2; !vstat(editor->test_reload_file, &file_info); i++)
     snprintf(editor->test_reload_file, MAX_PATH, TEST_WORLD_PATTERN, i);
 }
 
@@ -3916,7 +3916,7 @@ static void __edit_world(context *parent, boolean reload_curr_file)
   editor->edit_menu = create_edit_menu((context *)editor);
 
   // Reload the current world or create a blank world.
-  if(curr_file[0] && stat(curr_file, &stat_res))
+  if(curr_file[0] && vstat(curr_file, &stat_res))
     curr_file[0] = '\0';
 
   if(reload_curr_file && curr_file[0] &&

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -41,6 +41,7 @@
 #include "../window.h"
 #include "../world.h"
 #include "../io/path.h"
+#include "../io/vio.h"
 
 #include "../audio/audio.h"
 #include "../audio/sfx.h"
@@ -3217,8 +3218,8 @@ static boolean editor_key(context *ctx, int *key)
             char current_dir[MAX_PATH];
             char new_mod[MAX_PATH] = { 0 } ;
 
-            getcwd(current_dir, MAX_PATH);
-            chdir(editor->current_listening_dir);
+            vgetcwd(current_dir, MAX_PATH);
+            vchdir(editor->current_listening_dir);
 
             if(!choose_file(mzx_world, mod_ext, new_mod,
              "Choose a module file (listening only)", ALLOW_ALL_DIRS))
@@ -3230,7 +3231,7 @@ static boolean editor_key(context *ctx, int *key)
               editor->listening_mod_active = true;
             }
 
-            chdir(current_dir);
+            vchdir(current_dir);
           }
           else
           {
@@ -3425,7 +3426,7 @@ static boolean editor_key(context *ctx, int *key)
             save_world(mzx_world, world_name, false, MZX_VERSION);
 
             if(path_get_directory(new_path, MAX_PATH, world_name) > 0)
-              chdir(new_path);
+              vchdir(new_path);
 
             editor->modified = false;
           }
@@ -3458,7 +3459,7 @@ static boolean editor_key(context *ctx, int *key)
 
         if(!save_world(mzx_world, editor->test_reload_file, false, MZX_VERSION))
         {
-          getcwd(editor->test_reload_dir, MAX_PATH);
+          vgetcwd(editor->test_reload_dir, MAX_PATH);
           editor->test_reload_version = mzx_world->version;
           editor->test_reload_board = mzx_world->current_board_id;
           editor->reload_after_testing = true;
@@ -3777,7 +3778,7 @@ static void editor_resume(context *ctx)
   if(editor->reload_after_testing)
   {
     editor->reload_after_testing = false;
-    chdir(editor->test_reload_dir);
+    vchdir(editor->test_reload_dir);
 
     if(!reload_world(mzx_world, editor->test_reload_file, &ignore))
     {
@@ -3812,7 +3813,7 @@ static void editor_resume(context *ctx)
       fix_mod(editor);
     }
 
-    unlink(editor->test_reload_file);
+    vunlink(editor->test_reload_file);
   }
 
   // These may have changed if a robot was edited.
@@ -3875,7 +3876,7 @@ static void __edit_world(context *parent, boolean reload_curr_file)
 
   struct stat stat_res;
 
-  getcwd(editor->current_listening_dir, MAX_PATH);
+  vgetcwd(editor->current_listening_dir, MAX_PATH);
 
   if(editor_conf->board_editor_hide_help)
     editor->screen_height = EDIT_SCREEN_MINIMAL;

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -85,7 +85,6 @@
 static const char *const world_ext[] = { ".MZX", NULL };
 static const char *const mzb_ext[] = { ".MZB", NULL };
 static const char *const mzm_ext[] = { ".MZM", NULL };
-static const char *const sfx_ext[] = { ".SFX", NULL };
 static const char *const chr_ext[] = { ".CHR", NULL };
 static const char *const ans_ext[] = { ".ANS", ".TXT", NULL };
 static const char *const mod_ext[] =
@@ -2944,20 +2943,7 @@ static boolean editor_key(context *ctx, int *key)
             case 4:
             {
               // Sound effects
-              if(!choose_file(mzx_world, sfx_ext, import_name,
-               "Choose SFX file to import", ALLOW_ALL_DIRS))
-              {
-                FILE *sfx_file;
-
-                sfx_file = fopen_unsafe(import_name, "rb");
-                if(NUM_SFX !=
-                 fread(mzx_world->custom_sfx, SFX_SIZE, NUM_SFX, sfx_file))
-                  error_message(E_IO_READ, 0, NULL);
-
-                mzx_world->custom_sfx_on = 1;
-                fclose(sfx_file);
-                editor->modified = true;
-              }
+              import_sfx(ctx, &editor->modified);
               break;
             }
 
@@ -3590,23 +3576,7 @@ static boolean editor_key(context *ctx, int *key)
             case 3:
             {
               // Sound effects
-              if(!new_file(mzx_world, sfx_ext, ".sfx", export_name,
-               "Export SFX file", ALLOW_ALL_DIRS))
-              {
-                FILE *sfx_file;
-
-                sfx_file = fopen_unsafe(export_name, "wb");
-
-                if(sfx_file)
-                {
-                  if(mzx_world->custom_sfx_on)
-                    fwrite(mzx_world->custom_sfx, SFX_SIZE, NUM_SFX, sfx_file);
-                  else
-                    fwrite(sfx_strs, SFX_SIZE, NUM_SFX, sfx_file);
-
-                  fclose(sfx_file);
-                }
-              }
+              export_sfx(ctx);
               break;
             }
 

--- a/src/editor/sfx_edit.h
+++ b/src/editor/sfx_edit.h
@@ -24,9 +24,12 @@
 
 __M_BEGIN_DECLS
 
-#include "../world_struct.h"
+#include "../core.h"
 
 void sfx_edit(struct world *mzx_world);
+
+void import_sfx(context *parent, boolean *modified);
+void export_sfx(context *parent);
 
 __M_END_DECLS
 

--- a/src/error.c
+++ b/src/error.c
@@ -503,6 +503,16 @@ int error_message(enum error_code id, int parameter, const char *string)
       sprintf(error_mesg, "Error exporting text");
       code = 0x1401;
       break;
+
+    case E_SFX_IMPORT:
+      sprintf(error_mesg, "File is invalid or is not an SFX file");
+      code = 0;
+      break;
+
+    case E_SFX_EXPORT:
+      sprintf(error_mesg, "Error exporting SFX file");
+      code = 0;
+      break;
 #endif
 
 #ifdef CONFIG_UPDATER

--- a/src/error.h
+++ b/src/error.h
@@ -90,6 +90,8 @@ enum error_code
   E_ANSI_IMPORT,
   E_ANSI_EXPORT,
   E_TEXT_EXPORT,
+  E_SFX_IMPORT,
+  E_SFX_EXPORT,
 #endif
 #ifdef CONFIG_UPDATER
   E_UPDATE,

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -2760,7 +2760,7 @@ void dump_screen(void)
   {
     snprintf(name, MAX_NAME_SIZE - 1, "screen%d.%s", i, DUMP_FMT_EXT);
     name[MAX_NAME_SIZE - 1] = '\0';
-    if(stat(name, &file_info))
+    if(vstat(name, &file_info))
       break;
   }
 

--- a/src/io/path.c
+++ b/src/io/path.c
@@ -22,6 +22,10 @@
 #include <errno.h>
 #include <sys/stat.h>
 
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
+
 #include "path.h"
 #include "vio.h"
 

--- a/src/io/vio.c
+++ b/src/io/vio.c
@@ -798,9 +798,16 @@ int vf_vprintf(vfile *vf, const char *fmt, va_list args)
   if(vf->flags & VF_MEMORY)
   {
     // Get the expected output length from the format string and args.
-    int length = vsnprintf(NULL, 0, fmt, args);
+    // This requires a duplicate arglist so vsnprintf can be called twice.
+    // va_copy is supported by MSVC 2015+.
+    va_list tmp_args;
+    int length;
     char _buffer[512];
     void *buffer;
+
+    va_copy(tmp_args, args);
+    length = vsnprintf(NULL, 0, fmt, tmp_args);
+    va_end(tmp_args);
 
     // Note: vsnprintf will fail if this is actually MSVC's broken _vsnprintf.
     // This shouldn't happen since only MinGW and MSVC 2015+ are supported.

--- a/src/io/vio.h
+++ b/src/io/vio.h
@@ -25,7 +25,9 @@
 __M_BEGIN_DECLS
 
 #include "vfile.h"
+#include "../platform_attribute.h" /* ATTRIBUTE_PRINTF */
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <sys/stat.h>
 
@@ -74,6 +76,10 @@ UTILS_LIBSPEC int vfread(void *dest, size_t size, size_t count, vfile *vf);
 UTILS_LIBSPEC int vfwrite(const void *src, size_t size, size_t count, vfile *vf);
 UTILS_LIBSPEC char *vfsafegets(char *dest, int size, vfile *vf);
 UTILS_LIBSPEC int vfputs(const char *src, vfile *vf);
+UTILS_LIBSPEC int vf_printf(vfile *vf, const char *fmt, ...)
+ ATTRIBUTE_PRINTF(2, 3);
+UTILS_LIBSPEC int vf_vprintf(vfile *vf, const char *fmt, va_list args)
+ ATTRIBUTE_PRINTF(2, 0);
 UTILS_LIBSPEC int vungetc(int ch, vfile *vf);
 UTILS_LIBSPEC int vfseek(vfile *vf, long int offset, int whence);
 UTILS_LIBSPEC long int vftell(vfile *vf);

--- a/src/legacy_world.c
+++ b/src/legacy_world.c
@@ -710,7 +710,7 @@ static enum val_result __validate_legacy_world_file(vfile *vf, boolean savegame)
     int sfx_off = vftell(vf);
     int cur_sfx_size;
 
-    for(i = 0; i < NUM_SFX; i++)
+    for(i = 0; i < NUM_BUILTIN_SFX; i++)
     {
       cur_sfx_size = vfgetc(vf);
       if(cur_sfx_size < 0 || cur_sfx_size > LEGACY_SFX_SIZE)
@@ -720,7 +720,7 @@ static enum val_result __validate_legacy_world_file(vfile *vf, boolean savegame)
         break;
     }
 
-    if((i != NUM_SFX) || ((vftell(vf) - sfx_off) != sfx_size))
+    if((i != NUM_BUILTIN_SFX) || ((vftell(vf) - sfx_off) != sfx_size))
       goto err_invalid;
 
     num_boards = vfgetc(vf);
@@ -1129,7 +1129,7 @@ void legacy_load_world(struct world *mzx_world, vfile *vf, const char *file,
     vfgetw(vf); // Skip word size
 
     //Read sfx
-    for(i = 0; i < NUM_SFX; i++, sfx_offset += LEGACY_SFX_SIZE)
+    for(i = 0; i < NUM_BUILTIN_SFX; i++, sfx_offset += LEGACY_SFX_SIZE)
     {
       sfx_size = vfgetc(vf);
       if(sfx_size && !vfread(sfx_offset, sfx_size, 1, vf))

--- a/src/network/HTTPHost.cpp
+++ b/src/network/HTTPHost.cpp
@@ -534,7 +534,7 @@ HTTPHostStatus HTTPHost::head(HTTPRequestInfo &request)
   return HOST_SUCCESS;
 }
 
-HTTPHostStatus HTTPHost::_get(HTTPRequestInfo &request, vfile *file)
+HTTPHostStatus HTTPHost::get(HTTPRequestInfo &request, vfile *file)
 {
   boolean mid_inflate = false;
   boolean mid_chunk = false;
@@ -824,19 +824,10 @@ HTTPHostStatus HTTPHost::_get(HTTPRequestInfo &request, vfile *file)
   return HOST_SUCCESS;
 }
 
-HTTPHostStatus HTTPHost::get(HTTPRequestInfo &request, FILE *file)
-{
-  vfile *vf = vfile_init_fp(file, "wb");
-  HTTPHostStatus result = this->_get(request, vf);
-  // FIXME hack
-  free(vf);
-  return result;
-}
-
 HTTPHostStatus HTTPHost::get(HTTPRequestInfo &request, char *buffer, size_t len)
 {
   vfile *vf = vfile_init_mem(buffer, len, "wb");
-  HTTPHostStatus result = this->_get(request, vf);
+  HTTPHostStatus result = this->get(request, vf);
   vfclose(vf);
   return result;
 }

--- a/src/network/HTTPHost.hpp
+++ b/src/network/HTTPHost.hpp
@@ -114,9 +114,6 @@ struct UPDATER_LIBSPEC HTTPRequestInfo
  */
 class UPDATER_LIBSPEC HTTPHost: public Host
 {
-private:
-  HTTPHostStatus _get(HTTPRequestInfo &request, vfile *file);
-
 protected:
   ssize_t http_receive_line(char *buffer, size_t len);
   ssize_t http_send_line(const char *message);
@@ -159,7 +156,7 @@ public:
    *
    * @return see HTTPHostStatus.
    */
-  HTTPHostStatus get(HTTPRequestInfo &request, FILE *file);
+  HTTPHostStatus get(HTTPRequestInfo &request, vfile *file);
 
   /**
    * Send a GET request and stream the response (if any) to a buffer.

--- a/src/network/HTTPHost.hpp
+++ b/src/network/HTTPHost.hpp
@@ -181,7 +181,7 @@ public:
    *
    * @return see HTTPHostStatus.
    */
-  HTTPHostStatus send_file(FILE *file, const char *mime_type);
+  HTTPHostStatus send_file(vfile *file, const char *mime_type);
 
   /**
    * Handle an incoming HTTP request.

--- a/src/network/Manifest.cpp
+++ b/src/network/Manifest.cpp
@@ -24,6 +24,7 @@
 #include "../util.h"
 #include "../io/fsafeopen.h"
 #include "../io/memfile.h"
+#include "../io/vio.h"
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -590,7 +591,7 @@ boolean Manifest::download_and_replace_entry(HTTPHost &http,
   if(!f)
   {
     snprintf(buf, LINE_BUF_LEN, "%s-%u~", e->name, (unsigned int)time(NULL));
-    if(rename(e->name, buf))
+    if(vrename(e->name, buf))
     {
       warn("Failed to rename in-use file '%s' to '%s'\n", e->name, buf);
       return false;

--- a/src/network/Manifest.cpp
+++ b/src/network/Manifest.cpp
@@ -635,14 +635,13 @@ boolean Manifest::write_to_file(const char *filename) const
 {
   if(this->head)
   {
-    /* TODO vio */
-    ScopedFile<FILE, fclose> f = fopen_unsafe(filename, "ab");
-    if(!f)
+    ScopedFile<vfile, vfclose> vf = vfopen_unsafe(filename, "ab");
+    if(!vf)
       return false;
 
     for(ManifestEntry *e = this->head; e; e = e->next)
     {
-      fprintf(f, "%08x%08x%08x%08x%08x%08x%08x%08x %zu %s\n",
+      vf_printf(vf, "%08x%08x%08x%08x%08x%08x%08x%08x %zu %s\n",
        e->sha256[0], e->sha256[1], e->sha256[2], e->sha256[3],
        e->sha256[4], e->sha256[5], e->sha256[6], e->sha256[7],
        e->size, e->name);

--- a/src/network/Manifest.hpp
+++ b/src/network/Manifest.hpp
@@ -22,12 +22,12 @@
 #define __MANIFEST_HPP
 
 #include "../compat.h"
+#include "../io/vfile.h"
 
 #include "sha256.h"
 #include "HTTPHost.hpp"
 
 #include <stdint.h>
-#include <stdio.h>
 
 #define MANIFEST_TXT "manifest.txt"
 #define LOCAL_MANIFEST_TXT MANIFEST_TXT
@@ -49,11 +49,11 @@ public:
   /**
    * Check this manifest entry against its corresponding file.
    *
-   * @param fp          File pointer to validate.
+   * @param vf          File pointer to validate.
    *
    * @return `true` if the file exists and is an exact match, otherwise `false`.
    */
-  boolean validate(FILE *fp) const;
+  boolean validate(vfile *vf) const;
 
   /**
    * Check this manifest entry against its corresponding file (indicated by
@@ -82,7 +82,7 @@ public:
 
 private:
   void init(const uint32_t (&_sha256)[8], size_t _size, const char *name);
-  static boolean compute_sha256(SHA256_ctx &ctx, FILE *fp, size_t len);
+  static boolean compute_sha256(SHA256_ctx &ctx, vfile *vf, size_t len);
 };
 
 class UPDATER_LIBSPEC Manifest
@@ -98,7 +98,7 @@ private:
   Manifest &operator=(Manifest &&) { return *this; }
 #endif
 
-  void create(FILE *fp);
+  void create(vfile *vf);
   HTTPHostStatus get_remote(HTTPHost &http, HTTPRequestInfo &request,
    const char *basedir);
   void filter_duplicates(Manifest &local, Manifest &remote);

--- a/src/platform_attribute.h
+++ b/src/platform_attribute.h
@@ -1,0 +1,71 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2021 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef __PLATFORM_ATTRIBUTE_H
+#define __PLATFORM_ATTRIBUTE_H
+
+/**
+ * Header for misc. compiler-specific attributes.
+ */
+
+#ifdef __has_attribute
+#define HAS_ATTRIBUTE(x) __has_attribute(x)
+#else
+#define HAS_ATTRIBUTE(x) 0
+#endif
+
+/**
+ * Catch-all for GCC printf instrumentation. GCC will emit warnings
+ * if this attribute is not used on printf-like functions.
+ */
+#if (defined(__GNUC__) && !defined(__clang__)) || HAS_ATTRIBUTE(format)
+#if __GNUC__ >= 5 || (__GNUC__ == 4 &&  __GNUC_MINOR__ >= 4)
+
+// Note: param numbers are 1-indexed for normal functions and
+// 2-indexed for member functions (including constructors).
+#define ATTRIBUTE_PRINTF(string_index, first_to_check) \
+ __attribute__((format(gnu_printf, string_index, first_to_check)))
+
+#else
+
+#define ATTRIBUTE_PRINTF(string_index, first_to_check) \
+ __attribute__((format(printf, string_index, first_to_check)))
+
+#endif
+#endif
+
+#ifndef ATTRIBUTE_PRINTF
+#define ATTRIBUTE_PRINTF(string_index, first_to_check)
+#endif
+
+/**
+ * Turn off sanitizer instrumentation for a particular location.
+ */
+#if (defined(__GNUC__) && __GNUC__ >= 9) || \
+ (defined(__clang__) && HAS_ATTRIBUTE(no_sanitize))
+#define ATTRIBUTE_NO_SANITIZE(...) __attribute__((no_sanitize(__VA_ARGS__)))
+#endif
+
+#ifndef ATTRIBUTE_NO_SANITIZE
+#define ATTRIBUTE_NO_SANITIZE(...)
+#endif
+
+#undef HAS_ATTRIBUTE
+
+#endif // __PLATFORM_ATTRIBUTE_H

--- a/src/util.c
+++ b/src/util.c
@@ -410,7 +410,7 @@ boolean redirect_stdio_init(const char *base_path, boolean require_conf)
     struct stat stat_info;
 
     path_append(dest_path, MAX_PATH, "config.txt");
-    if(stat(dest_path, &stat_info))
+    if(vstat(dest_path, &stat_info))
       return false;
     dest_path[dest_len] = '\0';
   }

--- a/src/world.h
+++ b/src/world.h
@@ -211,6 +211,11 @@ CORE_LIBSPEC void refactor_board_list(struct world *mzx_world,
  struct board **new_board_list, int new_list_size,
  int *board_id_translation_list);
 CORE_LIBSPEC void optimize_null_boards(struct world *mzx_world);
+
+CORE_LIBSPEC void save_sfx_array(struct world *mzx_world,
+ char custom_sfx[NUM_BUILTIN_SFX * LEGACY_SFX_SIZE]);
+CORE_LIBSPEC boolean load_sfx_array(struct world *mzx_world,
+ char custom_sfx[NUM_BUILTIN_SFX * LEGACY_SFX_SIZE]);
 #endif // CONFIG_EDITOR
 
 __M_END_DECLS

--- a/unit/Unit.hpp
+++ b/unit/Unit.hpp
@@ -82,6 +82,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <csignal>
 #include <string>

--- a/unit/io/vio.cpp
+++ b/unit/io/vio.cpp
@@ -306,6 +306,23 @@ static void test_vfputs(vfile *vf)
   test_write_check(vf);
 }
 
+// Note: vf_printf is a wrapper for vf_vprintf, so both are tested by this.
+static void test_vf_printf(vfile *vf)
+{
+  long pos = vftell(vf);
+
+  int ret = vf_printf(vf, "%128.128s%.128s", (const char *)test_data, (const char *)test_data + 128);
+  ASSERTEQ(ret, 255, "vf_printf");
+
+  // *printf doesn't write a null terminator.
+  ret = vfputc(0, vf);
+  ASSERTEQ(ret, 0, "vfputc");
+
+  ret = vfseek(vf, pos, SEEK_SET);
+  ASSERTEQ(ret, 0, "vfseek");
+  test_write_check(vf);
+}
+
 static void test_vfseek_vftell_vrewind_read(vfile *vf)
 {
   static constexpr int set_valid[] = { 0, 128, 256, 7, 19, 157, 79, 9999 };
@@ -550,6 +567,7 @@ static void test_vfsafegets(vfile *vf, const char *filename,
   SECTION(write_vfputd)     test_vfputd(vf); \
   SECTION(write_vfwrite)    test_vfwrite(vf); \
   SECTION(write_vfputs)     test_vfputs(vf); \
+  SECTION(write_vf_printf)  test_vf_printf(vf); \
   /*if(!is_append) { SECTION(write_vfseektell)  test_vfseek_vftell_rewind_write(vf); } */ \
 } while(0)
 


### PR DESCRIPTION
Updates most places that use `fopen_unsafe` and unistd.h functions (aside from `fsafeopen`/`input_file`-related code) to use vio.c. This required adding a vio `fprintf` equivalent function.