### PR TITLE
Remove C++ STL includes and most function definitions from Unit.hpp.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,8 +172,8 @@ endif
 #
 
 ifneq (${X11DIR},)
-X11_CFLAGS  ?= -I${X11DIR}/../include
-X11_LDFLAGS ?= -L${X11DIR}/../lib -lX11
+X11_CFLAGS  ?= -I${X11DIR}/include
+X11_LDFLAGS ?= -L${X11DIR}/lib -Wl,-rpath,${X11DIR}/lib -lX11
 # Make these immediate
 X11_CFLAGS := $(X11_CFLAGS)
 X11_LDFLAGS := $(X11_LDFLAGS)

--- a/config.sh
+++ b/config.sh
@@ -1229,7 +1229,7 @@ if [ "$X11" = "true" ]; then
 
 	# figure out where X11 is prefixed
 	X11PATH=`which $XBIN`
-	X11DIR=`dirname $X11PATH`
+	X11DIR=$(dirname $(dirname $X11PATH))
 
 	# pass this along to the build system
 	echo "X11DIR=${X11DIR}" >> platform.inc

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -234,12 +234,6 @@ core_cobjs += ${core_obj}/render_egl.o
 core_ldflags := -lEGL ${core_ldflags}
 endif
 
-# X11 (headers included by SDL_syswm.h).
-ifneq (${X11DIR},)
-core_flags += ${X11_CFLAGS}
-core_ldflags := ${X11_LDFLAGS} ${core_ldflags}
-endif
-
 # Overlay renderers
 ifeq (${BUILD_RENDER_YUV},1)
 core_cobjs += ${core_obj}/render_yuv.o
@@ -345,14 +339,9 @@ endif
 core_flags   += $(SDL_CFLAGS)
 core_ldflags += $(SDL_LDFLAGS)
 
-# The MegaZeux and MZXRun targets don't use SDL directly in modular builds.
-# In some cases SDL needs to rename main() to SDL_main() and provide its own
-# main(), so add SDL_LDFLAGS only if it links "SDLmain" or "SDL2main".
 ifeq (${BUILD_MODULAR},1)
-ifneq ($(filter %SDLmain %SDL2main,$(SDL_LDFLAGS)),)
 mzx_ldflags    += $(SDL_LDFLAGS)
 mzxrun_ldflags += $(SDL_LDFLAGS)
-endif
 endif
 
 else
@@ -372,6 +361,12 @@ endif
 
 endif
 
+endif
+
+# X11 (headers included by SDL_syswm.h).
+ifneq (${X11DIR},)
+core_flags += ${X11_CFLAGS}
+core_ldflags += ${X11_LDFLAGS}
 endif
 
 core_cflags := ${ZLIB_CFLAGS} ${core_cflags}

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -232,10 +232,12 @@ endif
 ifeq (${BUILD_EGL},1)
 core_cobjs += ${core_obj}/render_egl.o
 core_ldflags := -lEGL ${core_ldflags}
+endif
+
+# X11 (headers included by SDL_syswm.h).
 ifneq (${X11DIR},)
 core_flags += ${X11_CFLAGS}
 core_ldflags := ${X11_LDFLAGS} ${core_ldflags}
-endif
 endif
 
 # Overlay renderers

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -345,9 +345,14 @@ endif
 core_flags   += $(SDL_CFLAGS)
 core_ldflags += $(SDL_LDFLAGS)
 
+# The MegaZeux and MZXRun targets don't use SDL directly in modular builds.
+# In some cases SDL needs to rename main() to SDL_main() and provide its own
+# main(), so add SDL_LDFLAGS only if it links "SDLmain" or "SDL2main".
 ifeq (${BUILD_MODULAR},1)
+ifneq ($(filter %SDLmain %SDL2main,$(SDL_LDFLAGS)),)
 mzx_ldflags    += $(SDL_LDFLAGS)
 mzxrun_ldflags += $(SDL_LDFLAGS)
+endif
 endif
 
 else

--- a/src/main.c
+++ b/src/main.c
@@ -55,7 +55,7 @@
 #include "network/network.h"
 
 #ifdef CONFIG_SDL
-#include <SDL.h>
+#include <SDL.h> /* SDL_main */
 #endif
 
 #ifndef VERSION

--- a/src/network/Scoped.hpp
+++ b/src/network/Scoped.hpp
@@ -181,7 +181,25 @@ public:
     }
   }
 
+#if IS_CXX_11
+  ScopedPtr &operator=(T *&&p)
+  {
+    reset(p);
+    return *this;
+  }
+#endif
+
   operator T *() const
+  {
+    return ptr;
+  }
+
+  T *operator->() const
+  {
+    return ptr;
+  }
+
+  T *get() const
   {
     return ptr;
   }
@@ -224,7 +242,25 @@ public:
     }
   }
 
+#if IS_CXX_11
+  ScopedPtr &operator=(T *&&p)
+  {
+    reset(p);
+    return *this;
+  }
+#endif
+
   operator T *() const
+  {
+    return ptr;
+  }
+
+  T *operator->() const
+  {
+    return ptr;
+  }
+
+  T *get() const
   {
     return ptr;
   }

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -23,6 +23,9 @@ else
 unit_ext        := .test
 endif
 
+unit_common_objs := \
+  ${unit_obj}/Unit.o                   \
+
 unit_objs := \
   ${unit_obj}/align${unit_ext}         \
   ${unit_obj}/expr${unit_ext}          \
@@ -91,6 +94,7 @@ DEBUG_CFLAGS ?= -O0
 #
 unit_cflags ?= ${CXXFLAGS} ${DEBUG_CFLAGS} -UDEBUG -UNDEBUG
 unit_cflags += -fexceptions -funsigned-char -std=gnu++11
+unit_cflags += -Wno-system-headers -Wno-undef -Wno-unused-macros
 
 unit_cflags += ${SDL_CFLAGS} -Umain
 unit_ldflags +=
@@ -110,33 +114,40 @@ unit_clean:
 
 else
 
+${unit_obj}/%.o: ${unit_src}/%.cpp
+	$(if ${V},,@echo "  CXX     " $<)
+	${CXX} -MD ${unit_cflags} -c $< -o $@
+
 ${unit_obj}/%${unit_ext}: ${unit_src}/%.cpp
 	$(if ${V},,@echo "  CXX     " $<)
-	${CXX} -MD ${unit_cflags} $< -o $@ ${unit_ldflags}
+	${CXX} -MD ${unit_cflags} $^ -o $@ ${unit_ldflags}
 
 ${unit_obj_editor}/%${unit_ext}: ${unit_src_editor}/%.cpp
 	$(if ${V},,@echo "  CXX     " $<)
-	${CXX} -MD ${unit_cflags} $< -o $@ ${unit_ldflags}
+	${CXX} -MD ${unit_cflags} $^ -o $@ ${unit_ldflags}
 
 ${unit_obj_io}/%${unit_ext}: ${unit_src_io}/%.cpp
 	$(if ${V},,@echo "  CXX     " $<)
-	${CXX} -MD ${unit_cflags} $< -o $@ ${unit_ldflags}
+	${CXX} -MD ${unit_cflags} $^ -o $@ ${unit_ldflags}
 
 ${unit_obj_network}/%${unit_ext}: ${unit_src_network}/%.cpp
 	$(if ${V},,@echo "  CXX     " $<)
-	${CXX} -MD ${unit_cflags} $< -o $@ ${unit_ldflags}
+	${CXX} -MD ${unit_cflags} $^ -o $@ ${unit_ldflags}
 
 ${unit_obj_utils}/%${unit_ext}: ${unit_src_utils}/%.cpp
 	$(if ${V},,@echo "  CXX     " $<)
-	${CXX} -MD ${unit_cflags} $< -o $@ ${unit_ldflags}
+	${CXX} -MD ${unit_cflags} $^ -o $@ ${unit_ldflags}
 
 -include ${unit_objs:${unit_ext}=.d}
+-include ${unit_common_objs:.o=.d}
 
