### PR TITLE
Misc. regression test script fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -394,9 +394,7 @@ source: build/${TARGET}src
 # Build source target
 # Targetting unix primarily, so turn off autocrlf if necessary
 #
-ifneq ($(shell command -v git),)
-USER_AUTOCRLF=$(shell git config core.autocrlf)
-endif
+USER_AUTOCRLF=$(shell if command -v git; then git config core.autocrlf; fi)
 build/${TARGET}src:
 	${RM} -r build/${TARGET}
 	${MKDIR} -p build/dist/source

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ MAKEFLAGS += -r
 endif
 
 .PHONY: all clean help_check mzx mzx.debug build build_clean source
-.PHONY: test unittest test_clean unit_clean
+.PHONY: test testworlds unit unittest test_clean unit_clean
 
 #
 # Define this first so arch-specific rules don't hijack the default target.
@@ -571,7 +571,9 @@ help_check: ${hlp2txt} assets/help.fil
 
 -include unit/Makefile.in
 
-test: unittest
+test: unit
+
+test testworlds:
 ifeq (${BUILD_MODULAR},1)
 	@${SHELL} testworlds/run.sh ${PLATFORM} "$(realpath ${core_target})"
 else

--- a/Makefile
+++ b/Makefile
@@ -400,7 +400,7 @@ build/${TARGET}src:
 	@git -c "core.autocrlf=false" checkout-index -a --prefix build/${TARGET}/
 	${RM} -r build/${TARGET}/scripts
 	${RM} build/${TARGET}/.gitignore build/${TARGET}/.gitattributes
-	@cd build/${TARGET} && make distclean
+	@cd build/${TARGET} && ${MAKE} distclean
 	@tar -C build -Jcf build/dist/source/${TARGET}src.tar.xz ${TARGET}
 
 #

--- a/Makefile
+++ b/Makefile
@@ -394,7 +394,7 @@ source: build/${TARGET}src
 # Build source target
 # Targetting unix primarily, so turn off autocrlf if necessary
 #
-USER_AUTOCRLF=$(shell if command -v git; then git config core.autocrlf; fi)
+USER_AUTOCRLF=$(shell command -v git >/dev/null && git config core.autocrlf)
 build/${TARGET}src:
 	${RM} -r build/${TARGET}
 	${MKDIR} -p build/dist/source

--- a/Makefile
+++ b/Makefile
@@ -392,15 +392,12 @@ source: build/${TARGET}src
 
 #
 # Build source target
-# Targetting unix primarily, so turn off autocrlf if necessary
+# Targeting unix primarily, so turn off autocrlf if necessary.
 #
-USER_AUTOCRLF=$(shell command -v git >/dev/null && git config core.autocrlf)
 build/${TARGET}src:
 	${RM} -r build/${TARGET}
 	${MKDIR} -p build/dist/source
-	@git config core.autocrlf false
-	@git checkout-index -a --prefix build/${TARGET}/
-	@git config core.autocrlf ${USER_AUTOCRLF}
+	@git -c "core.autocrlf=false" checkout-index -a --prefix build/${TARGET}/
 	${RM} -r build/${TARGET}/scripts
 	${RM} build/${TARGET}/.gitignore build/${TARGET}/.gitattributes
 	@cd build/${TARGET} && make distclean

--- a/testworlds/run.sh
+++ b/testworlds/run.sh
@@ -121,23 +121,27 @@ rm -f ../megazeux-config
 rm -f config.h
 rm -f data/audio/drivin.s3m
 
-# Color code PASS/FAIL tags and important numbers.
-
-COL_END=$(tput sgr0)
-COL_RED=$(tput bold)$(tput setaf 1)
-COL_GREEN=$(tput bold)$(tput setaf 2)
-COL_YELLOW=$(tput bold)$(tput setaf 3)
-
 if [ -z "$1" ] || [ "$1" != "-q" ];
 then
