### PR TITLE
Use vio.c wrapper functions for input/output files, help system, et al.

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -237,6 +237,10 @@ static inline FILE *check_fopen(const char *path, const char *mode)
 // strncpy and strncat are unsafe functions that get cargo cult usage as "safe"
 // versions of strcpy and strcat (which they aren't). strtok is non-reentrant.
 
+#ifdef _WIN32
+// Some MinGW headers use these functions inline for some reason...
+#include <io.h>
+#endif
 #include <string.h>
 static inline char *check_strncpy(char *, const char *, size_t)
  __attribute__((deprecated));

--- a/src/counter.c
+++ b/src/counter.c
@@ -2107,18 +2107,8 @@ static int fwrite_length_read(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int id)
 {
   if(mzx_world->output_file)
-  {
-    // Since this can change without updating the file on disk, the easiest
-    // way to get this value is SEEK_END/ftell.
-    // FIXME this should be fixed to never use fstat for write files in vfilelength + unit test.
-    long current_pos = vftell(mzx_world->output_file);
-    long length;
+    return vfilelength(mzx_world->output_file, false);
 
-    vfseek(mzx_world->output_file, 0, SEEK_END);
-    length = vftell(mzx_world->output_file);
-    vfseek(mzx_world->output_file, current_pos, SEEK_SET);
-    return length;
-  }
   return -1;
 }
 

--- a/src/counter.c
+++ b/src/counter.c
@@ -28,7 +28,6 @@
 #include <ctype.h>
 #include <limits.h>
 #include <time.h>
-#include <sys/stat.h>
 
 #ifdef _MSC_VER
 #include "win32time.h"
@@ -1989,7 +1988,7 @@ static int fread_read(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int id)
 {
   if(!mzx_world->input_is_dir && mzx_world->input_file)
-    return fgetc(mzx_world->input_file);
+    return vfgetc(mzx_world->input_file);
   return -1;
 }
 
@@ -1999,9 +1998,9 @@ static int fread_counter_read(struct world *mzx_world,
   if(!mzx_world->input_is_dir && mzx_world->input_file)
   {
     if(mzx_world->version < V282)
-      return fgetw(mzx_world->input_file);
+      return vfgetw(mzx_world->input_file);
     else
-      return fgetd(mzx_world->input_file);
+      return vfgetd(mzx_world->input_file);
   }
   return -1;
 }
