### PR TITLE
Add unit tests self check and misc. unit tests fixes.

### DIFF
--- a/unit/Unit.cpp
+++ b/unit/Unit.cpp
@@ -109,12 +109,23 @@ namespace Unit
 
   arg::arg() {}
 
+  const char *arg::fix_op(const arg &src)
+  {
+    if(src.op == src.tmpbuf)
+      return tmpbuf;
+
+    if(src.op == src.allocbuf)
+      return allocbuf;
+
+    return src.op;
+  }
+
   arg::arg(arg &&a)
   {
     memcpy(tmpbuf, a.tmpbuf, sizeof(tmpbuf));
     has_value = a.has_value;
-    op = a.op;
     allocbuf = a.allocbuf;
+    op = fix_op(a);
 
     a.has_value = false;
     a.op = nullptr;
@@ -125,7 +136,6 @@ namespace Unit
   {
     memcpy(tmpbuf, a.tmpbuf, sizeof(tmpbuf));
     has_value = a.has_value;
-    op = a.op;
 
     if(a.allocbuf)
     {
@@ -133,6 +143,7 @@ namespace Unit
       allocbuf = new char[len + 1];
       memcpy(allocbuf, a.allocbuf, len + 1);
     }
+    op = fix_op(a);
   }
 
   arg::arg(std::nullptr_t _op)

--- a/unit/Unit.cpp
+++ b/unit/Unit.cpp
@@ -657,7 +657,7 @@ namespace Unit
     {
       if(value.op != expected)
       {
-        Uerr("ERROR: self check '%s' failed: %p != %p\n", name, value.op, expected);
+        Uerr("ERROR: self check '%s' failed: %p != %p\n", name, (void *)value.op, (void *)expected);
         return false;
       }
     }

--- a/unit/Unit.cpp
+++ b/unit/Unit.cpp
@@ -20,11 +20,14 @@
 #include "Unit.hpp"
 
 #include <assert.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
 
 #include <csignal>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 /* Utility functions that inlined MegaZeux source expects to exist. */
@@ -84,6 +87,13 @@ int main(int argc, char *argv[])
       *fpos = tmp;
     }
   }
+
+  if(!Unit::self_check())
+  {
+    Uerr("ERROR: self check failed!\n");
+    return 1;
+  }
+
   std::signal(SIGABRT, sigabrt_handler);
   return !(Unit::unittestrunner::get().run());
 }
