### PR TITLE
Test worlds: replace ln -s with cp to support QEMU vfat drives.

### DIFF
--- a/testworlds/run.sh
+++ b/testworlds/run.sh
@@ -36,7 +36,7 @@ cd "$TESTS_DIR"
 cd ..
 
 # Unix release builds will try to find this if it isn't installed.
-ln -s config.txt megazeux-config
+cp config.txt megazeux-config
 
 # Give tests.mzx the MZX configuration so it can decide which tests to skip.
 cp src/config.h "$TESTS_DIR"


### PR DESCRIPTION
Fixes an issue creating `megazeux-config` when trying to run `make test` from a MegaZeux repository that exists in a QEMU vfat filesystem. The main use case for this is building MegaZeux in VMs with old Linux distributions that have non-functional Git and/or TLS.