### PR TITLE
Add virtual filesystem and misc. unit test tweaks.

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -71,6 +71,7 @@ usage() {
 	echo "  --disable-utils           Disable compilation of utils."
 	echo "  --disable-check-alloc     Disables memory allocator error handling."
 	echo "  --disable-counter-hash    Disables hash tables for counter/string lookups."
+	echo "  --disable-vfs             Disables MZX's built-in virtual filesystem."
 	echo "  --enable-extram           Enable board memory compression and storage hacks."
 	echo "  --enable-meter            Enable load/save meter display."
 	echo "  --enable-debytecode       Enable experimental 'debytecode' transform."
@@ -186,6 +187,7 @@ STDIO_REDIRECT="false"
 GAMECONTROLLERDB="true"
 FPSCOUNTER="false"
 LAYER_RENDERING="true"
+VFS="true"
 
 #
 # User may override above settings
@@ -403,6 +405,9 @@ while [ "$1" != "" ]; do
 
 	[ "$1" = "--enable-counter-hash" ]  && COUNTER_HASH="true"
 	[ "$1" = "--disable-counter-hash" ] && COUNTER_HASH="false"
+
+	[ "$1" = "--enable-vfs" ]  && VFS="true"
+	[ "$1" = "--disable-vfs" ] && VFS="false"
 
 	[ "$1" = "--enable-debytecode" ]  && DEBYTECODE="true"
 	[ "$1" = "--disable-debytecode" ] && DEBYTECODE="false"
@@ -761,6 +766,9 @@ if [ "$PLATFORM" = "emscripten" ]; then
 	echo "Force-disabling stack protector (Emscripten)."
 	STACK_PROTECTOR="false"
 
+	echo "Force-disabling virtual filesystem (Emscripten)."
+	VFS="false"
+
 	EDITOR="false"
 	SCREENSHOTS="false"
 	UPDATER="false"
@@ -791,6 +799,9 @@ if [ "$PLATFORM" = "nds" ]; then
 
 	echo "Force-disabling layer rendering on NDS."
 	LAYER_RENDERING="false"
+
+	echo "Force-disabling virtual filesystem on NDS."
+	VFS="false"
 
 	echo "Force-disabling existing music playback libraries on NDS."
 	MODPLUG="false"
@@ -1614,6 +1625,16 @@ if [ "$COUNTER_HASH" = "true" ]; then
 	echo "BUILD_COUNTER_HASH_TABLES=1" >> platform.inc
 else
 	echo "Hash table counter/string lookups disabled (using binary search)."
+fi
+
+#
+# Virtual filesystem, if enabled
+#
+if [ "$VFS" = "true" ]; then
+	echo "Virtual filesystem enabled."
+	echo "#define CONFIG_VFS" >> src/config.h
+else
+	echo "Virtual filesystem disabled."
 fi
 
 #

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -125,6 +125,7 @@ core_cobjs := \
   ${core_obj}/world.o             \
   ${io_obj}/fsafeopen.o           \
   ${io_obj}/path.o                \
+  ${io_obj}/vfs.o                 \
   ${io_obj}/vio.o                 \
   ${io_obj}/zip.o                 \
   ${io_obj}/zip_stream.o

--- a/src/io/path.c
+++ b/src/io/path.c
@@ -563,20 +563,10 @@ ssize_t path_remove_prefix(char *path, size_t buffer_len,
 }
 
 /**
- * Navigate a directory path to a target like chdir. The provided directory
- * path must be a valid directory. The target may be a relative path or an
- * absolute path in either Unix or Windows style. If "." or ".." is found in
- * the target, it will be handled appropriately. If the final resulting path
- * successfully stats, the provided path will be overwritten with the
- * destination. If the final path is not valid or if an error occurs, the
- * provided path will not be modified.
- *
- * @param  path       Directory path to navigate from.
- * @param  path_len   Size of path buffer.
- * @param  target     Target to navigate to.
- * @return            The new length of the path, or -1 on error.
+ * Internal common implementation for `path_navigate` and `path_navigate_no_check`.
  */
-ssize_t path_navigate(char *path, size_t path_len, const char *target)
+static ssize_t path_navigate_internal(char *path, size_t path_len, const char *target,
+ boolean allow_checks)
 {
   struct stat stat_info;
   char buffer[MAX_PATH];
@@ -608,7 +598,7 @@ ssize_t path_navigate(char *path, size_t path_len, const char *target)
      target);
     buffer[MAX_PATH - 1] = '\0';
 
-    if(vstat(buffer, &stat_info) < 0)
+    if(allow_checks && vstat(buffer, &stat_info) < 0)
       return -1;
 
     current = next + 1;
@@ -692,15 +682,53 @@ ssize_t path_navigate(char *path, size_t path_len, const char *target)
 
   // This needs to be done before the stat for some platforms (e.g. 3DS)
   len = path_clean_slashes(buffer, MAX_PATH);
-  if(len < path_len && vstat(buffer, &stat_info) >= 0 &&
-   S_ISDIR(stat_info.st_mode) && !vaccess(buffer, R_OK|X_OK))
+  if(len < path_len)
   {
+    if(allow_checks)
+    {
+      if(vstat(buffer, &stat_info) < 0 || !S_ISDIR(stat_info.st_mode) ||
+       vaccess(buffer, R_OK|X_OK) < 0)
+        return -1;
+    }
     memcpy(path, buffer, len + 1);
     path[path_len - 1] = '\0';
     return len;
   }
 
   return -1;
+}
+
+/**
+ * Navigate a directory path to a target like chdir. The provided directory
+ * path must be a valid directory. The target may be a relative path or an
+ * absolute path in either Unix or Windows style. If "." or ".." is found in
+ * the target, it will be handled appropriately. If the final resulting path
+ * successfully stats, the provided path will be overwritten with the
+ * destination. If the final path is not valid or if an error occurs, the
+ * provided path will not be modified.
+ *
+ * @param  path       Directory path to navigate from.
+ * @param  path_len   Size of path buffer.
+ * @param  target     Target to navigate to.
+ * @return            The new length of the path, or -1 on error.
+ */
+ssize_t path_navigate(char *path, size_t path_len, const char *target)
+{
+  return path_navigate_internal(path, path_len, target, true);
+}
+
+/**
+ * Like `path_navigate`, but no `vstat` or `vaccess` call will be performed to
+ * check the resulting path. See `path_navigate` for more info.
+ *
+ * @param  path       Directory path to navigate from.
+ * @param  path_len   Size of path buffer.
+ * @param  target     Target to navigate to.
+ * @return            The new length of the path, or -1 on error.
+ */
+ssize_t path_navigate_no_check(char *path, size_t path_len, const char *target)
+{
+  return path_navigate_internal(path, path_len, target, false);
 }
 
 /**

--- a/src/io/path.c
+++ b/src/io/path.c
@@ -30,6 +30,39 @@
 #include "vio.h"
 
 /**
+ * Tokenize a null terminated path string. This is a special implementation
+ * of `strsep` for paths.
+ *
+ * Note this function currently isn't aware of absolute paths, so "C:/a" will
+ * tokenize to "C:" followed by "a". If this behavior isn't desired, use the
+ * return value of `path_is_absolute` before tokenizing to skip the root. This
+ * function also does not skip duplicate slashes or trailing slashes
+ * (see `path_clean_slashes`).
+ *
+ * @param next  pointer to the current position in the path string.
+ *              The value will be updated to the location of the next token or
+ *              to `NULL` if there are no further tokens.
+ * @return      the initial value of `next` if it represents a token (i.e. is
+ *              not `NULL`), otherwise `NULL`.
+ */
+char *path_tokenize(char **next)
+{
+  char *src = *next;
+  if(src)
+  {
+    char *current = strpbrk(src, "\\/");
+    if(current)
+    {
+      *current = '\0';
+      *next = current + 1;
+    }
+    else
+      *next = NULL;
+  }
+  return src;
+}
+
+/**
  * Force a given filename path to use the provided file extension. If the
  * filename already has the given extension, the string will not be modified.
  *

--- a/src/io/path.h
+++ b/src/io/path.h
@@ -27,6 +27,7 @@
 __M_BEGIN_DECLS
 
 #include <stddef.h>
+#include <string.h>
 
 #ifndef DIR_SEPARATOR
 #ifdef __WIN32__
@@ -56,6 +57,8 @@ static inline boolean isslash(const char chr)
 {
   return (chr == '\\') || (chr == '/');
 }
+
+UTILS_LIBSPEC char *path_tokenize(char **next);
 
 UTILS_LIBSPEC boolean path_force_ext(char *path, size_t buffer_len, const char *ext);
 UTILS_LIBSPEC ssize_t path_get_ext_offset(const char *path);

--- a/src/io/path.h
+++ b/src/io/path.h
@@ -27,7 +27,6 @@
 __M_BEGIN_DECLS
 
 #include <stddef.h>
-#include <string.h>
 
 #ifndef DIR_SEPARATOR
 #ifdef __WIN32__

--- a/src/io/path.h
+++ b/src/io/path.h
@@ -83,6 +83,8 @@ UTILS_LIBSPEC ssize_t path_remove_prefix(char *path, size_t buffer_len,
 
 UTILS_LIBSPEC ssize_t path_navigate(char *path, size_t path_len,
  const char *target);
+UTILS_LIBSPEC ssize_t path_navigate_no_check(char *path, size_t path_len,
+ const char *target);
 
 UTILS_LIBSPEC enum path_create_error path_create_parent_recursively(
  const char *filename);

--- a/src/io/vfs.c
+++ b/src/io/vfs.c
@@ -408,6 +408,25 @@ static uint32_t vfs_get_inode_in_parent_by_name(vfilesystem *vfs,
 
   assert(parent->length >= 2);
 
+  /* Special case--current and parent dir. */
+  if(name[0] == '.')
+  {
+    if(name[1] == '.' && name[2] == '\0')
+    {
+      if(index)
+        *index = VFS_IDX_PARENT;
+      return parent->contents.inodes[VFS_IDX_PARENT];
+    }
+    else
+
+    if(name[1] == '\0')
+    {
+      if(index)
+        *index = VFS_IDX_SELF;
+      return parent->contents.inodes[VFS_IDX_SELF];
+    }
+  }
+
   while(a <= b)
   {
     current = (b - a) / 2 + a;
@@ -496,19 +515,6 @@ static uint32_t vfs_get_inode_by_path(vfilesystem *vfs, const char *path)
     parent = &(vfs->table[inode]);
     if(VFS_INODE_TYPE(parent) != VFS_INODE_DIR)
       return VFS_ERROR(ENOTDIR);
-
-    if(current[0] == '.')
-    {
-      if(current[1] == '.' && current[2] == '\0')
-      {
-        inode = parent->contents.inodes[VFS_IDX_PARENT];
-        continue;
-      }
-      else
-
-      if(current[1] == '\0')
-        continue;
-    }
 
     inode = vfs_get_inode_in_parent_by_name(vfs, parent, current, NULL);
     if(!inode)

--- a/src/io/vfs.c
+++ b/src/io/vfs.c
@@ -1501,6 +1501,13 @@ int vfs_rename(vfilesystem *vfs, const char *oldpath, const char *newpath)
   if(VFS_INODE_TYPE(new_p) != VFS_INODE_DIR || (new_n && VFS_IS_CACHED(new_n)))
     goto err;
 
+  // Special case: if old and new are the same, return early with success.
+  if(old_n == new_n)
+  {
+    vfs_read_unlock(vfs);
+    return 0;
+  }
+
   if(VFS_INODE_TYPE(old_n) == VFS_INODE_DIR)
   {
     // If old is a dir, the new parent should not be prefixed by old.

--- a/src/io/vfs.c
+++ b/src/io/vfs.c
@@ -1,0 +1,615 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2021 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdint.h>
+
+#include "vfs.h"
+
+#ifdef VIRTUAL_FILESYSTEM
+
+#include "../platform.h" /* get_ticks */
+#include "path.h"
+
+#define VFS_DEFAULT_FILE_SIZE 32
+#define VFS_DEFAULT_DIR_SIZE 4
+
+#define VFS_NO_INODE 0
+#define VFS_ROOT_INODE 1
+
+#define VFS_IDX_SELF   0
+#define VFS_IDX_PARENT 1
+
+#define VFS_ERROR(e) (errno = e, VFS_NO_INODE)
+
+#define VFS_INODE_TYPE(n) ((n)->flags & VFS_INODE_TYPEMASK)
+
+enum vfs_inode_flags
+{
+  VFS_INODE_FILE       = (1<<0),
+  VFS_INODE_DIR        = (1<<1),
+  VFS_INODE_TYPEMASK   = VFS_INODE_FILE | VFS_INODE_DIR,
+  VFS_INODE_IS_REAL    = (1<<2), // Cache of a real location in the filesystem.
+  VFS_INODE_NAME_ALLOC = (1<<7),
+};
+
+union vfs_inode_contents
+{
+  void *has_contents;
+  uint32_t *inodes;
+  uint8_t *data;
+};
+
+/* `name` buffer is long enough to confortably fit null terminated 8.3 names. */
+struct vfs_inode
+{
+  union vfs_inode_contents contents;
+  uint32_t length;
+  uint32_t length_alloc;
+  uint32_t timestamp;
+  uint8_t flags; // 0=deleted
+  uint8_t refcount; // If 255, refuse creation of new refs.
+  char name[14];
+};
+
+/* If `flags` & VFS_INODE_NAME_ALLOC, `name` is a pointer instead of a buffer.
+ * `name` is still null terminated in this case. Alloc size is strlen(name)+1. */
+struct vfs_inode_name_alloc
+{
+  union vfs_inode_contents contents;
+  uint32_t length;
+  uint32_t length_alloc;
+  uint32_t timestamp;
+  uint8_t flags; // 0=deleted
+  uint8_t refcount; // If 255, refuse creation of new refs.
+  char *name;
+};
+
+struct vfilesystem
+{
+  struct vfs_inode *table;
+  uint32_t table_length;
+  uint32_t table_alloc;
+  uint32_t table_next;
+  uint32_t current;
+  uint32_t current_root;
+};
+
+static uint64_t vfs_get_timestamp(void)
+{
+  return get_ticks() / 1000;
+}
+
+/**
+ * strsep but for paths.
+ * TODO: move to path.c.
+ */
+static char *vfs_tokenize(char **next)
+{
+  char *src = *next;
+  if(src)
+  {
+    char *current = strpbrk(src, "\\/");
+    if(current)
+    {
+      *current = '\0';
+      *next = current + 1;
+    }
+    else
+      *next = NULL;
+  }
+  return src;
+}
+
+static int vfs_name_cmp(const char *a, const char *b)
+{
+#ifdef VIRTUAL_FILESYSTEM_CASE_INSENSITIVE
+  return strcasecmp(a, b);
+#else
+  return strcmp(a, b);
+#endif
+}
+
+static boolean vfs_inode_init_name(struct vfs_inode *n, const char *name)
+{
+  size_t name_len = strlen(name);
+  if(name_len >= sizeof(n->name))
+  {
+    struct vfs_inode_name_alloc *_n = (struct vfs_inode_name_alloc *)n;
+    char *inode_name = malloc(name_len + 1);
+    if(!inode_name)
+      return false;
+
+    _n->flags |= VFS_INODE_NAME_ALLOC;
+    _n->name = inode_name;
+    memcpy(_n->name, name, name_len + 1);
+  }
+  else
+    memcpy(n->name, name, name_len + 1);
+
+  return true;
+}
+
+static boolean vfs_inode_rename(struct vfs_inode *n, const char *name)
+{
+  if(n->flags & VFS_INODE_NAME_ALLOC)
+  {
+    struct vfs_inode_name_alloc *_n = (struct vfs_inode_name_alloc *)n;
+    char *prev_name = _n->name;
+
+    if(!vfs_inode_init_name(n, name))
+    {
+      _n->name = prev_name;
+      return false;
+    }
+    free(_n->name);
+    return true;
+  }
+  return vfs_inode_init_name(n, name);
+}
+
+static inline const char *vfs_inode_name(struct vfs_inode *n)
+{
+  if(n->flags & VFS_INODE_NAME_ALLOC)
+  {
+    struct vfs_inode_name_alloc *_n = (struct vfs_inode_name_alloc *)n;
+    return _n->name;
+  }
+  return n->name;
+}
+
+static boolean vfs_inode_init_file(struct vfs_inode *n, const char *name,
+ size_t init_alloc, boolean is_real)
+{
+  if(init_alloc < VFS_DEFAULT_FILE_SIZE)
+    init_alloc = VFS_DEFAULT_FILE_SIZE;
+
+  n->contents.data = malloc(init_alloc);
+  if(!n->contents.data)
+    return false;
+
+  n->length = 0;
+  n->length_alloc = init_alloc;
+  n->timestamp = vfs_get_timestamp();
+  n->flags = VFS_INODE_FILE;
+  if(is_real)
+    n->flags |= VFS_INODE_IS_REAL;
+
+  if(!vfs_inode_init_name(n, name))
+  {
+    free(n->contents.data);
+    n->flags = 0;
+    return false;
+  }
+  return true;
+}
+
+static boolean vfs_inode_init_directory(struct vfs_inode *n, const char *name,
+ size_t init_alloc, boolean is_real)
+{
+  if(init_alloc < VFS_DEFAULT_DIR_SIZE)
+    init_alloc = VFS_DEFAULT_DIR_SIZE;
+
+  n->contents.inodes = malloc(init_alloc * sizeof(uint32_t));
+  if(!n->contents.inodes)
+    return false;
+
+  n->length = 2;
+  n->length_alloc = init_alloc;
+  n->timestamp = vfs_get_timestamp();
+  n->flags = VFS_INODE_DIR;
+  if(is_real)
+    n->flags |= VFS_INODE_IS_REAL;
+
+  if(!vfs_inode_init_name(n, name))
+  {
+    free(n->contents.inodes);
+    n->flags = 0;
+    return false;
+  }
+  return true;
+}
+
+static void vfs_inode_clear(struct vfs_inode *n)
+{
+  if(n->flags)
+  {
+    struct vfs_inode_name_alloc *_n = (struct vfs_inode_name_alloc *)n;
+
+    if(n->contents.has_contents)
+    {
+      free(n->contents.has_contents);
+      n->contents.has_contents = NULL;
+    }
+
+    if(n->flags & VFS_INODE_NAME_ALLOC)
+    {
+      free(_n->name);
+      _n->name = NULL;
+    }
+
+    n->flags = 0;
+  }
+}
+
+static boolean vfs_inode_expand_directory(struct vfs_inode *n, size_t count)
+{
+  uint32_t *inodes;
+  uint64_t new_length = n->length + count;
+  uint64_t new_alloc = n->length_alloc;
+
+  if(new_length > UINT32_MAX)
+    return false;
+
+  assert(VFS_INODE_TYPE(n) == VFS_INODE_DIR);
+
+  if(n->length_alloc >= new_length)
+    return true;
+
+  while(new_length > new_alloc)
+    new_alloc <<= 1;
+
+  if(new_alloc > UINT32_MAX)
+    return false;
+
+  inodes = realloc(n->contents.inodes, new_alloc * 2 * sizeof(uint32_t));
+  if(!inodes)
+    return false;
+
+  n->contents.inodes = inodes;
+  n->length_alloc = new_alloc;
+  return true;
+}
+
+/**
+ * Initialize the given VFS. The initialized VFS will contain one root inode
+ * corresponding to C: (Windows) or / (everything else).
+ */
+static boolean vfs_setup(vfilesystem *vfs)
+{
+  struct vfs_inode *n;
+
+  memset(vfs, 0, sizeof(vfilesystem));
+
+  vfs->table = calloc(4, sizeof(struct vfs_inode));
+  if(!vfs->table)
+    return false;
+
+  vfs->table_length = 2;
+  vfs->table_alloc = 4;
+  vfs->table_next = 2;
+  vfs->current = VFS_ROOT_INODE;
+  vfs->current_root = VFS_ROOT_INODE;
+
+  /* 0: list of roots. */
+  n = &(vfs->table[VFS_NO_INODE]);
+  n->contents.inodes = malloc(3 * sizeof(uint32_t));
+  if(!n->contents.has_contents)
+    return false;
+
+  n->contents.inodes[VFS_IDX_SELF]   = VFS_NO_INODE;
+  n->contents.inodes[VFS_IDX_PARENT] = VFS_NO_INODE;
+  n->contents.inodes[2] = VFS_ROOT_INODE;
+  n->length = 3;
+  n->length_alloc = 3;
+  n->timestamp = 0;
+  n->flags = VFS_INODE_DIR;
+  n->refcount = 255;
+  n->name[0] = '\0';
+
+  /* 1: / or C:\ */
+  n = &(vfs->table[VFS_ROOT_INODE]);
+  n->contents.inodes = malloc(4 * sizeof(uint32_t));
+  if(!n->contents.has_contents)
+    return false;
+
+  n->contents.inodes[VFS_IDX_SELF]   = VFS_ROOT_INODE;
+  n->contents.inodes[VFS_IDX_PARENT] = VFS_ROOT_INODE;
+  n->length = 2;
+  n->length_alloc = 4;
+  n->timestamp = 0;
+  n->flags = VFS_INODE_DIR | VFS_INODE_IS_REAL;
+  n->refcount = 0;
+#if defined(__WIN32__)
+  strcpy(n->name, "C:\\");
+#else
+  strcpy(n->name, "/");
+#endif
+
+  return true;
+}
+
+/**
+ * Release all allocated memory for a given VFS.
+ */
+static void vfs_clear(vfilesystem *vfs)
+{
+  size_t i;
+  for(i = 0; i < vfs->table_length; i++)
+    vfs_inode_clear(&(vfs->table[i]));
+
+  free(vfs->table);
+  vfs->table = NULL;
+}
+
+/**
+ * Clear a given inode and update table_next.
+ */
+static void vfs_release_inode(vfilesystem *vfs, uint32_t inode)
+{
+  vfs_inode_clear(&(vfs->table[inode]));
+  if(inode < vfs->table_next)
+    vfs->table_next = inode;
+}
+
+/**
+ * Get the next unused inode in the VFS. table_next will be advanced to the
+ * position of the returned inode. This will allocate more inode space in the
+ * VFS if needed.
+ */
+static uint32_t vfs_get_next_free_inode(vfilesystem *vfs)
+{
+  while(vfs->table_next < vfs->table_length)
+  {
+    if(!vfs->table[vfs->table_next].flags)
+      return vfs->table_next;
+
+    vfs->table_next++;
+  }
+
+  if(vfs->table_length >= vfs->table_alloc)
+  {
+    struct vfs_inode *ptr;
+    if(!vfs->table_alloc)
+      vfs->table_alloc = 4;
+
+    vfs->table_alloc <<= 1;
+    ptr = realloc(vfs->table, vfs->table_alloc * sizeof(struct vfs_inode));
+    if(!ptr)
+      return VFS_ERROR(ENOSPC);
+
+    vfs->table = ptr;
+  }
+
+  vfs->table[vfs->table_length].flags = 0;
+  return (vfs->table_length++);
+}
+
+/**
+ * Returns the inode of a given name within parent. This name should not include
+ * path separators. The value of `index` will be set to the index of the inode
+ * if it exists, otherwise the index where that inode should be placed.
+ */
+static uint32_t vfs_get_inode_in_parent_by_name(vfilesystem *vfs,
+ struct vfs_inode *parent, const char *name, uint32_t *index)
+{
+  uint32_t a = 2;
+  uint32_t b = parent->length - 1;
+  uint32_t current;
+  uint32_t i;
+  int cmp;
+
+  assert(parent->length >= 2);
+
+  while(a <= b)
+  {
+    current = (b - a) / 2 + a;
+    i = parent->contents.inodes[current];
+
+    cmp = vfs_name_cmp(name, vfs_inode_name(&(vfs->table[i])));
+    if(cmp > 0)
+    {
+      a = current + 1;
+    }
+    else
+
+    if(cmp < 0)
+    {
+      b = current - 1;
+    }
+    else
+    {
+      if(index)
+        *index = current;
+      return i;
+    }
+  }
+
+  if(index)
+    *index = a;
+  return VFS_NO_INODE;
+}
+
+/**
+ * Get the first inode for a given path string.
+ * This is either the "working directory" inode or a root inode.
+ */
+static uint32_t vfs_get_path_base_inode(vfilesystem *vfs, const char **path)
+{
+  ssize_t len = path_is_absolute(*path);
+  uint32_t inode;
+  char buffer[32];
+
+  if(len >= (ssize_t)sizeof(buffer))
+    return VFS_ERROR(ENOENT);
+
+  if(len > 0)
+  {
+    memcpy(buffer, *path, len);
+    buffer[len] = '\0';
+    *path += len;
+
+    inode = vfs_get_inode_in_parent_by_name(vfs, &(vfs->table[0]), buffer, NULL);
+    if(inode == VFS_NO_INODE)
+    {
+#if defined(__WIN32__)
+      // Windows and DJGPP: / behaves as the root of the current active drive.
+      if(!strcmp(buffer, "/") || !strcmp(buffer, "\\"))
+        return vfs->current_root;
+#endif
+
+      return VFS_ERROR(ENOENT);
+    }
+
+    return inode;
+  }
+  return vfs->current;
+}
+
+/**
+ * Find an inode in the VFS located at the given path.
+ */
+static uint32_t vfs_get_inode_by_path(vfilesystem *vfs, const char *path)
+{
+  struct vfs_inode *parent;
+  char buffer[MAX_PATH];
+  char *current;
+  char *next;
+  uint32_t inode;
+
+  inode = vfs_get_path_base_inode(vfs, &path);
+  if(!inode)
+    return VFS_NO_INODE;
+
+  snprintf(buffer, sizeof(buffer), "%s", path);
+
+  current = buffer;
+  while((current = vfs_tokenize(&next)))
+  {
+    parent = &(vfs->table[inode]);
+    if(VFS_INODE_TYPE(parent) != VFS_INODE_DIR)
+      return VFS_ERROR(ENOTDIR);
+
+    if(current[0] == '.')
+    {
+      if(current[1] == '.' && current[2] == '\0')
+      {
+        inode = parent->contents.inodes[VFS_IDX_PARENT];
+        continue;
+      }
+      else
+
+      if(current[1] == '\0')
+        continue;
+    }
+
+    inode = vfs_get_inode_in_parent_by_name(vfs, parent, current, NULL);
+    if(!inode)
+      return VFS_ERROR(ENOENT);
+  }
+
+  return inode;
+}
+
+/**
+ * Generate an inode in the VFS with a given name. This name should not include
+ * path separators.
+ */
+static uint32_t vfs_make_inode(vfilesystem *vfs, struct vfs_inode *parent,
+ const char *name, size_t init_alloc, int flags)
+{
+  struct vfs_inode *n;
+  uint32_t *inodes;
+  uint32_t pos;
+  uint32_t pos_in_parent;
+
+  assert(VFS_INODE_TYPE(parent) == VFS_INODE_DIR);
+  assert(flags & VFS_INODE_TYPEMASK);
+
+  pos = vfs_get_inode_in_parent_by_name(vfs, parent, name, &pos_in_parent);
+  if(pos != VFS_NO_INODE)
+    return VFS_ERROR(EEXIST);
+
+  pos = vfs_get_next_free_inode(vfs);
+  if(!pos)
+    return VFS_NO_INODE;
+
+  if(!vfs_inode_expand_directory(parent, 1))
+    return VFS_ERROR(ENOSPC);
+
+  n = &(vfs->table[pos]);
+
+  if((flags & VFS_INODE_TYPEMASK) == VFS_INODE_DIR)
+  {
+    if(!vfs_inode_init_directory(n, name, init_alloc, !!(flags & VFS_INODE_IS_REAL)))
+      return VFS_ERROR(ENOSPC);
+  }
+  else
+  {
+    if(!vfs_inode_init_file(n, name, init_alloc, !!(flags & VFS_INODE_IS_REAL)))
+      return VFS_ERROR(ENOSPC);
+  }
+
+  inodes = parent->contents.inodes;
+  if(pos_in_parent < parent->length)
+    memmove(inodes + pos_in_parent + 1, inodes + pos_in_parent, parent->length - pos_in_parent);
+  inodes[pos_in_parent] = pos;
+  parent->length++;
+
+  return pos;
+}
+
+/**
+ * Generate an inode in the VFS at the given path, generating parent directory
+ * inodes as-required.
+ */
+static uint32_t vfs_make_inode_recursively(vfilesystem *vfs, const char *path,
+ boolean is_real)
+{
+  /*
+  int flags = is_real ? VFS_INODE_IS_REAL : 0;
+  char buffer[MAX_PATH];
+  char *current;
+  char *next;
+  */
+  uint32_t inode;
+
+  inode = vfs_get_path_base_inode(vfs, &path);
+  if(!inode)
+    return VFS_NO_INODE;
+
+// FIXME
+/*
+  if((parent->flags & VFS_INODE_TYPE) != VFS_INODE_DIR)
+    return VFS_ERROR(ENOTDIR);
+*/
+
+  // FIXME
+  return VFS_NO_INODE;
+}
+
+#endif /* VIRTUAL_FILESYSTEM */
+
+vfilesystem *vfs_init(void)
+{
+#ifdef VIRTUAL_FILESYSTEM
+  vfilesystem *vfs = malloc(sizeof(vfilesystem));
+  vfs_setup(vfs);
+  return vfs;
+#endif
+}
+
+void vfs_free(vfilesystem *vfs)
+{
+#ifdef VIRTUAL_FILESYSTEM
+  vfs_clear(vfs);
+  free(vfs);
+#endif
+}

--- a/src/io/vfs.h
+++ b/src/io/vfs.h
@@ -46,6 +46,8 @@ __M_BEGIN_DECLS
 #define VIRTUAL_FILESYSTEM_DOS_DRIVE
 #endif
 
+#define VIRTUAL_FILESYSTEM_PARALLEL
+
 UTILS_LIBSPEC vfilesystem *vfs_init(void);
 UTILS_LIBSPEC void vfs_free(vfilesystem *vfs);
 
@@ -56,11 +58,11 @@ UTILS_LIBSPEC int vfs_cache_at_path(vfilesystem *vfs, const char *path);
 UTILS_LIBSPEC int vfs_invalidate_at_path(vfilesystem *vfs, const char *path);
 UTILS_LIBSPEC int vfs_create_file_at_path(vfilesystem *vfs, const char *path);
 
-UTILS_LIBSPEC uint32_t vfs_open_if_exists(vfilesystem *vfs,
- const char *path, boolean is_write);
-UTILS_LIBSPEC uint32_t vfs_open_if_exists_or_cacheable(vfilesystem *vfs,
- const char *path, boolean is_write);
-UTILS_LIBSPEC void vfs_close(vfilesystem *vfs, uint32_t inode);
+UTILS_LIBSPEC int vfs_open_if_exists(vfilesystem *vfs,
+ const char *path, boolean is_write, uint32_t *inode);
+UTILS_LIBSPEC int vfs_open_if_exists_or_cacheable(vfilesystem *vfs,
+ const char *path, boolean is_write, uint32_t *inode);
+UTILS_LIBSPEC int vfs_close(vfilesystem *vfs, uint32_t inode);
 
 UTILS_LIBSPEC int vfs_lock_file_read(vfilesystem *vfs, uint32_t inode,
  const unsigned char **data, size_t *data_length);
@@ -75,7 +77,6 @@ UTILS_LIBSPEC int vfs_unlink(vfilesystem *vfs, const char *path);
 UTILS_LIBSPEC int vfs_rmdir(vfilesystem *vfs, const char *path);
 UTILS_LIBSPEC int vfs_access(vfilesystem *vfs, const char *path, int mode);
 UTILS_LIBSPEC int vfs_stat(vfilesystem *vfs, const char *path, struct stat *st);
-UTILS_LIBSPEC int vfs_error(vfilesystem *vfs);
 
 #else /* !VIRTUAL_FILESYSTEM */
 
@@ -93,7 +94,6 @@ static inline int vfs_unlink(vfilesystem *, const char *) { return -1; }
 static inline int vfs_rmdir(vfilesystem *, const char *) { return -1; }
 static inline int vfs_access(vfilesystem *, const char *, int) { return -1; }
 static inline int vfs_stat(vfilesystem *, const char *, struct stat *) { return -1; }
-static inline int vfs_error(vfilesystem *) { return 0; }
 
 #endif /* !VIRTUAL_FILESYSTEM */
 

--- a/src/io/vfs.h
+++ b/src/io/vfs.h
@@ -48,6 +48,18 @@ __M_BEGIN_DECLS
 
 #define VIRTUAL_FILESYSTEM_PARALLEL
 
+struct vfs_dir_file
+{
+  char type;
+  char name[1];
+};
+
+struct vfs_dir
+{
+  struct vfs_dir_file **files;
+  size_t num_files;
+};
+
 UTILS_LIBSPEC vfilesystem *vfs_init(void);
 UTILS_LIBSPEC void vfs_free(vfilesystem *vfs);
 
@@ -60,10 +72,8 @@ UTILS_LIBSPEC int vfs_create_file_at_path(vfilesystem *vfs, const char *path);
 
 UTILS_LIBSPEC int vfs_open_if_exists(vfilesystem *vfs,
  const char *path, boolean is_write, uint32_t *inode);
-UTILS_LIBSPEC int vfs_open_if_exists_or_cacheable(vfilesystem *vfs,
- const char *path, boolean is_write, uint32_t *inode);
 UTILS_LIBSPEC int vfs_close(vfilesystem *vfs, uint32_t inode);
-
+UTILS_LIBSPEC int vfs_truncate(vfilesystem *vfs, uint32_t inode);
 UTILS_LIBSPEC int vfs_lock_file_read(vfilesystem *vfs, uint32_t inode,
  const unsigned char **data, size_t *data_length);
 UTILS_LIBSPEC int vfs_unlock_file_read(vfilesystem *vfs, uint32_t inode);
@@ -78,22 +88,36 @@ UTILS_LIBSPEC int vfs_rmdir(vfilesystem *vfs, const char *path);
 UTILS_LIBSPEC int vfs_access(vfilesystem *vfs, const char *path, int mode);
 UTILS_LIBSPEC int vfs_stat(vfilesystem *vfs, const char *path, struct stat *st);
 
+UTILS_LIBSPEC int vfs_readdir(vfilesystem *vfs, const char *path, struct vfs_dir *d);
+UTILS_LIBSPEC int vfs_readdir_free(struct vfs_dir *d);
+
 #else /* !VIRTUAL_FILESYSTEM */
 
 static inline void vfs_reset(vfilesystem *) {}
 static inline int vfs_cache_at_path(vfilesystem *, const char *) { return -1; }
 static inline int vfs_invalidate_at_path(vfilesystem *, const char *) { return -1; }
 static inline int vfs_create_file_at_path(vfilesystem *, const char *) { return -1; }
-static inline int vfs_sync_file(vfilesystem *, const char *) { return -1; }
-static inline uint32_t vfs_open_if_exists(vfilesystem *, const char *, boolean) { return 0; }
-static inline uint32_t vfs_open_if_exists_or_cacheable(vfilesystem *, const char *, boolean) { return 0; }
-static inline void vfs_close(vfilesystem *, uint32_t) {}
+
+static inline int vfs_open_if_exists(vfilesystem *,
+ const char *, boolean, uint32_t *) { return -1; }
+static inline int vfs_close(vfilesystem *, uint32_t) { return -1; }
+static inline int vfs_truncate(vfilesystem *, uint32_t) { return -1; }
+static inline int vfs_lock_file_read(vfilesystem *, uint32_t,
+ const unsigned char **, size_t *) { return -1; }
+static inline int vfs_unlock_file_read(vfilesystem *, uint32_t) { return -1; }
+static inline int vfs_lock_file_write(vfilesystem *, uint32_t,
+ unsigned char ***, size_t **, size_t **) { return -1; }
+static inline int vfs_unlock_file_write(vfilesystem *, uint32_t) { return -1; }
+
 static inline int vfs_mkdir(vfilesystem *, const char *, int) { return -1; }
 static inline int vfs_rename(vfilesystem *, const char *, const char *) { return -1; }
 static inline int vfs_unlink(vfilesystem *, const char *) { return -1; }
 static inline int vfs_rmdir(vfilesystem *, const char *) { return -1; }
 static inline int vfs_access(vfilesystem *, const char *, int) { return -1; }
 static inline int vfs_stat(vfilesystem *, const char *, struct stat *) { return -1; }
+
+static inline int vfs_readdir(vfilesystem *, const char *, struct vfs_dir *) { return -1; }
+static inline int vfs_readdir_free(struct vfs_dir *) { return -1; }
 
 #endif /* !VIRTUAL_FILESYSTEM */
 

--- a/src/io/vfs.h
+++ b/src/io/vfs.h
@@ -37,13 +37,28 @@ __M_BEGIN_DECLS
 UTILS_LIBSPEC vfilesystem *vfs_init(void);
 UTILS_LIBSPEC void vfs_free(vfilesystem *vfs);
 
-// TODO other vfs external API junk.
-
 /**
  * Internal functions for vio.c.
  */
 
-// FIXME
+void vfs_reset(vfilesystem *vfs);
+boolean vfs_cache_at_path(vfilesystem *vfs, const char *path);
+boolean vfs_invalidate_at_path(vfilesystem *vfs, const char *path);
+boolean vfs_create_file_at_path(vfilesystem *vfs, const char *path);
+boolean vfs_sync_file(vfilesystem *vfs, uint32_t inode,
+ void ***data, size_t **data_length, size_t **data_alloc);
+
+uint32_t vfs_open_if_exists(vfilesystem *vfs, const char *path, boolean is_write);
+uint32_t vfs_open_if_exists_or_cacheable(vfilesystem *vfs, const char *path,
+ boolean is_write);
+void vfs_close(vfilesystem *vfs, uint32_t inode);
+int vfs_mkdir(vfilesystem *vfs, const char *path, int mode);
+int vfs_rename(vfilesystem *vfs, const char *oldpath, const char *newpath);
+int vfs_unlink(vfilesystem *vfs, const char *path);
+int vfs_rmdir(vfilesystem *vfs, const char *path);
+int vfs_access(vfilesystem *vfs, const char *path, int mode);
+int vfs_stat(vfilesystem *vfs, const char *path, struct stat *st);
+int vfs_error(vfilesystem *vfs);
 
 __M_END_DECLS
 

--- a/src/io/vfs.h
+++ b/src/io/vfs.h
@@ -92,7 +92,6 @@ UTILS_LIBSPEC int vfs_readdir_free(struct vfs_dir *d);
 
 #else /* !VIRTUAL_FILESYSTEM */
 
-static inline void vfs_reset(vfilesystem *v) {}
 static inline int vfs_create_file_at_path(vfilesystem *v, const char *p) { return -1; }
 
 static inline int vfs_open_if_exists(vfilesystem *v,

--- a/src/io/vfs.h
+++ b/src/io/vfs.h
@@ -66,8 +66,6 @@ UTILS_LIBSPEC void vfs_free(vfilesystem *vfs);
 #ifdef VIRTUAL_FILESYSTEM
 
 UTILS_LIBSPEC void vfs_reset(vfilesystem *vfs);
-UTILS_LIBSPEC int vfs_cache_at_path(vfilesystem *vfs, const char *path);
-UTILS_LIBSPEC int vfs_invalidate_at_path(vfilesystem *vfs, const char *path);
 UTILS_LIBSPEC int vfs_create_file_at_path(vfilesystem *vfs, const char *path);
 
 UTILS_LIBSPEC int vfs_open_if_exists(vfilesystem *vfs,
@@ -81,6 +79,8 @@ UTILS_LIBSPEC int vfs_lock_file_write(vfilesystem *vfs, uint32_t inode,
  unsigned char ***data, size_t **data_length, size_t **data_alloc);
 UTILS_LIBSPEC int vfs_unlock_file_write(vfilesystem *vfs, uint32_t inode);
 
+UTILS_LIBSPEC int vfs_chdir(vfilesystem *vfs, const char *path);
+UTILS_LIBSPEC int vfs_getcwd(vfilesystem *vfs, char *dest, size_t dest_len);
 UTILS_LIBSPEC int vfs_mkdir(vfilesystem *vfs, const char *path, int mode);
 UTILS_LIBSPEC int vfs_rename(vfilesystem *vfs, const char *oldpath, const char *newpath);
 UTILS_LIBSPEC int vfs_unlink(vfilesystem *vfs, const char *path);

--- a/src/io/vfs.h
+++ b/src/io/vfs.h
@@ -94,8 +94,6 @@ UTILS_LIBSPEC int vfs_readdir_free(struct vfs_dir *d);
 #else /* !VIRTUAL_FILESYSTEM */
 
 static inline void vfs_reset(vfilesystem *) {}
-static inline int vfs_cache_at_path(vfilesystem *, const char *) { return -1; }
-static inline int vfs_invalidate_at_path(vfilesystem *, const char *) { return -1; }
 static inline int vfs_create_file_at_path(vfilesystem *, const char *) { return -1; }
 
 static inline int vfs_open_if_exists(vfilesystem *,
@@ -109,6 +107,8 @@ static inline int vfs_lock_file_write(vfilesystem *, uint32_t,
  unsigned char ***, size_t **, size_t **) { return -1; }
 static inline int vfs_unlock_file_write(vfilesystem *, uint32_t) { return -1; }
 
+static inline int vfs_chdir(vfilesystem *, const char *) { return -1; }
+static inline int vfs_getcwd(vfilesystem *, char *, size_t) { return -1; }
 static inline int vfs_mkdir(vfilesystem *, const char *, int) { return -1; }
 static inline int vfs_rename(vfilesystem *, const char *, const char *) { return -1; }
 static inline int vfs_unlink(vfilesystem *, const char *) { return -1; }

--- a/src/io/vfs.h
+++ b/src/io/vfs.h
@@ -30,6 +30,7 @@
 __M_BEGIN_DECLS
 
 #include <stdint.h>
+#include <stdlib.h>
 #include "vfile.h"
 
 // FIXME CONFIG_VFS or something similar to enable instead
@@ -54,14 +55,20 @@ UTILS_LIBSPEC void vfs_reset(vfilesystem *vfs);
 UTILS_LIBSPEC int vfs_cache_at_path(vfilesystem *vfs, const char *path);
 UTILS_LIBSPEC int vfs_invalidate_at_path(vfilesystem *vfs, const char *path);
 UTILS_LIBSPEC int vfs_create_file_at_path(vfilesystem *vfs, const char *path);
-UTILS_LIBSPEC int vfs_sync_file(vfilesystem *vfs, uint32_t inode,
- void ***data, size_t **data_length, size_t **data_alloc);
 
 UTILS_LIBSPEC uint32_t vfs_open_if_exists(vfilesystem *vfs,
  const char *path, boolean is_write);
 UTILS_LIBSPEC uint32_t vfs_open_if_exists_or_cacheable(vfilesystem *vfs,
  const char *path, boolean is_write);
 UTILS_LIBSPEC void vfs_close(vfilesystem *vfs, uint32_t inode);
+
+UTILS_LIBSPEC int vfs_lock_file_read(vfilesystem *vfs, uint32_t inode,
+ const unsigned char **data, size_t *data_length);
+UTILS_LIBSPEC int vfs_unlock_file_read(vfilesystem *vfs, uint32_t inode);
+UTILS_LIBSPEC int vfs_lock_file_write(vfilesystem *vfs, uint32_t inode,
+ unsigned char ***data, size_t **data_length, size_t **data_alloc);
+UTILS_LIBSPEC int vfs_unlock_file_write(vfilesystem *vfs, uint32_t inode);
+
 UTILS_LIBSPEC int vfs_mkdir(vfilesystem *vfs, const char *path, int mode);
 UTILS_LIBSPEC int vfs_rename(vfilesystem *vfs, const char *oldpath, const char *newpath);
 UTILS_LIBSPEC int vfs_unlink(vfilesystem *vfs, const char *path);

--- a/src/io/vfs.h
+++ b/src/io/vfs.h
@@ -33,8 +33,7 @@ __M_BEGIN_DECLS
 #include <stdlib.h>
 #include "vfile.h"
 
-// FIXME CONFIG_VFS or something similar to enable instead
-#ifndef CONFIG_NDS
+#ifdef CONFIG_VFS
 #define VIRTUAL_FILESYSTEM
 #endif
 

--- a/src/io/vfs.h
+++ b/src/io/vfs.h
@@ -32,11 +32,12 @@ __M_BEGIN_DECLS
 #include <stdint.h>
 #include "vfile.h"
 
+// FIXME CONFIG_VFS or something similar to enable instead
 #ifndef CONFIG_NDS
 #define VIRTUAL_FILESYSTEM
 #endif
 
-#if defined(__WIN32__) || defined(__APPLE__)
+#if defined(__WIN32__) || defined(CONFIG_DJGPP) || defined(__APPLE__)
 #define VIRTUAL_FILESYSTEM_CASE_INSENSITIVE
 #endif
 
@@ -47,11 +48,13 @@ __M_BEGIN_DECLS
 UTILS_LIBSPEC vfilesystem *vfs_init(void);
 UTILS_LIBSPEC void vfs_free(vfilesystem *vfs);
 
+#ifdef VIRTUAL_FILESYSTEM
+
 UTILS_LIBSPEC void vfs_reset(vfilesystem *vfs);
-UTILS_LIBSPEC boolean vfs_cache_at_path(vfilesystem *vfs, const char *path);
-UTILS_LIBSPEC boolean vfs_invalidate_at_path(vfilesystem *vfs, const char *path);
-UTILS_LIBSPEC boolean vfs_create_file_at_path(vfilesystem *vfs, const char *path);
-UTILS_LIBSPEC boolean vfs_sync_file(vfilesystem *vfs, uint32_t inode,
+UTILS_LIBSPEC int vfs_cache_at_path(vfilesystem *vfs, const char *path);
+UTILS_LIBSPEC int vfs_invalidate_at_path(vfilesystem *vfs, const char *path);
+UTILS_LIBSPEC int vfs_create_file_at_path(vfilesystem *vfs, const char *path);
+UTILS_LIBSPEC int vfs_sync_file(vfilesystem *vfs, uint32_t inode,
  void ***data, size_t **data_length, size_t **data_alloc);
 
 UTILS_LIBSPEC uint32_t vfs_open_if_exists(vfilesystem *vfs,
@@ -66,6 +69,26 @@ UTILS_LIBSPEC int vfs_rmdir(vfilesystem *vfs, const char *path);
 UTILS_LIBSPEC int vfs_access(vfilesystem *vfs, const char *path, int mode);
 UTILS_LIBSPEC int vfs_stat(vfilesystem *vfs, const char *path, struct stat *st);
 UTILS_LIBSPEC int vfs_error(vfilesystem *vfs);
+
+#else /* !VIRTUAL_FILESYSTEM */
+
+static inline void vfs_reset(vfilesystem *) {}
+static inline int vfs_cache_at_path(vfilesystem *, const char *) { return -1; }
+static inline int vfs_invalidate_at_path(vfilesystem *, const char *) { return -1; }
+static inline int vfs_create_file_at_path(vfilesystem *, const char *) { return -1; }
+static inline int vfs_sync_file(vfilesystem *, const char *) { return -1; }
+static inline uint32_t vfs_open_if_exists(vfilesystem *, const char *, boolean) { return 0; }
+static inline uint32_t vfs_open_if_exists_or_cacheable(vfilesystem *, const char *, boolean) { return 0; }
+static inline void vfs_close(vfilesystem *, uint32_t) {}
+static inline int vfs_mkdir(vfilesystem *, const char *, int) { return -1; }
+static inline int vfs_rename(vfilesystem *, const char *, const char *) { return -1; }
+static inline int vfs_unlink(vfilesystem *, const char *) { return -1; }
+static inline int vfs_rmdir(vfilesystem *, const char *) { return -1; }
+static inline int vfs_access(vfilesystem *, const char *, int) { return -1; }
+static inline int vfs_stat(vfilesystem *, const char *, struct stat *) { return -1; }
+static inline int vfs_error(vfilesystem *) { return 0; }
+
+#endif /* !VIRTUAL_FILESYSTEM */
 
 __M_END_DECLS
 

--- a/src/io/vfs.h
+++ b/src/io/vfs.h
@@ -1,6 +1,6 @@
 /* MegaZeux
  *
- * Copyright (C) 2019 Alice Rowan <petrifiedrowan@gmail.com>
+ * Copyright (C) 2021 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -17,24 +17,34 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/**
- * Types for vio.h and memfile.h so they don't have to be included in
- * world_struct.h and other high-traffic headers.
- */
-
-#ifndef __IO_VFILE_H
-#define __IO_VFILE_H
+#ifndef __IO_VFS_H
+#define __IO_VFS_H
 
 #include "../compat.h"
 
 __M_BEGIN_DECLS
 
-typedef struct vfile vfile;
-typedef struct vdir vdir;
-typedef struct vfilesystem vfilesystem;
-struct memfile;
-struct stat;
+#include "vfile.h"
+
+#ifndef CONFIG_NDS
+#define VIRTUAL_FILESYSTEM
+#endif
+
+#if defined(__WIN32__) || defined(__APPLE__)
+#define VIRTUAL_FILESYSTEM_CASE_INSENSITIVE
+#endif
+
+UTILS_LIBSPEC vfilesystem *vfs_init(void);
+UTILS_LIBSPEC void vfs_free(vfilesystem *vfs);
+
+// TODO other vfs external API junk.
+
+/**
+ * Internal functions for vio.c.
+ */
+
+// FIXME
 
 __M_END_DECLS
 
-#endif /* __IO_VFILE_H */
+#endif /* __IO_VFS_H */

--- a/src/io/vfs.h
+++ b/src/io/vfs.h
@@ -65,7 +65,6 @@ UTILS_LIBSPEC void vfs_free(vfilesystem *vfs);
 
 #ifdef VIRTUAL_FILESYSTEM
 
-UTILS_LIBSPEC void vfs_reset(vfilesystem *vfs);
 UTILS_LIBSPEC int vfs_create_file_at_path(vfilesystem *vfs, const char *path);
 
 UTILS_LIBSPEC int vfs_open_if_exists(vfilesystem *vfs,

--- a/src/io/vfs.h
+++ b/src/io/vfs.h
@@ -17,6 +17,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+/**
+ * MZX virtual filesystem. This is intended mainly as a support layer
+ * to be used internally by vio.c, but can also be used by itself.
+ */
+
 #ifndef __IO_VFS_H
 #define __IO_VFS_H
 
@@ -24,6 +29,7 @@
 
 __M_BEGIN_DECLS
 
+#include <stdint.h>
 #include "vfile.h"
 
 #ifndef CONFIG_NDS
@@ -34,31 +40,32 @@ __M_BEGIN_DECLS
 #define VIRTUAL_FILESYSTEM_CASE_INSENSITIVE
 #endif
 
+#if defined(__WIN32__) || defined(CONFIG_DJGPP)
+#define VIRTUAL_FILESYSTEM_DOS_DRIVE
+#endif
+
 UTILS_LIBSPEC vfilesystem *vfs_init(void);
 UTILS_LIBSPEC void vfs_free(vfilesystem *vfs);
 
-/**
- * Internal functions for vio.c.
- */
-
-void vfs_reset(vfilesystem *vfs);
-boolean vfs_cache_at_path(vfilesystem *vfs, const char *path);
-boolean vfs_invalidate_at_path(vfilesystem *vfs, const char *path);
-boolean vfs_create_file_at_path(vfilesystem *vfs, const char *path);
-boolean vfs_sync_file(vfilesystem *vfs, uint32_t inode,
+UTILS_LIBSPEC void vfs_reset(vfilesystem *vfs);
+UTILS_LIBSPEC boolean vfs_cache_at_path(vfilesystem *vfs, const char *path);
+UTILS_LIBSPEC boolean vfs_invalidate_at_path(vfilesystem *vfs, const char *path);
+UTILS_LIBSPEC boolean vfs_create_file_at_path(vfilesystem *vfs, const char *path);
+UTILS_LIBSPEC boolean vfs_sync_file(vfilesystem *vfs, uint32_t inode,
  void ***data, size_t **data_length, size_t **data_alloc);
 
-uint32_t vfs_open_if_exists(vfilesystem *vfs, const char *path, boolean is_write);
-uint32_t vfs_open_if_exists_or_cacheable(vfilesystem *vfs, const char *path,
- boolean is_write);
-void vfs_close(vfilesystem *vfs, uint32_t inode);
-int vfs_mkdir(vfilesystem *vfs, const char *path, int mode);
-int vfs_rename(vfilesystem *vfs, const char *oldpath, const char *newpath);
-int vfs_unlink(vfilesystem *vfs, const char *path);
-int vfs_rmdir(vfilesystem *vfs, const char *path);
-int vfs_access(vfilesystem *vfs, const char *path, int mode);
-int vfs_stat(vfilesystem *vfs, const char *path, struct stat *st);
-int vfs_error(vfilesystem *vfs);
+UTILS_LIBSPEC uint32_t vfs_open_if_exists(vfilesystem *vfs,
+ const char *path, boolean is_write);
+UTILS_LIBSPEC uint32_t vfs_open_if_exists_or_cacheable(vfilesystem *vfs,
+ const char *path, boolean is_write);
+UTILS_LIBSPEC void vfs_close(vfilesystem *vfs, uint32_t inode);
+UTILS_LIBSPEC int vfs_mkdir(vfilesystem *vfs, const char *path, int mode);
+UTILS_LIBSPEC int vfs_rename(vfilesystem *vfs, const char *oldpath, const char *newpath);
+UTILS_LIBSPEC int vfs_unlink(vfilesystem *vfs, const char *path);
+UTILS_LIBSPEC int vfs_rmdir(vfilesystem *vfs, const char *path);
+UTILS_LIBSPEC int vfs_access(vfilesystem *vfs, const char *path, int mode);
+UTILS_LIBSPEC int vfs_stat(vfilesystem *vfs, const char *path, struct stat *st);
+UTILS_LIBSPEC int vfs_error(vfilesystem *vfs);
 
 __M_END_DECLS
 

--- a/src/io/vfs.h
+++ b/src/io/vfs.h
@@ -92,31 +92,31 @@ UTILS_LIBSPEC int vfs_readdir_free(struct vfs_dir *d);
 
 #else /* !VIRTUAL_FILESYSTEM */
 
-static inline void vfs_reset(vfilesystem *) {}
-static inline int vfs_create_file_at_path(vfilesystem *, const char *) { return -1; }
+static inline void vfs_reset(vfilesystem *v) {}
+static inline int vfs_create_file_at_path(vfilesystem *v, const char *p) { return -1; }
 
-static inline int vfs_open_if_exists(vfilesystem *,
- const char *, boolean, uint32_t *) { return -1; }
-static inline int vfs_close(vfilesystem *, uint32_t) { return -1; }
-static inline int vfs_truncate(vfilesystem *, uint32_t) { return -1; }
-static inline int vfs_lock_file_read(vfilesystem *, uint32_t,
- const unsigned char **, size_t *) { return -1; }
-static inline int vfs_unlock_file_read(vfilesystem *, uint32_t) { return -1; }
-static inline int vfs_lock_file_write(vfilesystem *, uint32_t,
- unsigned char ***, size_t **, size_t **) { return -1; }
-static inline int vfs_unlock_file_write(vfilesystem *, uint32_t) { return -1; }
+static inline int vfs_open_if_exists(vfilesystem *v,
+ const char *p, boolean w, uint32_t *i) { return -1; }
+static inline int vfs_close(vfilesystem *v, uint32_t i) { return -1; }
+static inline int vfs_truncate(vfilesystem *v, uint32_t i) { return -1; }
+static inline int vfs_lock_file_read(vfilesystem *v, uint32_t i,
+ const unsigned char **d, size_t *l) { return -1; }
+static inline int vfs_unlock_file_read(vfilesystem *v, uint32_t i) { return -1; }
+static inline int vfs_lock_file_write(vfilesystem * v, uint32_t i,
+ unsigned char ***d, size_t **l, size_t **a) { return -1; }
+static inline int vfs_unlock_file_write(vfilesystem *v, uint32_t i) { return -1; }
 
-static inline int vfs_chdir(vfilesystem *, const char *) { return -1; }
-static inline int vfs_getcwd(vfilesystem *, char *, size_t) { return -1; }
-static inline int vfs_mkdir(vfilesystem *, const char *, int) { return -1; }
-static inline int vfs_rename(vfilesystem *, const char *, const char *) { return -1; }
-static inline int vfs_unlink(vfilesystem *, const char *) { return -1; }
-static inline int vfs_rmdir(vfilesystem *, const char *) { return -1; }
-static inline int vfs_access(vfilesystem *, const char *, int) { return -1; }
-static inline int vfs_stat(vfilesystem *, const char *, struct stat *) { return -1; }
+static inline int vfs_chdir(vfilesystem *v, const char *p) { return -1; }
+static inline int vfs_getcwd(vfilesystem *v, char *d, size_t l) { return -1; }
+static inline int vfs_mkdir(vfilesystem *v, const char *p, int m) { return -1; }
+static inline int vfs_rename(vfilesystem *v, const char *o, const char *n) { return -1; }
+static inline int vfs_unlink(vfilesystem *v, const char *p) { return -1; }
+static inline int vfs_rmdir(vfilesystem *v, const char *p) { return -1; }
+static inline int vfs_access(vfilesystem *v, const char *p, int m) { return -1; }
+static inline int vfs_stat(vfilesystem *v, const char *p, struct stat *s) { return -1; }
 
-static inline int vfs_readdir(vfilesystem *, const char *, struct vfs_dir *) { return -1; }
-static inline int vfs_readdir_free(struct vfs_dir *) { return -1; }
+static inline int vfs_readdir(vfilesystem *v, const char *p, struct vfs_dir *d) { return -1; }
+static inline int vfs_readdir_free(struct vfs_dir *d) { return -1; }
 
 #endif /* !VIRTUAL_FILESYSTEM */
 

--- a/src/io/vio.c
+++ b/src/io/vio.c
@@ -25,6 +25,7 @@
 
 #include "../util.h"
 #include "memfile.h"
+#include "vfs.h"
 #include "vio.h"
 //#include "zip.h"
 
@@ -40,6 +41,10 @@
 
 #ifndef VFILE_LARGE_BUFFER_SIZE
 #define VFILE_LARGE_BUFFER_SIZE 32768
+#endif
+
+#ifdef VIRTUAL_FILESYSTEM
+static vfilesystem *vfs;
 #endif
 
 enum vfileflags_private

--- a/src/io/vio.c
+++ b/src/io/vio.c
@@ -25,7 +25,6 @@
 
 #include "../util.h"
 #include "memfile.h"
-#include "vfs.h"
 #include "vio.h"
 //#include "zip.h"
 
@@ -43,10 +42,6 @@
 #define VFILE_LARGE_BUFFER_SIZE 32768
 #endif
 
-#ifdef VIRTUAL_FILESYSTEM
-static vfilesystem *vfs;
-#endif
-
 struct vfile
 {
   FILE *fp;
@@ -62,6 +57,8 @@ struct vfile
   // vungetc buffer for memory files.
   int tmp_chr;
   int flags;
+  // To avoid arithmetic on NULL...
+  char dummy[1];
 };
 
 /**
@@ -204,7 +201,7 @@ vfile *vfile_init_mem(void *buffer, size_t size, const char *mode)
     filesize = 0;
 
   vf = (vfile *)ccalloc(1, sizeof(vfile));
-  mfopen(buffer, filesize, &(vf->mf));
+  mfopen(buffer ? buffer : vf->dummy, filesize, &(vf->mf));
   vf->mf.seek_past_end = true;
   vf->tmp_chr = EOF;
   vf->flags = flags | VF_MEMORY;

--- a/src/io/vio.c
+++ b/src/io/vio.c
@@ -47,23 +47,6 @@
 static vfilesystem *vfs;
 #endif
 
-enum vfileflags_private
-{
-  VF_FILE               = (1<<0),
-  VF_MEMORY             = (1<<1),
-  VF_MEMORY_EXPANDABLE  = (1<<2),
-  VF_MEMORY_FREE        = (1<<3), // Free memory buffer on vfclose.
-//VF_IN_ARCHIVE         = (1<<3),
-  VF_READ               = (1<<4),
-  VF_WRITE              = (1<<5),
-  VF_APPEND             = (1<<6),
-  VF_BINARY             = (1<<7),
-  VF_TRUNCATE           = (1<<8),
-
-  VF_STORAGE_MASK       = (VF_FILE | VF_MEMORY),
-  VF_PUBLIC_MASK        = (V_SMALL_BUFFER | V_LARGE_BUFFER)
-};
-
 struct vfile
 {
   FILE *fp;
@@ -84,7 +67,7 @@ struct vfile
 /**
  * Parse vfile mode flags from a standard fopen mode string.
  */
-static int get_vfile_mode_flags(const char *mode)
+int vfile_get_mode_flags(const char *mode)
 {
   int flags = 0;
 
@@ -137,7 +120,7 @@ static int get_vfile_mode_flags(const char *mode)
 vfile *vfopen_unsafe_ext(const char *filename, const char *mode,
  int user_flags)
 {
-  int flags = get_vfile_mode_flags(mode);
+  int flags = vfile_get_mode_flags(mode);
   vfile *vf = NULL;
 
   assert(filename && flags);
@@ -191,7 +174,7 @@ vfile *vfopen_unsafe(const char *filename, const char *mode)
  */
 vfile *vfile_init_fp(FILE *fp, const char *mode)
 {
-  int flags = get_vfile_mode_flags(mode);
+  int flags = vfile_get_mode_flags(mode);
   vfile *vf = NULL;
 
   assert(fp && flags);
@@ -208,7 +191,7 @@ vfile *vfile_init_fp(FILE *fp, const char *mode)
  */
 vfile *vfile_init_mem(void *buffer, size_t size, const char *mode)
 {
-  int flags = get_vfile_mode_flags(mode);
+  int flags = vfile_get_mode_flags(mode);
   vfile *vf = NULL;
   size_t filesize = size;
 
@@ -234,6 +217,10 @@ vfile *vfile_init_mem(void *buffer, size_t size, const char *mode)
  * Create a vfile from an existing memory buffer.
  * This vfile will be resizable and, when resized, the source pointer and size
  * will be updated to match.
+ *
+  // vfs_init_mem_ext needs to be modified to allow readable files from
+  // external buffers. attempt to sync vfile to external buffer for each op
+  // also need a way to insert the inode into the vfile from here.
  */
 vfile *vfile_init_mem_ext(void **external_buffer, size_t *external_buffer_size,
  const char *mode)

--- a/src/io/vio.h
+++ b/src/io/vio.h
@@ -33,8 +33,23 @@ __M_BEGIN_DECLS
 
 enum vfileflags
 {
+  /* Internal flags. */
+  VF_FILE               = (1<<0),
+  VF_MEMORY             = (1<<1),
+  VF_MEMORY_EXPANDABLE  = (1<<2),
+  VF_MEMORY_FREE        = (1<<3), // Free memory buffer on vfclose.
+  VF_READ               = (1<<4),
+  VF_WRITE              = (1<<5),
+  VF_APPEND             = (1<<6),
+  VF_BINARY             = (1<<7),
+  VF_TRUNCATE           = (1<<8),
+
+  /* Public flags. */
   V_SMALL_BUFFER = (1<<29), // setvbuf <= 256 for real files in binary mode.
-  V_LARGE_BUFFER = (1<<30)  // setvbuf >= 8192 for real files in binary mode.
+  V_LARGE_BUFFER = (1<<30), // setvbuf >= 8192 for real files in binary mode.
+
+  VF_STORAGE_MASK       = (VF_FILE | VF_MEMORY),
+  VF_PUBLIC_MASK        = (V_SMALL_BUFFER | V_LARGE_BUFFER)
 };
 
 enum vdir_type
@@ -48,13 +63,14 @@ enum vdir_type
 UTILS_LIBSPEC vfile *vfopen_unsafe_ext(const char *filename, const char *mode,
  int user_flags);
 UTILS_LIBSPEC vfile *vfopen_unsafe(const char *filename, const char *mode);
-vfile *vfile_init_fp(FILE *fp, const char *mode);
-vfile *vfile_init_mem(void *buffer, size_t size, const char *mode);
-vfile *vfile_init_mem_ext(void **external_buffer, size_t *external_buffer_size,
- const char *mode);
+UTILS_LIBSPEC vfile *vfile_init_fp(FILE *fp, const char *mode);
+UTILS_LIBSPEC vfile *vfile_init_mem(void *buffer, size_t size, const char *mode);
+UTILS_LIBSPEC vfile *vfile_init_mem_ext(void **external_buffer,
+ size_t *external_buffer_size, const char *mode);
 UTILS_LIBSPEC vfile *vtempfile(size_t initial_size);
 UTILS_LIBSPEC int vfclose(vfile *vf);
 
+UTILS_LIBSPEC int vfile_get_mode_flags(const char *mode);
 boolean vfile_get_memfile_block(vfile *vf, size_t length, struct memfile *dest);
 
 UTILS_LIBSPEC int vchdir(const char *path);

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -34,6 +34,7 @@ unit_objs := \
   ${unit_obj_io}/memfile${unit_ext}    \
   ${unit_obj_io}/path${unit_ext}       \
   ${unit_obj_io}/vio${unit_ext}        \
+  ${unit_obj_io}/zip${unit_ext}        \
 
 ifneq (${BUILD_EDITOR},)
 
@@ -67,7 +68,6 @@ unit_objs += \
   ${unit_obj}/configure${unit_ext}     \
   ${unit_obj}/intake${unit_ext}        \
   ${unit_obj}/world${unit_ext}         \
-  ${unit_obj_io}/zip${unit_ext}
 
 unit_ldflags += -L. -lcore
 
@@ -79,6 +79,20 @@ ifneq (${BUILD_NETWORK},)
 unit_objs += \
   ${unit_obj_network}/Manifest${unit_ext}
 endif
+
+else # !BUILD_MODULAR
+
+#
+# Certain tests that don't rely on many core MZX features can be patched in
+# by directly linking their objects.
+#
+unit_common_objs += \
+  ${io_obj}/path.o        \
+  ${io_obj}/vfs.o         \
+  ${io_obj}/vio.o         \
+  ${io_obj}/zip.o         \
+  ${io_obj}/zip_stream.o  \
+
 endif
 
 #

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -33,6 +33,7 @@ unit_objs := \
   ${unit_obj_io}/bitstream${unit_ext}  \
   ${unit_obj_io}/memfile${unit_ext}    \
   ${unit_obj_io}/path${unit_ext}       \
+  ${unit_obj_io}/vfs${unit_ext}        \
   ${unit_obj_io}/vio${unit_ext}        \
   ${unit_obj_io}/zip${unit_ext}        \
 

--- a/unit/Unit.cpp
+++ b/unit/Unit.cpp
@@ -161,8 +161,13 @@ namespace Unit
 
   arg::arg(const char *_op)
   {
-    op = coalesce(_op);
     has_value = !!_op;
+    _op = coalesce(_op);
+
+    size_t len = strlen(_op);
+    allocbuf = new char[len + 1];
+    memcpy(allocbuf, _op, len + 1);
+    op = allocbuf;
   }
 
   arg::arg(const void *_op)

--- a/unit/Unit.cpp
+++ b/unit/Unit.cpp
@@ -18,11 +18,13 @@
  */
 
 #include "Unit.hpp"
+#include "../src/platform.h"
 
 #include <assert.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <time.h>
 #include <unistd.h>
 
 #include <csignal>
@@ -54,6 +56,12 @@ void *check_realloc(void *ptr, size_t size, const char *file,
   ptr = realloc(ptr, size);
   assert(ptr);
   return ptr;
+}
+
+static const clock_t get_ticks_base = clock();
+uint64_t get_ticks()
+{
+  return clock() - get_ticks_base;
 }
 
 /* Main functions. */

--- a/unit/io/memfile.cpp
+++ b/unit/io/memfile.cpp
@@ -32,10 +32,10 @@ UNITTEST(mfopen)
   {
     struct memfile mf;
 
-    mfopen(buffer, arraysize(buffer), &mf);
+    mfopen(buffer, sizeof(buffer), &mf);
     ASSERTEQ(mf.start, buffer, "");
     ASSERTEQ(mf.current, buffer, "");
-    ASSERTEQ(mf.end, mf.start + arraysize(buffer), "");
+    ASSERTEQ(mf.end, mf.start + sizeof(buffer), "");
     ASSERTEQ(mf.alloc, false, "");
   }
 
@@ -43,11 +43,11 @@ UNITTEST(mfopen)
   {
     struct memfile *mf;
 
-    mf = mfopen_alloc(buffer, arraysize(buffer));
+    mf = mfopen_alloc(buffer, sizeof(buffer));
     ASSERT(mf, "");
     ASSERTEQ(mf->start, buffer, "");
     ASSERTEQ(mf->current, buffer, "");
-    ASSERTEQ(mf->end, buffer + arraysize(buffer), "");
+    ASSERTEQ(mf->end, buffer + sizeof(buffer), "");
     ASSERTEQ(mf->alloc, true, "");
 
     int ret = mf_alloc_free(mf);
@@ -57,13 +57,13 @@ UNITTEST(mfopen)
   SECTION(mf_alloc_free_on_static_memfile)
   {
     struct memfile mf;
-    mfopen(buffer, arraysize(buffer), &mf);
+    mfopen(buffer, sizeof(buffer), &mf);
 
     int ret = mf_alloc_free(&mf);
     ASSERTEQ(ret, -1, "");
     ASSERTEQ(mf.start, buffer, "");
     ASSERTEQ(mf.current, buffer, "");
-    ASSERTEQ(mf.end, buffer + arraysize(buffer), "");
+    ASSERTEQ(mf.end, buffer + sizeof(buffer), "");
   }
 }
 
@@ -78,19 +78,19 @@ UNITTEST(mfsync)
 
   for(i = 0; i < arraysize(buffers); i++)
   {
-    mfopen(buffers[i], arraysize(buffers[i]), &mf);
+    mfopen(buffers[i], sizeof(buffers[i]), &mf);
     ASSERTEQ(mf.start, buffers[i], "%d", i);
-    ASSERTEQ(mf.end, buffers[i] + arraysize(buffers[i]), "%d", i);
+    ASSERTEQ(mf.end, buffers[i] + sizeof(buffers[i]), "%d", i);
 
     mfsync(&buf, &len, &mf);
     ASSERTEQ(buf, (void *)buffers[i], "%d", i);
-    ASSERTEQ((int)len, arraysize(buffers[i]), "%d", i);
+    ASSERTEQ((int)len, sizeof(buffers[i]), "%d", i);
 
     mfsync(&buf, nullptr, &mf);
     ASSERTEQ(buf, (void *)buffers[i], "%d", i);
 
     mfsync(nullptr, &len, &mf);
-    ASSERTEQ((int)len, arraysize(buffers[i]), "%d", i);
+    ASSERTEQ((int)len, sizeof(buffers[i]), "%d", i);
 
     mfsync(nullptr, nullptr, &mf);
   }
@@ -118,12 +118,12 @@ UNITTEST(mfhasspace)
   char buffere[256];
   struct buffer_data pairs[] =
   {
-    { buffer8, arraysize(buffer8), true, true, false, false, false, false },
-    { buffera, arraysize(buffera), true, true, true,  false, false, false },
-    { bufferb, arraysize(bufferb), true, true, true,  true,  false, false },
-    { bufferc, arraysize(bufferc), true, true, true,  true,  true,  false },
-    { bufferd, arraysize(bufferd), true, true, true,  true,  true,  true  },
-    { buffere, arraysize(buffere), true, true, true,  true,  true,  true  },
+    { buffer8, sizeof(buffer8), true, true, false, false, false, false },
+    { buffera, sizeof(buffera), true, true, true,  false, false, false },
+    { bufferb, sizeof(bufferb), true, true, true,  true,  false, false },
+    { bufferc, sizeof(bufferc), true, true, true,  true,  true,  false },
+    { bufferd, sizeof(bufferd), true, true, true,  true,  true,  true  },
+    { buffere, sizeof(buffere), true, true, true,  true,  true,  true  },
   };
   struct memfile mf;
   int i;
@@ -160,22 +160,22 @@ UNITTEST(mfmove)
   unsigned char bufferc[64];
   struct memfile mf;
 
-  static_assert(arraysize(bufferc) < OFFSET,
+  static_assert(sizeof(bufferc) < OFFSET,
    "OFFSET should be larger than the size of bufferc.");
 
-  mfopen(buffera, arraysize(buffera), &mf);
+  mfopen(buffera, sizeof(buffera), &mf);
   mf.current = mf.start + 96;
   ASSERTEQ(mf.current, buffera + 96, "");
 
-  mfmove(bufferb, arraysize(bufferb), &mf);
+  mfmove(bufferb, sizeof(bufferb), &mf);
   ASSERTEQ(mf.start, bufferb, "");
-  ASSERTEQ(mf.end, bufferb + arraysize(bufferb), "");
+  ASSERTEQ(mf.end, bufferb + sizeof(bufferb), "");
   ASSERTEQ(mf.current, bufferb + 96, "");
 
-  mfmove(bufferc, arraysize(bufferc), &mf);
+  mfmove(bufferc, sizeof(bufferc), &mf);
   ASSERTEQ(mf.start, bufferc, "");
-  ASSERTEQ(mf.end, bufferc + arraysize(bufferc), "");
-  ASSERTEQ(mf.current, bufferc + arraysize(bufferc), "");
+  ASSERTEQ(mf.end, bufferc + sizeof(bufferc), "");
+  ASSERTEQ(mf.current, bufferc + sizeof(bufferc), "");
 }
 
 UNITTEST(mfresize)
@@ -230,13 +230,13 @@ UNITTEST(mfseek_mftell)
   };
   static const int offs_maybe_safe[] =
   {
-    arraysize(buffer) + 1,
+    sizeof(buffer) + 1,
     1024,
     9999,
   };
   int ret;
 
-  mfopen(buffer, arraysize(buffer), &mf);
+  mfopen(buffer, sizeof(buffer), &mf);
 
   SECTION(mftell)
   {
@@ -298,7 +298,7 @@ UNITTEST(mfseek_mftell)
   SECTION(seek_end)
   {
     mfseek(&mf, 0, SEEK_END);
-    ASSERTEQ(mftell(&mf), arraysize(buffer), "seek_end");
+    ASSERTEQ(mftell(&mf), sizeof(buffer), "seek_end");
   }
 
   SECTION(seek_past_end)
@@ -338,7 +338,7 @@ UNITTEST(read_write)
     0x341200FF, 0xAB896745,
   };
 
-  const int SIZE = arraysize(data8);
+  const int SIZE = sizeof(data8);
   uint8_t dest[SIZE * 2];
   struct memfile mf;
   int res;
@@ -457,7 +457,7 @@ UNITTEST(read_write)
   {
     // NOTE: this function does not perform bounds checks since when using it
     // it is assumed these have already been performed.
-    mfopen(dest, arraysize(dest), &mf);
+    mfopen(dest, sizeof(dest), &mf);
 
     for(i = 0; i < arraysize(data8); i++)
     {
@@ -471,7 +471,7 @@ UNITTEST(read_write)
   {
     // NOTE: this function does not perform bounds checks since when using it
     // it is assumed these have already been performed.
-    mfopen(dest, arraysize(dest), &mf);
+    mfopen(dest, sizeof(dest), &mf);
 
     for(i = 0; i < arraysize(data16); i++)
     {
@@ -485,7 +485,7 @@ UNITTEST(read_write)
   {
     // NOTE: this function does not perform bounds checks since when using it
     // it is assumed these have already been performed.
-    mfopen(dest, arraysize(dest), &mf);
+    mfopen(dest, sizeof(dest), &mf);
 
     for(i = 0; i < arraysize(data32s); i++)
     {
@@ -501,7 +501,7 @@ UNITTEST(read_write)
   {
     // NOTE: this function does not perform bounds checks since when using it
     // it is assumed these have already been performed.
-    mfopen(dest, arraysize(dest), &mf);
+    mfopen(dest, sizeof(dest), &mf);
 
     for(i = 0; i < arraysize(data32u); i++)
     {
@@ -646,43 +646,42 @@ UNITTEST(mfsafegets)
   };
   struct memfile mf;
   char buffer[512];
-  int i;
   int j;
 
   SECTION(NormalData)
   {
-    for(i = 0; i < arraysize(data); i++)
+    for(const memsafegets_data &d : data)
     {
-      mfopen(data[i].input, strlen(data[i].input), &mf);
+      mfopen(d.input, strlen(d.input), &mf);
 
-      for(j = 0; j < arraysize(data[i].output); j++)
+      for(j = 0; j < arraysize(d.output); j++)
       {
-        char *result = mfsafegets(buffer, arraysize(buffer), &mf);
-        if(result && data[i].output[j])
+        char *result = mfsafegets(buffer, sizeof(buffer), &mf);
+        if(result && d.output[j])
         {
-          ASSERTCMP(result, data[i].output[j], "%d %d", i, j);
+          ASSERTCMP(result, d.output[j], "%s: %d", d.input, j);
         }
         else
-          ASSERTEQ(result, data[i].output[j], "%d %d", i, j);
+          ASSERTEQ(result, d.output[j], "%s: %d", d.input, j);
       }
     }
   }
 
   SECTION(SmallData)
   {
-    for(i = 0; i < arraysize(short_data); i++)
+    for(const memsafegets_data &d : short_data)
     {
-      mfopen(short_data[i].input, strlen(short_data[i].input), &mf);
+      mfopen(d.input, strlen(d.input), &mf);
 
-      for(j = 0; j < arraysize(short_data[i].output); j++)
+      for(j = 0; j < arraysize(d.output); j++)
       {
         char *result = mfsafegets(buffer, SHORT_BUF_LEN, &mf);
-        if(result && short_data[i].output[j])
+        if(result && d.output[j])
         {
-          ASSERTCMP(result, short_data[i].output[j], "%d %d", i, j);
+          ASSERTCMP(result, d.output[j], "%s: %d", d.input, j);
         }
         else
-          ASSERTEQ(result, short_data[i].output[j], "%d %d", i, j);
+          ASSERTEQ(result, d.output[j], "%s: %d", d.input, j);
       }
     }
   }

--- a/unit/io/path.cpp
+++ b/unit/io/path.cpp
@@ -18,51 +18,33 @@
  */
 
 #include "../Unit.hpp"
-#include "../../src/io/path.c"
+#include "../../src/io/path.h"
+#include "../../src/io/vio.h"
 
 #include <errno.h>
+#include <sys/stat.h>
 
-/**
- * Allow tests to specify when stat should succeed or fail...
- */
-static enum
+#define PATH_FILE_EXISTS        "path_file_exists"
+#define PATH_DIR_EXISTS         "path_dir_exists"
+#define PATH_DIR_EXISTS_2       PATH_DIR_EXISTS DIR_SEPARATOR "path_dir_exists"
+#define PATH_DIR_NOT_EXISTS     "path_dir_kgdfsdlf"
+#define PATH_DIR_RECURSIVE      "path_dir_recursive"
+#define PATH_DIR_RECURSIVE_2    "path_dir_recursive" DIR_SEPARATOR PATH_DIR_RECURSIVE
+#define PATH_DIR_RECURSIVE_3    "path_dir_recursive" DIR_SEPARATOR PATH_DIR_RECURSIVE_2
+#define PATH_FILE_RECURSIVE     PATH_DIR_RECURSIVE DIR_SEPARATOR PATH_FILE_EXISTS
+
+UNITTEST(Init)
 {
-  STAT_FAIL,
-  STAT_REG,
-  STAT_DIR
-} stat_result_type = STAT_FAIL;
-int stat_result_errno = 0;
-int mkdir_result = 0;
-
-// Custom vstat so this builds without vfile.c and can control the output.
-int vstat(const char *path, struct stat *buf)
-{
-  memset(buf, 0, sizeof(struct stat));
-  switch(stat_result_type)
-  {
-    default:
-    case STAT_FAIL:
-      errno = stat_result_errno;
-      return -1;
-
-    case STAT_REG:
-      buf->st_mode = S_IFREG;
-      return 0;
-
-    case STAT_DIR:
-      buf->st_mode = S_IFDIR;
-      return 0;
-  }
-}
-
-int vmkdir(const char *path, int mode)
-{
-  return mkdir_result;
-}
-
-int vaccess(const char *path, int mode)
-{
-  return 0;
+  vfile *vf;
+  vrmdir(PATH_DIR_RECURSIVE_3);
+  vrmdir(PATH_DIR_RECURSIVE_2);
+  vmkdir(PATH_DIR_EXISTS, 0755);
+  vmkdir(PATH_DIR_EXISTS_2, 0755);
+  vmkdir(PATH_DIR_RECURSIVE, 0755);
+  vf = vfopen_unsafe(PATH_FILE_EXISTS, "wb");
+  vfclose(vf);
+  vf = vfopen_unsafe(PATH_FILE_RECURSIVE, "wb");
+  vfclose(vf);
 }
 
 struct path_ext_result
@@ -586,36 +568,24 @@ UNITTEST(path_split_functions)
       16,
       true
     },
-  };
-  // Internally all of these functions may stat the provided directory to
-  // determine how much of it is/isn't a path. These paths all assume that
-  // a directory stat succeeds for the input path.
-  static const path_split_data data_stat[] =
-  {
+    // Internally all of these functions may stat the provided directory to
+    // determine how much of it is/isn't a path. These paths all assume that
+    // a directory stat succeeds for the input path.
     {
-      "actually_a_path",
-      "actually_a_path",
-      "actually_a_path",
+      PATH_DIR_EXISTS,
+      PATH_DIR_EXISTS,
+      PATH_DIR_EXISTS,
       "",
       15,
       0,
       true
     },
     {
-      "directory/with/no/trailing/slash",
-      "directory/with/no/trailing/slash",
-      "directory\\with\\no\\trailing\\slash",
+      PATH_DIR_EXISTS_2,
+      PATH_DIR_EXISTS_2,
+      PATH_DIR_EXISTS_2,
       "",
-      32,
-      0,
-      true
-    },
-    {
-      "C:\\dos\\style\\directory",
-      "C:/dos/style/directory",
-      "C:\\dos\\style\\directory",
-      "",
-      22,
+      31,
       0,
       true
     },
@@ -624,19 +594,9 @@ UNITTEST(path_split_functions)
   char file_buffer[MAX_PATH];
   ssize_t result;
 
-  stat_result_type = STAT_FAIL;
-
   SECTION(path_has_directory)
   {
     for(const path_split_data &d : data)
-    {
-      boolean result = path_has_directory(d.path);
-      ASSERTEQ(result, d.dir_return_value > 0, "%s", d.path);
-    }
-
-    stat_result_type = STAT_DIR;
-
-    for(const path_split_data &d : data_stat)
     {
       boolean result = path_has_directory(d.path);
       ASSERTEQ(result, d.dir_return_value > 0, "%s", d.path);
@@ -646,19 +606,6 @@ UNITTEST(path_split_functions)
   SECTION(path_to_directory)
   {
     for(const path_split_data &d : data)
-    {
-      snprintf(dir_buffer, MAX_PATH, "%s", d.path);
-      dir_buffer[MAX_PATH - 1] = '\0';
-
-      result = path_to_directory(dir_buffer, MAX_PATH);
-      ASSERTEQ(result, d.dir_return_value, "%s", d.path);
-      if(result >= 0 && d.SPLIT_DIRECTORY)
-        ASSERTCMP(dir_buffer, d.SPLIT_DIRECTORY, "%s", d.path);
-    }
-
-    stat_result_type = STAT_DIR;
-
-    for(const path_split_data &d : data_stat)
     {
       snprintf(dir_buffer, MAX_PATH, "%s", d.path);
       dir_buffer[MAX_PATH - 1] = '\0';
@@ -679,34 +626,11 @@ UNITTEST(path_split_functions)
       if(result >= 0 && d.SPLIT_DIRECTORY)
         ASSERTCMP(dir_buffer, d.SPLIT_DIRECTORY, "%s", d.path);
     }
-
-    stat_result_type = STAT_DIR;
-
-    for(const path_split_data &d : data_stat)
-    {
-      result = path_get_directory(dir_buffer, MAX_PATH, d.path);
-      ASSERTEQ(result, d.dir_return_value, "%s", d.path);
-      if(result >= 0 && d.SPLIT_DIRECTORY)
-        ASSERTCMP(dir_buffer, d.SPLIT_DIRECTORY, "%s", d.path);
-    }
   }
 
   SECTION(path_to_filename)
   {
     for(const path_split_data &d : data)
-    {
-      snprintf(file_buffer, MAX_PATH, "%s", d.path);
-      file_buffer[MAX_PATH - 1] = '\0';
-
-      result = path_to_filename(file_buffer, MAX_PATH);
-      ASSERTEQ(result, d.file_return_value, "%s", d.path);
-      if(result >= 0 && d.filename)
-        ASSERTCMP(file_buffer, d.filename, "%s", d.path);
-    }
-
-    stat_result_type = STAT_DIR;
-
-    for(const path_split_data &d : data_stat)
     {
       snprintf(file_buffer, MAX_PATH, "%s", d.path);
       file_buffer[MAX_PATH - 1] = '\0';
@@ -727,16 +651,6 @@ UNITTEST(path_split_functions)
       if(result >= 0 && d.filename)
         ASSERTCMP(file_buffer, d.filename, "%s", d.path);
     }
-
-    stat_result_type = STAT_DIR;
-
-    for(const path_split_data &d : data_stat)
-    {
-      result = path_get_filename(file_buffer, MAX_PATH, d.path);
-      ASSERTEQ(result, d.file_return_value, "%s", d.path);
-      if(result >= 0 && d.filename)
-        ASSERTCMP(file_buffer, d.filename, "%s", d.path);
-    }
   }
 
   SECTION(path_get_directory_and_filename)
@@ -744,23 +658,6 @@ UNITTEST(path_split_functions)
     boolean result;
 
     for(const path_split_data &d : data)
-    {
-      result = path_get_directory_and_filename(
-       dir_buffer, MAX_PATH, file_buffer, MAX_PATH, d.path);
-      ASSERTEQ(result, d.dir_and_file_return_value, "%s", d.path);
-      if(result)
-      {
-        if(d.SPLIT_DIRECTORY)
-          ASSERTCMP(dir_buffer, d.SPLIT_DIRECTORY, "%s", d.path);
-
-        if(d.filename)
-          ASSERTCMP(file_buffer, d.filename, "%s", d.path);
-      }
-    }
-
-    stat_result_type = STAT_DIR;
-
-    for(const path_split_data &d : data_stat)
     {
       result = path_get_directory_and_filename(
        dir_buffer, MAX_PATH, file_buffer, MAX_PATH, d.path);
@@ -1080,7 +977,7 @@ UNITTEST(path_remove_prefix)
 
 UNITTEST(path_navigate)
 {
-  static const path_target_output data[] =
+  static const path_target_output no_check[] =
   {
     {
       "",
@@ -1195,14 +1092,57 @@ UNITTEST(path_navigate)
       38
     },
   };
+  static const path_target_output with_check[] =
+  {
+    {
+      "",
+      "",
+      nullptr,
+      nullptr,
+      -1
+    },
+    {
+      ".",
+      PATH_DIR_NOT_EXISTS,
+      nullptr,
+      nullptr,
+      -1
+    },
+    {
+      ".",
+      PATH_DIR_EXISTS,
+      "./" PATH_DIR_EXISTS,
+      ".\\" PATH_DIR_EXISTS,
+      17
+    },
+    {
+      PATH_FILE_RECURSIVE,
+      "..",
+      PATH_DIR_RECURSIVE,
+      PATH_DIR_RECURSIVE,
+      18
+    },
+  };
   char buffer[MAX_PATH];
   ssize_t result;
 
-  SECTION(Success)
+  SECTION(path_navigate_no_check)
   {
-    stat_result_type = STAT_DIR;
+    for(const path_target_output &d : no_check)
+    {
+      snprintf(buffer, MAX_PATH, "%s", d.path);
+      buffer[MAX_PATH - 1] = '\0';
 
-    for(const path_target_output &d : data)
+      result = path_navigate_no_check(buffer, MAX_PATH, d.target);
+      ASSERTEQ(result, d.return_value, "%s", d.path);
+      if(result && d.PATH_CLEAN_RESULT)
+        ASSERTCMP(buffer, d.PATH_CLEAN_RESULT, "%s", d.path);
+    }
+  }
+
+  SECTION(path_navigate)
+  {
+    for(const path_target_output &d : with_check)
     {
       snprintf(buffer, MAX_PATH, "%s", d.path);
       buffer[MAX_PATH - 1] = '\0';
@@ -1213,93 +1153,37 @@ UNITTEST(path_navigate)
         ASSERTCMP(buffer, d.PATH_CLEAN_RESULT, "%s", d.path);
     }
   }
-
-  SECTION(Fail)
-  {
-    stat_result_type = STAT_FAIL;
-
-    for(const path_target_output &d : data)
-    {
-      snprintf(buffer, MAX_PATH, "%s", d.path);
-      buffer[MAX_PATH - 1] = '\0';
-
-      result = path_navigate(buffer, MAX_PATH, d.target);
-      ASSERTEQ(result, -1, "%s", d.path);
-      ASSERTCMP(buffer, d.path, "");
-    }
-  }
 }
 
 struct path_mkdir_data
 {
   const char *path;
+  enum path_create_error expected;
 };
-
-template<size_t N>
-static void test_mkdir(const path_mkdir_data (&data)[N],
- enum path_create_error expected)
-{
-  for(const path_mkdir_data &cur : data)
-  {
-    enum path_create_error ret = path_create_parent_recursively(cur.path);
-    ASSERTEQ(ret, expected, "%s", cur.path);
-  }
-}
 
 UNITTEST(path_create_parent_recursively)
 {
-  static const path_mkdir_data has_parent[] =
+  static const path_mkdir_data data[] =
   {
-    { "path/with/parent.txt" },
-    { "not\\really\\a\\lot\\to\\test\\here\\right\\now" },
-    { "check/out\\my/cool\\slashes" },
+    // Parent does not exist, call succeeds.
+    { PATH_DIR_RECURSIVE_3 DIR_SEPARATOR PATH_FILE_EXISTS,
+      PATH_CREATE_SUCCESS },
+    // No parent in the input path, call succeeds.
+    { "config.txt", PATH_CREATE_SUCCESS },
+    { "lol.cnf", PATH_CREATE_SUCCESS },
+    { "megazeux.exe", PATH_CREATE_SUCCESS },
+    // Parent exists, call succeeds.
+    { PATH_FILE_RECURSIVE, PATH_CREATE_SUCCESS },
+    // mkdir fails due to existing file.
+    { PATH_FILE_RECURSIVE DIR_SEPARATOR PATH_DIR_RECURSIVE,
+      PATH_CREATE_ERR_FILE_EXISTS },
+    // TODO: PATH_CREATE_ERR_MKDIR_FAILED is returned when mkdir fails.
+    // TODO: PATH_CREATE_ERR_STAT_ERROR is returned when stat fails.
   };
 
-  static const path_mkdir_data no_parent[] =
+  for(const path_mkdir_data &cur : data)
   {
-    { "config.txt" },
-    { "lol.cnf" },
-    { "megazeux.exe" },
-  };
-
-  mkdir_result = 0;
-  stat_result_type = STAT_FAIL;
-  stat_result_errno = ENOENT;
-
-  SECTION(Success)
-  {
-    test_mkdir(has_parent, PATH_CREATE_SUCCESS);
-  }
-
-  SECTION(NoParent)
-  {
-    test_mkdir(no_parent, PATH_CREATE_SUCCESS);
-  }
-
-  SECTION(ParentExists)
-  {
-    stat_result_type = STAT_DIR;
-    test_mkdir(has_parent, PATH_CREATE_SUCCESS);
-  }
-
-  SECTION(FileExists)
-  {
-    stat_result_type = STAT_REG;
-    test_mkdir(no_parent, PATH_CREATE_SUCCESS);
-    test_mkdir(has_parent, PATH_CREATE_ERR_FILE_EXISTS);
-  }
-
-  SECTION(mkdirFail)
-  {
-    mkdir_result = -1;
-    test_mkdir(no_parent, PATH_CREATE_SUCCESS);
-    test_mkdir(has_parent, PATH_CREATE_ERR_MKDIR_FAILED);
-  }
-
-  SECTION(StatError)
-  {
-    stat_result_errno = EACCES;
-    test_mkdir(no_parent, PATH_CREATE_SUCCESS);
-    test_mkdir(has_parent, PATH_CREATE_ERR_STAT_ERROR);
+    enum path_create_error ret = path_create_parent_recursively(cur.path);
+    ASSERTEQ(ret, cur.expected, "%s", cur.path);
   }
 }

--- a/unit/io/path.cpp
+++ b/unit/io/path.cpp
@@ -47,6 +47,55 @@ UNITTEST(Init)
   vfclose(vf);
 }
 
+UNITTEST(path_tokenize)
+{
+  struct path_tokenize_result
+  {
+    const char *input;
+    const char *expected[8];
+  };
+
+  static const path_tokenize_result data[] =
+  {
+    { nullptr,        { nullptr }},
+    { "",             { "", nullptr }},
+    { "shdfkjshdf",   { "shdfkjshdf", nullptr }},
+    { "/",            { "", "", nullptr }},
+    { "C:\\a",        { "C:", "a", nullptr }},
+    { "sdcard:/bees", { "sdcard:", "bees", nullptr }},
+    { "a\\lomg/path", { "a", "lomg", "path", nullptr }},
+    { "test///path",  { "test", "", "", "path", nullptr }},
+    { "trailing/",    { "trailing", "", nullptr }},
+    {
+      u8"/home/\u00C8śŚ/megazeux/DE/saved.sav",
+      { "", "home", u8"\u00C8śŚ", "megazeux", "DE", "saved.sav", nullptr }
+    },
+  };
+
+  for(const path_tokenize_result &d : data)
+  {
+    char buffer[256];
+    char *cursor;
+    char *current;
+    int pos = 0;
+
+    if(d.input)
+    {
+      snprintf(buffer, sizeof(buffer), "%s", d.input);
+      cursor = buffer;
+    }
+    else
+      cursor = nullptr;
+
+    while((current = path_tokenize(&cursor)))
+    {
+      ASSERTCMP(current, d.expected[pos], "%s : %d", d.input, pos);
+      pos++;
+    }
+    ASSERTEQ(current, d.expected[pos], "%s : %d", d.input, pos);
+  }
+}
+
 struct path_ext_result
 {
   const char *path;

--- a/unit/io/vfs.cpp
+++ b/unit/io/vfs.cpp
@@ -176,6 +176,10 @@ UNITTEST(vfs_stat)
   // This function will be further tested in other tests that use it to fetch
   // info to verify other calls worked.
 
+#ifndef CONFIG_VFS
+  SKIP();
+#endif
+
   static const vfs_stat_result valid_data[]
   {
     // These are all the default root since that's the only default file...
@@ -228,6 +232,10 @@ UNITTEST(vfs_stat)
 
 UNITTEST(vfs_create_file_at_path)
 {
+#ifndef CONFIG_VFS
+  SKIP();
+#endif
+
   static const vfs_stat_result valid_data[] =
   {
     { "file.txt", 0,                            { 2, S_IFREG, 0 }},
@@ -285,6 +293,10 @@ UNITTEST(vfs_create_file_at_path)
 
 UNITTEST(vfs_mkdir)
 {
+#ifndef CONFIG_VFS
+  SKIP();
+#endif
+
   static const vfs_stat_result valid_data[] =
   {
     { "aaa", 0,                         { 2, S_IFDIR, 0 }},
@@ -351,6 +363,10 @@ UNITTEST(vfs_mkdir)
 
 UNITTEST(vfs_chdir_getcwd)
 {
+#ifndef CONFIG_VFS
+  SKIP();
+#endif
+
 #ifdef VIRTUAL_FILESYSTEM_DOS_DRIVE
 #define BASE "C:\\"
 #else
@@ -437,6 +453,10 @@ UNITTEST(vfs_chdir_getcwd)
 
 UNITTEST(vfs_rename)
 {
+#ifndef CONFIG_VFS
+  SKIP();
+#endif
+
   static const vfs_op_result valid_data[] =
   {
     // No overwrite.
@@ -539,6 +559,10 @@ UNITTEST(vfs_rename)
 
 UNITTEST(vfs_unlink)
 {
+#ifndef CONFIG_VFS
+  SKIP();
+#endif
+
   static const vfs_op_result valid_data[] =
   {
     { "file1", "", DO_CREATE, 0,              0,        { 2, S_IFREG, 0 }},
@@ -603,6 +627,10 @@ UNITTEST(vfs_unlink)
 
 UNITTEST(vfs_rmdir)
 {
+#ifndef CONFIG_VFS
+  SKIP();
+#endif
+
   static const vfs_op_result valid_data[] =
   {
     { "file1", "", DO_CREATE, 0,              0,        { 2, S_IFREG, 0 }},
@@ -650,6 +678,10 @@ UNITTEST(vfs_rmdir)
 
 UNITTEST(vfs_access)
 {
+#ifndef CONFIG_VFS
+  SKIP();
+#endif
+
   static const vfs_op_result valid_data[] =
   {
     { "/", "", DO_ACCESS, 0,                  0,        { 1, S_IFDIR, 0 }},
@@ -692,6 +724,10 @@ UNITTEST(vfs_access)
 
 UNITTEST(vfs_readdir)
 {
+#ifndef CONFIG_VFS
+  SKIP();
+#endif
+
   struct vfs_readdir_result
   {
     const char *path;
@@ -791,6 +827,10 @@ UNITTEST(vfs_readdir)
 
 UNITTEST(FileIO)
 {
+#ifndef CONFIG_VFS
+  SKIP();
+#endif
+
   static const char name[] = "file.ext";
   static const char *strs[] =
   {

--- a/unit/io/vfs.cpp
+++ b/unit/io/vfs.cpp
@@ -376,7 +376,7 @@ UNITTEST(vfs_chdir_getcwd)
     { BASE "dir" DIR_SEPARATOR "dir2", "", DO_GETCWD, 0, 0, { 4, S_IFDIR, 0 }},
     { "../../file", "", DO_STAT, ignore,  0,        { 3, S_IFREG, 0 }},
     { "/", "", DO_CHDIR, 0,               0,        { 1, S_IFDIR, 0 }},
-    { DIR_SEPARATOR, "", DO_GETCWD, 0,    0,        { 1, S_IFDIR, 0 }},
+    { BASE, "", DO_GETCWD, 0,             0,        { 1, S_IFDIR, 0 }},
   };
 
   static const vfs_op_result invalid_data[] =

--- a/unit/io/vfs.cpp
+++ b/unit/io/vfs.cpp
@@ -340,6 +340,9 @@ UNITTEST(vfs_rename)
     { "dir4/dir3", "dir", DO_RENAME, 0,         0,        { 3, S_IFDIR, 0 }},
     { "dir4/dir3", "", DO_STAT, ignore,         -ENOENT,  {}},
     { "dir2", "", DO_MKDIR, 0,                  0,        { 6, S_IFDIR, 0 }},
+    // Same old/new should return success but change nothing.
+    { "dir", "dir", DO_RENAME, 0,               0,        { 3, S_IFDIR, 0 }},
+    { "file", "file", DO_RENAME, 0,             0,        { 2, S_IFREG, 0 }},
   };
 
   static const vfs_op_result invalid_data[] =

--- a/unit/io/vfs.cpp
+++ b/unit/io/vfs.cpp
@@ -107,6 +107,9 @@ static void check_stat(const char *path, const vfs_stat_data &d, struct stat &st
   ASSERTEQ(st.st_ino, d.inode, "%s", path);
   ASSERTEQ(st.st_mode & S_IFMT, d.filetype, "%s", path);
   ASSERTEQ(st.st_size, d.size, "%s", path);
+  ASSERT(st.st_atime, "%s", path);
+  ASSERT(st.st_mtime, "%s", path);
+  ASSERT(st.st_ctime, "%s", path);
   ASSERT(st.st_atime >= create_time, "%s", path);
   ASSERT(st.st_mtime >= modify_time, "%s", path);
   ASSERT(st.st_ctime >= modify_time, "%s", path);

--- a/unit/io/vfs.cpp
+++ b/unit/io/vfs.cpp
@@ -1,0 +1,190 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2021 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "../Unit.hpp"
+
+#include "../../src/io/vfs.h"
+
+#include <errno.h>
+#include <sys/stat.h>
+
+static constexpr dev_t MZX_DEVICE = ('M'<<24) | ('Z'<<16) | ('X'<<8) | ('V');
+
+class ScopedVFS
+{
+  vfilesystem *vfs;
+
+public:
+  ScopedVFS(vfilesystem *p = nullptr) : vfs(p) {}
+  ~ScopedVFS() { if(vfs) vfs_free(vfs); }
+
+  operator vfilesystem *() { return vfs; }
+};
+
+struct vfs_result
+{
+  const char *path;
+  int expected_ret;
+  int expected_error;
+};
+
+struct vfs_stat_result
+{
+  const char *path;
+  int expected_ret;
+  int expected_error;
+  ino_t inode;
+  mode_t filetype;
+  off_t size;
+};
+
+static void check_stat(const vfs_stat_result &d, struct stat &st)
+{
+  ASSERTEQ(st.st_dev, MZX_DEVICE, "%s", d.path);
+  ASSERTEQ(st.st_ino, d.inode, "%s", d.path);
+  ASSERTEQ(st.st_mode & S_IFMT, d.filetype, "%s", d.path);
+  ASSERTEQ(st.st_size, d.size, "%s", d.path);
+}
+
+UNITTEST(vfs_stat)
+{
+  // Simple test to make sure it works on known valid/invalid default files.
+  // This function will be further tested in other tests that use it to fetch
+  // info to verify other calls worked.
+
+  static const vfs_stat_result valid_data[]
+  {
+    // These are all the default root since that's the only default file...
+    { "..", 0, 0,       1, S_IFDIR, 0 },
+    { ".", 0, 0,        1, S_IFDIR, 0 },
+    { "./", 0, 0,       1, S_IFDIR, 0 },
+    { "/", 0, 0,        1, S_IFDIR, 0 },
+    { "/./../", 0, 0,   1, S_IFDIR, 0 },
+    { "\\", 0, 0,       1, S_IFDIR, 0 },
+    { "\\..\\.", 0, 0,  1, S_IFDIR, 0 },
+#ifdef VIRTUAL_FILESYSTEM_DOS_DRIVE
+    { "C:/", 0, 0,      1, S_IFDIR, 0 },
+    { "C:\\", 0, 0,     1, S_IFDIR, 0 },
+    { "c:\\", 0, 0,     1, S_IFDIR, 0 },
+#endif
+  };
+
+  static const vfs_result invalid_data[]
+  {
+    { "", -1, ENOENT },
+    { "jsdjfk", -1, ENOENT },
+    { "sdcard:/", -1, ENOENT },
+    { "verylongrootnamewhywouldyouevennamearootthis:/", -1, ENOENT },
+    { "D:\\", -1, ENOENT },
+  };
+
+  ScopedVFS vfs = vfs_init();
+  struct stat st;
+  ASSERT(vfs, "");
+
+  SECTION(Valid)
+  {
+    for(const vfs_stat_result &d : valid_data)
+    {
+      int ret = vfs_stat(vfs, d.path, &st);
+      int err = vfs_error(vfs);
+      ASSERTEQ(err, d.expected_error, "%s", d.path);
+      ASSERTEQ(ret, d.expected_ret, "%s", d.path);
+      check_stat(d, st);
+    }
+  }
+
+  SECTION(Invalid)
+  {
+    for(const vfs_result &d : invalid_data)
+    {
+      int ret = vfs_stat(vfs, d.path, &st);
+      int err = vfs_error(vfs);
+      ASSERTEQ(err, d.expected_error, "%s", d.path);
+      ASSERTEQ(ret, d.expected_ret, "%s", d.path);
+      // vfs_error should return 0 when called again.
+      err = vfs_error(vfs);
+      ASSERTEQ(err, 0, "%s", d.path);
+    }
+  }
+}
+
+UNITTEST(vfs_mkdir)
+{
+  static const vfs_stat_result valid_data[] =
+  {
+    { "aaa", 0, 0,                        2, S_IFDIR, 0 },
+    { "./aaa/b", 0, 0,                    3, S_IFDIR, 0 },
+    { "/ccc", 0, 0,                       4, S_IFDIR, 0 },
+    { "aaa/..\\ccc/d", 0, 0,              5, S_IFDIR, 0 },
+    { "ccc/d\\.././..\\aaa/b\\e/", 0, 0,  6, S_IFDIR, 0 },
+    { "0", 0, 0,                          7, S_IFDIR, 0 }, // Test inserting before existing.
+    { "1", 0, 0,                          8, S_IFDIR, 0 },
+#ifdef VIRTUAL_FILESYSTEM_DOS_DRIVE
+    { "c:/fff/", 0, 0,                    9, S_IFDIR, 0 },
+#endif
+  };
+
+  static const vfs_result invalid_data[] =
+  {
+    { "",               -1, ENOENT },
+    { "aaa",            0, 0 },
+    { "aaa",            -1, EEXIST },
+    { "wtf/a",          -1, ENOENT },
+    { "/",              -1, EEXIST },
+    { "D:\\",           -1, ENOENT },
+    { "sdcardsfdfds:/", -1, ENOENT },
+    // FIXME create file (ENOTDIR)
+#ifdef VIRTUAL_FILESYSTEM_DOS_DRIVE
+    { "C:\\",           -1, EEXIST },
+#endif
+  };
+
+  ScopedVFS vfs = vfs_init();
+  struct stat st;
+  ASSERT(vfs, "");
+
+  SECTION(Valid)
+  {
+    for(const vfs_stat_result &d : valid_data)
+    {
+      int ret = vfs_mkdir(vfs, d.path, 0755);
+      int err = vfs_error(vfs);
+      ASSERTEQ(err, d.expected_error, "%s", d.path);
+      ASSERTEQ(ret, d.expected_ret, "%s", d.path);
+
+      ret = vfs_stat(vfs, d.path, &st);
+      err = vfs_error(vfs);
+      ASSERTEQ(err, 0, "stat %s", d.path);
+      ASSERTEQ(ret, 0, "stat %s", d.path);
+      check_stat(d, st);
+    }
+  }
+
+  SECTION(Invalid)
+  {
+    for(const vfs_result &d : invalid_data)
+    {
+      int ret = vfs_mkdir(vfs, d.path, 0755);
+      int err = vfs_error(vfs);
+      ASSERTEQ(err, d.expected_error, "%s", d.path);
+      ASSERTEQ(ret, d.expected_ret, "%s", d.path);
+    }
+  }
+}

--- a/unit/io/vio.cpp
+++ b/unit/io/vio.cpp
@@ -104,17 +104,17 @@ static const vfsafegets_data vfsafegets_test_data[] =
 #define back_up(bytes_from_end, vf) \
 { \
   static_assert(bytes_from_end < 0, "invalid bytes from end value :("); \
-  vfseek(vf, arraysize(test_data) + bytes_from_end - 1, SEEK_SET); \
+  vfseek(vf, sizeof(test_data) + bytes_from_end - 1, SEEK_SET); \
   int c = vfgetc(vf); \
-  ASSERTEQ(c, test_data[arraysize(test_data) + bytes_from_end - 1], "not eof"); \
+  ASSERTEQ(c, test_data[sizeof(test_data) + bytes_from_end - 1], "not eof"); \
 }
 
 static void test_vfgetc(vfile *vf)
 {
-  for(int i = 0; i < arraysize(test_data); i++)
+  for(size_t i = 0; i < sizeof(test_data); i++)
   {
     int c = vfgetc(vf);
-    ASSERTEQ(c, test_data[i], "vfgetc offset=%d", i);
+    ASSERTEQ(c, test_data[i], "vfgetc offset=%zu", i);
   }
   int c = vfgetc(vf);
   ASSERTEQ(c, EOF, "eof");
@@ -125,11 +125,11 @@ static void test_vfgetw(vfile *vf)
   int expected;
   int c;
 
-  for(int i = 0; i < arraysize(test_data); i += 2)
+  for(size_t i = 0; i < sizeof(test_data); i += 2)
   {
     c = vfgetw(vf);
     expected = test_data[i] | (test_data[i + 1] << 8);
-    ASSERTEQ(c, expected, "vfgetw offset=%d", i);
+    ASSERTEQ(c, expected, "vfgetw offset=%zu", i);
   }
   // Both bytes should cause EOF.
   c = vfgetw(vf);
@@ -145,12 +145,12 @@ static void test_vfgetd(vfile *vf)
   int expected;
   int c;
 
-  for(int i = 0; i < arraysize(test_data); i += 4)
+  for(size_t i = 0; i < sizeof(test_data); i += 4)
   {
     c = vfgetd(vf);
     expected = static_cast<int>(test_data[i] | (test_data[i + 1] << 8) |
      (test_data[i + 2] << 16) | (test_data[i + 3] << 24));
-    ASSERTEQ(c, expected, "vfgetd offset=%d", i);
+    ASSERTEQ(c, expected, "vfgetd offset=%zu", i);
   }
   // All four bytes should cause EOF.
   c = vfgetd(vf);
@@ -171,7 +171,7 @@ static void test_vfgetd(vfile *vf)
 
 static void test_vfread(vfile *vf)
 {
-  static constexpr int len = arraysize(test_data);
+  static constexpr int len = sizeof(test_data);
   char buffer[len * 2];
   int ret;
 
@@ -211,10 +211,10 @@ static void test_vfread(vfile *vf)
 
 static void test_write_check(vfile *vf)
 {
-  uint8_t tmp[arraysize(test_data)];
-  int r = vfread(tmp, arraysize(test_data), 1, vf);
+  uint8_t tmp[sizeof(test_data)];
+  int r = vfread(tmp, sizeof(test_data), 1, vf);
   ASSERTEQ(r, 1, "test_write_check vfread");
-  ASSERTMEM(test_data, tmp, arraysize(test_data), "test_write_check memcmp");
+  ASSERTMEM(test_data, tmp, sizeof(test_data), "test_write_check memcmp");
   r = vfgetc(vf);
   ASSERTEQ(r, EOF, "test_write_check eof");
 }
@@ -224,9 +224,9 @@ static void test_vfputc(vfile *vf)
   //char buf[64];
   long pos = vftell(vf);
 
-  for(int i = 0; i < arraysize(test_data); i++)
+  for(size_t i = 0; i < sizeof(test_data); i++)
   {
-    //snprintf(buf, arraysize(buf), "vfputc offset=%d", i);
+    //snprintf(buf, sizeof(buf), "vfputc offset=%d", i);
     vfputc(test_data[i], vf);
   }
   int r = vfseek(vf, pos, SEEK_SET);
@@ -239,10 +239,10 @@ static void test_vfputw(vfile *vf)
   //char buf[64];
   long pos = vftell(vf);
 
-  for(int i = 0; i < arraysize(test_data); i += 2)
+  for(size_t i = 0; i < sizeof(test_data); i += 2)
   {
     int d = test_data[i] | (test_data[i + 1] << 8);
-    //snprintf(buf, arraysize(buf), "vfputw offset=%d", i);
+    //snprintf(buf, sizeof(buf), "vfputw offset=%zu", i);
     vfputw(d, vf);
   }
   int r = vfseek(vf, pos, SEEK_SET);
@@ -255,11 +255,11 @@ static void test_vfputd(vfile *vf)
   //char buf[64];
   long pos = vftell(vf);
 
-  for(int i = 0; i < arraysize(test_data); i += 4)
+  for(size_t i = 0; i < sizeof(test_data); i += 4)
   {
     int d = test_data[i] | (test_data[i + 1] << 8) |
      (test_data[i + 2] << 16) | (test_data[i + 3] << 24);
-    //snprintf(buf, arraysize(buf), "vfputw offset=%d", i);
+    //snprintf(buf, sizeof(buf), "vfputw offset=%zu, i);
     vfputd(d, vf);
   }
   int r = vfseek(vf, pos, SEEK_SET);
@@ -271,8 +271,8 @@ static void test_vfwrite(vfile *vf)
 {
   long pos = vftell(vf);
 
-  int r = vfwrite(test_data, 1, arraysize(test_data), vf);
-  ASSERTEQ(r, arraysize(test_data), "vfwrite");
+  int r = vfwrite(test_data, 1, sizeof(test_data), vf);
+  ASSERTEQ(r, sizeof(test_data), "vfwrite");
 
   r = vfseek(vf, pos, SEEK_SET);
   ASSERTEQ(r, 0, "vfseek");
@@ -328,7 +328,7 @@ static void test_vfseek_vftell_vrewind_read(vfile *vf)
   static constexpr int set_cur_invalid[] = { -15, -120312, -1 };
   static constexpr int end_valid[] = { 0, -1, -5, -20, -256, 10, 9999 };
   static constexpr int end_invalid[] = { -257, -2000, -127848, -2391231 };
-  static constexpr int len = arraysize(test_data);
+  static constexpr int len = sizeof(test_data);
 
   long expected;
   long pos;
@@ -468,7 +468,7 @@ static void test_vungetc(vfile *vf)
 
   first_dword = vfgetd(vf);
   vfread(next_64, 64, 1, vf);
-  vfseek(vf, arraysize(test_data) - 5, SEEK_SET);
+  vfseek(vf, sizeof(test_data) - 5, SEEK_SET);
   vfread(last_5, 5, 1, vf);
   vrewind(vf);
 
@@ -508,10 +508,10 @@ static void test_vungetc(vfile *vf)
   ASSERTMEM(tmp + 1, next_64, 63, "vfread 0x12 ...");
 
   // vfsafegets should read the buffered char + n-1 chars from the data.
-  vfseek(vf, arraysize(test_data) - 5, SEEK_SET);
+  vfseek(vf, sizeof(test_data) - 5, SEEK_SET);
   ret = vungetc(0xFF, vf);
   ASSERTEQ(ret, 0xFF, "vungetc 0xFF");
-  retstr = vfsafegets(tmp, arraysize(tmp), vf);
+  retstr = vfsafegets(tmp, sizeof(tmp), vf);
   ASSERT(retstr, "vfsafegets 0xFF ...");
   ASSERTEQ(tmp[0], 0xFF, "vfsafegets 0xFF ...");
   ASSERTMEM(tmp + 1, last_5, 5, "vfsafegets 0xFF ...");
@@ -520,7 +520,7 @@ static void test_vungetc(vfile *vf)
   vfseek(vf, 0, SEEK_SET);
   ret = vungetc(0x0D, vf);
   ASSERTEQ(ret, 0x0D, "vungetc 0x0D");
-  retstr = vfsafegets(tmp, arraysize(tmp), vf);
+  retstr = vfsafegets(tmp, sizeof(tmp), vf);
   ASSERT(retstr, "vfsafegets 0x0D ...");
   ASSERTEQ((int)tmp[0], 0, "vfsafegets 0x0D ...");
   pos = vftell(vf);
@@ -530,11 +530,11 @@ static void test_vungetc(vfile *vf)
   vfseek(vf, 0, SEEK_END);
   ret = vungetc('a', vf);
   ASSERTEQ(ret, 'a', "vungetc 'a'");
-  retstr = vfsafegets(tmp, arraysize(tmp), vf);
+  retstr = vfsafegets(tmp, sizeof(tmp), vf);
   ASSERT(retstr, "vsafegets 'a'");
   ASSERTCMP(retstr, "a", "vsafegets 'a'");
   pos = vftell(vf);
-  ASSERTEQ(pos, arraysize(test_data), "vsafegets 'a'");
+  ASSERTEQ(pos, sizeof(test_data), "vsafegets 'a'");
 
   // vseek should discard the buffered char.
   ret = vungetc(0x34, vf);
@@ -554,7 +554,7 @@ static void test_vungetc(vfile *vf)
   ret = vungetc(0x78, vf);
   ASSERTEQ(ret, 0x78, "vungetc 0x78");
   long len = vfilelength(vf, true);
-  ASSERTEQ(len, arraysize(test_data), "vfgetd NOT 0x78");
+  ASSERTEQ(len, sizeof(test_data), "vfgetd NOT 0x78");
   value = vfgetd(vf);
   ASSERTEQ(value, first_dword, "vfgetd NOT 0x78");
 
@@ -591,7 +591,7 @@ static void test_vfsafegets(vfile *vf, const char *filename,
   SECTION(read_vfgetd)      test_vfgetd(vf); \
   SECTION(read_vfread)      test_vfread(vf); \
   SECTION(read_vfseektell)  test_vfseek_vftell_vrewind_read(vf); \
-  SECTION(read_filelength)  test_filelength(arraysize(test_data), vf); \
+  SECTION(read_filelength)  test_filelength(sizeof(test_data), vf); \
   SECTION(read_vungetc)     test_vungetc(vf); \
 } while(0)
 
@@ -713,16 +713,16 @@ UNITTEST(FileAppend)
 
 UNITTEST(MemoryRead)
 {
-  char buffer[arraysize(test_data)];
-  memcpy(buffer, test_data, arraysize(test_data));
-  ScopedFile<vfile, vfclose> vf_in = vfile_init_mem(buffer, arraysize(buffer), "rb");
+  char buffer[sizeof(test_data)];
+  memcpy(buffer, test_data, sizeof(test_data));
+  ScopedFile<vfile, vfclose> vf_in = vfile_init_mem(buffer, sizeof(test_data), "rb");
   ASSERT(vf_in, "");
   READ_TESTS(vf_in);
 }
 
 UNITTEST(MemoryWrite)
 {
-  static constexpr int len = arraysize(test_data);
+  static constexpr int len = sizeof(test_data);
   char buffer[len];
   int ret;
 
@@ -785,7 +785,7 @@ UNITTEST(MemoryAppendExt)
   }
   free(buffer);
   if(this->expected_section)
-    ASSERTEQ(size, arraysize(test_data) + BUF_SIZE, "");
+    ASSERTEQ(size, sizeof(test_data) + BUF_SIZE, "");
 }
 
 UNITTEST(vfsafegets)
@@ -840,7 +840,7 @@ UNITTEST(vtempfile)
 
   SECTION(Memory)
   {
-    ScopedFile<vfile, vfclose> vf = vtempfile(arraysize(test_data));
+    ScopedFile<vfile, vfclose> vf = vtempfile(sizeof(test_data));
     ASSERT(vf, "");
     test_vfwrite(vf);
   }
@@ -863,7 +863,7 @@ UNITTEST(Filesystem)
 
   if(!this->expected_section)
   {
-    char *t = getcwd(execdir, arraysize(execdir));
+    char *t = getcwd(execdir, sizeof(execdir));
     ASSERTEQ(t, execdir, "");
   }
   else
@@ -889,11 +889,11 @@ UNITTEST(Filesystem)
   {
     char buffer[1024];
     char buffer2[1024];
-    char *t = getcwd(buffer, arraysize(buffer));
+    char *t = getcwd(buffer, sizeof(buffer));
     ASSERTEQ(t, buffer, "");
     ret = vchdir("..");
     ASSERTEQ(ret, 0, "");
-    t = getcwd(buffer2, arraysize(buffer2));
+    t = getcwd(buffer2, sizeof(buffer2));
     ASSERTEQ(t, buffer2, "");
     size_t len = strlen(buffer2);
     ASSERT(len < sizeof(buffer), "");
@@ -980,9 +980,9 @@ UNITTEST(Filesystem)
     char buffer[1024];
 
     // Clean up from any previous tests...
-    snprintf(buffer, arraysize(buffer), "%s" DIR_SEPARATOR "%s", TEST_RENAME_DIR, TEST_RENAME_FILENAME);
+    snprintf(buffer, sizeof(buffer), "%s" DIR_SEPARATOR "%s", TEST_RENAME_DIR, TEST_RENAME_FILENAME);
     vunlink(buffer);
-    snprintf(buffer, arraysize(buffer), "%s" DIR_SEPARATOR "%s", TEST_DIR, TEST_RENAME_FILENAME);
+    snprintf(buffer, sizeof(buffer), "%s" DIR_SEPARATOR "%s", TEST_DIR, TEST_RENAME_FILENAME);
     vunlink(buffer);
     vrmdir(TEST_RENAME_DIR);
     vrmdir(TEST_DIR);
@@ -1027,7 +1027,7 @@ UNITTEST(Filesystem)
     static constexpr char UTF8_DIR[] = u8"\u00e6Ro\u0308e\u0300mMJ\u00b7\u2021\u00b2\u2019\u02c6\u00de\u2018$";
     static constexpr char UTF8_FILE[] = u8"\u00A5\u2014\U0001F970";
     static constexpr char UTF8_FILE2[] = u8"\U0001F970\u2014\u00A5";
-    static constexpr int utf8_dir_len = arraysize(UTF8_DIR) - 1;
+    static constexpr int utf8_dir_len = sizeof(UTF8_DIR) - 1;
 
     ret = vstat(UTF8_DIR, &stat_info);
     if(!ret)
@@ -1053,7 +1053,7 @@ UNITTEST(Filesystem)
     ASSERTEQ(ret, 0, "");
     char buffer[1024];
 
-    char *t = vgetcwd(buffer, arraysize(buffer));
+    char *t = vgetcwd(buffer, sizeof(buffer));
     ASSERTEQ(t, buffer, "");
     size_t len = strlen(buffer);
     ASSERTCMP(buffer + len - utf8_dir_len, UTF8_DIR, "");
@@ -1061,13 +1061,13 @@ UNITTEST(Filesystem)
     {
       ScopedFile<vfile, vfclose> vf = vfopen_unsafe(UTF8_FILE, "wb");
       ASSERT(vf, "");
-      ret = vfwrite(test_data, arraysize(test_data), 1, vf);
+      ret = vfwrite(test_data, sizeof(test_data), 1, vf);
       ASSERTEQ(ret, 1, "");
     }
 
     ret = vstat(UTF8_FILE, &stat_info);
     ASSERTEQ(ret, 0, "");
-    ASSERTEQ(stat_info.st_size, arraysize(test_data), "");
+    ASSERTEQ(stat_info.st_size, sizeof(test_data), "");
     ASSERT(S_ISREG(stat_info.st_mode), "");
 
     ret = vaccess(UTF8_FILE, R_OK|W_OK);
@@ -1078,7 +1078,7 @@ UNITTEST(Filesystem)
 
     ret = vstat(UTF8_FILE2, &stat_info);
     ASSERTEQ(ret, 0, "");
-    ASSERTEQ(stat_info.st_size, arraysize(test_data), "");
+    ASSERTEQ(stat_info.st_size, sizeof(test_data), "");
     ASSERT(S_ISREG(stat_info.st_mode), "");
 
     ret = vunlink(UTF8_FILE2);

--- a/unit/io/vio.cpp
+++ b/unit/io/vio.cpp
@@ -20,7 +20,7 @@
 #include "../Unit.hpp"
 #include "../../src/network/Scoped.hpp"
 #include "../../src/io/path.h"
-#include "../../src/io/vio.c"
+#include "../../src/io/vio.h"
 
 static constexpr char TEST_READ_FILENAME[]  = "VFILE_TEST_DATA";
 static constexpr char TEST_WRITE_FILENAME[] = "VFILE_TEST_WRITE";
@@ -682,7 +682,7 @@ UNITTEST(ModeFlags)
 
   for(const mode_flag_pairs &d : data)
   {
-    int res = get_vfile_mode_flags(d.mode);
+    int res = vfile_get_mode_flags(d.mode);
     ASSERTEQ(res, d.expected, "%s", d.mode);
   }
 }

--- a/unit/io/zip.cpp
+++ b/unit/io/zip.cpp
@@ -210,7 +210,7 @@ static void debase64(char *dest, size_t dest_len, const char *_src, size_t src_l
 static char *load_file(const char *path)
 {
   char buffer[MAX_PATH];
-  if(path_join(buffer, arraysize(buffer), DATA_DIR, path) < 1)
+  if(path_join(buffer, sizeof(buffer), DATA_DIR, path) < 1)
     return nullptr;
 
   FILE *fp = fopen_unsafe(buffer, "rb");
@@ -232,7 +232,7 @@ static char *load_file(const char *path)
 static char *load_file(const char *path, char *buffer, size_t *buffer_len)
 {
   char path_buffer[MAX_PATH];
-  if(path_join(path_buffer, arraysize(path_buffer), DATA_DIR, path) < 1)
+  if(path_join(path_buffer, sizeof(path_buffer), DATA_DIR, path) < 1)
     return nullptr;
 
   FILE *fp = fopen_unsafe(path_buffer, "rb");
@@ -693,7 +693,7 @@ static zip_archive *zip_test_open(const zip_test_data &d)
   if(!d.data_length)
   {
     char buffer[MAX_PATH];
-    if(path_join(buffer, arraysize(buffer), DATA_DIR, d.data) < 0)
+    if(path_join(buffer, sizeof(buffer), DATA_DIR, d.data) < 0)
       return nullptr;
 
     return zip_open_file_read(buffer);
@@ -861,9 +861,9 @@ UNITTEST(ZipRead)
           ASSERTEQ(result, ZIP_SUCCESS, "%s file %zu", d.testname, j);
 
           const char *contents  = ZIP_GET_CONTENTS(df);
-          for(size_t k = 0; k < real_length; k += arraysize(small_buffer))
+          for(size_t k = 0; k < real_length; k += sizeof(small_buffer))
           {
-            size_t n = MIN((size_t)arraysize(small_buffer), real_length - k);
+            size_t n = MIN(sizeof(small_buffer), real_length - k);
             result = zread(small_buffer, n, zp);
             ASSERTEQ(result, ZIP_SUCCESS, "%s file %zu", d.testname, j);
             cmp = memcmp(small_buffer, contents + k, n);
@@ -910,9 +910,9 @@ UNITTEST(ZipRead)
             const char *contents  = ZIP_GET_CONTENTS(df);
             ASSERTEQ(result, ZIP_SUCCESS, "%s file %zu", d.testname, j);
 
-            for(size_t k = 0; k < real_length; k += arraysize(small_buffer))
+            for(size_t k = 0; k < real_length; k += sizeof(small_buffer))
             {
-              size_t n = MIN((size_t)arraysize(small_buffer), real_length - k);
+              size_t n = MIN(sizeof(small_buffer), real_length - k);
               cmp = mfread(small_buffer, n, 1, &mf);
               ASSERTEQ(cmp, 1, "%s file %zu", d.testname, j);
               cmp = memcmp(small_buffer, contents + k, n);
@@ -1154,7 +1154,7 @@ UNITTEST(ZipWrite)
     zp = zip_open_mem_write_ext(reinterpret_cast<void **>(&ext_buffer), &ext_buffer_size, 0);
     ASSERT(zp, "");
 
-    result = zip_write_file(zp, "", tmp, arraysize(tmp), ZIP_M_NONE);
+    result = zip_write_file(zp, "", tmp, sizeof(tmp), ZIP_M_NONE);
     ASSERTEQ(result, ZIP_SUCCESS, "Failed to write dummy file.");
 
     // This is the bad thing you shouldn't do!


### PR DESCRIPTION
Adds a virtual filesystem data structure for MegaZeux. Currently it does nothing except pass its own unit tests (as far as I've tested). vio.c integration, file caching, etc. will probably be added in separate patches.

Also cleans up/modifies the IO unit tests so they can build with `--disable-modular` builds and reduces the number of `arraysize` uses in the unit tests.

- [x] config.sh option, force disable for Emscripten (currently pointless) and NDS (not enough RAM, SD isn't slow enough to justify it).
- [x] `chdir` and `getcwd`.
- [x] ~~The tests can probably be improved.~~ ugh
- [x] Better function documentation.
- [x] Some of the unfinished caching features still have declarations that can be removed for now.
- [x] The unfinished vio.c integration can also be removed for now.
- [x] ~~`vfs_tokenize` might be better suited to path.c.~~ It's `path_tokenize` now.