-${unit_objs}: | $(filter-out $(wildcard ${unit_obj}), ${unit_obj})
-${unit_objs}: | $(filter-out $(wildcard ${unit_obj_editor}), ${unit_obj_editor})
-${unit_objs}: | $(filter-out $(wildcard ${unit_obj_io}), ${unit_obj_io})
-${unit_objs}: | $(filter-out $(wildcard ${unit_obj_network}), ${unit_obj_network})
-${unit_objs}: | $(filter-out $(wildcard ${unit_obj_utils}), ${unit_obj_utils})
+${unit_objs}: ${unit_common_objs}
+
+${unit_objs} ${unit_common_objs}: | $(filter-out $(wildcard ${unit_obj}), ${unit_obj})
+${unit_objs} ${unit_common_objs}: | $(filter-out $(wildcard ${unit_obj_editor}), ${unit_obj_editor})
+${unit_objs} ${unit_common_objs}: | $(filter-out $(wildcard ${unit_obj_io}), ${unit_obj_io})
+${unit_objs} ${unit_common_objs}: | $(filter-out $(wildcard ${unit_obj_network}), ${unit_obj_network})
+${unit_objs} ${unit_common_objs}: | $(filter-out $(wildcard ${unit_obj_utils}), ${unit_obj_utils})
 
 unittest: ${unit_objs}
 	@failcount=0; \
@@ -152,7 +163,7 @@ unittest: ${unit_objs}
 	fi;
 
 unit_clean:
-	$(if ${V},,@echo "  RM      " ${unit_obj} ${unit_obj_editor} ${unit_obj_io} ${unit_obj_network})
-	${RM} -r ${unit_obj} ${unit_obj_editor} ${unit_obj_io} ${unit_obj_network}
+	$(if ${V},,@echo "  RM      " ${unit_obj} ${unit_obj_editor} ${unit_obj_io} ${unit_obj_network} ${unit_obj_utils})
+	${RM} -r ${unit_obj} ${unit_obj_editor} ${unit_obj_io} ${unit_obj_network} ${unit_obj_utils}
 
 endif

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -94,7 +94,6 @@ DEBUG_CFLAGS ?= -O0
 #
 unit_cflags ?= ${CXXFLAGS} ${DEBUG_CFLAGS} -UDEBUG -UNDEBUG
 unit_cflags += -fexceptions -funsigned-char -std=gnu++11
-unit_cflags += -Wno-system-headers -Wno-undef -Wno-unused-macros
 
 unit_cflags += ${SDL_CFLAGS} -Umain
 unit_ldflags +=

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -113,34 +113,34 @@ unit_clean:
 
 else
 
+${unit_objs}: ${unit_common_objs}
+
 ${unit_obj}/%.o: ${unit_src}/%.cpp
 	$(if ${V},,@echo "  CXX     " $<)
 	${CXX} -MD ${unit_cflags} -c $< -o $@
 
 ${unit_obj}/%${unit_ext}: ${unit_src}/%.cpp
 	$(if ${V},,@echo "  CXX     " $<)
-	${CXX} -MD ${unit_cflags} $^ -o $@ ${unit_ldflags}
+	${CXX} -MD ${unit_cflags} $< -o $@ ${unit_common_objs} ${unit_ldflags}
 
 ${unit_obj_editor}/%${unit_ext}: ${unit_src_editor}/%.cpp
 	$(if ${V},,@echo "  CXX     " $<)
-	${CXX} -MD ${unit_cflags} $^ -o $@ ${unit_ldflags}
+	${CXX} -MD ${unit_cflags} $< -o $@ ${unit_common_objs} ${unit_ldflags}
 
 ${unit_obj_io}/%${unit_ext}: ${unit_src_io}/%.cpp
 	$(if ${V},,@echo "  CXX     " $<)
-	${CXX} -MD ${unit_cflags} $^ -o $@ ${unit_ldflags}
+	${CXX} -MD ${unit_cflags} $< -o $@ ${unit_common_objs} ${unit_ldflags}
 
 ${unit_obj_network}/%${unit_ext}: ${unit_src_network}/%.cpp
 	$(if ${V},,@echo "  CXX     " $<)
-	${CXX} -MD ${unit_cflags} $^ -o $@ ${unit_ldflags}
+	${CXX} -MD ${unit_cflags} $< -o $@ ${unit_common_objs} ${unit_ldflags}
 
 ${unit_obj_utils}/%${unit_ext}: ${unit_src_utils}/%.cpp
 	$(if ${V},,@echo "  CXX     " $<)
-	${CXX} -MD ${unit_cflags} $^ -o $@ ${unit_ldflags}
+	${CXX} -MD ${unit_cflags} $< -o $@ ${unit_common_objs} ${unit_ldflags}
 
 -include ${unit_objs:${unit_ext}=.d}
 -include ${unit_common_objs:.o=.d}
-
-${unit_objs}: ${unit_common_objs}
 
 ${unit_objs} ${unit_common_objs}: | $(filter-out $(wildcard ${unit_obj}), ${unit_obj})
 ${unit_objs} ${unit_common_objs}: | $(filter-out $(wildcard ${unit_obj_editor}), ${unit_obj_editor})

--- a/unit/Unit.cpp
+++ b/unit/Unit.cpp
@@ -464,12 +464,14 @@ namespace Unit
    */
 
   static std::vector<unittest *> tests;