@@ -92,122 +102,128 @@ int main(int argc, char *argv[])
 namespace Unit
 {
   /************************************************************************
-   * Unit::exception functions.
+   * Unit::arg functions.
    */
 
-  exception::exception(const exception &e)
+  arg::~arg()
   {
-    memcpy(this, &e, sizeof(Unit::exception));
-    for(size_t i = 0; i < sizeof(allocbuf); i++)
+    delete[] allocbuf;
+  }
+
+  arg::arg() {}
+
+  arg::arg(arg &&a)
+  {
+    memcpy(tmpbuf, a.tmpbuf, sizeof(tmpbuf));
+    has_value = a.has_value;
+    op = a.op;
+    allocbuf = a.allocbuf;
+
+    a.has_value = false;
+    a.op = nullptr;
+    a.allocbuf = nullptr;
+  }
+
+  arg::arg(const arg &a)
+  {
+    memcpy(tmpbuf, a.tmpbuf, sizeof(tmpbuf));
+    has_value = a.has_value;
+    op = a.op;
+
+    if(a.allocbuf)
     {
-      char *buf = allocbuf[i];
-      if(buf)
-      {
-        size_t len = strlen(buf) + 1;
-        allocbuf[i] = new char[len];
-        memcpy(allocbuf[i], buf, len);
-        if(left == buf)
-          left = allocbuf[i];
-        if(right == buf)
-          right = allocbuf[i];
-      }
+      size_t len = strlen(a.allocbuf);
+      allocbuf = new char[len + 1];
+      memcpy(allocbuf, a.allocbuf, len + 1);
     }
   }
 
-  void exception::set_reason_fmt(const char *_reason_fmt, va_list vl)
-  {
-    vsnprintf(reasonbuf, sizeof(reasonbuf), _reason_fmt, vl);
-    reason = reasonbuf;
-    has_reason = true;
-  }
-
-  boolean exception::set_operand(const char *&op, std::nullptr_t _op)
+  arg::arg(std::nullptr_t _op)
   {
     op = coalesce(_op);
-    return false;
   }
 
-  boolean exception::set_operand(const char *&op, const char *_op)
+  arg::arg(const char *_op)
   {
     op = coalesce(_op);
-    return true;
+    has_value = !!_op;
   }
 
-  boolean exception::set_operand(const char *&op, const void *_op)
+  arg::arg(const void *_op)
   {
-    sprintf(tmpbuf[num], "0x%08zx", reinterpret_cast<size_t>(_op));
-    op = tmpbuf[num++];
-    return true;
+    sprintf(tmpbuf, "0x%08zx", reinterpret_cast<size_t>(_op));
+    op = tmpbuf;
+    has_value = true;
   }
 
-  boolean exception::set_operand(const char *&op, unsigned char _op)
+  arg::arg(unsigned char _op)
   {
-    sprintf(tmpbuf[num], "%u", _op);
-    op = tmpbuf[num++];
-    return true;
+    sprintf(tmpbuf, "%u", _op);
+    op = tmpbuf;
+    has_value = true;
   }
 
-  boolean exception::set_operand(const char *&op, unsigned short _op)
+  arg::arg(unsigned short _op)
   {
-    sprintf(tmpbuf[num], "%u", _op);
-    op = tmpbuf[num++];
-    return true;
+    sprintf(tmpbuf, "%u", _op);
+    op = tmpbuf;
+    has_value = true;
   }
 
-  boolean exception::set_operand(const char *&op, unsigned int _op)
+  arg::arg(unsigned int _op)
   {
-    sprintf(tmpbuf[num], "%d", _op);
-    op = tmpbuf[num++];
-    return true;
+    sprintf(tmpbuf, "%d", _op);
+    op = tmpbuf;
+    has_value = true;
   }
 
-  boolean exception::set_operand(const char *&op, unsigned long _op)
+  arg::arg(unsigned long _op)
   {
-    sprintf(tmpbuf[num], "%lu", _op);
-    op = tmpbuf[num++];
-    return true;
+    sprintf(tmpbuf, "%lu", _op);
+    op = tmpbuf;
+    has_value = true;
   }
 
-  boolean exception::set_operand(const char *&op, unsigned long long _op)
+  arg::arg(unsigned long long _op)
   {
-    sprintf(tmpbuf[num], "%llu", _op);
-    op = tmpbuf[num++];
-    return true;
+    sprintf(tmpbuf, "%llu", _op);
+    op = tmpbuf;
+    has_value = true;
   }
 
-  boolean exception::set_operand(const char *&op, signed char _op)
+  arg::arg(signed char _op)
   {
-    sprintf(tmpbuf[num], "%d", _op);
-    op = tmpbuf[num++];
-    return true;
+    sprintf(tmpbuf, "%d", _op);
+    op = tmpbuf;
+    has_value = true;
   }
 
-  boolean exception::set_operand(const char *&op, short _op)
+  arg::arg(short _op)
   {
-    sprintf(tmpbuf[num], "%d", _op);
-    op = tmpbuf[num++];
-    return true;
+    sprintf(tmpbuf, "%d", _op);
+    op = tmpbuf;
+    has_value = true;
   }
 
-  boolean exception::set_operand(const char *&op, int _op)
+  arg::arg(int _op)
   {
-    sprintf(tmpbuf[num], "%d", _op);
-    op = tmpbuf[num++];
-    return true;
+    sprintf(tmpbuf, "%d", _op);
+    op = tmpbuf;
+    has_value = true;
   }
 
-  boolean exception::set_operand(const char *&op, long _op)
+  arg::arg(long _op)
   {
-    sprintf(tmpbuf[num], "%ld", _op);
-    op = tmpbuf[num++];
-    return true;
+    sprintf(tmpbuf, "%ld", _op);
+    op = tmpbuf;
+    has_value = true;
   }
 
-  boolean exception::set_operand(const char *&op, long long _op)
+  arg::arg(long long _op)
   {
-    sprintf(tmpbuf[num], "%lld", _op);
-    op = tmpbuf[num++];
-    return true;
+    sprintf(tmpbuf, "%lld", _op);
+    op = tmpbuf;
+    has_value = true;
   }
 
   template<class T, class E = std::enable_if<std::is_integral<T>::value>>
@@ -224,7 +240,8 @@ namespace Unit
 
       for(size_t i = 0; i < length; i++)
       {
-        size_t n = snprintf(pos, allocleft, "%0*lx ", (int)sizeof(T) * 2, (unsigned long)_op[i]);
+        typename std::make_unsigned<T>::type tmp = _op[i];
+        size_t n = snprintf(pos, allocleft, "%0*lx ", (int)sizeof(T) * 2, (unsigned long)tmp);
         if(n >= allocleft)
           break;
 
@@ -237,43 +254,108 @@ namespace Unit
     return nullptr;
   }
 
-  void exception::set_operand_alloc(const char *&op, char *buf)
+  arg::arg(const void *_ptr, size_t length_bytes)
   {
-    if(buf)
+    // Print most memcmp types (including  non-integral types) bytewise.
+    const unsigned char *_ptr8 = reinterpret_cast<const unsigned char *>(_ptr);
+    allocbuf = _set_operand_integral_ptr(_ptr8, length_bytes / sizeof(char));
+    op = allocbuf;
+    has_value = !!allocbuf;
+  }
+
+  arg::arg(const unsigned short *_ptr, size_t length_bytes)
+  {
+    allocbuf = _set_operand_integral_ptr(_ptr, length_bytes / sizeof(short));
+    op = allocbuf;
+    has_value = !!allocbuf;
+  }
+
+  arg::arg(const unsigned int *_ptr, size_t length_bytes)
+  {
+    allocbuf = _set_operand_integral_ptr(_ptr, length_bytes / sizeof(int));
+    op = allocbuf;
+    has_value = !!allocbuf;
+  }
+
+
+  /************************************************************************
+   * Unit::exception functions.
+   */
+
+  template<size_t N>
+  static void set_reason_fmt(Unit::exception *e, char (&reasonbuf)[N], const char *_reason_fmt, va_list vl)
+  {
+    /**
+     * The reason format may be prefixed with a ~. This is so the format string
+     * provided to Unit::exception constructors can be checked by the compiler
+     * and not be flagged as invalid due to an empty input string.
+     */
+    if(_reason_fmt[0] == '~')
+      _reason_fmt++;
+
+    if(_reason_fmt[0] == '\0')
+      return;
+
+    vsnprintf(reasonbuf, sizeof(reasonbuf), _reason_fmt, vl);
+    e->reason = reasonbuf;
+    e->has_reason = true;
+  }
+
+  exception::exception(const exception &e):
+   leftarg(e.leftarg), rightarg(e.rightarg)
+  {
+    memcpy(reasonbuf, e.reasonbuf, sizeof(reasonbuf));
+    line = e.line;
+    test = e.test;
+    reason = e.reason;
+    has_reason = e.has_reason;
+    left = e.left;
+    right = e.right;
+    has_values = e.has_values;
+  }
+
+  exception::exception(int _line, const char *_test):
+   line(_line), test(coalesce(_test)), reason("") {}
+
+  exception::exception(int _line, const char *_test, const char *_reason_fmt, ...):
+   line(_line), test(coalesce(_test))
+  {
+    if(_reason_fmt)
     {
-      allocbuf[num++] = buf;
-      op = buf;
+      va_list vl;
+      va_start(vl, _reason_fmt);
+      set_reason_fmt(this, reasonbuf, _reason_fmt, vl);
+      va_end(vl);
     }
   }
 
-  void exception::set_operand_integral_ptr(const char *&op, const char *_op, size_t length)
+  exception::exception(int _line, const char *_test, Unit::arg &&_left, Unit::arg &&_right,
+   const char *_reason_fmt, ...):
+   leftarg(std::move(_left)), rightarg(std::move(_right)), line(_line), test(coalesce(_test))
   {
-    char *buf = _set_operand_integral_ptr(_op, length);
-    set_operand_alloc(op, buf);
-  }
+    if(_reason_fmt)
+    {
+      va_list vl;
+      va_start(vl, _reason_fmt);
+      set_reason_fmt(this, reasonbuf, _reason_fmt, vl);
+      va_end(vl);
+    }
 
-  void exception::set_operand_integral_ptr(const char *&op, const unsigned char *_op, size_t length)
-  {
-    char *buf = _set_operand_integral_ptr(_op, length);
-    set_operand_alloc(op, buf);
-  }
-
-  void exception::set_operand_integral_ptr(const char *&op, const unsigned short *_op, size_t length)
-  {
-    char *buf = _set_operand_integral_ptr(_op, length);
-    set_operand_alloc(op, buf);
-  }
-
-  void exception::set_operand_integral_ptr(const char *&op, const unsigned int *_op, size_t length)
-  {
-    char *buf = _set_operand_integral_ptr(_op, length);
-    set_operand_alloc(op, buf);
+    left = leftarg.op;
+    right = rightarg.op;
+    has_values = leftarg.has_value || rightarg.has_value;
   }
 
 
   /************************************************************************
    * Unit::unittest functions.
    */
+
+  unittest::unittest(const char *_file, const char *_test_name):
+   file_name(_file), test_name(_test_name)
+  {
+    unittestrunner::get().addtest(this);
+  }
 
   void unittest::run_section(void)
   {
@@ -291,7 +373,7 @@ namespace Unit
     }
   }
 