@@ -2011,7 +2010,7 @@ static int fread_pos_read(struct world *mzx_world,
 {
   if(!mzx_world->input_is_dir && mzx_world->input_file)
   {
-    return ftell(mzx_world->input_file);
+    return vftell(mzx_world->input_file);
   }
   else
 
@@ -2029,9 +2028,9 @@ static void fread_pos_write(struct world *mzx_world,
   if(!mzx_world->input_is_dir && mzx_world->input_file)
   {
     if(value == -1)
-      fseek(mzx_world->input_file, 0, SEEK_END);
+      vfseek(mzx_world->input_file, 0, SEEK_END);
     else
-      fseek(mzx_world->input_file, value, SEEK_SET);
+      vfseek(mzx_world->input_file, value, SEEK_SET);
   }
   else if(mzx_world->input_is_dir)
   {
@@ -2047,22 +2046,8 @@ static int fread_length_read(struct world *mzx_world,
     return vdir_length(mzx_world->input_directory);
 
   if(mzx_world->input_file)
-  {
-    struct stat stat_info;
-    long current_pos;
-    long length;
+    return vfilelength(mzx_world->input_file, false);
 
-    // Since this is read-only, this info is likely accurate and faster to get.
-    if(!fstat(fileno(mzx_world->input_file), &stat_info))
-      return stat_info.st_size;
-
-    // Fall back to SEEK_END/ftell
-    current_pos = ftell(mzx_world->input_file);
-    fseek(mzx_world->input_file, 0, SEEK_END);
-    length = ftell(mzx_world->input_file);
-    fseek(mzx_world->input_file, current_pos, SEEK_SET);
-    return length;
-  }
   return -1;
 }
 
@@ -2082,7 +2067,7 @@ static int fwrite_pos_read(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int id)
 {
   if(mzx_world->output_file)
-    return ftell(mzx_world->output_file);
+    return vftell(mzx_world->output_file);
   else
     return -1;
 }
@@ -2093,9 +2078,9 @@ static void fwrite_pos_write(struct world *mzx_world,
   if(mzx_world->output_file)
   {
     if(value == -1)
-      fseek(mzx_world->output_file, 0, SEEK_END);
+      vfseek(mzx_world->output_file, 0, SEEK_END);
     else
-      fseek(mzx_world->output_file, value, SEEK_SET);
+      vfseek(mzx_world->output_file, value, SEEK_SET);
   }
 }
 
@@ -2103,7 +2088,7 @@ static void fwrite_write(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int value, int id)
 {
   if(mzx_world->output_file)
-    fputc(value, mzx_world->output_file);
+    vfputc(value, mzx_world->output_file);
 }
 
 static void fwrite_counter_write(struct world *mzx_world,
@@ -2112,9 +2097,9 @@ static void fwrite_counter_write(struct world *mzx_world,
   if(mzx_world->output_file)
   {
     if(mzx_world->version < V282)
-      fputw(value, mzx_world->output_file);
+      vfputw(value, mzx_world->output_file);
     else
-      fputd(value, mzx_world->output_file);
+      vfputd(value, mzx_world->output_file);
   }
 }
 
@@ -2125,12 +2110,13 @@ static int fwrite_length_read(struct world *mzx_world,
   {
     // Since this can change without updating the file on disk, the easiest
     // way to get this value is SEEK_END/ftell.
-    long current_pos = ftell(mzx_world->output_file);
+    // FIXME this should be fixed to never use fstat for write files in vfilelength + unit test.
+    long current_pos = vftell(mzx_world->output_file);
     long length;
 
-    fseek(mzx_world->output_file, 0, SEEK_END);
-    length = ftell(mzx_world->output_file);
-    fseek(mzx_world->output_file, current_pos, SEEK_SET);
+    vfseek(mzx_world->output_file, 0, SEEK_END);
+    length = vftell(mzx_world->output_file);
+    vfseek(mzx_world->output_file, current_pos, SEEK_SET);
     return length;
   }
   return -1;
@@ -2925,7 +2911,7 @@ int set_counter_special(struct world *mzx_world, char *char_value,
 
         if(!mzx_world->input_is_dir && mzx_world->input_file)
         {
-          fclose(mzx_world->input_file);
+          vfclose(mzx_world->input_file);
           mzx_world->input_file = NULL;
         }
 
@@ -2947,7 +2933,7 @@ int set_counter_special(struct world *mzx_world, char *char_value,
         else
 
         if(err == -FSAFE_SUCCESS)
-          mzx_world->input_file = fopen_unsafe(translated_path, "rb");
+          mzx_world->input_file = vfopen_unsafe(translated_path, "rb");
 
         if(mzx_world->input_file || mzx_world->input_is_dir)
           strcpy(mzx_world->input_file_name, translated_path);
@@ -2958,7 +2944,7 @@ int set_counter_special(struct world *mzx_world, char *char_value,
       {
         if(!mzx_world->input_is_dir && mzx_world->input_file)
         {
-          fclose(mzx_world->input_file);
+          vfclose(mzx_world->input_file);
           mzx_world->input_file = NULL;
         }
 
@@ -2980,7 +2966,7 @@ int set_counter_special(struct world *mzx_world, char *char_value,
       if(char_value[0])
       {
         if(mzx_world->output_file)
-          fclose(mzx_world->output_file);
+          vfclose(mzx_world->output_file);
 
         mzx_world->output_file = fsafeopen(char_value, "wb");
         if(mzx_world->output_file)
@@ -2990,7 +2976,7 @@ int set_counter_special(struct world *mzx_world, char *char_value,
       {
         if(mzx_world->output_file)
         {
-          fclose(mzx_world->output_file);
+          vfclose(mzx_world->output_file);
           mzx_world->output_file = NULL;
         }
       }
@@ -3005,7 +2991,7 @@ int set_counter_special(struct world *mzx_world, char *char_value,
       if(char_value[0])
       {
         if(mzx_world->output_file)
-          fclose(mzx_world->output_file);
+          vfclose(mzx_world->output_file);
 
         mzx_world->output_file = fsafeopen(char_value, "ab");
         if(mzx_world->output_file)
@@ -3015,7 +3001,7 @@ int set_counter_special(struct world *mzx_world, char *char_value,
       {
         if(mzx_world->output_file)
         {
-          fclose(mzx_world->output_file);
+          vfclose(mzx_world->output_file);
           mzx_world->output_file = NULL;
         }
       }
@@ -3030,7 +3016,7 @@ int set_counter_special(struct world *mzx_world, char *char_value,
       if(char_value[0])
       {
         if(mzx_world->output_file)
-          fclose(mzx_world->output_file);
+          vfclose(mzx_world->output_file);
 
         mzx_world->output_file = fsafeopen(char_value, "r+b");
         if(mzx_world->output_file)
@@ -3040,7 +3026,7 @@ int set_counter_special(struct world *mzx_world, char *char_value,
       {
         if(mzx_world->output_file)
         {
-          fclose(mzx_world->output_file);
+          vfclose(mzx_world->output_file);
           mzx_world->output_file = NULL;
         }
       }
@@ -3178,19 +3164,19 @@ int set_counter_special(struct world *mzx_world, char *char_value,
         // translated into actual commands eventually.
         if(mzx_world->version >= VERSION_SOURCE)
         {
-          FILE *fp = fsafeopen(char_value, "rb");
-          if(fp)
+          vfile *vf = fsafeopen(char_value, "rb");
+          if(vf)
           {
-            new_length = ftell_and_rewind(fp);
+            new_length = vfilelength(vf, true);
             new_source = cmalloc(new_length + 1);
             new_source[new_length] = 0;
 
-            if(!fread(new_source, new_length, 1, fp))
+            if(!vfread(new_source, new_length, 1, vf))
             {
               free(new_source);
               new_source = NULL;
             }
-            fclose(fp);
+            vfclose(vf);
           }
         }
         else
@@ -3234,7 +3220,7 @@ int set_counter_special(struct world *mzx_world, char *char_value,
       // It's basically like LOAD_ROBOT except that it first has to disassmble
       // the bytecode.
 
-      FILE *bc_file = fsafeopen(char_value, "rb");
+      vfile *bc_file = fsafeopen(char_value, "rb");
 
       if(bc_file)
       {
@@ -3243,10 +3229,10 @@ int set_counter_special(struct world *mzx_world, char *char_value,
 
         if(cur_robot)
         {
-          int program_bytecode_length = ftell_and_rewind(bc_file);
+          int program_bytecode_length = vfilelength(bc_file, true);
           char *program_legacy_bytecode = malloc(program_bytecode_length + 1);
 
-          fread(program_legacy_bytecode, program_bytecode_length, 1,
+          vfread(program_legacy_bytecode, program_bytecode_length, 1,
            bc_file);
 
           if(!validate_legacy_bytecode(&program_legacy_bytecode,
@@ -3278,12 +3264,12 @@ int set_counter_special(struct world *mzx_world, char *char_value,
           // OR LOAD_BCn was used where n is &robot_id&.
           if(value == -1 || value == id)
           {
-            fclose(bc_file);
+            vfclose(bc_file);
             return 1;
           }
         }
 
-        fclose(bc_file);
+        vfclose(bc_file);
       }
       break;
     }
@@ -3300,14 +3286,14 @@ int set_counter_special(struct world *mzx_world, char *char_value,
 
       if(cur_robot && cur_robot->program_source)
       {
-        FILE *fp = fsafeopen(char_value, "wb");
+        vfile *vf = fsafeopen(char_value, "wb");
         size_t len = cur_robot->program_source_length;
 
-        if(fp)
+        if(vf)
         {
           // TODO: this doesn't apply zaps...
-          fwrite(cur_robot->program_source, len, 1, fp);
-          fclose(fp);
+          vfwrite(cur_robot->program_source, len, 1, vf);
+          vfclose(vf);
         }
       }
       break;
@@ -3373,7 +3359,7 @@ int set_counter_special(struct world *mzx_world, char *char_value,
 
     case FOPEN_LOAD_BC:
     {
-      FILE *bc_file = fsafeopen(char_value, "rb");
+      vfile *bc_file = fsafeopen(char_value, "rb");
 
       if(bc_file)
       {
@@ -3382,10 +3368,10 @@ int set_counter_special(struct world *mzx_world, char *char_value,
 
         if(cur_robot)
         {
-          int new_size = ftell_and_rewind(bc_file);
+          int new_size = vfilelength(bc_file, true);
           char *program_bytecode = malloc(new_size + 1);
 
-          if(!fread(program_bytecode, new_size, 1, bc_file))
+          if(!vfread(program_bytecode, new_size, 1, bc_file))
           {
             free(program_bytecode);
             break;
@@ -3420,12 +3406,12 @@ int set_counter_special(struct world *mzx_world, char *char_value,
           // OR LOAD_BCn was used where n is &robot_id&.
           if(value == -1 || value == id)
           {
-            fclose(bc_file);
+            vfclose(bc_file);
             return 1;
           }
         }
 
-        fclose(bc_file);
+        vfclose(bc_file);
       }
       break;
     }
@@ -3446,7 +3432,7 @@ int set_counter_special(struct world *mzx_world, char *char_value,
 
     case FOPEN_SAVE_BC:
     {
-      FILE *bc_file = fsafeopen(char_value, "wb");
+      vfile *bc_file = fsafeopen(char_value, "wb");
 
       if(bc_file)
       {
@@ -3455,11 +3441,11 @@ int set_counter_special(struct world *mzx_world, char *char_value,
 
         if(cur_robot)
         {
-          fwrite(cur_robot->program_bytecode,
+          vfwrite(cur_robot->program_bytecode,
            cur_robot->program_bytecode_length, 1, bc_file);
         }
 
-        fclose(bc_file);
+        vfclose(bc_file);
       }
       break;
     }

--- a/src/helpsys.c
+++ b/src/helpsys.c
@@ -31,6 +31,7 @@
 #include "util.h"
 #include "window.h"
 #include "world.h"
+#include "io/vio.h"
 
 static char *help;
 
@@ -38,7 +39,7 @@ void help_open(struct world *mzx_world, const char *file_name)
 {
   if(file_name)
   {
-    mzx_world->help_file = fopen_unsafe(file_name, "rb");
+    mzx_world->help_file = vfopen_unsafe(file_name, "rb");
     if(!mzx_world->help_file)
       return;
 
@@ -50,7 +51,7 @@ void help_close(struct world *mzx_world)
 {
   if(mzx_world->help_file)
   {
-    fclose(mzx_world->help_file);
+    vfclose(mzx_world->help_file);
     mzx_world->help_file = NULL;
   }
 
@@ -70,25 +71,25 @@ void help_system(context *ctx, struct world *mzx_world)
 {
   char file[13], file2[13], label[13];
   int where, offs, size, t1, t2;
-  FILE *fp;
+  vfile *vf;
 
-  fp = mzx_world->help_file;
-  if(!fp)
+  vf = mzx_world->help_file;
+  if(!vf)
     return;
 
-  rewind(fp);
-  t1 = fgetw(fp);
-  fseek(fp, t1 * 21 + 4 + get_context(ctx) * 12, SEEK_SET);
+  vrewind(vf);
+  t1 = vfgetw(vf);
+  vfseek(vf, t1 * 21 + 4 + get_context(ctx) * 12, SEEK_SET);
 
   // At proper context info
-  where = fgetd(fp);    // Where file to load is
-  size = fgetd(fp);     // Size of file to load
-  offs = fgetd(fp);     // Offset within file of link
+  where = vfgetd(vf);    // Where file to load is
+  size = vfgetd(vf);     // Size of file to load
+  offs = vfgetd(vf);     // Offset within file of link
 
   // Jump to file
-  fseek(fp, where, SEEK_SET);
+  vfseek(vf, where, SEEK_SET);
   // Read it in
-  size = fread(help, 1, size, fp);
+  size = vfread(help, 1, size, vf);
   // Display it
   cursor_off();
 
@@ -99,23 +100,23 @@ labelled:
   if(file[0])
   {
     // Yep. Search for file.
-    fseek(fp, 2, SEEK_SET);
+    vfseek(vf, 2, SEEK_SET);
     for(t2 = 0; t2 < t1; t2++)
     {
-      if(!fread(file2, 13, 1, fp))
+      if(!vfread(file2, 13, 1, vf))
         return;
       if(!strcmp(file, file2))
         break;
-      fseek(fp, 8, SEEK_CUR);
+      vfseek(vf, 8, SEEK_CUR);
     }
 
     if(t2 < t1)
     {
       // Found file.
-      where = fgetd(fp);
-      size = fgetd(fp);
-      fseek(fp, where, SEEK_SET);
-      size = fread(help, 1, size, fp);
+      where = vfgetd(vf);
+      size = vfgetd(vf);
+      vfseek(vf, where, SEEK_SET);
+      size = vfread(help, 1, size, vf);
 
       // Search for label
       for(t2 = 0; t2 < size; t2++)

--- a/src/io/fsafeopen.c
+++ b/src/io/fsafeopen.c
@@ -411,7 +411,7 @@ static int match(char *path, size_t buffer_len)
         for(i = 0; i < 5; i++)
         {
           // check file
-          if(stat(path, &inode) == 0)
+          if(vstat(path, &inode) == 0)
             break;
 
           // try normal cases, then try brute force
@@ -449,7 +449,7 @@ static int match(char *path, size_t buffer_len)
       for(i = 0; i < 3; i++)
       {
         // check directory
-        if(stat(path, &inode) == 0)
+        if(vstat(path, &inode) == 0)
           break;
 
         // try normal cases, then try brute force
@@ -561,7 +561,7 @@ int fsafetranslate(const char *path, char *newpath, size_t buffer_len)
   if(ret == FSAFE_SUCCESS)
   {
     // see if file is already there
-    if(stat(newpath, &file_info) != 0)
+    if(vstat(newpath, &file_info) != 0)
     {
 #ifdef ENABLE_DOS_COMPAT_TRANSLATIONS
       // it isn't, so try harder..
@@ -569,7 +569,7 @@ int fsafetranslate(const char *path, char *newpath, size_t buffer_len)
       if(ret == FSAFE_SUCCESS)
       {
         // ..and update the stat information for the new path
-        if(stat(newpath, &file_info) != 0)
+        if(vstat(newpath, &file_info) != 0)
           ret = -FSAFE_MATCH_FAILED;
       }
       else
@@ -607,11 +607,11 @@ int fsafetranslate(const char *path, char *newpath, size_t buffer_len)
   return ret;
 }
 
-FILE *fsafeopen(const char *path, const char *mode)
+vfile *fsafeopen(const char *path, const char *mode)
 {
   char *newpath;
   int i, ret;
-  FILE *f;
+  vfile *f;
 
   newpath = cmalloc(MAX_PATH);
 
@@ -631,7 +631,9 @@ FILE *fsafeopen(const char *path, const char *mode)
       }
     }
   }
-  else if(ret < 0)
+  else
+
+  if(ret < 0)
   {
     // bad name, or security checks failed
     free(newpath);
@@ -639,7 +641,7 @@ FILE *fsafeopen(const char *path, const char *mode)
   }
 
   // _TRY_ opening the file
-  f = fopen_unsafe(newpath, mode);
+  f = vfopen_unsafe(newpath, mode);
   free(newpath);
   return f;
 }
@@ -653,6 +655,7 @@ FILE *fsafeopen(const char *path, const char *mode)
  * endings from the buffer, and should work at least until somebody invents
  * a new three byte string terminator ;-(
  */
+/*
 char *fsafegets(char *s, int size, FILE *stream)
 {
   char *ret = fgets(s, size, stream);
@@ -672,4 +675,4 @@ char *fsafegets(char *s, int size, FILE *stream)
 
   return ret;
 }
-
+*/

--- a/src/io/fsafeopen.h
+++ b/src/io/fsafeopen.h
@@ -22,9 +22,9 @@
 
 #include "../compat.h"
 
-#include <stdio.h>
-
 __M_BEGIN_DECLS
+
+#include "vfile.h"
 
 enum
 {
@@ -40,10 +40,8 @@ enum
   FSAFE_PARENT_DIRECTORY_ERROR
 };
 
-CORE_LIBSPEC char *fsafegets(char *s, int size, FILE *stream);
-
 int fsafetranslate(const char *path, char *newpath, size_t buffer_len);
-FILE *fsafeopen(const char *path, const char *mode);
+vfile *fsafeopen(const char *path, const char *mode);
 
 __M_END_DECLS
 

--- a/src/io/memfile.h
+++ b/src/io/memfile.h
@@ -97,7 +97,7 @@ static inline void mfsync(void **buf, size_t *len, struct memfile *mf)
  */
 static inline boolean mfhasspace(size_t len, struct memfile *mf)
 {
-  return mf->current && mf->current < mf->end ? (size_t)(mf->end - mf->current) >= len : false;
+  return mf->current && mf->current <= mf->end ? (size_t)(mf->end - mf->current) >= len : false;
 }
 
 /**

--- a/src/io/vio.c
+++ b/src/io/vio.c
@@ -53,6 +53,7 @@ enum vfileflags_private
   VF_WRITE              = (1<<5),
   VF_APPEND             = (1<<6),
   VF_BINARY             = (1<<7),
+  VF_TRUNCATE           = (1<<8),
 
   VF_STORAGE_MASK       = (VF_FILE | VF_MEMORY),
   VF_PUBLIC_MASK        = (V_SMALL_BUFFER | V_LARGE_BUFFER)
@@ -63,7 +64,7 @@ struct vfile
   FILE *fp;
 
   struct memfile mf;
-  // Local copy of pointer/size of expandable vfile buffer.
+  // Local copy of pointer/size of a memory vfile buffer (expandable or not).
   void *local_buffer;
   size_t local_buffer_size;
   // External copy of pointer/size of expandable vfile buffer.
@@ -91,7 +92,7 @@ static int get_vfile_mode_flags(const char *mode)
       break;
 
     case 'w':
-      flags |= VF_WRITE;
+      flags |= VF_WRITE | VF_TRUNCATE;
       break;
 
     case 'a':
@@ -204,15 +205,23 @@ vfile *vfile_init_mem(void *buffer, size_t size, const char *mode)
 {
   int flags = get_vfile_mode_flags(mode);
   vfile *vf = NULL;
+  size_t filesize = size;
 
   assert((buffer && size) || (!buffer && !size));
   assert(flags);
 
+  // "w"-based modes should start at size 0 and expand as-needed, either in
+  // their fixed buffer or with an extendable buffer (see vfile_init_mem_ext).
+  if(flags & VF_TRUNCATE)
+    filesize = 0;
+
   vf = (vfile *)ccalloc(1, sizeof(vfile));
-  mfopen(buffer, size, &(vf->mf));
+  mfopen(buffer, filesize, &(vf->mf));
   vf->mf.seek_past_end = true;
   vf->tmp_chr = EOF;
   vf->flags = flags | VF_MEMORY;
+  vf->local_buffer = buffer;
+  vf->local_buffer_size = size;
   return vf;
 }
 
@@ -229,8 +238,6 @@ vfile *vfile_init_mem_ext(void **external_buffer, size_t *external_buffer_size,
   assert(vf->flags & VF_WRITE);
 
   vf->flags |= VF_MEMORY_EXPANDABLE;
-  vf->local_buffer = *external_buffer;
-  vf->local_buffer_size = *external_buffer_size;
   vf->external_buffer = external_buffer;
   vf->external_buffer_size = external_buffer_size;
   return vf;
@@ -295,17 +302,6 @@ int vfclose(vfile *vf)
 
   free(vf);
   return retval;
-}
-
-/**
- * Get the underlying memfile of a memory vfile. This should pretty much
- * not be used, but some things in the zip code already relied on it.
- */
-struct memfile *vfile_get_memfile(vfile *vf)
-{
-  assert(vf);
-  assert(vf->flags & VF_MEMORY);
-  return &(vf->mf);
 }
 
 
@@ -401,7 +397,7 @@ int vstat(const char *path, struct stat *buf)
  * Ensure an amount of space exists in a memory vfile or expand the vfile
  * (if possible). This should be used for writing only.
  */
-static inline boolean vfile_ensure_space(int amount_to_write, vfile *vf)
+static inline boolean vfile_ensure_space(size_t amount_to_write, vfile *vf)
 {
   struct memfile *mf = &(vf->mf);
   size_t new_size;
@@ -414,15 +410,15 @@ static inline boolean vfile_ensure_space(int amount_to_write, vfile *vf)
 
   if(!mfhasspace(amount_to_write, mf))
   {
-    if(!(vf->flags & VF_MEMORY_EXPANDABLE))
-      return false;
-
     new_size = (mf->start ? (mf->current - mf->start) : 0) + amount_to_write;
     if(new_size > vf->local_buffer_size)
     {
       size_t new_size_alloc = 32;
       void *t;
       int i;
+
+      if(!(vf->flags & VF_MEMORY_EXPANDABLE))
+        return false;
 
       for(i = 0; i < 64 && new_size_alloc < new_size; i++)
         new_size_alloc <<= 1;
@@ -446,6 +442,29 @@ static inline boolean vfile_ensure_space(int amount_to_write, vfile *vf)
 
     return (mf->end - mf->start) >= (ptrdiff_t)new_size;
   }
+  return true;
+}
+
+/**
+ * Get a direct memory access memfile of a given length starting at the current
+ * position of a memory vfile. This should pretty much not be used, but some
+ * things in the zip code already relied on it. If dest is NULL, a size check
+ * (and potential expansion) will still be performed.
+ */
+boolean vfile_get_memfile_block(vfile *vf, size_t length, struct memfile *dest)
+{
+  assert(vf);
+  assert(vf->flags & VF_MEMORY);
+  if(vf->flags & VF_WRITE)
+  {
+    if(!vfile_ensure_space(length, vf))
+      return false;
+  }
+  if(!mfhasspace(length, &(vf->mf)))
+    return false;
+
+  if(dest)
+    mfopen(vf->mf.current, length, dest);
   return true;
 }
 
@@ -956,7 +975,8 @@ void vrewind(vfile *vf)
  * If rewind is false, this function is guaranteed to either not modify the
  * current file position or to restore it to its position prior to calling this.
  * This function is not guaranteed to work correctly on streams that have been
- * written to or on memory write streams with fixed buffers.
+ * written to or on memory write streams with fixed buffers, but is probably
+ * safe to use for these cases.
  */
 long vfilelength(vfile *vf, boolean rewind)
 {
@@ -974,6 +994,11 @@ long vfilelength(vfile *vf, boolean rewind)
   {
     struct stat st;
     int fd = fileno(vf->fp);
+
+    // fstat (and maybe _filelength) rely on the copy on-disk being up to date.
+    // The SEEK_END hack works without this, since fseek also flushes the file.
+    if(vf->flags & VF_WRITE)
+      fflush(vf->fp);
 
 #ifdef __WIN32__
     size = _filelength(fd);

--- a/src/io/vio.c
+++ b/src/io/vio.c
@@ -110,6 +110,10 @@ static int get_vfile_mode_flags(const char *mode)
         flags |= VF_BINARY;
         break;
 
+      // Explicitly "text" mode. Does nothing, but some libcs support it.
+      case 't':
+        break;
+
       case '+':
         flags |= (VF_READ | VF_WRITE);
         break;

--- a/src/io/vio.h
+++ b/src/io/vio.h
@@ -55,7 +55,7 @@ vfile *vfile_init_mem_ext(void **external_buffer, size_t *external_buffer_size,
 UTILS_LIBSPEC vfile *vtempfile(size_t initial_size);
 UTILS_LIBSPEC int vfclose(vfile *vf);
 
-struct memfile *vfile_get_memfile(vfile *vf);
+boolean vfile_get_memfile_block(vfile *vf, size_t length, struct memfile *dest);
 
 UTILS_LIBSPEC int vchdir(const char *path);
 UTILS_LIBSPEC char *vgetcwd(char *buf, size_t size);

--- a/src/io/zip.c
+++ b/src/io/zip.c
@@ -1235,8 +1235,12 @@ enum zip_error zip_read_open_mem_stream(struct zip_archive *zp,
   if(result)
     goto err_out;
 
-  mfopen(vfile_get_memfile(zp->vf)->current,
-   zp->streaming_file->compressed_size, mf);
+  if(!vfile_get_memfile_block(zp->vf, zp->streaming_file->compressed_size, mf))
+  {
+    result = ZIP_EOF;
+    goto err_out;
+  }
+
   return ZIP_SUCCESS;
 
 err_out:
@@ -1263,12 +1267,15 @@ enum zip_error zip_read_close_stream(struct zip_archive *zp)
   // mem streams need special cleanup but are mostly the same.
   if(zp && zp->mode == ZIP_S_READ_MEMSTREAM)
   {
-    struct memfile *mf = vfile_get_memfile(zp->vf);
+    struct memfile mf;
     uint32_t c_size = zp->streaming_file->compressed_size;
+
+    // If this doesn't work, something modified the zip archive structures.
+    assert(vfile_get_memfile_block(zp->vf, c_size, &mf));
 
     zp->read_stream_error = ZIP_SUCCESS;
     zp->stream_u_left = 0;
-    zp->stream_crc32 = crc32(0, mf->current, c_size);
+    zp->stream_crc32 = crc32(0, mf.current, c_size);
   }
 
   result = (zp ? zp->read_stream_error : ZIP_NULL);
@@ -1428,35 +1435,16 @@ err_out:
 /***********/
 
 /**
- * Check if there's enough room in a memory archive to write a number of bytes.
- * If there isn't and the buffer is expandable, expand it to fit the required
- * size. Otherwise, return ZIP_EOF.
+ * Check if there's enough room in a memory archive to write a number of bytes
+ * at the current position in the file. If there isn't, and if the buffer is
+ * expandable, vfile_get_memfile_block will ensure that the buffer is expanded
+ * to allow the requested size. Otherwise, this function will return ZIP_EOF.
  */
 static enum zip_error zip_ensure_capacity(size_t len, struct zip_archive *zp)
 {
-  struct memfile *mf = vfile_get_memfile(zp->vf);
-  void *external_buffer;
-  size_t external_buffer_size;
-  size_t size_required;
-
-  if(mfhasspace(len, mf))
-    return ZIP_SUCCESS;
-
-  if(!zp->external_buffer || !zp->external_buffer_size)
+  if(!vfile_get_memfile_block(zp->vf, len, NULL))
     return ZIP_EOF;
 
-  size_required = mftell(mf) + len;
-  external_buffer = *(zp->external_buffer);
-  external_buffer_size = *(zp->external_buffer_size);
-
-  while(external_buffer_size < size_required)
-    external_buffer_size *= 2;
-
-  external_buffer = crealloc(external_buffer, external_buffer_size);
-  *(zp->external_buffer) = external_buffer;
-  *(zp->external_buffer_size) = external_buffer_size;
-
-  mfmove(external_buffer, external_buffer_size, mf);
   return ZIP_SUCCESS;
 }
 
@@ -1804,25 +1792,25 @@ err_out:
 /**
  * Like zip_write_open_file_stream, but allows the direct writing of
  * uncompressed files to memory (deflate is not supported by this method).
- * This is abusable, but quicker than the alternatives.
+ * This is abusable, but quicker than the alternatives. The exact filesize
+ * of the file to be written must be provided to this function.
  *
  * ZIP_NOT_MEMORY_ARCHIVE will be silently returned if the current archive
  * doesn't support this; use regular functions instead in this case.
  */
 enum zip_error zip_write_open_mem_stream(struct zip_archive *zp,
- struct memfile *mf, const char *name)
+ struct memfile *mf, const char *name, size_t length)
 {
   enum zip_error result = zip_write_open_stream(zp, name, ZIP_M_NONE,
    ZIP_S_WRITE_MEMSTREAM);
-  struct memfile *zp_mf;
   if(result)
     goto err_out;
 
-  zp_mf = vfile_get_memfile(zp->vf);
-
-  mf->start = zp_mf->current;
-  mf->end = zp_mf->end;
-  mf->current = mf->start;
+  if(!vfile_get_memfile_block(zp->vf, length, mf))
+  {
+    result = ZIP_EOF;
+    goto err_out;
+  }
   return ZIP_SUCCESS;
 
 err_out:
@@ -2319,6 +2307,10 @@ enum zip_error zip_close(struct zip_archive *zp, size_t *final_length)
     if(final_length)
       *final_length = end_pos;
 
+    // Just to be sure, close the vfile before attempting any changes to the
+    // external buffer if this is an expandable memory ZIP.
+    vfclose(zp->vf);
+
     // Reduce the size of the buffer if this is an expandable memory zip.
     if(zp->is_memory && zp->external_buffer && zp->external_buffer_size &&
      *(zp->external_buffer_size) > end_pos)
@@ -2327,9 +2319,9 @@ enum zip_error zip_close(struct zip_archive *zp, size_t *final_length)
       *(zp->external_buffer_size) = end_pos;
     }
   }
-
   else
   {
+    vfclose(zp->vf);
     if(final_length)
       *final_length = zp->end_in_file;
   }
@@ -2337,8 +2329,6 @@ enum zip_error zip_close(struct zip_archive *zp, size_t *final_length)
   for(i = 0; i < ARRAY_SIZE(zp->stream_data_ptrs); i++)
     if(zip_method_handlers[i] && zp->stream_data_ptrs[i])
       zip_method_handlers[i]->destroy(zp->stream_data_ptrs[i]);
-
-  vfclose(zp->vf);
 
   free(zp->header_buffer);
   free(zp->stream_buffer);
@@ -2551,14 +2541,23 @@ struct zip_archive *zip_open_mem_write(void *src, size_t len, size_t start_pos)
 struct zip_archive *zip_open_mem_write_ext(void **external_buffer,
  size_t *external_buffer_size, size_t start_pos)
 {
-  struct zip_archive *zp =
-   zip_open_mem_write(*external_buffer, *external_buffer_size, start_pos);
-
-  if(zp)
+  if(external_buffer && external_buffer_size)
   {
+    struct zip_archive *zp = zip_new_archive();
+
+    // Allow expansion to be managed by vio.c. The external buffer pointers are
+    // stored here as well, so zip_close can shrink the buffer.
+    zp->vf = vfile_init_mem_ext(external_buffer, external_buffer_size, "wb");
     zp->external_buffer = external_buffer;
     zp->external_buffer_size = external_buffer_size;
-  }
+    zp->is_memory = true;
 
-  return zp;
+    zip_init_for_write(zp, ZIP_DEFAULT_NUM_FILES);
+    vfseek(zp->vf, start_pos, SEEK_SET);
+
+    precalculate_read_errors(zp);
+    precalculate_write_errors(zp);
+    return zp;
+  }
+  return NULL;
 }

--- a/src/io/zip.c
+++ b/src/io/zip.c
@@ -1271,7 +1271,8 @@ enum zip_error zip_read_close_stream(struct zip_archive *zp)
     uint32_t c_size = zp->streaming_file->compressed_size;
 
     // If this doesn't work, something modified the zip archive structures.
-    assert(vfile_get_memfile_block(zp->vf, c_size, &mf));
+    if(!vfile_get_memfile_block(zp->vf, c_size, &mf))
+      assert(0);
 
     zp->read_stream_error = ZIP_SUCCESS;
     zp->stream_u_left = 0;

--- a/src/io/zip.h
+++ b/src/io/zip.h
@@ -276,7 +276,7 @@ UTILS_LIBSPEC enum zip_error zip_write_open_file_stream(struct zip_archive *zp,
 UTILS_LIBSPEC enum zip_error zip_write_close_stream(struct zip_archive *zp);
 
 UTILS_LIBSPEC enum zip_error zip_write_open_mem_stream(struct zip_archive *zp,
- struct memfile *mf, const char *name);
+ struct memfile *mf, const char *name, size_t length);
 
 UTILS_LIBSPEC enum zip_error zip_write_close_mem_stream(struct zip_archive *zp,
  struct memfile *mf);

--- a/src/legacy_rasm.c
+++ b/src/legacy_rasm.c
@@ -29,6 +29,7 @@
 #include "util.h"
 #include "io/fsafeopen.h"
 #include "io/memfile.h"
+#include "io/vio.h"
 
 #define IMM_U16            (1 << 0)
 #define IMM_S16            (1 << 0)
@@ -2030,7 +2031,7 @@ err_buffer:
 
 char *assemble_file(char *name, int *size)
 {
-  FILE *input_file = fsafeopen(name, "rb");
+  vfile *input_file = fsafeopen(name, "rb");
   char line_buffer[256];
   char bytecode_buffer[256];
   char error_buffer[256];
@@ -2047,7 +2048,7 @@ char *assemble_file(char *name, int *size)
   buffer[0] = 0xFF;
 
   // fsafegets ensures no line terminators are present
-  while(fsafegets(line_buffer, 255, input_file))
+  while(vfsafegets(line_buffer, 255, input_file))
   {
     line_bytecode_length =
      legacy_assemble_line(line_buffer, bytecode_buffer, error_buffer, NULL, NULL);
@@ -2078,7 +2079,7 @@ char *assemble_file(char *name, int *size)
   *size = current_size + 1;
 
 exit_out:
-  fclose(input_file);
+  vfclose(input_file);
   return buffer;
 }
 
@@ -2592,7 +2593,7 @@ __editor_maybe_static int disassemble_line(char *cpos, char **next,
 void disassemble_file(char *name, char *program, int program_length,
  int allow_ignores, int base)
 {
-  FILE *output_file = fsafeopen(name, "wb");
+  vfile *output_file = fsafeopen(name, "wb");
   char command_buffer[256];
   char error_buffer[256];
   char *current_robot_pos = program + 1;
@@ -2611,14 +2612,14 @@ void disassemble_file(char *name, char *program, int program_length,
 
     if(new_line)
     {
-      fwrite(command_buffer, line_text_length, 1, output_file);
-      fputc('\n', output_file);
+      vfwrite(command_buffer, line_text_length, 1, output_file);
+      vfputc('\n', output_file);
     }
 
     current_robot_pos = next;
   } while(new_line);
 
-  fclose(output_file);
+  vfclose(output_file);
 }
 
 static inline int get_program_line_count(char *program, int program_length)

--- a/src/network/HTTPHost.cpp
+++ b/src/network/HTTPHost.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <assert.h>
+#include <ctype.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/rasm.c
+++ b/src/rasm.c
@@ -28,6 +28,7 @@
 #include "counter.h"
 #include "io/fsafeopen.h"
 #include "io/memfile.h"
+#include "io/vio.h"
 
 #ifdef CONFIG_DEBYTECODE
 
@@ -5860,7 +5861,7 @@ char *legacy_disassemble_program(char *program_bytecode, int bytecode_length,
 char *legacy_convert_file(char *file_name, int *_disasm_length,
  boolean print_ignores, int base)
 {
-  FILE *legacy_source_file = fsafeopen(file_name, "rt");
+  vfile *legacy_source_file = fsafeopen(file_name, "rt");
 
   if(legacy_source_file)
   {
@@ -5876,7 +5877,7 @@ char *legacy_convert_file(char *file_name, int *_disasm_length,
 
     int disasm_line_length;
 
-    while(fsafegets(source_buffer, 256, legacy_source_file))
+    while(vfsafegets(source_buffer, 256, legacy_source_file))
     {
       // Assemble line
       legacy_assemble_line(source_buffer, bytecode_buffer, errors,
@@ -5913,7 +5914,7 @@ char *legacy_convert_file(char *file_name, int *_disasm_length,
     program_disasm[disasm_offset] = 0;
     *_disasm_length = disasm_length;
 
-    fclose(legacy_source_file);
+    vfclose(legacy_source_file);
     return program_disasm;
   }
 

--- a/src/robot.c
+++ b/src/robot.c
@@ -728,17 +728,16 @@ void save_robot(struct world *mzx_world, struct robot *cur_robot,
       prepare_robot_bytecode(mzx_world, cur_robot);
 #endif
 
-    // The regular way works with memory zips too, but this is faster.
+    actual_size = save_robot_calculate_size(mzx_world, cur_robot, savegame,
+     file_version);
 
     if(zp->is_memory)
     {
-      zip_write_open_mem_stream(zp, &mf, name);
+      // The regular way works with memory zips too, but this is faster.
+      zip_write_open_mem_stream(zp, &mf, name, actual_size);
     }
-
     else
     {
-      actual_size = save_robot_calculate_size(mzx_world, cur_robot, savegame,
-       file_version);
       buffer = cmalloc(actual_size);
 
       mfopen(buffer, actual_size, &mf);
@@ -750,7 +749,6 @@ void save_robot(struct world *mzx_world, struct robot *cur_robot,
     {
       zip_write_close_mem_stream(zp, &mf);
     }
-
     else
     {
       zip_write_file(zp, name, buffer, actual_size, ZIP_M_NONE);

--- a/src/str.c
+++ b/src/str.c
@@ -887,7 +887,7 @@ int set_string(struct world *mzx_world, char *name, struct string *src,
   if(special_name_partial("fread") &&
    !mzx_world->input_is_dir && mzx_world->input_file)
   {
-    FILE *input_file = mzx_world->input_file;
+    vfile *input_file = mzx_world->input_file;
 
     if(src_length > 5)
     {
@@ -898,14 +898,8 @@ int set_string(struct world *mzx_world, char *name, struct string *src,
       // You know what would be great, is not trying to allocate 4GB of memory
       read_count = MIN(read_count, MAX_STRING_LEN);
 
-      /* This is hacky, but we don't want to prematurely allocate more space
-       * to the string than can possibly be read from the file. So we save the
-       * old file pointer, figure out the length of the current input file,
-       * and put it back where we found it.
-       */
-      current_pos = ftell(input_file);
-      file_size = ftell_and_rewind(input_file);
-      fseek(input_file, current_pos, SEEK_SET);
+      file_size = vfilelength(input_file, false);
+      current_pos = vftell(input_file);
 
       /* We then truncate the user read to the maximum difference between the
        * current position and the file end; this won't affect normal reads,
@@ -918,7 +912,7 @@ int set_string(struct world *mzx_world, char *name, struct string *src,
        read_count, offset, offset_specified, &size, size_specified))
         return 0;
 
-      actual_read = fread(dest->value + offset, 1, read_count, input_file);
+      actual_read = vfread(dest->value + offset, 1, read_count, input_file);
       if(offset == 0 && !offset_specified)
         dest->length = actual_read;
     }
@@ -943,7 +937,7 @@ int set_string(struct world *mzx_world, char *name, struct string *src,
         for(read_allocate = 0; read_allocate < new_allocated;
          read_allocate++, read_pos++)
         {
-          current_char = fgetc(input_file);
+          current_char = vfgetc(input_file);
 
           if((current_char == terminate_char) || (current_char == EOF) ||
            (read_pos + offset == MAX_STRING_LEN))
@@ -1076,7 +1070,7 @@ int set_string(struct world *mzx_world, char *name, struct string *src,
      */
     if(dest != NULL && dest->length > 0)
     {
-      FILE *output_file = mzx_world->output_file;
+      vfile *output_file = mzx_world->output_file;
       char *dest_value = dest->value;
       size_t dest_length = dest->length;
 
@@ -1092,7 +1086,7 @@ int set_string(struct world *mzx_world, char *name, struct string *src,
       if(offset + size > dest_length)
         size = dest_length - offset;
 
-      fwrite(dest_value + offset, size, 1, output_file);
+      vfwrite(dest_value + offset, size, 1, output_file);
     }
     else
     {
@@ -1106,7 +1100,7 @@ int set_string(struct world *mzx_world, char *name, struct string *src,
     }
 
     if(write_delimiter)
-      fputc(mzx_world->fwrite_delimiter, mzx_world->output_file);
+      vfputc(mzx_world->fwrite_delimiter, mzx_world->output_file);
   }
   else
 

--- a/src/util.c
+++ b/src/util.c
@@ -474,59 +474,6 @@ void redirect_stdio_exit(void)
 
 #endif /* CONFIG_STDIO_REDIRECT */
 
-// Get 2 bytes, little endian
-
-int fgetw(FILE *fp)
-{
-  int a = fgetc(fp), b = fgetc(fp);
-  if((a == EOF) || (b == EOF))
-    return EOF;
-
-  return (b << 8) | a;
-}
-
-// Get 4 bytes, little endian
-
-int fgetd(FILE *fp)
-{
-  int a = fgetc(fp), b = fgetc(fp), c = fgetc(fp), d = fgetc(fp);
-  if((a == EOF) || (b == EOF) || (c == EOF) || (d == EOF))
-    return EOF;
-
-  return ((unsigned int)d << 24) | (c << 16) | (b << 8) | a;
-}
-
-// Put 2 bytes, little endian
-
-void fputw(int src, FILE *fp)
-{
-  fputc(src & 0xFF, fp);
-  fputc(src >> 8, fp);
-}
-
-// Put 4 bytes, little endian
-
-void fputd(int src, FILE *fp)
-{
-  fputc(src & 0xFF, fp);
-  fputc((src >> 8) & 0xFF, fp);
-  fputc((src >> 16) & 0xFF, fp);
-  fputc((src >> 24) & 0xFF, fp);
-}
-
-// Determine file size of an open FILE and rewind it
-
-long ftell_and_rewind(FILE *f)
-{
-  long size;
-
-  fseek(f, 0, SEEK_END);
-  size = ftell(f);
-  rewind(f);
-
-  return size;
-}
-
 // Random function, returns an integer [0-range)
 
 static uint64_t rng_state;

--- a/src/util.h
+++ b/src/util.h
@@ -102,14 +102,6 @@ CORE_LIBSPEC boolean redirect_stdio_init(const char *base_path, boolean require_
 CORE_LIBSPEC void redirect_stdio_exit(void);
 #endif
 
-// Code to load multi-byte ints from little endian file
-int fgetw(FILE *fp);
-CORE_LIBSPEC int fgetd(FILE *fp);
-void fputw(int src, FILE *fp);
-void fputd(int src, FILE *fp);
-
-CORE_LIBSPEC long ftell_and_rewind(FILE *f);
-
 CORE_LIBSPEC void rng_seed_init(void);
 uint64_t rng_get_seed(void);
 void rng_set_seed(uint64_t seed);

--- a/src/world.c
+++ b/src/world.c
@@ -2288,7 +2288,7 @@ int save_world(struct world *mzx_world, const char *file, boolean savegame,
   // Prepare input pos
   if(!mzx_world->input_is_dir && mzx_world->input_file)
   {
-    mzx_world->temp_input_pos = ftell(mzx_world->input_file);
+    mzx_world->temp_input_pos = vftell(mzx_world->input_file);
   }
   else
 
@@ -2304,7 +2304,7 @@ int save_world(struct world *mzx_world, const char *file, boolean savegame,
   // Prepare output pos
   if(mzx_world->output_file)
   {
-    mzx_world->temp_output_pos = ftell(mzx_world->output_file);
+    mzx_world->temp_output_pos = vftell(mzx_world->output_file);
   }
   else
   {
@@ -2649,9 +2649,9 @@ static void load_world(struct world *mzx_world, struct zip_archive *zp,
     }
     else if(err == -FSAFE_SUCCESS)
     {
-      mzx_world->input_file = fopen_unsafe(translated_path, "rb");
+      mzx_world->input_file = vfopen_unsafe(translated_path, "rb");
       if(mzx_world->input_file)
-        fseek(mzx_world->input_file, mzx_world->temp_input_pos, SEEK_SET);
+        vfseek(mzx_world->input_file, mzx_world->temp_input_pos, SEEK_SET);
     }
   }
 
@@ -2663,7 +2663,7 @@ static void load_world(struct world *mzx_world, struct zip_archive *zp,
 
     if(mzx_world->output_file)
     {
-      fseek(mzx_world->output_file, mzx_world->temp_output_pos, SEEK_SET);
+      vfseek(mzx_world->output_file, mzx_world->temp_output_pos, SEEK_SET);
     }
   }
 
@@ -3238,7 +3238,7 @@ void clear_world(struct world *mzx_world)
 
   if(!mzx_world->input_is_dir && mzx_world->input_file)
   {
-    fclose(mzx_world->input_file);
+    vfclose(mzx_world->input_file);
     mzx_world->input_file = NULL;
   }
   else
@@ -3252,7 +3252,7 @@ void clear_world(struct world *mzx_world)
 
   if(mzx_world->output_file)
   {
-    fclose(mzx_world->output_file);
+    vfclose(mzx_world->output_file);
     mzx_world->output_file = NULL;
   }
 

--- a/src/world_struct.h
+++ b/src/world_struct.h
@@ -120,11 +120,11 @@ struct world
   int bi_shoot_status;
   int bi_mesg_status;
   char output_file_name[MAX_PATH];
-  FILE *output_file;
   char input_file_name[MAX_PATH];
-  FILE *input_file;
-  boolean input_is_dir;
+  vfile *output_file;
+  vfile *input_file;
   vdir *input_directory;
+  boolean input_is_dir;
   int temp_input_pos;
   int temp_output_pos;
   int commands;
@@ -228,7 +228,7 @@ struct world
   int raw_world_info_size;
 
   // Keep this open, just once
-  FILE *help_file;
+  vfile *help_file;
 
   // An array for game2.cpp
   char *update_done;

--- a/unit/io/memfile.cpp
+++ b/unit/io/memfile.cpp
@@ -99,6 +99,7 @@ struct buffer_data
 {
   char *buffer;
   size_t buffer_len;
+  boolean has0;
   boolean has8;
   boolean has16;
   boolean has32;
@@ -116,12 +117,12 @@ UNITTEST(mfhasspace)
   char buffere[256];
   struct buffer_data pairs[] =
   {
-    { buffer8, arraysize(buffer8), true, false, false, false, false },
-    { buffera, arraysize(buffera), true, true,  false, false, false },
-    { bufferb, arraysize(bufferb), true, true,  true,  false, false },
-    { bufferc, arraysize(bufferc), true, true,  true,  true,  false },
-    { bufferd, arraysize(bufferd), true, true,  true,  true,  true  },
-    { buffere, arraysize(buffere), true, true,  true,  true,  true  },
+    { buffer8, arraysize(buffer8), true, true, false, false, false, false },
+    { buffera, arraysize(buffera), true, true, true,  false, false, false },
+    { bufferb, arraysize(bufferb), true, true, true,  true,  false, false },
+    { bufferc, arraysize(bufferc), true, true, true,  true,  true,  false },
+    { bufferd, arraysize(bufferd), true, true, true,  true,  true,  true  },
+    { buffere, arraysize(buffere), true, true, true,  true,  true,  true  },
   };
   struct memfile mf;
   int i;
@@ -129,6 +130,7 @@ UNITTEST(mfhasspace)
   for(i = 0; i < arraysize(pairs); i++)
   {
     mfopen(pairs[i].buffer, pairs[i].buffer_len, &mf);
+    ASSERTEQ(pairs[i].has0,   mfhasspace(0, &mf), "%d", i);
     ASSERTEQ(pairs[i].has8,   mfhasspace(8, &mf), "%d", i);
     ASSERTEQ(pairs[i].has16,  mfhasspace(16, &mf), "%d", i);
     ASSERTEQ(pairs[i].has32,  mfhasspace(32, &mf), "%d", i);
@@ -140,7 +142,13 @@ UNITTEST(mfhasspace)
     ASSERTEQ(pairs[i].has32,  mfhasspace(16, &mf), "%d", i);
     ASSERTEQ(pairs[i].has64,  mfhasspace(32, &mf), "%d", i);
     ASSERTEQ(pairs[i].has128, mfhasspace(64, &mf), "%d", i);
+
+    mf.current = mf.end;
+    ASSERTEQ(pairs[i].has0,   mfhasspace(0, &mf), "%d", i);
   }
+
+  struct memfile tmp{};
+  ASSERTEQ(mfhasspace(0, &tmp), false, "NULL memfile->current should return false");
 }
 
 UNITTEST(mfmove)

--- a/unit/io/vio.cpp
+++ b/unit/io/vio.cpp
@@ -632,6 +632,63 @@ UNITTEST(Init)
   }
 }
 
+UNITTEST(ModeFlags)
+{
+  struct mode_flag_pairs
+  {
+    const char *mode;
+    int expected;
+  };
+
+  static const mode_flag_pairs data[] =
+  {
+    { "r", VF_READ },
+    { "w", VF_WRITE | VF_TRUNCATE },
+    { "a", VF_WRITE | VF_APPEND },
+    { "r+", VF_READ | VF_WRITE },
+    { "w+", VF_READ | VF_WRITE | VF_TRUNCATE },
+    { "a+", VF_READ | VF_WRITE | VF_APPEND },
+    { "rb", VF_READ | VF_BINARY },
+    { "wb", VF_WRITE | VF_TRUNCATE | VF_BINARY },
+    { "ab", VF_WRITE | VF_APPEND | VF_BINARY },
+    // Both orderings of '+' and 'b' are valid.
+    { "r+b", VF_READ | VF_WRITE | VF_BINARY },
+    { "w+b", VF_READ | VF_WRITE | VF_TRUNCATE | VF_BINARY },
+    { "a+b", VF_READ | VF_WRITE | VF_APPEND | VF_BINARY },
+    { "rb+", VF_READ | VF_WRITE | VF_BINARY },
+    { "wb+", VF_READ | VF_WRITE | VF_TRUNCATE | VF_BINARY },
+    { "ab+", VF_READ | VF_WRITE | VF_APPEND | VF_BINARY },
+    // 't' to explicitly state text mode is non-standard but seems to be well-supported.
+    { "rt", VF_READ },
+    { "wt", VF_WRITE | VF_TRUNCATE },
+    { "at", VF_WRITE | VF_APPEND },
+    { "r+t", VF_READ | VF_WRITE },
+    { "w+t", VF_READ | VF_WRITE | VF_TRUNCATE },
+    { "a+t", VF_READ | VF_WRITE | VF_APPEND },
+    // 'r'/'w'/'a' must be first.
+    { "br", 0 },
+    { "bw", 0 },
+    { "ba", 0 },
+    { "+r", 0 },
+    { "+w", 0 },
+    { "+a", 0 },
+    { "tr", 0 },
+    // Other invalid junk.
+    { "+", 0 },
+    { "b", 0 },
+    { "t", 0 },
+    { "    ", 0 },
+    { "fjdskfdj", 0 },
+    { "", 0 },
+  };
+
+  for(const mode_flag_pairs &d : data)
+  {
+    int res = get_vfile_mode_flags(d.mode);
+    ASSERTEQ(res, d.expected, "%s", d.mode);
+  }
+}
+
 UNITTEST(FileRead)
 {
   ScopedFile<vfile, vfclose> vf_in =

--- a/unit/io/zip.cpp
+++ b/unit/io/zip.cpp
@@ -1095,7 +1095,7 @@ UNITTEST(ZipWrite)
         const char *contents = ZIP_GET_CONTENTS(df);
         struct memfile mf;
 
-        result = zip_write_open_mem_stream(zp, &mf, df.filename);
+        result = zip_write_open_mem_stream(zp, &mf, df.filename, df.uncompressed_size);
         ASSERTEQ(result, ZIP_SUCCESS, "%s %s %zu", label, d.testname, j);
         int res = mfwrite(contents, df.uncompressed_size, 1, &mf);
         int expected = df.uncompressed_size != 0;


### PR DESCRIPTION
This cleans up the remaining few features that were using stdio directly rather than vio.c, mostly related to gameplay features in counter.c and str.c. This required fixing `vfilelength` for write mode and making memory ZIPs use vio.c expansion instead of their old direct expansion.

- [x] Still need a vio.c mode string unit test.
- [x] More testing.