+  unittestrunner_cls unittestrunner;
 
   void unittestrunner_cls::print_status()
   {
     if(!total)
     {
       Uerr("ERROR: no tests defined!\n\n");
+      failed = 1;
       return;
     }
 

--- a/unit/Unit.cpp
+++ b/unit/Unit.cpp
@@ -17,6 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#define UNIT_NO_RUNNER
 #include "Unit.hpp"
 
 #include <assert.h>
@@ -464,7 +465,6 @@ namespace Unit
    */
 
   static std::vector<unittest *> tests;
-  unittestrunner_cls unittestrunner;
 
   void unittestrunner_cls::print_status()
   {

--- a/unit/Unit.cpp
+++ b/unit/Unit.cpp
@@ -1,0 +1,539 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2019 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "Unit.hpp"
+
+#include <assert.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <csignal>
+#include <type_traits>
+#include <vector>
+
+/* Utility functions that inlined MegaZeux source expects to exist. */
+
+void *check_calloc(size_t nmemb, size_t size, const char *file,
+ int line)
+{
+  void *p = calloc(nmemb, size);
+  assert(p);
+  return p;
+}
+
+void *check_malloc(size_t size, const char *file,
+ int line)
+{
+  void *p = malloc(size);
+  assert(p);
+  return p;
+}
+
+void *check_realloc(void *ptr, size_t size, const char *file,
+ int line)
+{
+  ptr = realloc(ptr, size);
+  assert(ptr);
+  return ptr;
+}
+
+/* Main functions. */
+
+static void sigabrt_handler(int signal)
+{
+  if(signal == SIGABRT)
+  {
+    Uerr("Received SIGABRT: ");
+  }
+  else
+    Uerr("Unexpected signal %d received: ", signal);
+
+  Unit::unittestrunner.signal_fail();
+}
+
+int main(int argc, char *argv[])
+{
+  if(argc && argv && argv[0])
+  {
+    char *fpos = strrchr(argv[0], '/');
+    char *bpos = strrchr(argv[0], '\\');
+    char tmp;
+
+    if(fpos || bpos)
+    {
+      fpos = (fpos > bpos) ? fpos : bpos;
+      tmp = *fpos;
+      *fpos = '\0';
+      chdir(argv[0]);
+      *fpos = tmp;
+    }
+  }
+  std::signal(SIGABRT, sigabrt_handler);
+  return !(Unit::unittestrunner.run());
+}
+
+
+namespace Unit
+{
+  /************************************************************************
+   * Unit::exception functions.
+   */
+
+  exception::exception(const exception &e)
+  {
+    memcpy(this, &e, sizeof(Unit::exception));
+    for(size_t i = 0; i < sizeof(allocbuf); i++)
+    {
+      char *buf = allocbuf[i];
+      if(buf)
+      {
+        size_t len = strlen(buf) + 1;
+        allocbuf[i] = new char[len];
+        memcpy(allocbuf[i], buf, len);
+        if(left == buf)
+          left = allocbuf[i];
+        if(right == buf)
+          right = allocbuf[i];
+      }
+    }
+  }
+
+  void exception::set_reason_fmt(const char *_reason_fmt, va_list vl)
+  {
+    vsnprintf(reasonbuf, sizeof(reasonbuf), _reason_fmt, vl);
+    reason = reasonbuf;
+    has_reason = true;
+  }
+
+  boolean exception::set_operand(const char *&op, std::nullptr_t _op)
+  {
+    op = coalesce(_op);
+    return false;
+  }
+
+  boolean exception::set_operand(const char *&op, const char *_op)
+  {
+    op = coalesce(_op);
+    return true;
+  }
+
+  boolean exception::set_operand(const char *&op, const void *_op)
+  {
+    sprintf(tmpbuf[num], "0x%08zx", reinterpret_cast<size_t>(_op));
+    op = tmpbuf[num++];
+    return true;
+  }
+
+  boolean exception::set_operand(const char *&op, unsigned char _op)
+  {
+    sprintf(tmpbuf[num], "%u", _op);
+    op = tmpbuf[num++];
+    return true;
+  }
+
+  boolean exception::set_operand(const char *&op, unsigned short _op)
+  {
+    sprintf(tmpbuf[num], "%u", _op);
+    op = tmpbuf[num++];
+    return true;
+  }
+
+  boolean exception::set_operand(const char *&op, unsigned int _op)
+  {
+    sprintf(tmpbuf[num], "%d", _op);
+    op = tmpbuf[num++];
+    return true;
+  }
+
+  boolean exception::set_operand(const char *&op, unsigned long _op)
+  {
+    sprintf(tmpbuf[num], "%lu", _op);
+    op = tmpbuf[num++];
+    return true;
+  }
+
+  boolean exception::set_operand(const char *&op, unsigned long long _op)
+  {
+    sprintf(tmpbuf[num], "%llu", _op);
+    op = tmpbuf[num++];
+    return true;
+  }
+
+  boolean exception::set_operand(const char *&op, signed char _op)
+  {
+    sprintf(tmpbuf[num], "%d", _op);
+    op = tmpbuf[num++];
+    return true;
+  }
+
+  boolean exception::set_operand(const char *&op, short _op)
+  {
+    sprintf(tmpbuf[num], "%d", _op);
+    op = tmpbuf[num++];
+    return true;
+  }
+
+  boolean exception::set_operand(const char *&op, int _op)
+  {
+    sprintf(tmpbuf[num], "%d", _op);
+    op = tmpbuf[num++];
+    return true;
+  }
+
+  boolean exception::set_operand(const char *&op, long _op)
+  {
+    sprintf(tmpbuf[num], "%ld", _op);
+    op = tmpbuf[num++];
+    return true;
+  }
+
+  boolean exception::set_operand(const char *&op, long long _op)
+  {
+    sprintf(tmpbuf[num], "%lld", _op);
+    op = tmpbuf[num++];
+    return true;
+  }
+
+  template<class T, class E = std::enable_if<std::is_integral<T>::value>>
+  char *_set_operand_integral_ptr(const T *_op, size_t length)
+  {
+    if(_op)
+    {
+      char *buf;
+      char *pos;
+      size_t allocleft = length * (sizeof(T) * 2 + 1);
+
+      buf = new char[allocleft];
+      pos = buf;
+
+      for(size_t i = 0; i < length; i++)
+      {
+        size_t n = snprintf(pos, allocleft, "%0*lx ", (int)sizeof(T) * 2, (unsigned long)_op[i]);
+        if(n >= allocleft)
+          break;
+
+        pos += n;
+        allocleft -= n;
+      }
+
+      return buf;
+    }
+    return nullptr;
+  }
+
+  void exception::set_operand_alloc(const char *&op, char *buf)
+  {
+    if(buf)
+    {
+      allocbuf[num++] = buf;
+      op = buf;
+    }
+  }
+
+  void exception::set_operand_integral_ptr(const char *&op, const char *_op, size_t length)
+  {
+    char *buf = _set_operand_integral_ptr(_op, length);
+    set_operand_alloc(op, buf);
+  }
+
+  void exception::set_operand_integral_ptr(const char *&op, const unsigned char *_op, size_t length)
+  {
+    char *buf = _set_operand_integral_ptr(_op, length);
+    set_operand_alloc(op, buf);
+  }
+
+  void exception::set_operand_integral_ptr(const char *&op, const unsigned short *_op, size_t length)
+  {
+    char *buf = _set_operand_integral_ptr(_op, length);
+    set_operand_alloc(op, buf);
+  }
+
+  void exception::set_operand_integral_ptr(const char *&op, const unsigned int *_op, size_t length)
+  {
+    char *buf = _set_operand_integral_ptr(_op, length);
+    set_operand_alloc(op, buf);
+  }
+
+
+  /************************************************************************
+   * Unit::unittest functions.
+   */
+
+  void unittest::run_section(void)
+  {
+    try
+    {
+      run_impl();
+    }
+    catch(const Unit::skip &e)
+    {
+      this->skip();
+    }
+    catch(const Unit::exception &e)
+    {
+      this->print_exception(e);
+    }
+  }
+
+  bool unittest::run(void)
+  {
+    assert(!has_run);
+    has_run = true;
+
+    // NOTE-- first time doesn't run any section if sections are present.
+    this->failed_sections = 0;
+    this->count_sections = 0;
+    this->expected_section = 0;
+    this->skipped_sections = 0;
+    this->entire_test_skipped = false;
+    run_section();
+
+    if(has_failed_main)
+      return false;
+
+    if(this->entire_test_skipped)
+    {
+      print_test_skipped();
+      return true;
+    }
+
+    this->num_sections = this->count_sections;
+
+    while(this->expected_section < this->num_sections)
+    {
+      this->count_sections = 0;
+      this->expected_section++;
+      run_section();
+    }
+
+    if(this->entire_test_skipped ||
+      (this->num_sections && this->skipped_sections == this->num_sections))
+    {
+      print_test_skipped();
+      this->entire_test_skipped = true;
+      return true;
+    }
+
+    if(this->last_failed_section)
+    {
+      unsigned int passed = this->passed_sections();
+      Uerr("  Failed %u section(s)", this->failed_sections);
+
+      if(this->skipped_sections)
+      {
+        Uerr(" (passed %u, skipped %u).\n", passed, this->skipped_sections);
+      }
+      else
+        Uerr(" (passed %u).\n", passed);
+
+      UerrFlush();
+      return false;
+    }
+
+    print_test_success();
+    return true;
+  }
+
+  void unittest::print_test_success(void)
+  {
+    const char *_test_name = coalesce(test_name);
+    unsigned int passed = this->passed_sections();
+
+    Uerr("Passed test '%s::%s'", file_name, _test_name);
+
+    if(num_sections > 0)
+    {
+      Uerr(" (%u section%s", passed, (passed > 1) ? "s" : "");
+
+      if(this->skipped_sections)
+        Uerr(", %u skipped)\n", this->skipped_sections);
+      else
+        Uerr(")\n");
+    }
+    else
+      Uerr("\n");
+
+    UerrFlush();
+  }
+
+  void unittest::print_test_failed(void)
+  {
+    if(!printed_failed)
+    {
+      const char *_test_name = coalesce(test_name);
+
+      Uerr("Failed test '%s::%s'\n", file_name, _test_name);
+      printed_failed = true;
+    }
+  }
+
+  void unittest::print_test_skipped(void)
+  {
+    const char *_test_name = coalesce(test_name);
+    Uerr("Skipping test '%s::%s'", file_name, _test_name);
+
+    if(this->skipped_sections)
+    {
+      Uerr(" (%u section%s)\n", this->skipped_sections,
+        (this->skipped_sections > 0) ? "s" : "");
+    }
+    else
+      Uerr("\n");
+
+    UerrFlush();
+  }
+
+  void unittest::signal_fail()
+  {
+    const char *_test_name = coalesce(this->test_name);
+    const char *_section_name = coalesce(this->section_name);
+
+    if(this->expected_section)
+    {
+      Uerr("Test '%s::%s' aborted in section '%s' (#%u out of %u)\n",
+        file_name, _test_name, _section_name, this->expected_section, this->num_sections);
+    }
+    else
+      Uerr("Test '%s::%s' aborted\n", file_name, _test_name);
+  }
+
+  void unittest::print_exception(const Unit::exception &e)
+  {
+    const char *_section_name = coalesce(this->section_name);
+
+    print_test_failed();
+
+    if(this->expected_section)
+    {
+      if(this->last_failed_section < this->expected_section)
+      {
+        this->failed_sections++;
+        Uerr("  In section '%s': \n", _section_name);
+        this->last_failed_section = this->expected_section;
+      }
+      Uerr("    Assert failed at line %d: %s", e.line, e.test);
+    }
+    else
+    {
+      Uerr("  Assert failed at line %d: %s", e.line, e.test);
+      this->has_failed_main = true;
+    }
+
+    if(e.has_reason)
+      Uerr(" (%s)\n", e.reason);
+    else
+      Uerr("\n");
+
+    if(e.has_values)
+    {
+      Uerr("    Left:  %s\n", e.left);
+      Uerr("    Right: %s\n", e.right);
+    }
+    UerrFlush();
+  }
+
+  void unittest::skip()
+  {
+    if(!this->expected_section)
+    {
+      this->entire_test_skipped = true;
+    }
+    else
+      this->skipped_sections++;
+  }
+
+
+  /************************************************************************
+   * Unit::unittestrunner_cls and support functions.
+   */
+
+  static std::vector<unittest *> tests;
+
+  void unittestrunner_cls::print_status()
+  {
+    if(!total)
+    {
+      Uerr("ERROR: no tests defined!\n\n");
+      return;
+    }
+
+    if(total == count && total == passed && !failed && !skipped)
+    {
+      // Print a shorter summary for the general case...
+      Uerr("Passed %u test%s.\n\n", total, (total > 1) ? "s" : "");
+      UerrFlush();
+      return;
+    }
+
+    Uerr("\nSummary:\n  Tests total: %u\n", total);
+
+    if(passed)  Uerr("  Tests passed: %u\n", passed);
+    if(failed)  Uerr("  Tests failed: %u\n", failed);
+    if(skipped) Uerr("  Tests skipped: %u\n", skipped);
+
+    Uerr("\n");
+    UerrFlush();
+  }
+
+  bool unittestrunner_cls::run()
+  {
+    count = 0;
+    passed = 0;
+    failed = 0;
+    skipped = 0;
+    total = tests.size();
+
+    for(unittest *t : tests)
+    {
+      count++;
+      current_test = t;
+      bool result = t->run();
+
+      if(result)
+      {
+        if(!t->entire_test_skipped)
+          passed++;
+        else
+          skipped++;
+      }
+      else
+        failed++;
+    }
+
+    print_status();
+    return !failed;
+  }
+
+  void unittestrunner_cls::signal_fail()
+  {
+    if(current_test)
+      current_test->signal_fail();
+    else
+      Uerr("ERROR: NULL test!\n");
+
+    failed++;
+    skipped += total - count;
+    print_status();
+  }
+
+  void unittestrunner_cls::addtest(unittest *t)
+  {
+    tests.push_back(t);
+  }
+}

--- a/unit/Unit.hpp
+++ b/unit/Unit.hpp
@@ -375,7 +375,11 @@ namespace Unit
     void signal_fail();
     void addtest(unittest *t);
   };
+#ifdef UNIT_NO_RUNNER
   extern unittestrunner_cls unittestrunner;
+#else
+  unittestrunner_cls unittestrunner{};
+#endif
 
   /**
    * Class for an individual unit test. Don't use directly; create individual

--- a/unit/Unit.hpp
+++ b/unit/Unit.hpp
@@ -241,6 +241,24 @@ namespace Unit
 {
   class unittest;
 
+  template<class T>
+  constexpr const T &min(const T &a, const T &b)
+  {
+    return (a < b) ? a : b;
+  }
+
+  template<class T>
+  constexpr const T &max(const T &a, const T &b)
+  {
+    return (a > b) ? a : b;
+  }
+
+  template<class T>
+  constexpr const T &clamp(const T &a, const T &_min, const T &_max)
+  {
+    return Unit::max(_min, Unit::min(_max, a));
+  }
+
   class skip final {};
 
   /**

--- a/unit/Unit.hpp
+++ b/unit/Unit.hpp
@@ -374,8 +374,8 @@ namespace Unit
     bool run(void);
     void signal_fail();
     void addtest(unittest *t);
-  }
-  static unittestrunner;
+  };
+  extern unittestrunner_cls unittestrunner;
 
   /**
    * Class for an individual unit test. Don't use directly; create individual

--- a/unit/Unit.hpp
+++ b/unit/Unit.hpp
@@ -263,12 +263,10 @@ namespace Unit
     exception(const exception &e);
 
     exception(int _line, const char *_test):
-     line(_line), test(coalesce(_test)), reason(""),
-     left(coalesce(nullptr)), right(coalesce(nullptr)) {}
+     line(_line), test(coalesce(_test)), reason("") {}
 
     exception(int _line, const char *_test, const char *_reason_fmt, ...):
-     line(_line), test(coalesce(_test)),
-     left(coalesce(nullptr)), right(coalesce(nullptr))
+     line(_line), test(coalesce(_test))
     {
       if(_reason_fmt && _reason_fmt[0])
       {

--- a/unit/Unit.hpp
+++ b/unit/Unit.hpp
@@ -75,43 +75,10 @@
 #define EDITOR_LIBSPEC
 #define SKIP_SDL
 #include "../src/compat.h"
-#include "../src/platform_endian.h"
 
-#include <assert.h>
-#include <inttypes.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
-
-#include <csignal>
-#include <string>
-#include <type_traits>
-#include <vector>
-
-void *check_calloc(size_t nmemb, size_t size, const char *file,
- int line)
-{
-  void *p = calloc(nmemb, size);
-  assert(p);
-  return p;
-}
-
-void *check_malloc(size_t size, const char *file,
- int line)
-{
-  void *p = malloc(size);
-  assert(p);
-  return p;
-}
-
-void *check_realloc(void *ptr, size_t size, const char *file,
- int line)
-{
-  ptr = realloc(ptr, size);
-  assert(ptr);
-  return ptr;
-}
 
 /**
  * Utility templates.
@@ -146,7 +113,7 @@ static inline const char *coalesce(const char *var)
   return (var ? var : "NULL");
 }
 
-static inline constexpr const char *coalesce(std::nullptr_t ignore)
+static inline constexpr const char *coalesce(decltype(nullptr) ignore)
 {
   return "NULL";
 }
@@ -166,15 +133,17 @@ public:
   alignstr(const char (&str)[B])
   {
     static_assert(A >= B, "alignstr buffer is too small!");
-    std::copy(str, str + B - 1, u.arr);
+    memcpy(u.arr, str, B);
   }
 
+/*
   alignstr(const char * const str)
   {
     size_t slen = strlen(str);
     assert(slen + 1 <= A);
-    std::copy(str, str + slen, u.arr);
+    memcpy(u.arr, str, slen);
   }
+*/
 
   constexpr const char *c_str() const
   {
@@ -271,26 +240,32 @@ namespace Unit
 {
   class unittest;
 
-  class skip final: std::exception {};
+  class skip final {};
 
-  class exception final: std::exception
+  /**
+   * Thrown on test failure (see ASSERT macros above).
+   */
+  class exception final
   {
   public:
     int line;
-    std::string test;
-    std::string reason;
-    bool has_reason;
-    std::string left;
-    std::string right;
-    bool has_values;
+    const char *test      = coalesce(nullptr);
+    const char *reason    = coalesce(nullptr);
+    bool has_reason       = false;
+    const char *left      = coalesce(nullptr);
+    const char *right     = coalesce(nullptr);
+    bool has_values       = false;
+
+    /* A copy constructor is required to be throwable. */
+    exception(const exception &e);
 
     exception(int _line, const char *_test):
-     line(_line), test(coalesce(_test)), reason(""), has_reason(false),
-     left(coalesce(nullptr)), right(coalesce(nullptr)), has_values(false) {}
+     line(_line), test(coalesce(_test)), reason(""),
+     left(coalesce(nullptr)), right(coalesce(nullptr)) {}
 
     exception(int _line, const char *_test, const char *_reason_fmt, ...):
-     line(_line), test(coalesce(_test)), has_reason(false),
-     left(coalesce(nullptr)), right(coalesce(nullptr)), has_values(false)
+     line(_line), test(coalesce(_test)),
+     left(coalesce(nullptr)), right(coalesce(nullptr))
     {
       if(_reason_fmt && _reason_fmt[0])
       {
@@ -299,13 +274,11 @@ namespace Unit
         set_reason_fmt(_reason_fmt, vl);
         va_end(vl);
       }
-      else
-        reason = coalesce(nullptr);
     }
 
     template<class T, class S>
     exception(int _line, const char *_test, T _left, S _right, const char *_reason_fmt, ...):
-     line(_line), test(coalesce(_test)), has_reason(false), has_values(false)
+     line(_line), test(coalesce(_test))
     {
       if(_reason_fmt && _reason_fmt[0])
       {
@@ -314,17 +287,15 @@ namespace Unit
         set_reason_fmt(_reason_fmt, vl);
         va_end(vl);
       }
-      else
-        reason = coalesce(nullptr);
 
       has_values |= set_operand(left, _left);
       has_values |= set_operand(right, _right);
     }
 
-    template<class T, class E = std::enable_if<std::is_integral<T>::value>>
+    template<class T>
     exception(int _line, const char *_test, const T *_left, const T *_right,
      size_t length, const char *_reason_fmt, ...):
-     line(_line), test(coalesce(_test)), has_reason(false)
+     line(_line), test(coalesce(_test))
     {
       if(_reason_fmt && _reason_fmt[0])
       {
@@ -333,8 +304,6 @@ namespace Unit
         set_reason_fmt(_reason_fmt, vl);
         va_end(vl);
       }
-      else
-        reason = coalesce(nullptr);
 
       has_values = (_left || _right);
       length /= sizeof(T);
@@ -346,139 +315,52 @@ namespace Unit
     // Print non-integral memcmp types bytewise.
     exception(int _line, const char *_test, const void *_left, const void *_right,
      size_t length, const char *_reason):
-     exception(_line, _test, (const uint8_t *)_left, (const uint8_t *)_right,
+     exception(_line, _test, (const unsigned char *)_left, (const unsigned char *)_right,
       length, _reason) {}
+
+    ~exception()
+    {
+      delete[] allocbuf[0];
+      delete[] allocbuf[1];
+    }
 
   private:
 
-    char tmpbuf[32];
+    static constexpr int BUF_SIZE = 24;
+    char reasonbuf[1024];
+    char tmpbuf[2][BUF_SIZE];
+    char *allocbuf[2] = { nullptr, nullptr };
+    int num = 0;
 
-    void set_reason_fmt(const char *_reason_fmt, va_list vl)
-    {
-      char reasonbuf[1024];
+    void set_reason_fmt(const char *_reason_fmt, va_list vl);
+    boolean set_operand(const char *&op, decltype(nullptr) _op);
+    boolean set_operand(const char *&op, const char *_op);
+    boolean set_operand(const char *&op, const void *_op);
+    boolean set_operand(const char *&op, unsigned char _op);
+    boolean set_operand(const char *&op, unsigned short _op);
+    boolean set_operand(const char *&op, unsigned int _op);
+    boolean set_operand(const char *&op, unsigned long _op);
+    boolean set_operand(const char *&op, unsigned long long _op);
+    boolean set_operand(const char *&op, signed char _op);
+    boolean set_operand(const char *&op, short _op);
+    boolean set_operand(const char *&op, int _op);
+    boolean set_operand(const char *&op, long _op);
+    boolean set_operand(const char *&op, long long _op);
 
-      vsnprintf(reasonbuf, sizeof(reasonbuf), _reason_fmt, vl);
-
-      reason = reasonbuf;
-      has_reason = true;
-    }
-
-    boolean set_operand(std::string &op, std::nullptr_t _op)
-    {
-      op = coalesce(_op);
-      return false;
-    }
-
-    boolean set_operand(std::string &op, const char *_op)
-    {
-      op = coalesce(_op);
-      return true;
-    }
-
-    boolean set_operand(std::string &op, const void *_op)
-    {
-      sprintf(tmpbuf, "0x%08zx", reinterpret_cast<size_t>(_op));
-      op = tmpbuf;
-      return true;
-    }
-
-    boolean set_operand(std::string &op, uint8_t _op)
-    {
-      sprintf(tmpbuf, "%u", _op);
-      op = tmpbuf;
-      return true;
-    }
-
-    boolean set_operand(std::string &op, unsigned short _op)
-    {
-      sprintf(tmpbuf, "%u", _op);
-      op = tmpbuf;
-      return true;
-    }
-
-    boolean set_operand(std::string &op, unsigned int _op)
-    {
-      sprintf(tmpbuf, "%d", _op);
-      op = tmpbuf;
-      return true;
-    }
-
-    boolean set_operand(std::string &op, unsigned long _op)
-    {
-      sprintf(tmpbuf, "%lu", _op);
-      op = tmpbuf;
-      return true;
-    }
-
-    boolean set_operand(std::string &op, unsigned long long _op)
-    {
-      sprintf(tmpbuf, "%llu", _op);
-      op = tmpbuf;
-      return true;
-    }
-
-    boolean set_operand(std::string &op, int8_t _op)
-    {
-      sprintf(tmpbuf, "%d", _op);
-      op = tmpbuf;
-      return true;
-    }
-
-    boolean set_operand(std::string &op, short _op)
-    {
-      sprintf(tmpbuf, "%d", _op);
-      op = tmpbuf;
-      return true;
-    }
-
-    boolean set_operand(std::string &op, int _op)
-    {
-      sprintf(tmpbuf, "%d", _op);
-      op = tmpbuf;
-      return true;
-    }
-
-    boolean set_operand(std::string &op, long _op)
-    {
-      sprintf(tmpbuf, "%ld", _op);
-      op = tmpbuf;
-      return true;
-    }
-
-    boolean set_operand(std::string &op, long long _op)
-    {
-      sprintf(tmpbuf, "%lld", _op);
-      op = tmpbuf;
-      return true;
-    }
-
-    template<class T, class E = std::enable_if<std::is_integral<T>::value>>
-    void set_operand_integral_ptr(std::string &op, const T *_op, size_t length)
-    {
-      if(_op)
-      {
-        size_t pos = 0;
-        op.resize(length * (sizeof(T) * 2 + 1));
-
-        for(size_t i = 0; i < length; i++)
-        {
-          snprintf(tmpbuf, sizeof(tmpbuf), "%0*lx", (int)sizeof(T) * 2, (unsigned long)_op[i]);
-          for(size_t j = 0; j < sizeof(T) * 2; j++)
-            op[pos++] = tmpbuf[j];
-
-          op[pos++] = ' ';
-        }
-      }
-      else
-        op = coalesce(nullptr);
-    }
+    void set_operand_alloc(const char *&op, char *buf);
+    void set_operand_integral_ptr(const char *&op, const char *_op, size_t length);
+    void set_operand_integral_ptr(const char *&op, const unsigned char *_op, size_t length);
+    void set_operand_integral_ptr(const char *&op, const unsigned short *_op, size_t length);
+    void set_operand_integral_ptr(const char *&op, const unsigned int *_op, size_t length);
   };
 
+  /**
+   * Class for running all unit tests in the current set of unit tests.
+   */
   class unittestrunner_cls final
   {
   private:
 
-    std::vector<unittest *> tests;
     unittest *current_test;
     unsigned int count;
     unsigned int passed;
@@ -486,43 +368,19 @@ namespace Unit
     unsigned int skipped;
     unsigned int total;
 
-    void print_status()
-    {
-      if(!total)
-      {
-        Uerr("ERROR: no tests defined!\n\n");
-        return;
-      }
-
-      if(total == count && total == passed && !failed && !skipped)
-      {
-        // Print a shorter summary for the general case...
-        Uerr("Passed %u test%s.\n\n", total, (total > 1) ? "s" : "");
-        UerrFlush();
-        return;
-      }
-
-      Uerr("\nSummary:\n  Tests total: %u\n", total);
-
-      if(passed)  Uerr("  Tests passed: %u\n", passed);
-      if(failed)  Uerr("  Tests failed: %u\n", failed);
-      if(skipped) Uerr("  Tests skipped: %u\n", skipped);
-
-      Uerr("\n");
-      UerrFlush();
-    }
+    void print_status();
 
   public:
     bool run(void);
     void signal_fail();
-
-    void addtest(unittest *t)
-    {
-      tests.push_back(t);
-    }
+    void addtest(unittest *t);
   }
   static unittestrunner;
 
+  /**
+   * Class for an individual unit test. Don't use directly; create individual
+   * test subclasses using the UNITTEST() macro.
+   */
   class unittest
   {
     bool has_run = false;
@@ -554,270 +412,24 @@ namespace Unit
 
     ~unittest() {};
 
-    inline void run_section(void)
-    {
-      try
-      {
-        run_impl();
-      }
-      catch(const Unit::skip &e)
-      {
-        this->skip();
-      }
-      catch(const Unit::exception &e)
-      {
-        this->print_exception(e);
-      }
-    }
-
-    inline bool run(void)
-    {
-      assert(!has_run);
-      has_run = true;
-
-      // NOTE-- first time doesn't run any section if sections are present.
-      this->failed_sections = 0;
-      this->count_sections = 0;
-      this->expected_section = 0;
-      this->skipped_sections = 0;
-      this->entire_test_skipped = false;
-      run_section();
-
-      if(has_failed_main)
-        return false;
-
-      if(this->entire_test_skipped)
-      {
-        print_test_skipped();
-        return true;
-      }
-
-      this->num_sections = this->count_sections;
-
-      while(this->expected_section < this->num_sections)
-      {
-        this->count_sections = 0;
-        this->expected_section++;
-        run_section();
-      }
-
-      if(this->entire_test_skipped ||
-       (this->num_sections && this->skipped_sections == this->num_sections))
-      {
-        print_test_skipped();
-        this->entire_test_skipped = true;
-        return true;
-      }
-
-      if(this->last_failed_section)
-      {
-        unsigned int passed = this->passed_sections();
-        Uerr("  Failed %u section(s)", this->failed_sections);
-
-        if(this->skipped_sections)
-        {
-          Uerr(" (passed %u, skipped %u).\n", passed, this->skipped_sections);
-        }
-        else
-          Uerr(" (passed %u).\n", passed);
-
-        UerrFlush();
-        return false;
-      }
-
-      print_test_success();
-      return true;
-    }
-
     inline int passed_sections(void)
     {
       return this->count_sections - this->failed_sections - this->skipped_sections;
     }
 
-    inline void print_test_success(void)
-    {
-      const char *_test_name = coalesce(test_name);
-      unsigned int passed = this->passed_sections();
+    bool run(void);
+    void signal_fail();
 
-      Uerr("Passed test '%s::%s'", file_name, _test_name);
+  private:
+    void run_section(void);
+    void print_test_success(void);
+    void print_test_failed(void);
+    void print_test_skipped(void);
+    void print_exception(const Unit::exception &e);
+    void skip();
 
-      if(num_sections > 0)
-      {
-        Uerr(" (%u section%s", passed, (passed > 1) ? "s" : "");
-
-        if(this->skipped_sections)
-          Uerr(", %u skipped)\n", this->skipped_sections);
-        else
-          Uerr(")\n");
-      }
-      else
-        Uerr("\n");
-
-      UerrFlush();
-    }
-
-    inline void print_test_failed(void)
-    {
-      if(!printed_failed)
-      {
-        const char *_test_name = coalesce(test_name);
-
-        Uerr("Failed test '%s::%s'\n", file_name, _test_name);
-        printed_failed = true;
-      }
-    }
-
-    inline void print_test_skipped(void)
-    {
-      const char *_test_name = coalesce(test_name);
-      Uerr("Skipping test '%s::%s'", file_name, _test_name);
-
-      if(this->skipped_sections)
-      {
-        Uerr(" (%u section%s)\n", this->skipped_sections,
-         (this->skipped_sections > 0) ? "s" : "");
-      }
-      else
-        Uerr("\n");
-
-      UerrFlush();
-    }
-
-    inline void signal_fail()
-    {
-      const char *_test_name = coalesce(this->test_name);
-      const char *_section_name = coalesce(this->section_name);
-
-      if(this->expected_section)
-      {
-        Uerr("Test '%s::%s' aborted in section '%s' (#%u out of %u)\n",
-         file_name, _test_name, _section_name, this->expected_section, this->num_sections);
-      }
-      else
-        Uerr("Test '%s::%s' aborted\n", file_name, _test_name);
-    }
-
-    inline void print_exception(const Unit::exception &e)
-    {
-      const char *_section_name = coalesce(this->section_name);
-
-      print_test_failed();
-
-      if(this->expected_section)
-      {
-        if(this->last_failed_section < this->expected_section)
-        {
-          this->failed_sections++;
-          Uerr("  In section '%s': \n", _section_name);
-          this->last_failed_section = this->expected_section;
-        }
-        Uerr("    Assert failed at line %d: %s", e.line, e.test.c_str());
-      }
-      else
-      {
-        Uerr("  Assert failed at line %d: %s", e.line, e.test.c_str());
-        this->has_failed_main = true;
-      }
-
-      if(e.has_reason)
-        Uerr(" (%s)\n", e.reason.c_str());
-      else
-        Uerr("\n");
-
-      if(e.has_values)
-      {
-        Uerr("    Left:  %s\n", e.left.c_str());
-        Uerr("    Right: %s\n", e.right.c_str());
-      }
-      UerrFlush();
-    }
-
-    void skip()
-    {
-      if(!this->expected_section)
-      {
-        this->entire_test_skipped = true;
-      }
-      else
-        this->skipped_sections++;
-    }
-
-    virtual void run_impl(void) {};
+    virtual void run_impl(void) = 0;
   };
-
-  bool unittestrunner_cls::run(void)
-  {
-    count = 0;
-    passed = 0;
-    failed = 0;
-    skipped = 0;
-    total = tests.size();
-
-    for(unittest *t : tests)
-    {
-      count++;
-      current_test = t;
-      bool result = t->run();
-
-      if(result)
-      {
-        if(!t->entire_test_skipped)
-          passed++;
-        else
-          skipped++;
-      }
-      else
-        failed++;
-    }
-
-    print_status();
-    return !failed;
-  }
-
-  void unittestrunner_cls::signal_fail()
-  {
-    if(current_test)
-      current_test->signal_fail();
-    else
-      Uerr("ERROR: NULL test!\n");
-
-    failed++;
-    skipped += total - count;
-    print_status();
-  }
-}
-
-static void sigabrt_handler(int signal)
-{
-  if(signal == SIGABRT)
-  {
-    Uerr("Received SIGABRT: ");
-  }
-  else
-    Uerr("Unexpected signal %d received: ", signal);
-
-  Unit::unittestrunner.signal_fail();
-}
-
-int main(int argc, char *argv[])
-{
-  if(argc && argv && argv[0])
-  {
-    char *fpos = strrchr(argv[0], '/');
-    char *bpos = strrchr(argv[0], '\\');
-    char tmp;
-
-    if(fpos || bpos)
-    {
-      fpos = (fpos > bpos) ? fpos : bpos;
-      tmp = *fpos;
-      *fpos = '\0';
-      chdir(argv[0]);
-      *fpos = tmp;
-    }
-  }
-  std::signal(SIGABRT, sigabrt_handler);
-  return !(Unit::unittestrunner.run());
 }
 
 #endif /* UNIT_HPP */

--- a/unit/Unit.hpp
+++ b/unit/Unit.hpp
@@ -360,7 +360,7 @@ namespace Unit
   /**
    * Class for running all unit tests in the current set of unit tests.
    */
-  class unittestrunner_cls final
+  class unittestrunner final
   {
   private:
 
@@ -374,15 +374,11 @@ namespace Unit
     void print_status();
 
   public:
+    static unittestrunner &get();
     bool run(void);
     void signal_fail();
     void addtest(unittest *t);
   };
-#ifdef UNIT_NO_RUNNER
-  extern unittestrunner_cls unittestrunner;
-#else
-  unittestrunner_cls unittestrunner{};
-#endif
 
   /**
    * Class for an individual unit test. Don't use directly; create individual
@@ -414,7 +410,7 @@ namespace Unit
     unittest(const char *_file, const char *_test_name):
      file_name(_file), test_name(_test_name)
     {
-      unittestrunner.addtest(this);
+      unittestrunner::get().addtest(this);
     };
 
     ~unittest() {};

--- a/unit/Unit.hpp
+++ b/unit/Unit.hpp
@@ -71,6 +71,9 @@
 #error "Include Unit.hpp first!"
 #endif
 
+/* Need at least one C++ header to make clang shut up. */
+#include <cstdlib>
+
 #define CORE_LIBSPEC
 #define EDITOR_LIBSPEC
 #define SKIP_SDL

--- a/unit/Unit.hpp
+++ b/unit/Unit.hpp
@@ -71,9 +71,6 @@
 #error "Include Unit.hpp first!"
 #endif
 
-/* Need at least one C++ header to make clang shut up. */
-#include <cstdlib>
-
 #define CORE_LIBSPEC
 #define EDITOR_LIBSPEC
 #define SKIP_SDL
@@ -81,6 +78,7 @@
 
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 /**

--- a/unit/align.cpp
+++ b/unit/align.cpp
@@ -26,6 +26,7 @@
 
 #include "Unit.hpp"
 #include "../src/counter_struct.h"
+#include "../src/platform_endian.h"
 #include "../src/io/zip.h"
 
 UNITTEST(counter_struct_name)

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -146,13 +146,12 @@ static void load_arg(char *arg)
 static boolean write_config(const char *path, const char *config)
 {
   FILE *fp = fopen_unsafe(path, "wb");
-  assert(fp);
+  ASSERT(fp, "failed to open '%s'", path);
   if(fp)
   {
     int ret = fwrite(config, strlen(config), 1, fp);
-    assert(ret == 1);
+    ASSERT(ret == 1, "write error for '%s'", path);
     ret = fclose(fp);
-    assert(!ret);
     return true;
   }
   return false;

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -17,9 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <algorithm>
-#include <climits>
-#include <cstdio>
+#include <limits.h>
+#include <stdio.h>
 #include <limits>
 
 #include "Unit.hpp"
@@ -292,7 +291,7 @@ void TEST_STRING(const char *setting_name, char (&setting)[S],
 
   for(int i = 0; i < NUM_TESTS; i++)
   {
-    size_t len = std::min(strlen(data[i].expected), S - 1);
+    size_t len = Unit::min(strlen(data[i].expected), S - 1);
     snprintf(arg, arraysize(arg), "%s=%s", setting_name, data[i].value);
 
     setting[0] = '\0';

--- a/unit/editor/stringsearch.cpp
+++ b/unit/editor/stringsearch.cpp
@@ -20,7 +20,6 @@
 #include "../Unit.hpp"
 
 #include <string.h>
-#include <tuple>
 
 #include "../../src/editor/stringsearch.c"
 

--- a/unit/intake.cpp
+++ b/unit/intake.cpp
@@ -25,8 +25,6 @@
 #include "Unit.hpp"
 #include "../src/intake.c"
 
-#include <algorithm>
-
 // TODO shut up the linker as this isn't CORE_LIBSPEC currently.
 boolean has_unicode_input() { return false; }
 
@@ -267,7 +265,7 @@ UNITTEST(PosLength)
 
     for(const int_pair &d : length_data)
     {
-      dest_len = std::max(0, std::min(dest_len, d.input));
+      dest_len = Unit::clamp(dest_len, 0, d.input);
       intake_set_length(&intk, d.input);
       intake_sync((subcontext *)&intk);
       ASSERTEQ(intk.current_length, dest_len, "%d -> %d", d.input, dest_len);

--- a/unit/intake.cpp
+++ b/unit/intake.cpp
@@ -25,6 +25,8 @@
 #include "Unit.hpp"
 #include "../src/intake.c"
 
+#include <algorithm>
+
 // TODO shut up the linker as this isn't CORE_LIBSPEC currently.
 boolean has_unicode_input() { return false; }
 

--- a/unit/io/memfile.cpp
+++ b/unit/io/memfile.cpp
@@ -21,6 +21,7 @@
 #include "../../src/io/memfile.h"
 
 #include <limits.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 UNITTEST(mfopen)

--- a/unit/io/vio.cpp
+++ b/unit/io/vio.cpp
@@ -17,8 +17,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <memory>
-
 #include "../Unit.hpp"
 #include "../../src/network/Scoped.hpp"
 #include "../../src/io/path.h"
@@ -821,7 +819,7 @@ UNITTEST(vfsafegets)
     for(const vfsafegets_data &d : vfsafegets_test_data)
     {
       size_t len = strlen(d.input);
-      std::unique_ptr<char[]> tmp(new char[len + 1]);
+      ScopedPtr<char[]> tmp = new char[len + 1];
 
       memcpy(tmp.get(), d.input, len + 1);
       ScopedFile<vfile, vfclose> vf = vfile_init_mem(tmp.get(), len, "rb");

--- a/unit/io/zip.cpp
+++ b/unit/io/zip.cpp
@@ -17,8 +17,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <memory>
-
 #include "../Unit.hpp"
 
 #include "../../src/util.h"
@@ -26,6 +24,8 @@
 #include "../../src/io/path.h"
 #include "../../src/io/zip.h"
 #include "../../src/io/zip_stream.h"
+
+#include "../../src/network/Scoped.hpp"
 
 static const size_t BUFFER_SIZE = (1 << 17);
 static const char DATA_DIR[] = "../data";
@@ -381,12 +381,9 @@ static enum zip_error decompress(zip_method_handler *stream, zip_stream_data *sd
 static void decompress_boilerplate(zip_method_handler *stream,
  pair zip_stream_test_data::*field, enum zip_compression_method method)
 {
-  std::unique_ptr<char[]> _buffer(new char[BUFFER_SIZE]);
-  std::unique_ptr<char[]> _buffer_a(new char[BUFFER_SIZE]);
-  std::unique_ptr<char[]> _buffer_b(new char[BUFFER_SIZE]);
-  char *buffer = _buffer.get();
-  char *buffer_a = _buffer_a.get();
-  char *buffer_b = _buffer_b.get();
+  ScopedPtr<char[]> buffer = new char[BUFFER_SIZE];
+  ScopedPtr<char[]> buffer_a = new char[BUFFER_SIZE];
+  ScopedPtr<char[]> buffer_b = new char[BUFFER_SIZE];
   const char *a;
   const char *b;
   size_t a_len;
@@ -551,12 +548,9 @@ UNITTEST(Decompress)
  */
 UNITTEST(Compress)
 {
-  std::unique_ptr<char[]> _buffer_a(new char[BUFFER_SIZE]);
-  std::unique_ptr<char[]> _buffer_cmp(new char[BUFFER_SIZE]);
-  std::unique_ptr<char[]> _buffer_dcmp(new char[BUFFER_SIZE]);
-  char *buffer_a = _buffer_a.get();
-  char *buffer_cmp = _buffer_cmp.get();
-  char *buffer_dcmp = _buffer_dcmp.get();
+  ScopedPtr<char[]> buffer_a = new char[BUFFER_SIZE];
+  ScopedPtr<char[]> buffer_cmp = new char[BUFFER_SIZE];
+  ScopedPtr<char[]> buffer_dcmp = new char[BUFFER_SIZE];
   const char *a;
   size_t a_len;
   size_t cmp_len;
@@ -587,7 +581,7 @@ UNITTEST(Compress)
      buffer_dcmp, BUFFER_SIZE);
     ASSERTEQ(result, ZIP_STREAM_FINISHED, "%s", d.testname);
 
-    ASSERTMEM(a, buffer_dcmp, a_len, "%s", d.testname);
+    ASSERTMEM(a, buffer_dcmp.get(), a_len, "%s", d.testname);
   }
   stream->destroy(sd);
 }
@@ -778,12 +772,9 @@ static void zip_check(const zip_test_data &d, struct zip_archive *zp)
 
 UNITTEST(ZipRead)
 {
-  std::unique_ptr<char[]> buffer_ptr(new char[BUFFER_SIZE]);
-  std::unique_ptr<char[]> db64_ptr(new char[BUFFER_SIZE]);
-  std::unique_ptr<char[]> file_ptr(new char[BUFFER_SIZE]);
-  char *buffer = buffer_ptr.get();
-  char *file_buffer = file_ptr.get();
-  char *db64_buffer = db64_ptr.get();
+  ScopedPtr<char[]> buffer = new char[BUFFER_SIZE];
+  ScopedPtr<char[]> db64_buffer = new char[BUFFER_SIZE];
+  ScopedPtr<char[]> file_buffer = new char[BUFFER_SIZE];
   struct zip_archive *zp;
   enum zip_error result;
   char small_buffer[32];
@@ -972,10 +963,8 @@ static void verify_boilerplate(const zip_test_data &d, struct zip_archive *zp,
 
 UNITTEST(ZipWrite)
 {
-  std::unique_ptr<char[]> verify_ptr(new char[BUFFER_SIZE]);
-  std::unique_ptr<char[]> db64_ptr(new char[BUFFER_SIZE]);
-  char *verify_buffer = verify_ptr.get();
-  char *db64_buffer = db64_ptr.get();
+  ScopedPtr<char[]> verify_buffer = new char[BUFFER_SIZE];
+  ScopedPtr<char[]> db64_buffer = new char[BUFFER_SIZE];
   // This buffer needs to be resized by C code...
   char *ext_buffer = (char *)cmalloc(32);
   size_t ext_buffer_size = 32;

--- a/unit/memcasecmp.cpp
+++ b/unit/memcasecmp.cpp
@@ -21,7 +21,6 @@
 #include "../src/memcasecmp.h"
 
 #include <string.h>
-#include <tuple>
 
 struct string_pair
 {

--- a/unit/network/Manifest.cpp
+++ b/unit/network/Manifest.cpp
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <memory>
 #include <stdint.h>
 
 #include "../Unit.hpp"
 
 #include "../../src/util.h"
+#include "../../src/network/Scoped.hpp"
 #include "../../src/network/Manifest.hpp"
 
 static const char *DATA_DIR = "../data";
@@ -182,7 +182,7 @@ UNITTEST(ManifestEntry)
 
     for(const manifestdata &f : filedata)
     {
-      std::unique_ptr<ManifestEntry> e(ManifestEntry::create_from_file(f.filename));
+      ScopedPtr<ManifestEntry> e = ManifestEntry::create_from_file(f.filename);
       ASSERT(e, "%s", f.filename);
 
       ASSERTMEM(e->sha256, f.sha256, sizeof(f.sha256), "%s", f.filename);

--- a/unit/network/sha256.cpp
+++ b/unit/network/sha256.cpp
@@ -22,8 +22,6 @@
 
 #include "../../src/network/sha256.c"
 
-#include <algorithm>
-
 #define ASSETS_DIR "../../../assets"
 #define IO_DATA_DIR "../../io/data"
 
@@ -127,7 +125,7 @@ UNITTEST(SHA256File)
     ssize_t j = 0;
     while(j < file_len)
     {
-      ssize_t len = std::min(file_len - j, (ssize_t)arraysize(buffer));
+      ssize_t len = Unit::min(file_len - j, (ssize_t)arraysize(buffer));
       size_t ret = fread(buffer, len, 1, fp);
       ASSERTEQ(ret, 1, "%s", d.input);
 

--- a/unit/network/sha256.cpp
+++ b/unit/network/sha256.cpp
@@ -22,6 +22,8 @@
 
 #include "../../src/network/sha256.c"
 
+#include <algorithm>
+
 #define ASSETS_DIR "../../../assets"
 #define IO_DATA_DIR "../../io/data"
 

--- a/unit/world.cpp
+++ b/unit/world.cpp
@@ -29,7 +29,7 @@
 #include "../src/io/memfile.h"
 #include "../src/io/zip.h"
 
-#include <memory>
+#include "../src/network/Scoped.hpp"
 
 /**
  * world.c functions.
@@ -149,7 +149,7 @@ struct world_assign_file_result
 };
 
 static void init_test_archive(struct zip_archive &zp,
- struct zip_file_header **fha, std::unique_ptr<uint8_t[]> *fh_ptrs,
+ struct zip_file_header **fha, ScopedPtr<uint8_t[]> *fh_ptrs,
  const world_assign_file_input *input, size_t NUM_FILES)
 {
   /* This function only needs these zip_archive fields. */
@@ -161,7 +161,7 @@ static void init_test_archive(struct zip_archive &zp,
     const world_assign_file_input &d = input[i];
     size_t name_len = strlen(d.filename);
 
-    fh_ptrs[i] = std::unique_ptr<uint8_t[]>(new uint8_t[sizeof(zip_file_header) + name_len]{});
+    fh_ptrs[i] = new uint8_t[sizeof(zip_file_header) + name_len]{};
     fha[i] = reinterpret_cast<zip_file_header *>(fh_ptrs[i].get());
 
     fha[i]->method = d.method;
@@ -195,7 +195,7 @@ UNITTEST(world_assign_file_ids)
 {
   static const size_t MAX_FILES = 256;
 
-  std::unique_ptr<uint8_t[]> fh_ptrs[MAX_FILES];
+  ScopedPtr<uint8_t[]> fh_ptrs[MAX_FILES];
   struct zip_file_header *fha[MAX_FILES];
   struct zip_archive zp{};
 
@@ -516,7 +516,7 @@ UNITTEST(Properties)
 
     // The following tests won't be writing past the property header,
     // but to protect this against checks/asserts...
-    std::unique_ptr<uint8_t[]> bigbuffer(new uint8_t[0x20000]);
+    ScopedPtr<uint8_t[]> bigbuffer = new uint8_t[0x20000];
     mfopen(bigbuffer.get(), 0x20000, &mf);
 
     static const uint8_t expected2[] = { 0x01, 0x00, 0xff, 0x7f, '\0', '\0' };


### PR DESCRIPTION
Removing `#include <string>` and some other misc. includes from Unit.hpp and moving most function definitions to a new compilation unit (Unit.cpp) seems to have further improved the compilation time of the unit tests locally. Opening a PR to see if this helps anything else.

(Separating unit test build from linking only benefits parallel make and is slightly slower in MSYS2 so I didn't bother.)

edit: this *halved* unit test compilation time in my SPARC64 VM.