-  bool unittest::run(void)
+  bool unittest::run()
   {
     assert(!has_run);
     has_run = true;
@@ -348,6 +430,11 @@ namespace Unit
 
     print_test_success();
     return true;
+  }
+
+  int unittest::passed_sections()
+  {
+    return this->count_sections - this->failed_sections - this->skipped_sections;
   }
 
   void unittest::print_test_success(void)
@@ -547,5 +634,192 @@ namespace Unit
   void unittestrunner::addtest(unittest *t)
   {
     gettests().push_back(t);
+  }
+
+
+  /************************************************************************
+   * Unit::self_check
+   *
+   * Precheck Unit::arg and Unit::exception to make sure they will behave
+   * as expected if one of the actual tests fails.
+   */
+
+  static bool match(const char *name, const Unit::arg &value, const char *expected, boolean has_value=true)
+  {
+    if(value.has_value != has_value)
+    {
+      Uerr("ERROR: self check '%s' failed: has_value %u != %u\n", name, value.has_value, has_value);
+      return false;
+    }
+    else
+
+    if(value.op == nullptr || expected == nullptr)
+    {
+      if(value.op != expected)
+      {
+        Uerr("ERROR: self check '%s' failed: %p != %p\n", name, value.op, expected);
+        return false;
+      }
+    }
+    else
+
+    if(strcmp(value.op, expected))
+    {
+      Uerr("ERROR: self check '%s' failed: '%s' != '%s'\n", name, value.op, expected);
+      return false;
+    }
+    return true;
+  }
+
+  static bool match(const char *name, const Unit::exception &e, int line,
+   const char *test, const char *left, const char *right, const char *reason)
+  {
+    if(!e.test)
+    {
+      Uerr("ERROR: self check '%s' failed: NULL test\n", name);
+      return false;
+    }
+    if(!e.left)
+    {
+      Uerr("ERROR: self check '%s' failed: NULL left\n", name);
+      return false;
+    }
+    if(!e.right)
+    {
+      Uerr("ERROR: self check '%s' failed: NULL right\n", name);
+      return false;
+    }
+    if(!e.reason)
+    {
+      Uerr("ERROR: self check '%s' failed: NULL reason\n", name);
+      return false;
+    }
+    if(e.line != line)
+    {
+      Uerr("ERROR: self check '%s' failed: line %d != %d\n", name, e.line, line);
+      return false;
+    }
+    if(strcmp(e.test, test))
+    {
+      Uerr("ERROR: self check '%s' failed: test '%s' != '%s'\n", name, e.test, test);
+      return false;
+    }
+    if(strcmp(e.left, left))
+    {
+      Uerr("ERROR: self check '%s' failed: left '%s' != '%s'\n", name, e.left, left);
+      return false;
+    }
+    if(strcmp(e.right, right))
+    {
+      Uerr("ERROR: self check '%s' failed: right '%s' != '%s'\n", name, e.right, right);
+      return false;
+    }
+    if(strcmp(e.reason, reason))
+    {
+      Uerr("ERROR: self check '%s' failed: reason '%s' != '%s'\n", name, e.reason, reason);
+      return false;
+    }
+    return true;
+  }
+
+  bool self_check()
+  {
+    /* Test Unit::arg. */
+    if(!match("arg::default", Unit::arg(), nullptr, false))
+      return false;
+
+    if(!match("arg::nullptr", Unit::arg(nullptr), "NULL", false))
+      return false;
+
+    if(!match("arg::string", Unit::arg("abfjksdsfl"), "abfjksdsfl"))
+      return false;
+
+    if(!match("arg::void *", Unit::arg((const void *)0x12345678), "0x12345678"))
+      return false;
+
+    if(!match("arg::unsigned char", Unit::arg((unsigned char)255), "255"))
+      return false;
+
+    if(!match("arg::unsigned short", Unit::arg((unsigned short)65535), "65535"))
+      return false;
+
+    if(!match("arg::unsigned int", Unit::arg(65535U), "65535"))
+      return false;
+
+    if(!match("arg::unsigned long", Unit::arg(2147483647UL), "2147483647"))
+      return false;
+
+    Unit::arg ulln(18446744073709551615ULL);
+    if(!match("arg::unsigned long long", ulln, "18446744073709551615"))
+      return false;
+
+    if(!match("arg::signed char", Unit::arg((signed char)-1), "-1"))
+      return false;
+
+    if(!match("arg::short", Unit::arg((signed short)-32767), "-32767"))
+      return false;
+
+    if(!match("arg::int", Unit::arg(-32767), "-32767"))
+      return false;
+
+    if(!match("arg::long", Unit::arg(-2147483647L), "-2147483647"))
+      return false;
+
+    Unit::arg lln(-9223372036854775807LL);
+    if(!match("arg::long long", lln, "-9223372036854775807"))
+      return false;
+
+    int8_t values8s[] = { -1, -2, -3, -4, -5 };
+    uint8_t values8[] = { 1, 2, 3, 4, 5 };
+    uint16_t values16[] = { 0x1234, 0x5678, 0x9abc, 0xdef0 };
+    uint32_t values32[] = { 0xfedc, 0xab98, 0x7654, 0x3210 };
+
+    Unit::arg alloc8s(values8s, sizeof(values8s));
+    if(!match("arg::int8_t array", alloc8s, "ff fe fd fc fb"))
+      return false;
+
+    Unit::arg alloc8(values8, sizeof(values8));
+    if(!match("arg::uint8_t array", alloc8, "01 02 03 04 05"))
+      return false;
+
+    Unit::arg alloc16(values16, sizeof(values16));
+    if(!match("arg::uint16_t array", alloc16, "1234 5678 9abc def0"))
+      return false;
+
+    Unit::arg alloc32(values32, sizeof(values32));
+    if(!match("arg::uint32_t array", alloc32, "0000fedc 0000ab98 00007654 00003210"))
+      return false;
+
+    if(!match("arg::move dest", Unit::arg(std::move(alloc8)), "01 02 03 04 05"))
+      return false;
+    if(!match("arg::move src", alloc8, nullptr, false))
+      return false;
+
+    /* Test Unit::exception. */
+
+    if(!match("exception::fixed", Unit::exception(1, "Test name only."),
+     1, "Test name only.", coalesce(nullptr), coalesce(nullptr), ""))
+      return false;
+
+    if(!match("exception::fail", Unit::exception(2, "Test name+reason", "%s%d", "abc", 123),
+     2, "Test name+reason", coalesce(nullptr), coalesce(nullptr), "abc123"))
+      return false;
+
+    Unit::exception e_equal(3, "Test equal", Unit::arg("abc"), Unit::arg(456),
+     "~Should remove the ~.");
+    if(!match("exception::equal", e_equal, 3, "Test equal", "abc", "456", "Should remove the ~."))
+      return false;
+
+    Unit::exception e_memcmp(4, "Test memcmp",
+     Unit::arg("0123", 4), Unit::arg("4567", 4), "mesg 0x%08x", 0x1234);
+    if(!match("exception::memcmp", e_memcmp, 4, "Test memcmp",
+     "30 31 32 33", "34 35 36 37", "mesg 0x00001234"))
+      return false;
+
+    Unit::exception e_noreason(5, "No reason!", Unit::arg(1), Unit::arg(2), "~");
+    if(!match("exception::noreason", e_noreason, 5, "No reason!", "1", "2", coalesce(nullptr)))
+      return false;
+
+    return true;
   }
 }