-	cat log/failures \
-	  | sed -e "s/\[PASS\]/\[${COL_GREEN}PASS${COL_END}\]/g" \
-	  | sed -e "s/\[FAIL\]/\[${COL_RED}FAIL${COL_END}\]/g" \
-	  | sed -e "s/\[\(WARN\|SKIP\)\]/\[${COL_YELLOW}\1${COL_END}\]/g" \
-	  | sed -e "s/passes: \([1-9][0-9]*\)/passes: ${COL_GREEN}\1${COL_END}/g" \
-	  | sed -e "s/failures: \([1-9][0-9]*\)/failures: ${COL_RED}\1${COL_END}/g" \
+	if command -v tput >/dev/null;
+	then
+		# Color code PASS/FAIL tags and important numbers.
+		COL_END=$(tput sgr0)
+		COL_RED=$(tput bold)$(tput setaf 1)
+		COL_GREEN=$(tput bold)$(tput setaf 2)
+		COL_YELLOW=$(tput bold)$(tput setaf 3)
 
-	tput bel
+		cat log/failures \
+		  | sed -e "s/\[PASS\]/\[${COL_GREEN}PASS${COL_END}\]/g" \
+		  | sed -e "s/\[FAIL\]/\[${COL_RED}FAIL${COL_END}\]/g" \
+		  | sed -e "s/\[\(WARN\|SKIP\)\]/\[${COL_YELLOW}\1${COL_END}\]/g" \
+		  | sed -e "s/passes: \([1-9][0-9]*\)/passes: ${COL_GREEN}\1${COL_END}/g" \
+		  | sed -e "s/failures: \([1-9][0-9]*\)/failures: ${COL_RED}\1${COL_END}/g" \
+
+		tput bel
+	else
+		cat log/failures
+	fi
 fi
 
 # Exit 1 if there are any failures.

--- a/testworlds/run.sh
+++ b/testworlds/run.sh
@@ -130,14 +130,12 @@ COL_YELLOW=$(tput bold)$(tput setaf 3)
 
 if [ -z "$1" ] || [ "$1" != "-q" ];
 then
-	echo "$(\
-	  cat log/failures \
+	cat log/failures \
 	  | sed -e "s/\[PASS\]/\[${COL_GREEN}PASS${COL_END}\]/g" \
 	  | sed -e "s/\[FAIL\]/\[${COL_RED}FAIL${COL_END}\]/g" \
 	  | sed -e "s/\[\(WARN\|SKIP\)\]/\[${COL_YELLOW}\1${COL_END}\]/g" \
 	  | sed -e "s/passes: \([1-9][0-9]*\)/passes: ${COL_GREEN}\1${COL_END}/g" \
 	  | sed -e "s/failures: \([1-9][0-9]*\)/failures: ${COL_RED}\1${COL_END}/g" \
-	  )"
 
 	tput bel
 fi

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -4,7 +4,7 @@
 # Unit tests require C++11.
 #
 
-.PHONY: unittest unit_clean
+.PHONY: unit unittest unit_clean
 
 unit_src        := unit
 unit_obj        := unit/.build
@@ -106,7 +106,7 @@ endif
 
 ifneq (${HAS_CXX_11},1)
 
-unittest:
+unit unittest:
 	$(if ${V},,@echo "Skipping unit tests (requires C++11).")
 
 unit_clean:
@@ -148,7 +148,7 @@ ${unit_objs} ${unit_common_objs}: | $(filter-out $(wildcard ${unit_obj_io}), ${u
 ${unit_objs} ${unit_common_objs}: | $(filter-out $(wildcard ${unit_obj_network}), ${unit_obj_network})
 ${unit_objs} ${unit_common_objs}: | $(filter-out $(wildcard ${unit_obj_utils}), ${unit_obj_utils})
 
-unittest: ${unit_objs}
+unit unittest: ${unit_objs}
 	@failcount=0; \
 	for t in ${unit_objs}; do \
 		LD_LIBRARY_PATH="." ./$$t ; \


### PR DESCRIPTION
* Fixed the `run.sh` hang detection loop for implementations of `ps` that don't contain the `-p` option e.g. BusyBox (Alpine Linux).
* Fixed printed errors when `tput` is missing (Alpine Linux).
* The `-q` option for `run.sh` is now shifted off of the arguments list prior to other argument checks. It also now applies to all printed text emitted by `run.sh` instead of just the results.
* Fixed most ShellCheck pedantry for `run.sh`.
* Fixed Makefile warnings caused by some versions of GNU Make trying to optimize `$(shell command -v git)`, causing it to fail.
* The Makefile unit tests now have both `unit` and `unittest` as targets.
* The test worlds now have a `testworlds` target that allows them to execute without first running the unit tests.