--- a/unit/Unit.cpp
+++ b/unit/Unit.cpp
@@ -89,10 +89,7 @@ int main(int argc, char *argv[])
   }
 
   if(!Unit::self_check())
-  {
-    Uerr("ERROR: self check failed!\n");
     return 1;
-  }
 
   std::signal(SIGABRT, sigabrt_handler);
   return !(Unit::unittestrunner::get().run());

--- a/unit/Unit.cpp
+++ b/unit/Unit.cpp
@@ -798,9 +798,36 @@ namespace Unit
     if(!match("arg::uint32_t array", alloc32, "0000fedc 0000ab98 00007654 00003210"))
       return false;
 
-    if(!match("arg::move dest", Unit::arg(std::move(alloc8)), "01 02 03 04 05"))
+    Unit::arg src(12345U);
+    if(!match("arg::copy int dest", Unit::arg(src), "12345"))
       return false;
-    if(!match("arg::move src", alloc8, nullptr, false))
+    if(!match("arg::copy int src", src, "12345"))
+      return false;
+
+    Unit::arg str("abcdef");
+    if(!match("arg::copy str dest", Unit::arg(str), "abcdef"))
+      return false;
+    if(!match("arg::copy str src", str, "abcdef"))
+      return false;
+
+    if(!match("arg::copy array dest", Unit::arg(alloc8s), "ff fe fd fc fb"))
+      return false;
+    if(!match("arg::copy array src", alloc8s, "ff fe fd fc fb"))
+      return false;
+
+    if(!match("arg::move int dest", Unit::arg(std::move(src)), "12345"))
+      return false;
+    if(!match("arg::move int src", src, nullptr, false))
+      return false;
+
+    if(!match("arg::move str dest", Unit::arg(std::move(str)), "abcdef"))
+      return false;
+    if(!match("arg::move str src", str, nullptr, false))
+      return false;
+
+    if(!match("arg::move array dest", Unit::arg(std::move(alloc8)), "01 02 03 04 05"))
+      return false;
+    if(!match("arg::move array src", alloc8, nullptr, false))
       return false;
 
     /* Test Unit::exception. */

--- a/unit/Unit.hpp
+++ b/unit/Unit.hpp
@@ -137,14 +137,13 @@ public:
     memcpy(u.arr, str, B);
   }
 
-/*
   alignstr(const char * const str)
   {
     size_t slen = strlen(str);
-    assert(slen + 1 <= A);
+    if(slen + 1 > A)
+      abort();
     memcpy(u.arr, str, slen);
   }
-*/
 
   constexpr const char *c_str() const
   {

--- a/unit/Unit.hpp
+++ b/unit/Unit.hpp
@@ -75,8 +75,8 @@
 #define EDITOR_LIBSPEC
 #define SKIP_SDL
 #include "../src/compat.h"
+#include "../src/platform_attribute.h"
 
-#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -167,7 +167,7 @@ public:
   {\
     if(!(test)) \
     { \
-      throw Unit::exception(__LINE__, #test, "" __VA_ARGS__); \
+      throw Unit::exception(__LINE__, #test, "~" __VA_ARGS__); \
     } \
   } while(0)
 
@@ -176,7 +176,8 @@ public:
   {\
     if(!((a) == (b)))\
     { \
-      throw Unit::exception(__LINE__, #a " == " #b, (a), (b), "" __VA_ARGS__); \
+      throw Unit::exception(__LINE__, #a " == " #b, \
+       Unit::arg(a), Unit::arg(b), "~" __VA_ARGS__); \
     } \
   } while(0)
 
@@ -185,7 +186,8 @@ public:
   {\
     if(strcmp(a,b)) \
     {\
-      throw Unit::exception(__LINE__, "strcmp(" #a ", " #b ")", (a), (b), "" __VA_ARGS__); \
+      throw Unit::exception(__LINE__, "strcmp(" #a ", " #b ")", \
+       Unit::arg(a), Unit::arg(b), "~" __VA_ARGS__); \
     }\
   } while(0)
 
@@ -194,7 +196,8 @@ public:
   {\
     if(strncmp(a,b,n)) \
     {\
-      throw Unit::exception(__LINE__, "strncmp(" #a ", " #b ", " #n ")", (a), (b), "" __VA_ARGS__); \
+      throw Unit::exception(__LINE__, "strncmp(" #a ", " #b ", " #n ")", \
+       Unit::arg(a), Unit::arg(b), "~" __VA_ARGS__); \
     }\
   } while(0)
 
@@ -203,14 +206,15 @@ public:
   {\
     if(memcmp(a,b,l)) \
     {\
-      throw Unit::exception(__LINE__, "memcmp(" #a ", " #b ", " #l ")", (a), (b), (l), "" __VA_ARGS__); \
+      throw Unit::exception(__LINE__, "memcmp(" #a ", " #b ", " #l ")", \
+       Unit::arg(a, l), Unit::arg(b, l), "~" __VA_ARGS__); \
     }\
   } while(0)
 
 #define FAIL(...) \
   do\
   {\
-    throw Unit::exception(__LINE__, -1, "" __VA_ARGS__); \
+    throw Unit::exception(__LINE__, nullptr, "" __VA_ARGS__); \
   } while(0)
 
 #define SKIP() \
@@ -259,6 +263,49 @@ namespace Unit
     return Unit::max(_min, Unit::min(_max, a));
   }
 
+  /**
+   * Input value to a failed assertion. These are generated for Unit::exception
+   * instances thrown from assertions with multiple operands. This provides a
+   * printable text representation of the operand (i.e. std::string but worse)
+   * and also disambiguates the correct Unit::exception constructor to use.
+   */
+  class arg final
+  {
+    static constexpr int BUF_SIZE = 23;
+    char *allocbuf = nullptr;
+    char tmpbuf[BUF_SIZE] = { '\0' };
+
+  public:
+    boolean has_value = false;
+    const char *op = nullptr;
+
+    arg();
+    arg(arg &&a);
+    arg(const arg &a);
+    ~arg();
+
+    explicit arg(decltype(nullptr) _op);
+    explicit arg(const char *_op);
+    explicit arg(const void *_op);
+    explicit arg(unsigned char _op);
+    explicit arg(unsigned short _op);
+    explicit arg(unsigned int _op);
+    explicit arg(unsigned long _op);
+    explicit arg(unsigned long long _op);
+    explicit arg(signed char _op);
+    explicit arg(short _op);
+    explicit arg(int _op);
+    explicit arg(long _op);
+    explicit arg(long long _op);
+
+    explicit arg(const void *_ptr, size_t length_bytes);
+    explicit arg(const unsigned short *_ptr, size_t length_bytes);
+    explicit arg(const unsigned int *_ptr, size_t length_bytes);
+  };
+
+  /**
+   * Thrown to signal the current test (or test section) has been skipped.
+   */
   class skip final {};
 
   /**
@@ -266,6 +313,11 @@ namespace Unit
    */
   class exception final
   {
+  private:
+    char reasonbuf[1024];
+    Unit::arg leftarg;
+    Unit::arg rightarg;
+
   public:
     int line;
     const char *test      = coalesce(nullptr);
@@ -278,109 +330,12 @@ namespace Unit
     /* A copy constructor is required to be throwable. */
     exception(const exception &e);
 
-    exception(int _line, const char *_test):
-     line(_line), test(coalesce(_test)), reason("") {}
-
-    exception(int _line, int _ignore, const char *_reason_fmt, ...):
-     line(_line), test(coalesce(nullptr))
-    {
-      if(_reason_fmt && _reason_fmt[0])
-      {
-        va_list vl;
-        va_start(vl, _reason_fmt);
-        set_reason_fmt(_reason_fmt, vl);
-        va_end(vl);
-      }
-    }
-
-    exception(int _line, const char *_test, const char *_reason_fmt, ...):
-     line(_line), test(coalesce(_test))
-    {
-      if(_reason_fmt && _reason_fmt[0])
-      {
-        va_list vl;
-        va_start(vl, _reason_fmt);
-        set_reason_fmt(_reason_fmt, vl);
-        va_end(vl);
-      }
-    }
-
-    template<class T, class S>
-    exception(int _line, const char *_test, T _left, S _right, const char *_reason_fmt, ...):
-     line(_line), test(coalesce(_test))
-    {
-      if(_reason_fmt && _reason_fmt[0])
-      {
-        va_list vl;
-        va_start(vl, _reason_fmt);
-        set_reason_fmt(_reason_fmt, vl);
-        va_end(vl);
-      }
-
-      has_values |= set_operand(left, _left);
-      has_values |= set_operand(right, _right);
-    }
-
-    template<class T>
-    exception(int _line, const char *_test, const T *_left, const T *_right,
-     size_t length, const char *_reason_fmt, ...):
-     line(_line), test(coalesce(_test))
-    {
-      if(_reason_fmt && _reason_fmt[0])
-      {
-        va_list vl;
-        va_start(vl, _reason_fmt);
-        set_reason_fmt(_reason_fmt, vl);
-        va_end(vl);
-      }
-
-      has_values = (_left || _right);
-      length /= sizeof(T);
-
-      set_operand_integral_ptr(left, _left, length);
-      set_operand_integral_ptr(right, _right, length);
-    }
-
-    // Print non-integral memcmp types bytewise.
-    exception(int _line, const char *_test, const void *_left, const void *_right,
-     size_t length, const char *_reason):
-     exception(_line, _test, (const unsigned char *)_left, (const unsigned char *)_right,
-      length, _reason) {}
-
-    ~exception()
-    {
-      delete[] allocbuf[0];
-      delete[] allocbuf[1];
-    }
-
-  private:
-
-    static constexpr int BUF_SIZE = 24;
-    char reasonbuf[1024];
-    char tmpbuf[2][BUF_SIZE];
-    char *allocbuf[2] = { nullptr, nullptr };
-    int num = 0;
-
-    void set_reason_fmt(const char *_reason_fmt, va_list vl);
-    boolean set_operand(const char *&op, decltype(nullptr) _op);
-    boolean set_operand(const char *&op, const char *_op);
-    boolean set_operand(const char *&op, const void *_op);
-    boolean set_operand(const char *&op, unsigned char _op);
-    boolean set_operand(const char *&op, unsigned short _op);
-    boolean set_operand(const char *&op, unsigned int _op);
-    boolean set_operand(const char *&op, unsigned long _op);
-    boolean set_operand(const char *&op, unsigned long long _op);
-    boolean set_operand(const char *&op, signed char _op);
-    boolean set_operand(const char *&op, short _op);
-    boolean set_operand(const char *&op, int _op);
-    boolean set_operand(const char *&op, long _op);
-    boolean set_operand(const char *&op, long long _op);
-
-    void set_operand_alloc(const char *&op, char *buf);
-    void set_operand_integral_ptr(const char *&op, const char *_op, size_t length);
-    void set_operand_integral_ptr(const char *&op, const unsigned char *_op, size_t length);
-    void set_operand_integral_ptr(const char *&op, const unsigned short *_op, size_t length);
-    void set_operand_integral_ptr(const char *&op, const unsigned int *_op, size_t length);
+    exception(int _line, const char *_test);
+    ATTRIBUTE_PRINTF(4, 5)
+    exception(int _line, const char *_test, const char *_reason_fmt, ...);
+    ATTRIBUTE_PRINTF(6, 7)
+    exception(int _line, const char *_test, Unit::arg &&_left, Unit::arg &&_right,
+     const char *_reason_fmt, ...);
   };
 
   /**
@@ -401,7 +356,7 @@ namespace Unit
 
   public:
     static unittestrunner &get();
-    bool run(void);
+    bool run();
     void signal_fail();
     void addtest(unittest *t);
   };
@@ -433,24 +388,14 @@ namespace Unit
 
     bool entire_test_skipped;
 
-    unittest(const char *_file, const char *_test_name):
-     file_name(_file), test_name(_test_name)
-    {
-      unittestrunner::get().addtest(this);
-    };
+    unittest(const char *_file, const char *_test_name);
 
-    ~unittest() {};
-
-    inline int passed_sections(void)
-    {
-      return this->count_sections - this->failed_sections - this->skipped_sections;
-    }
-
-    bool run(void);
+    bool run();
     void signal_fail();
 
   private:
     void run_section(void);
+    int passed_sections();
     void print_test_success(void);
     void print_test_failed(void);
     void print_test_skipped(void);
@@ -459,6 +404,11 @@ namespace Unit
 
     virtual void run_impl(void) = 0;
   };
+
+  /**
+   * Check the unit test system before running any tests.
+   */
+  bool self_check();
 }
 
 #endif /* UNIT_HPP */

--- a/unit/Unit.hpp
+++ b/unit/Unit.hpp
@@ -300,6 +300,9 @@ namespace Unit
     explicit arg(const void *_ptr, size_t length_bytes);
     explicit arg(const unsigned short *_ptr, size_t length_bytes);
     explicit arg(const unsigned int *_ptr, size_t length_bytes);
+
+  private:
+    const char *fix_op(const arg &src);
   };
 
   /**

--- a/unit/intake.cpp
+++ b/unit/intake.cpp
@@ -631,10 +631,10 @@ UNITTEST(EventFixed)
       intake_set_pos(&intk, d.start_pos);
 
       result = intake_apply_event_fixed(sub, INTK_CLEAR, 0, 0, nullptr);
-      ASSERTEQ(result, true, "%s", "%s @ %d", d.base, d.start_pos);
-      ASSERTCMP(dest, "", "%s", "%s @ %d", d.base, d.start_pos);
-      ASSERTEQ(intk.current_length, 0, "%s", "%s @ %d", d.base, d.start_pos);
-      ASSERTEQ(intk.pos, d.new_pos, "%s", "%s @ %d", d.base, d.start_pos);
+      ASSERTEQ(result, true, "%s @ %d", d.base, d.start_pos);
+      ASSERTCMP(dest, "", "%s @ %d", d.base, d.start_pos);
+      ASSERTEQ(intk.current_length, 0, "%s @ %d", d.base, d.start_pos);
+      ASSERTEQ(intk.pos, d.new_pos, "%s @ %d", d.base, d.start_pos);
     }
   }
 

--- a/unit/io/memfile.cpp
+++ b/unit/io/memfile.cpp
@@ -289,9 +289,9 @@ UNITTEST(mfseek_mftell)
 
     for(const seq seq : sequence)
     {
-      ASSERTEQ(mftell(&mf), seq.position, "seek_cur sequence %d->%d", seq.position, seq.next);
+      ASSERTEQ(mftell(&mf), seq.position, "seek_cur sequence %ld->%d", seq.position, seq.next);
       ret = mfseek(&mf, seq.next, SEEK_CUR);
-      ASSERTEQ(ret, seq.retval, "seek_cur sequence %d->%d", seq.position, seq.next);
+      ASSERTEQ(ret, seq.retval, "seek_cur sequence %ld->%d", seq.position, seq.next);
     }
   }
 


### PR DESCRIPTION
* Due to some issues in how the variadic `Unit::exception` constructors were implemented, the wrong constructor could be selected when comparing strings, resulting in a nonsense error report. This has been fixed by replacing the `const char *` argument fields with a new class `Unit::arg` (that does more or less the same thing `std::string` was used for before). Usage of `Unit::arg` also means the `Unit::exception` constructors no longer need to be templates.
* `memcmp` array exception arguments are now handled by `Unit::arg`, meaning several `Unit::exception` constructors are no longer needed and have been removed.
* The `Unit::exception` variadic constructors now use `__attribute__((format(printf)))`. This caught several broken format strings.
* `main` runs `Unit::self_check` before running any unit tests now. This function makes sure `Unit::arg` and `Unit::exception` are doing (mostly) what they're intended. (This could probably be more thorough.)
* The `alignstr` `const char *` constructor has been fixed since I forgot GCC 4.8.5 relies on it.
* All functions related to unit test running and exceptions have been moved to Unit.cpp. Only the utility functions/classes remain in the header.