### PR TITLE
Overhaul graphics.c string functions and allow colors in scrolls.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -167,6 +167,7 @@ USERS
   stdin using the input filename "-".
 + Fixed bugs caused by missing validation in the Import SFX
   feature in the editor.
++ Scrolls can now display standard message ~@ color codes.
 - Removed GL4ES from the GLSL blacklist.
 - Removed 3DS CIA support. (asie)
 

--- a/src/editor/char_ed.c
+++ b/src/editor/char_ed.c
@@ -567,12 +567,12 @@ static void draw_multichar_smzx(char *buffer, int start_x, int start_y,
         if(current_pixel)
         {
           write_string("\xDB\xDB\xDB\xDB", start_x + (x * 4),
-           start_y + y, base_colors[current_pixel], 1);
+           start_y + y, base_colors[current_pixel], false);
         }
         else
         {
           write_string("\xFA\xFA\xFA\xFA", start_x + (x * 4),
-           start_y + y, bg_color, 1);
+           start_y + y, bg_color, false);
         }
       }
     }
@@ -589,13 +589,13 @@ static void draw_multichar_smzx(char *buffer, int start_x, int start_y,
         {
           write_string("\xDB\xDB\xDB\xDB", start_x +
            ((x + current_x) * 4), start_y + current_y + y,
-           highlight_colors[current_pixel], 1);
+           highlight_colors[current_pixel], false);
         }
         else
         {
           write_string("\xFA\xFA\xFA\xFA", start_x +
            ((x + current_x) * 4), start_y + y + current_y,
-           0x1B, 1);
+           0x1B, false);
         }
       }
     }
@@ -1210,39 +1210,39 @@ int char_editor(struct world *mzx_world)
      128, 143, 135, 0, 0);
 
     // Current character
-    write_string("Current char-\t(#000)", info_x, info_y, 0x8F, 1);
+    write_string("Current char-\t(#000)", info_x, info_y, 0x8F, W_TABS);
     write_number(current_char + (current_charset * 256), 0x8F,
      info_x + 22, info_y, 3, 3, 10);
 
     // Help
     write_string(help_text[help_page],
-     info_x, info_y + pad_height + 2, 0x8F, 1);
+     info_x, info_y + pad_height + 2, 0x8F, W_TABS | W_NEWLINES);
 
     if(screen_mode)
     {
       // Correct "Toggle pixel" to "Place pixel"
       if(help_page == 0)
         write_string("Place pixel ",
-         info_x + 8, info_y + pad_height + 4, 0x8F, 1);
+         info_x + 8, info_y + pad_height + 4, 0x8F, W_TABS);
 
       // Correct F5 to "SMZX"
       if(help_page == 1)
         write_string("SMZX",
-         info_x + 18, info_y + pad_height + 8, 0x8F, 1);
+         info_x + 18, info_y + pad_height + 8, 0x8F, W_TABS);
 
       // 1-4 Select
       write_string(help_text_smzx,
-       info_x, info_y + pad_height + 14, 0x8F, 1);
+       info_x, info_y + pad_height + 14, 0x8F, W_TABS);
 
       if(current_pixel)
       {
         write_string("\xDB\xDB\xDB\xDB", info_x + 16,
-         info_y + pad_height + 14, smzx_colors[current_pixel], 1);
+         info_y + pad_height + 14, smzx_colors[current_pixel], false);
       }
       else
       {
         write_string("\xFA\xFA\xFA\xFA", info_x + 16,
-         info_y + pad_height + 14, (smzx_colors[0] << 4) + smzx_colors[3], 1);
+         info_y + pad_height + 14, (smzx_colors[0] << 4) + smzx_colors[3], false);
       }
     }
 
@@ -1253,17 +1253,17 @@ int char_editor(struct world *mzx_world)
     {
       case 0:
         write_string("(off)   ", info_x + 16,
-         info_y + pad_height + 13, 0x8F, 0);
+         info_y + pad_height + 13, 0x8F, false);
         break;
 
       case 1:
         write_string("(set)   ", info_x + 16,
-         info_y + pad_height + 13, 0x8F, 0);
+         info_y + pad_height + 13, 0x8F, false);
         break;
 
       case 2:
         write_string("(clear) ", info_x + 16,
-         info_y + pad_height + 13, 0x8F, 0);
+         info_y + pad_height + 13, 0x8F, false);
         break;
     }
 

--- a/src/editor/char_ed.c
+++ b/src/editor/char_ed.c
@@ -567,12 +567,12 @@ static void draw_multichar_smzx(char *buffer, int start_x, int start_y,
         if(current_pixel)
         {
           write_string("\xDB\xDB\xDB\xDB", start_x + (x * 4),
-           start_y + y, base_colors[current_pixel], false);
+           start_y + y, base_colors[current_pixel], WR_NONE);
         }
         else
         {
           write_string("\xFA\xFA\xFA\xFA", start_x + (x * 4),
-           start_y + y, bg_color, false);
+           start_y + y, bg_color, WR_NONE);
         }
       }
     }
@@ -589,13 +589,13 @@ static void draw_multichar_smzx(char *buffer, int start_x, int start_y,
         {
           write_string("\xDB\xDB\xDB\xDB", start_x +
            ((x + current_x) * 4), start_y + current_y + y,
-           highlight_colors[current_pixel], false);
+           highlight_colors[current_pixel], WR_NONE);
         }
         else
         {
           write_string("\xFA\xFA\xFA\xFA", start_x +
            ((x + current_x) * 4), start_y + y + current_y,
-           0x1B, false);
+           0x1B, WR_NONE);
         }
       }
     }
@@ -1210,39 +1210,39 @@ int char_editor(struct world *mzx_world)
      128, 143, 135, 0, 0);
 
     // Current character
-    write_string("Current char-\t(#000)", info_x, info_y, 0x8F, W_TABS);
+    write_string("Current char-\t(#000)", info_x, info_y, 0x8F, WR_TAB);
     write_number(current_char + (current_charset * 256), 0x8F,
      info_x + 22, info_y, 3, 3, 10);
 
     // Help
     write_string(help_text[help_page],
-     info_x, info_y + pad_height + 2, 0x8F, W_TABS | W_NEWLINES);
+     info_x, info_y + pad_height + 2, 0x8F, WR_TAB | WR_NEWLINE);
 
     if(screen_mode)
     {
       // Correct "Toggle pixel" to "Place pixel"
       if(help_page == 0)
         write_string("Place pixel ",
-         info_x + 8, info_y + pad_height + 4, 0x8F, W_TABS);
+         info_x + 8, info_y + pad_height + 4, 0x8F, WR_TAB);
 
       // Correct F5 to "SMZX"
       if(help_page == 1)
         write_string("SMZX",
-         info_x + 18, info_y + pad_height + 8, 0x8F, W_TABS);
+         info_x + 18, info_y + pad_height + 8, 0x8F, WR_TAB);
 
       // 1-4 Select
       write_string(help_text_smzx,
-       info_x, info_y + pad_height + 14, 0x8F, W_TABS);
+       info_x, info_y + pad_height + 14, 0x8F, WR_TAB);
 
       if(current_pixel)
       {
         write_string("\xDB\xDB\xDB\xDB", info_x + 16,
-         info_y + pad_height + 14, smzx_colors[current_pixel], false);
+         info_y + pad_height + 14, smzx_colors[current_pixel], WR_NONE);
       }
       else
       {
         write_string("\xFA\xFA\xFA\xFA", info_x + 16,
-         info_y + pad_height + 14, (smzx_colors[0] << 4) + smzx_colors[3], false);
+         info_y + pad_height + 14, (smzx_colors[0] << 4) + smzx_colors[3], WR_NONE);
       }
     }
 
@@ -1253,17 +1253,17 @@ int char_editor(struct world *mzx_world)
     {
       case 0:
         write_string("(off)   ", info_x + 16,
-         info_y + pad_height + 13, 0x8F, false);
+         info_y + pad_height + 13, 0x8F, WR_NONE);
         break;
 
       case 1:
         write_string("(set)   ", info_x + 16,
-         info_y + pad_height + 13, 0x8F, false);
+         info_y + pad_height + 13, 0x8F, WR_NONE);
         break;
 
       case 2:
         write_string("(clear) ", info_x + 16,
-         info_y + pad_height + 13, 0x8F, false);
+         info_y + pad_height + 13, 0x8F, WR_NONE);
         break;
     }
 

--- a/src/editor/debug.c
+++ b/src/editor/debug.c
@@ -3377,11 +3377,11 @@ void __draw_debug_box(struct world *mzx_world, int x, int y, int d_x, int d_y,
     "X/Y:        /     \n"
     "Board:            \n"
     "Robot mem:      kb\n",
-    x + 1, y + 1, DI_DEBUG_LABEL, W_NEWLINES
+    x + 1, y + 1, DI_DEBUG_LABEL, WR_NEWLINE
   );
 
   version_string_len = get_version_string(version_string, mzx_world->version);
-  write_string(version_string, x + 19 - version_string_len, y, DI_DEBUG_BOX, 0);
+  write_string(version_string, x + 19 - version_string_len, y, DI_DEBUG_BOX, WR_NONE);
 
   if(show_keys)
   {
@@ -3391,7 +3391,7 @@ void __draw_debug_box(struct world *mzx_world, int x, int y, int d_x, int d_y,
     {
       sprintf(key_string, "%d", key);
       write_string(key_string, x + 15 - strlen(key_string), y + 5,
-       DI_DEBUG_BOX_DARK + 0x0A, 0);
+       DI_DEBUG_BOX_DARK + 0x0A, WR_NONE);
     }
 
     // key_pressed
@@ -3408,7 +3408,7 @@ void __draw_debug_box(struct world *mzx_world, int x, int y, int d_x, int d_y,
     {
       sprintf(key_string, "%d", key);
       write_string(key_string, x + 19 - strlen(key_string), y + 5,
-       DI_DEBUG_BOX_DARK + 0x0D, 0);
+       DI_DEBUG_BOX_DARK + 0x0D, WR_NONE);
     }
   }
 
@@ -3437,17 +3437,17 @@ void __draw_debug_box(struct world *mzx_world, int x, int y, int d_x, int d_y,
       char tempc = src_board->mod_playing[18];
       src_board->mod_playing[18] = 0;
       write_string(src_board->mod_playing, x + 1, y + 4,
-       DI_DEBUG_NUMBER, 0);
+       DI_DEBUG_NUMBER, WR_NONE);
       src_board->mod_playing[18] = tempc;
     }
     else
     {
       write_string(src_board->mod_playing, x + 1, y + 4,
-       DI_DEBUG_NUMBER, 0);
+       DI_DEBUG_NUMBER, WR_NONE);
     }
   }
   else
   {
-    write_string("(no module)", x + 2, y + 4, DI_DEBUG_NUMBER, 0);
+    write_string("(no module)", x + 2, y + 4, DI_DEBUG_NUMBER, WR_NONE);
   }
 }

--- a/src/editor/debug.c
+++ b/src/editor/debug.c
@@ -3377,7 +3377,7 @@ void __draw_debug_box(struct world *mzx_world, int x, int y, int d_x, int d_y,
     "X/Y:        /     \n"
     "Board:            \n"
     "Robot mem:      kb\n",
-    x + 1, y + 1, DI_DEBUG_LABEL, 0
+    x + 1, y + 1, DI_DEBUG_LABEL, W_NEWLINES
   );
 
   version_string_len = get_version_string(version_string, mzx_world->version);

--- a/src/editor/pal_ed.c
+++ b/src/editor/pal_ed.c
@@ -671,7 +671,7 @@ static void draw_color_components(struct pal_ed_subcontext *current)
      current->x + 3,
      current->y + 1 + i,
      DI_GREY_NUMBER,
-     0
+     WR_NONE
     );
 
     write_string(
@@ -679,7 +679,7 @@ static void draw_color_components(struct pal_ed_subcontext *current)
      current->x,
      current->y + 1 + i,
      DI_GREY_TEXT,
-     0
+     WR_NONE
     );
 
     if(c->min_val == 0 && c->max_val == 359)
@@ -720,7 +720,7 @@ static boolean color_editor_draw(subcontext *ctx)
    current->x,
    current->y,
    DI_GREY_TEXT,
-   0
+   WR_NONE
   );
 
   write_number(current_id, DI_GREY_TEXT,
@@ -736,7 +736,7 @@ static boolean color_editor_draw(subcontext *ctx)
      current->x + mode_list[i].draw_x,
      current->y,
      color,
-     0
+     WR_NONE
     );
   }
 
@@ -1032,8 +1032,8 @@ static void menu_buffer_draw(int x, int y, boolean show_indices)
     DI_GREY, DI_GREY_DARK, DI_GREY_CORNER, false, false
   );
 
-  write_string("Buffer", x + 2, y + 1, DI_GREY_TEXT, false);
-  write_string("     \n     \n     ", x + 9, y + 1, 0x55, W_NEWLINES);
+  write_string("Buffer", x + 2, y + 1, DI_GREY_TEXT, WR_NONE);
+  write_string("     \n     \n     ", x + 9, y + 1, 0x55, WR_NEWLINE);
 
   if(mode >= 2 && saved_subpalette_display)
   {
@@ -1059,7 +1059,7 @@ static void menu_buffer_draw(int x, int y, boolean show_indices)
     int x2;
     int y2;
 
-    write_string("1    3\n2    4", x + 2, y + 2, DI_GREY_CORNER, W_NEWLINES);
+    write_string("1    3\n2    4", x + 2, y + 2, DI_GREY_CORNER, WR_NEWLINE);
     for(i = 0; i < 4; i++)
     {
       x2 = x + 3 + (i/2*2);
@@ -1116,11 +1116,11 @@ static boolean menu_16_draw(subcontext *ctx)
     menu->x,
     menu->y,
     DI_GREY_TEXT,
-    W_NEWLINES
+    WR_NEWLINE
   );
 
   write_string(palette_labels[!pal_ed->current], menu->x + 49, menu->y + 6,
-   DI_GREY_TEXT, false);
+   DI_GREY_TEXT, WR_NONE);
 
   // Component instructions
   y = menu->y + 1;
@@ -1129,16 +1129,16 @@ static boolean menu_16_draw(subcontext *ctx)
     c = &(current_mode->components[i]);
     x = menu->x;
 
-    write_string(c->name_key, x, y, DI_GREY_TEXT, false);
+    write_string(c->name_key, x, y, DI_GREY_TEXT, WR_NONE);
     x += 12;
 
-    write_string(c->name_long, x, y, DI_GREY_TEXT, false);
+    write_string(c->name_long, x, y, DI_GREY_TEXT, WR_NONE);
     x += 11;
 
-    write_string(c->name_key, x, y, DI_GREY_TEXT, false);
+    write_string(c->name_key, x, y, DI_GREY_TEXT, WR_NONE);
     x += 12;
 
-    write_string(c->name_long, x, y, DI_GREY_TEXT, false);
+    write_string(c->name_long, x, y, DI_GREY_TEXT, WR_NONE);
   }
 
   // All
@@ -1149,7 +1149,7 @@ static boolean menu_16_draw(subcontext *ctx)
      menu->x,
      menu->y + 4,
      DI_GREY_TEXT,
-     false
+     WR_NEWLINE
     );
   }
 
@@ -1213,7 +1213,7 @@ static boolean palette_16_draw(subcontext *ctx)
   if(pal_ed->current != GAME_PALETTE)
   {
     write_string("TEMPORARY -- WILL NOT BE SAVED", pal->border_x + 3,
-     pal->border_y, 0x8E, false);
+     pal->border_y, 0x8E, WR_NONE);
   }
 
   // Draw palette bars
@@ -1259,7 +1259,7 @@ static boolean palette_16_draw(subcontext *ctx)
     {
       // Draw '^^'
       write_string("\x1e\x1e",
-       x, y + 4, DI_GREY_TEXT, false);
+       x, y + 4, DI_GREY_TEXT, WR_NONE);
     }
   }
   return true;
@@ -1436,14 +1436,14 @@ static boolean menu_256_draw(subcontext *ctx)
     menu->x,
     menu->y,
     DI_GREY_TEXT,
-    W_NEWLINES
+    WR_NEWLINE
   );
 
   write_string(palette_labels[!pal_ed->current], menu->x + 5, menu->y + 10,
-   DI_GREY_TEXT, false);
+   DI_GREY_TEXT, WR_NONE);
 
   if(subpalette_cursors)
-    write_string("(on) ", menu->x + 13, menu->y + 8, DI_GREY_TEXT, false);
+    write_string("(on) ", menu->x + 13, menu->y + 8, DI_GREY_TEXT, WR_NONE);
 
   if(smzx_mode == 2)
   {
@@ -1459,7 +1459,7 @@ static boolean menu_256_draw(subcontext *ctx)
       menu->x + 19,
       menu->y + 5,
       DI_GREY_TEXT,
-      W_NEWLINES
+      WR_NEWLINE
     );
   }
   else
@@ -1476,14 +1476,14 @@ static boolean menu_256_draw(subcontext *ctx)
       menu->x + 19,
       menu->y + 5,
       DI_GREY_TEXT,
-      false
+      WR_NEWLINE
     );
     write_string(
       "Middle/wheel- subpalette\n",
       menu->x,
       menu->y + 15,
       DI_GREY_TEXT,
-      W_NEWLINES
+      WR_NEWLINE
     );
   }
 
@@ -1494,16 +1494,16 @@ static boolean menu_256_draw(subcontext *ctx)
     c = &(current_mode->components[i]);
     x = menu->x;
 
-    write_string(c->name_key, x, y, DI_GREY_TEXT, false);
+    write_string(c->name_key, x, y, DI_GREY_TEXT, WR_NONE);
     x += 12;
 
-    write_string(c->name_long, x, y, DI_GREY_TEXT, false);
+    write_string(c->name_long, x, y, DI_GREY_TEXT, WR_NONE);
     x += 11;
 
-    write_string(c->name_key, x, y, DI_GREY_TEXT, false);
+    write_string(c->name_key, x, y, DI_GREY_TEXT, WR_NONE);
     x += 12;
 
-    write_string(c->name_long, x, y, DI_GREY_TEXT, false);
+    write_string(c->name_long, x, y, DI_GREY_TEXT, WR_NONE);
   }
 
   // All
@@ -1514,7 +1514,7 @@ static boolean menu_256_draw(subcontext *ctx)
       menu->x,
       menu->y + 4,
       DI_GREY_TEXT,
-      false
+      WR_NEWLINE
     );
   }
 
@@ -1624,7 +1624,7 @@ static boolean palette_256_draw(subcontext *ctx)
   if(pal_ed->current != GAME_PALETTE)
   {
     write_string("TEMPORARY -- WILL NOT BE SAVED", pal->border_x + 3,
-     pal->border_y, 0x8E, false);
+     pal->border_y, 0x8E, WR_NONE);
   }
 
   // Erase the spot where the palette will go.
@@ -1832,7 +1832,6 @@ static boolean subpalette_256_draw(subcontext *ctx)
 {
   struct pal_ed_subcontext *spal = (struct pal_ed_subcontext *)ctx;
   struct pal_ed_context *pal_ed = spal->pal_ed;
-  char buffer[5];
   int subpalette_num;
   int c0 = 0;
   int c1 = 0;
@@ -1857,7 +1856,7 @@ static boolean subpalette_256_draw(subcontext *ctx)
    spal->x,
    spal->y,
    DI_GREY_TEXT,
-   W_NEWLINES
+   WR_NEWLINE
   );
 
   write_string(
@@ -1865,7 +1864,7 @@ static boolean subpalette_256_draw(subcontext *ctx)
    spal->x + 9,
    spal->y,
    DI_GREY_CORNER,
-   false
+   WR_NONE
   );
 
   // Erase spots where palette colors will go
@@ -1924,20 +1923,14 @@ static boolean subpalette_256_draw(subcontext *ctx)
   select_layer(UI_LAYER);
 
   // Current subpalette number
-  sprintf(buffer, "%03d", subpalette_num);
-  write_string(buffer, spal->x + 3, spal->y + 1, DI_GREY_TEXT, false);
-  sprintf(buffer, "%02X", subpalette_num);
-  write_string(buffer, spal->x + 5, spal->y + 3, DI_GREY_TEXT, false);
+  write_number(subpalette_num, DI_GREY_TEXT, spal->x + 3, spal->y + 1, 3, false, 10);
+  write_number(subpalette_num, DI_GREY_TEXT, spal->x + 5, spal->y + 3, 2, false, 16);
 
   // Subpalette indices
-  sprintf(buffer, "%03d", c0);
-  write_string(buffer, spal->x + 11, spal->y, DI_GREY_TEXT, false);
-  sprintf(buffer, "%03d", c1);
-  write_string(buffer, spal->x + 17, spal->y, DI_GREY_TEXT, false);
-  sprintf(buffer, "%03d", c2);
-  write_string(buffer, spal->x + 23, spal->y, DI_GREY_TEXT, false);
-  sprintf(buffer, "%03d", c3);
-  write_string(buffer, spal->x + 29, spal->y, DI_GREY_TEXT, false);
+  write_number(c0, DI_GREY_TEXT, spal->x + 11, spal->y, 3, false, 10);
+  write_number(c1, DI_GREY_TEXT, spal->x + 17, spal->y, 3, false, 10);
+  write_number(c2, DI_GREY_TEXT, spal->x + 23, spal->y, 3, false, 10);
+  write_number(c3, DI_GREY_TEXT, spal->x + 29, spal->y, 3, false, 10);
   return true;
 }
 

--- a/src/editor/pal_ed.c
+++ b/src/editor/pal_ed.c
@@ -1033,7 +1033,7 @@ static void menu_buffer_draw(int x, int y, boolean show_indices)
   );
 
   write_string("Buffer", x + 2, y + 1, DI_GREY_TEXT, false);
-  write_string("     \n     \n     ", x + 9, y + 1, 0x55, false);
+  write_string("     \n     \n     ", x + 9, y + 1, 0x55, W_NEWLINES);
 
   if(mode >= 2 && saved_subpalette_display)
   {
@@ -1059,7 +1059,7 @@ static void menu_buffer_draw(int x, int y, boolean show_indices)
     int x2;
     int y2;
 
-    write_string("1    3\n2    4", x + 2, y + 2, DI_GREY_CORNER, false);
+    write_string("1    3\n2    4", x + 2, y + 2, DI_GREY_CORNER, W_NEWLINES);
     for(i = 0; i < 4; i++)
     {
       x2 = x + 3 + (i/2*2);
@@ -1116,7 +1116,7 @@ static boolean menu_16_draw(subcontext *ctx)
     menu->x,
     menu->y,
     DI_GREY_TEXT,
-    false
+    W_NEWLINES
   );
 
   write_string(palette_labels[!pal_ed->current], menu->x + 49, menu->y + 6,
@@ -1436,7 +1436,7 @@ static boolean menu_256_draw(subcontext *ctx)
     menu->x,
     menu->y,
     DI_GREY_TEXT,
-    1
+    W_NEWLINES
   );
 
   write_string(palette_labels[!pal_ed->current], menu->x + 5, menu->y + 10,
@@ -1459,7 +1459,7 @@ static boolean menu_256_draw(subcontext *ctx)
       menu->x + 19,
       menu->y + 5,
       DI_GREY_TEXT,
-      false
+      W_NEWLINES
     );
   }
   else
@@ -1483,7 +1483,7 @@ static boolean menu_256_draw(subcontext *ctx)
       menu->x,
       menu->y + 15,
       DI_GREY_TEXT,
-      false
+      W_NEWLINES
     );
   }
 
@@ -1514,7 +1514,7 @@ static boolean menu_256_draw(subcontext *ctx)
       menu->x,
       menu->y + 4,
       DI_GREY_TEXT,
-      1
+      false
     );
   }
 
@@ -1857,7 +1857,7 @@ static boolean subpalette_256_draw(subcontext *ctx)
    spal->x,
    spal->y,
    DI_GREY_TEXT,
-   0
+   W_NEWLINES
   );
 
   write_string(
@@ -1865,7 +1865,7 @@ static boolean subpalette_256_draw(subcontext *ctx)
    spal->x + 9,
    spal->y,
    DI_GREY_CORNER,
-   0
+   false
   );
 
   // Erase spots where palette colors will go

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -3587,14 +3587,14 @@ static boolean robot_editor_draw(context *ctx)
 
   if(rstate->scr_hide_mode)
   {
-    write_string(key_help_hide, 0, 24, bottom_text_color, false);
+    write_string(key_help_hide, 0, 24, bottom_text_color, W_NEWLINES);
     rstate->scr_line_start = 1;
     rstate->scr_line_middle = 12;
     rstate->scr_line_end = 23;
   }
   else
   {
-    write_string(key_help, 0, 22, bottom_text_color, false);
+    write_string(key_help, 0, 22, bottom_text_color, W_NEWLINES);
     rstate->scr_line_start = 2;
     rstate->scr_line_middle = 11;
     rstate->scr_line_end = 20;

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -3127,7 +3127,7 @@ static void display_robot_line(struct robot_editor_context *rstate,
             else
             {
               write_string_ext(temp_buffer, x, y, current_color,
-               false, chars_offset, 16);
+               WR_NONE, chars_offset, 16);
             }
           }
 

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -2927,12 +2927,12 @@ static void display_robot_line(struct robot_editor_context *rstate,
       {
         temp_char = line_text[76];
         line_text[76] = 0;
-        write_string(line_text, x, y, line_color, W_MASK_MIDCHARS);
+        write_string(line_text, x, y, line_color, WR_MASK);
         line_text[76] = temp_char;
       }
       else
       {
-        write_string(line_text, x, y, line_color, W_MASK_MIDCHARS);
+        write_string(line_text, x, y, line_color, WR_MASK);
       }
     }
   }
@@ -2968,7 +2968,7 @@ static void display_robot_line(struct robot_editor_context *rstate,
             temp_char = line_text[76];
             line_text[76] = 0;
 
-            write_string(line_text + offset, x + offset, y, color, W_MASK_MIDCHARS);
+            write_string(line_text + offset, x + offset, y, color, WR_MASK);
             line_text[76] = temp_char;
           }
           break;
@@ -2976,7 +2976,7 @@ static void display_robot_line(struct robot_editor_context *rstate,
 
         temp_char = line_text[offset + length];
         line_text[offset + length] = 0;
-        write_string(line_text + offset, x + offset, y, color, W_MASK_MIDCHARS);
+        write_string(line_text + offset, x + offset, y, color, WR_MASK);
         line_text[offset + length] = temp_char;
       }
     }
@@ -3019,12 +3019,12 @@ static void display_robot_line(struct robot_editor_context *rstate,
       {
         temp_char = current_rline->line_text[76];
         current_rline->line_text[76] = 0;
-        write_string(current_rline->line_text, x, y, current_color, W_MASK_MIDCHARS);
+        write_string(current_rline->line_text, x, y, current_color, WR_MASK);
         current_rline->line_text[76] = temp_char;
       }
       else
       {
-        write_string(current_rline->line_text, x, y, current_color, W_MASK_MIDCHARS);
+        write_string(current_rline->line_text, x, y, current_color, WR_MASK);
       }
     }
     else
@@ -3045,7 +3045,7 @@ static void display_robot_line(struct robot_editor_context *rstate,
       memcpy(temp_buffer, line_pos, arg_length);
       temp_buffer[arg_length] = 0;
 
-      write_string(temp_buffer, x, y, current_color, false);
+      write_string(temp_buffer, x, y, current_color, WR_NONE);
 
       line_pos += arg_length;
       x += (int)arg_length;
@@ -3112,18 +3112,17 @@ static void display_robot_line(struct robot_editor_context *rstate,
 
           if(use_mask)
           {
-            write_string(temp_buffer, x, y, current_color, W_MASK_MIDCHARS);
+            write_string(temp_buffer, x, y, current_color, WR_MASK);
           }
           else
           {
             if(current_arg == S_CHARACTER)
             {
               temp_buffer[arg_length - 2] = 0;
-              write_string("'", x, y, current_color, W_MASK_MIDCHARS);
+              write_string("'", x, y, current_color, WR_MASK);
               write_string_ext(temp_buffer + 1, x + 1, y, current_color,
-               false, chars_offset, 16);
-              write_string("'", x + (int)arg_length - 2, y,
-               current_color, W_MASK_MIDCHARS);
+               WR_NONE, chars_offset, 16);
+              write_string("'", x + (int)arg_length - 2, y, current_color, WR_MASK);
             }
             else
             {
@@ -3587,14 +3586,14 @@ static boolean robot_editor_draw(context *ctx)
 
   if(rstate->scr_hide_mode)
   {
-    write_string(key_help_hide, 0, 24, bottom_text_color, W_NEWLINES);
+    write_string(key_help_hide, 0, 24, bottom_text_color, WR_NEWLINE);
     rstate->scr_line_start = 1;
     rstate->scr_line_middle = 12;
     rstate->scr_line_end = 23;
   }
   else
   {
-    write_string(key_help, 0, 22, bottom_text_color, W_NEWLINES);
+    write_string(key_help, 0, 22, bottom_text_color, WR_NEWLINE);
     rstate->scr_line_start = 2;
     rstate->scr_line_middle = 11;
     rstate->scr_line_end = 20;
@@ -3625,26 +3624,26 @@ static boolean robot_editor_draw(context *ctx)
   // Make sure the line length and current char are up-to-date.
   intake_sync(rstate->intk);
 
-  write_string("Line:", 2, 0, top_highlight_color, false);
-  write_string("/", 14, 0, top_highlight_color, false);
+  write_string("Line:", 2, 0, top_highlight_color, WR_NONE);
+  write_string("/", 14, 0, top_highlight_color, WR_NONE);
   write_number(rstate->current_line, top_text_color, 8, 0, 6, false, 10);
   write_number(rstate->total_lines, top_text_color, 15, 0, 6, false, 10);
 
-  write_string("Col:", 23, 0, top_highlight_color, false);
-  write_string("/", 31, 0, top_highlight_color, false);
+  write_string("Col:", 23, 0, top_highlight_color, WR_NONE);
+  write_string("/", 31, 0, top_highlight_color, WR_NONE);
   write_number(rstate->current_x + 1, top_text_color, 28, 0, 3, false, 10);
   write_number(rstate->current_line_len + 1, top_text_color, 32, 0, 3, false,
    10);
 
-  write_string("Size:", 37, 0, top_highlight_color, false);
-  write_string("/", 50, 0, top_highlight_color, false);
+  write_string("Size:", 37, 0, top_highlight_color, WR_NONE);
+  write_string("/", 50, 0, top_highlight_color, WR_NONE);
   write_number(rstate->size, top_text_color, 43, 0, 7, false, 10);
   write_number(rstate->max_size, top_text_color, 51, 0, 7, false, 10);
 
-  write_string("X:", 60, 0, top_highlight_color, false);
+  write_string("X:", 60, 0, top_highlight_color, WR_NONE);
   write_number(rstate->cur_robot->xpos, top_text_color, 63, 0, 5, false, 10);
 
-  write_string("Y:", 70, 0, top_highlight_color, false);
+  write_string("Y:", 70, 0, top_highlight_color, WR_NONE);
   write_number(rstate->cur_robot->ypos, top_text_color, 73, 0, 5, false, 10);
 
   // Now, draw the lines. Start with 9 back from the current.
@@ -3786,12 +3785,12 @@ static boolean robot_editor_draw(context *ctx)
   if(use_mask)
   {
     write_string(rstate->command_buffer + start_offset,
-     2, rstate->scr_line_middle, intk_color, W_MASK_MIDCHARS);
+     2, rstate->scr_line_middle, intk_color, WR_MASK);
   }
   else
   {
     write_string_ext(rstate->command_buffer + start_offset,
-     2, rstate->scr_line_middle, intk_color, false, 0, 16);
+     2, rstate->scr_line_middle, intk_color, WR_NONE, 0, 16);
   }
 
   // Fill non-text portions of the middle line.

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -2888,7 +2888,7 @@ static const char _new_color_code_table[] =
   0,    // ARG_TYPE_INDEXED_COMMENT
 };
 
-// TODO: write_string_mask seriously needs to have a length field,
+// TODO: write_string seriously needs to have a length field,
 // so we don't have to keep stuffing null terminators in the thing.
 
 static void display_robot_line(struct robot_editor_context *rstate,
@@ -2927,12 +2927,12 @@ static void display_robot_line(struct robot_editor_context *rstate,
       {
         temp_char = line_text[76];
         line_text[76] = 0;
-        write_string_mask(line_text, x, y, line_color, false);
+        write_string(line_text, x, y, line_color, W_MASK_MIDCHARS);
         line_text[76] = temp_char;
       }
       else
       {
-        write_string_mask(line_text, x, y, line_color, false);
+        write_string(line_text, x, y, line_color, W_MASK_MIDCHARS);
       }
     }
   }
@@ -2968,7 +2968,7 @@ static void display_robot_line(struct robot_editor_context *rstate,
             temp_char = line_text[76];
             line_text[76] = 0;
 
-            write_string_mask(line_text + offset, x + offset, y, color, false);
+            write_string(line_text + offset, x + offset, y, color, W_MASK_MIDCHARS);
             line_text[76] = temp_char;
           }
           break;
@@ -2976,7 +2976,7 @@ static void display_robot_line(struct robot_editor_context *rstate,
 
         temp_char = line_text[offset + length];
         line_text[offset + length] = 0;
-        write_string_mask(line_text + offset, x + offset, y, color, false);
+        write_string(line_text + offset, x + offset, y, color, W_MASK_MIDCHARS);
         line_text[offset + length] = temp_char;
       }
     }
@@ -3019,14 +3019,12 @@ static void display_robot_line(struct robot_editor_context *rstate,
       {
         temp_char = current_rline->line_text[76];
         current_rline->line_text[76] = 0;
-        write_string_mask(current_rline->line_text, x,
-         y, current_color, false);
+        write_string(current_rline->line_text, x, y, current_color, W_MASK_MIDCHARS);
         current_rline->line_text[76] = temp_char;
       }
       else
       {
-        write_string_mask(current_rline->line_text, x,
-         y, current_color, false);
+        write_string(current_rline->line_text, x, y, current_color, W_MASK_MIDCHARS);
       }
     }
     else
@@ -3047,7 +3045,7 @@ static void display_robot_line(struct robot_editor_context *rstate,
       memcpy(temp_buffer, line_pos, arg_length);
       temp_buffer[arg_length] = 0;
 
-      write_string(temp_buffer, x, y, current_color, 0);
+      write_string(temp_buffer, x, y, current_color, false);
 
       line_pos += arg_length;
       x += (int)arg_length;
@@ -3114,23 +3112,23 @@ static void display_robot_line(struct robot_editor_context *rstate,
 
           if(use_mask)
           {
-            write_string_mask(temp_buffer, x, y, current_color, false);
+            write_string(temp_buffer, x, y, current_color, W_MASK_MIDCHARS);
           }
           else
           {
             if(current_arg == S_CHARACTER)
             {
               temp_buffer[arg_length - 2] = 0;
-              write_string_mask("'", x, y, current_color, false);
+              write_string("'", x, y, current_color, W_MASK_MIDCHARS);
               write_string_ext(temp_buffer + 1, x + 1, y, current_color,
                false, chars_offset, 16);
-              write_string_mask("'", x + (int)arg_length - 2, y,
-               current_color, false);
+              write_string("'", x + (int)arg_length - 2, y,
+               current_color, W_MASK_MIDCHARS);
             }
             else
             {
               write_string_ext(temp_buffer, x, y, current_color,
-               0, chars_offset, 16);
+               false, chars_offset, 16);
             }
           }
 
@@ -3589,14 +3587,14 @@ static boolean robot_editor_draw(context *ctx)
 
   if(rstate->scr_hide_mode)
   {
-    write_string(key_help_hide, 0, 24, bottom_text_color, 0);
+    write_string(key_help_hide, 0, 24, bottom_text_color, false);
     rstate->scr_line_start = 1;
     rstate->scr_line_middle = 12;
     rstate->scr_line_end = 23;
   }
   else
   {
-    write_string(key_help, 0, 22, bottom_text_color, 0);
+    write_string(key_help, 0, 22, bottom_text_color, false);
     rstate->scr_line_start = 2;
     rstate->scr_line_middle = 11;
     rstate->scr_line_end = 20;
@@ -3627,26 +3625,26 @@ static boolean robot_editor_draw(context *ctx)
   // Make sure the line length and current char are up-to-date.
   intake_sync(rstate->intk);
 
-  write_string("Line:", 2, 0, top_highlight_color, 0);
-  write_string("/", 14, 0, top_highlight_color, 0);
+  write_string("Line:", 2, 0, top_highlight_color, false);
+  write_string("/", 14, 0, top_highlight_color, false);
   write_number(rstate->current_line, top_text_color, 8, 0, 6, false, 10);
   write_number(rstate->total_lines, top_text_color, 15, 0, 6, false, 10);
 
-  write_string("Col:", 23, 0, top_highlight_color, 0);
-  write_string("/", 31, 0, top_highlight_color, 0);
+  write_string("Col:", 23, 0, top_highlight_color, false);
+  write_string("/", 31, 0, top_highlight_color, false);
   write_number(rstate->current_x + 1, top_text_color, 28, 0, 3, false, 10);
   write_number(rstate->current_line_len + 1, top_text_color, 32, 0, 3, false,
    10);
 
-  write_string("Size:", 37, 0, top_highlight_color, 0);
-  write_string("/", 50, 0, top_highlight_color, 0);
+  write_string("Size:", 37, 0, top_highlight_color, false);
+  write_string("/", 50, 0, top_highlight_color, false);
   write_number(rstate->size, top_text_color, 43, 0, 7, false, 10);
   write_number(rstate->max_size, top_text_color, 51, 0, 7, false, 10);
 
-  write_string("X:", 60, 0, top_highlight_color, 0);
+  write_string("X:", 60, 0, top_highlight_color, false);
   write_number(rstate->cur_robot->xpos, top_text_color, 63, 0, 5, false, 10);
 
-  write_string("Y:", 70, 0, top_highlight_color, 0);
+  write_string("Y:", 70, 0, top_highlight_color, false);
   write_number(rstate->cur_robot->ypos, top_text_color, 73, 0, 5, false, 10);
 
   // Now, draw the lines. Start with 9 back from the current.
@@ -3787,8 +3785,8 @@ static boolean robot_editor_draw(context *ctx)
 
   if(use_mask)
   {
-    write_string_mask(rstate->command_buffer + start_offset,
-     2, rstate->scr_line_middle, intk_color, false);
+    write_string(rstate->command_buffer + start_offset,
+     2, rstate->scr_line_middle, intk_color, W_MASK_MIDCHARS);
   }
   else
   {

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -2032,10 +2032,11 @@ static int write_string_intl(const char *str, unsigned int x, unsigned int y,
     {
       if(allow_tabs)
       {
-        // The write_line functions used 10 here!?!?
-        int tab = (end_newline) ? 10 : 5;
-        dest += tab;
-        dest_copy += tab;
+        // Note: the write_line functions used 10 here, but they were used
+        // only for scrolls, which don't allow control codes. 1.x allowed
+        // char 9 but displayed them as char 9.
+        dest += 5;
+        dest_copy += 5;
         continue;
       }
     }
@@ -2101,8 +2102,8 @@ static int write_string_intl(const char *str, unsigned int x, unsigned int y,
 void write_string_ext(const char *str, unsigned int x, unsigned int y,
  uint8_t color, int flags, unsigned int chr_offset, unsigned int color_offset)
 {
-  boolean allow_tabs      = (flags & W_ALLOW_TAB) != 0;
-  boolean allow_newlines  = (flags & W_ALLOW_NEWLINE) != 0;
+  boolean allow_tabs      = (flags & W_TABS) != 0;
+  boolean allow_newlines  = (flags & W_NEWLINES) != 0;
   boolean end_newline     = (flags & W_LINE) != 0;
   boolean allow_colors    = (flags & W_COLOR) != 0;
   boolean mask_midchars   = (flags & W_MASK_MIDCHARS) && !chr_offset;

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1983,342 +1983,145 @@ static int offset_adjust(int offset, unsigned int x, unsigned int y)
   return offset;
 }
 
-void color_string_ext_special(const char *str, unsigned int x, unsigned int y,
- uint8_t *color, boolean allow_newline, unsigned int chr_offset, unsigned int color_offset)
+static int hexdigit(uint8_t hex)
+{
+  if(hex >= '0' && hex <= '9')
+    return hex - '0';
+  if(hex >= 'A' && hex <= 'F')
+    return hex - 'A' + 10;
+  if(hex >= 'a' && hex <= 'f')
+    return hex - 'a' + 10;
+  return -1;
+}
+
+static int write_string_intl(const char *str, unsigned int x, unsigned int y,
+ uint8_t color, boolean allow_tabs, boolean allow_newline, boolean end_newline,
+ boolean allow_colors, boolean mask_midchars, int chr_offset, int color_offset)
 {
   int scr_off = (y * SCREEN_W) + x;
   struct char_element *dest = graphics.current_video + offset_adjust(scr_off, x, y);
   struct char_element *dest_copy = graphics.text_video + scr_off;
-  const char *src = str;
-  uint8_t cur_char = *src;
-  uint8_t next;
-  uint8_t bg_color = (*color >> 4) + color_offset;
-  uint8_t fg_color = (*color & 0x0F) + color_offset;
 
-  char next_str[2];
-  next_str[1] = 0;
+  int bg_color = (color >> 4) + color_offset;
+  int fg_color = (color & 0x0F) + color_offset;
+  int code;
 
   dirty_ui();
   dirty_current();
 
-  while(cur_char && dest < graphics.current_video_end)
+  while(*str && dest < graphics.current_video_end)
   {
-    switch(cur_char)
+    int cur_char = *str++;
+
+    if(cur_char == '\n')
     {
-      // Color character
-      case '@':
-      {
-        str++;
-        next = *str;
-
-        // If 0, stop right there
-        if(!next)
-          goto exit_out;
-
-        // If the next isn't hex, count as one
-        if(isxdigit(next))
-        {
-          next_str[0] = next;
-          bg_color = (uint8_t)(strtol(next_str, NULL, 16) + color_offset);
-        }
-        else
-        {
-          if(next == '@')
-          {
-            dest->char_value = '@' + chr_offset;
-            dest->bg_color = bg_color;
-            dest->fg_color = fg_color;
-            *(dest_copy++) = *dest;
-            dest++;
-          }
-          else
-          {
-            str--;
-          }
-        }
-
+      if(end_newline)
         break;
-      }
 
-      case '~':
+      if(allow_newline)
       {
-        str++;
-        next = *str;
-
-        // If 0, stop right there
-        if(!next)
-          goto exit_out;
-
-        // If the next isn't hex, count as one
-        if(isxdigit(next))
-        {
-          next_str[0] = next;
-          fg_color = (uint8_t)(strtol(next_str, NULL, 16) + color_offset);
-        }
-        else
-        {
-          if(next == '~')
-          {
-            dest->char_value = '~' + chr_offset;
-            dest->bg_color = bg_color;
-            dest->fg_color = fg_color;
-            *(dest_copy++) = *dest;
-            dest++;
-          }
-          else
-          {
-            str--;
-          }
-        }
-
-        break;
+        y++;
+        dest = graphics.current_video + offset_adjust((y * SCREEN_W) + x, x, y);
+        dest_copy = graphics.text_video + (y * SCREEN_W) + x;
+        continue;
       }
+    }
+    else
 
-      // Newline
-      case '\n':
+    if(cur_char == '\t')
+    {
+      if(allow_tabs)
       {
-        if(allow_newline)
-        {
-          y++;
-          dest = graphics.current_video + offset_adjust((y * SCREEN_W) + x, x, y);
-          dest_copy = graphics.text_video + (y * SCREEN_W) + x;
+        // The write_line functions used 10 here!?!?
+        int tab = (end_newline) ? 10 : 5;
+        dest += tab;
+        dest_copy += tab;
+        continue;
+      }
+    }
+    else
+
+    if(allow_colors)
+    {
+      if(cur_char == '@')
+      {
+        if(!*str)
           break;
+
+        code = hexdigit(*str);
+        if(code >= 0)
+        {
+          bg_color = code + color_offset;
+          str++;
+          continue;
         }
+        else
+
+        if(*str == '@')
+          str++;
       }
+      else
 
-      /* fallthrough */
-
-      default:
+      if(cur_char == '~')
       {
-        dest->char_value = cur_char + chr_offset;
-        dest->bg_color = bg_color;
-        dest->fg_color = fg_color;
-        *(dest_copy++) = *dest;
-        dest++;
+        if(!*str)
+          break;
+
+        code = hexdigit(*str);
+        if(code >= 0)
+        {
+          fg_color = code + color_offset;
+          str++;
+          continue;
+        }
+        else
+
+        if(*str == '~')
+          str++;
       }
     }
 
-    str++;
-    cur_char = *str;
+    if(mask_midchars)
+    {
+      if(cur_char >= 32 && cur_char <= 126)
+        cur_char += PRO_CH;
+    }
+
+    /* Draw char */
+    dest->char_value = cur_char + chr_offset;
+    dest->bg_color = bg_color;
+    dest->fg_color = fg_color;
+    *(dest_copy++) = *dest;
+    dest++;
   }
 
-exit_out:
-  *color = (((bg_color - color_offset) << 4) & 0xF0) |
-           (((fg_color - color_offset) << 0) & 0x0F);
+  return ((bg_color & 0xf) << 4) | (fg_color & 0xf);
+}
+
+void write_string_ext(const char *str, unsigned int x, unsigned int y,
+ uint8_t color, int flags, unsigned int chr_offset, unsigned int color_offset)
+{
+  boolean allow_tabs      = (flags & W_ALLOW_TAB) != 0;
+  boolean allow_newlines  = (flags & W_ALLOW_NEWLINE) != 0;
+  boolean end_newline     = (flags & W_LINE) != 0;
+  boolean allow_colors    = (flags & W_COLOR) != 0;
+  boolean mask_midchars   = (flags & W_MASK_MIDCHARS) && !chr_offset;
+
+  write_string_intl(str, x, y, color, allow_tabs, allow_newlines,
+   end_newline, allow_colors, mask_midchars, chr_offset, color_offset);
+}
+
+void color_string_ext_special(const char *str, unsigned int x, unsigned int y,
+ uint8_t *color, boolean allow_newline, unsigned int chr_offset, unsigned int color_offset)
+{
+  *color = write_string_intl(str, x, y, *color,
+   false, allow_newline, false, true, false, chr_offset, color_offset);
 }
 
 void color_string_ext(const char *str, unsigned int x, unsigned int y,
  uint8_t color, boolean allow_newline, unsigned int chr_offset, unsigned int color_offset)
 {
   color_string_ext_special(str, x, y, &color, allow_newline, chr_offset, color_offset);
-}
-
-// Write a normal string
-
-void write_string_ext(const char *str, unsigned int x, unsigned int y,
- uint8_t color, boolean tab_allowed, unsigned int chr_offset, unsigned int color_offset)
-{
-  int scr_off = (y * SCREEN_W) + x;
-  struct char_element *dest = graphics.current_video + offset_adjust(scr_off, x, y);
-  struct char_element *dest_copy = graphics.text_video + scr_off;
-  const char *src = str;
-  uint8_t cur_char = *src;
-  uint8_t bg_color = (color >> 4) + color_offset;
-  uint8_t fg_color = (color & 0x0F) + color_offset;
-
-  dirty_ui();
-  dirty_current();
-
-  while(cur_char && (cur_char != 0) && dest < graphics.current_video_end)
-  {
-    switch(cur_char)
-    {
-      // Newline
-      case '\n':
-      {
-        y++;
-        dest = graphics.current_video + offset_adjust((y * SCREEN_W) + x, x, y);
-        dest_copy = graphics.text_video + (y * SCREEN_W) + x;
-        break;
-      }
-
-      case '\t':
-      {
-        if(tab_allowed)
-        {
-          dest += 5;
-          dest_copy += 5;
-          break;
-        }
-      }
-
-      /* fallthrough */
-
-      default:
-      {
-        dest->char_value = cur_char + chr_offset;
-        dest->bg_color = bg_color;
-        dest->fg_color = fg_color;
-        *(dest_copy++) = *dest;
-        dest++;
-      }
-    }
-    str++;
-    cur_char = *str;
-  }
-}
-
-void write_string_mask(const char *str, unsigned int x, unsigned int y,
- uint8_t color, boolean tab_allowed)
-{
-  int scr_off = (y * SCREEN_W) + x;
-  struct char_element *dest = graphics.current_video + offset_adjust(scr_off, x, y);
-  struct char_element *dest_copy = graphics.text_video + scr_off;
-  const char *src = str;
-  uint8_t cur_char = *src;
-  uint8_t bg_color = (color >> 4) + 16;
-  uint8_t fg_color = (color & 0x0F) + 16;
-
-  dirty_ui();
-  dirty_current();
-
-  while(cur_char && (cur_char != 0) && dest < graphics.current_video_end)
-  {
-    switch(cur_char)
-    {
-      // Newline
-      case '\n':
-      {
-        y++;
-        dest = graphics.current_video + offset_adjust((y * SCREEN_W) + x, x, y);
-        dest_copy = graphics.text_video + (y * SCREEN_W) + x;
-        break;
-      }
-
-      case '\t':
-      {
-        if(tab_allowed)
-        {
-          dest += 5;
-          dest_copy += 5;
-          break;
-        }
-      }
-
-      /* fallthrough */
-
-      default:
-      {
-        if((cur_char >= 32) && (cur_char <= 126))
-          dest->char_value = cur_char + PRO_CH;
-        else
-          dest->char_value = cur_char;
-
-        dest->bg_color = bg_color;
-        dest->fg_color = fg_color;
-        *(dest_copy++) = *dest;
-        dest++;
-      }
-    }
-    str++;
-    cur_char = *str;
-  }
-}
-
-// Write a normal string, without carriage returns
-
-void write_line_ext(const char *str, unsigned int x, unsigned int y,
- uint8_t color, boolean tab_allowed, unsigned int chr_offset, unsigned int color_offset)
-{
-  int scr_off = (y * SCREEN_W) + x;
-  struct char_element *dest = graphics.current_video + offset_adjust(scr_off, x, y);
-  struct char_element *dest_copy = graphics.text_video + scr_off;
-  const char *src = str;
-  uint8_t cur_char = *src;
-  uint8_t bg_color = (color >> 4) + color_offset;
-  uint8_t fg_color = (color & 0x0F) + color_offset;
-
-  dirty_ui();
-  dirty_current();
-
-  while(cur_char && (cur_char != '\n') && dest < graphics.current_video_end)
-  {
-    switch(cur_char)
-    {
-      // Color character
-      case '\t':
-      {
-        if(tab_allowed)
-        {
-          dest += 10;
-          dest_copy += 10;
-          break;
-        }
-      }
-
-      /* fallthrough */
-
-      default:
-      {
-        dest->char_value = cur_char + chr_offset;
-        dest->bg_color = bg_color;
-        dest->fg_color = fg_color;
-        *(dest_copy++) = *dest;
-        dest++;
-      }
-    }
-    str++;
-    cur_char = *str;
-  }
-}
-
-void write_line_mask(const char *str, unsigned int x, unsigned int y,
- uint8_t color, boolean tab_allowed)
-{
-  int scr_off = (y * SCREEN_W) + x;
-  struct char_element *dest = graphics.current_video + offset_adjust(scr_off, x, y);
-  struct char_element *dest_copy = graphics.text_video + scr_off;
-  const char *src = str;
-  uint8_t cur_char = *src;
-  uint8_t bg_color = (color >> 4) + 16;
-  uint8_t fg_color = (color & 0x0F) + 16;
-
-  dirty_ui();
-  dirty_current();
-
-  while(cur_char && (cur_char != '\n') && dest < graphics.current_video_end)
-  {
-    switch(cur_char)
-    {
-      // Color character
-      case '\t':
-      {
-        if(tab_allowed)
-        {
-          dest += 10;
-          dest_copy += 10;
-          break;
-        }
-      }
-
-      /* fallthrough */
-
-      default:
-      {
-        if((cur_char >= 32) && (cur_char <= 127))
-          dest->char_value = cur_char + PRO_CH;
-        else
-          dest->char_value = cur_char;
-
-        dest->bg_color = bg_color;
-        dest->fg_color = fg_color;
-        *(dest_copy++) = *dest;
-        dest++;
-      }
-    }
-    str++;
-    cur_char = *str;
-  }
 }
 
 // Set rightalign to print the rightmost char at xy and proceed to the left
@@ -2346,7 +2149,8 @@ void write_number(int number, uint8_t color, unsigned int x, unsigned int y,
       x = 0;
   }
 
-  write_line_ext(temp, x, y, color, false, PRO_CH, 16);
+  write_string_intl(temp, x, y, color,
+   false, false, false, false, false, PRO_CH, 16);
 }
 
 static void color_line_ext(unsigned int length, unsigned int x, unsigned int y,
@@ -2476,9 +2280,9 @@ void color_string(const char *string, unsigned int x, unsigned int y, uint8_t co
 }
 
 void write_string(const char *string, unsigned int x, unsigned int y,
- uint8_t color, boolean tab_allowed)
+ uint8_t color, int flags)
 {
-  write_string_ext(string, x, y, color, tab_allowed, PRO_CH, 16);
+  write_string_ext(string, x, y, color, flags, PRO_CH, 16);
 }
 
 void color_line(unsigned int length, unsigned int x, unsigned int y, uint8_t color)

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -2085,7 +2085,9 @@ static int write_string_intl(const char *str, unsigned int x, unsigned int y,
     if(mask_midchars)
     {
       if(cur_char >= 32 && cur_char <= 126)
-        cur_char += PRO_CH;
+        chr_offset = PRO_CH;
+      else
+        chr_offset = 0;
     }
 
     /* Draw char */
@@ -2102,11 +2104,11 @@ static int write_string_intl(const char *str, unsigned int x, unsigned int y,
 void write_string_ext(const char *str, unsigned int x, unsigned int y,
  uint8_t color, int flags, unsigned int chr_offset, unsigned int color_offset)
 {
-  boolean allow_tabs      = (flags & W_TABS) != 0;
-  boolean allow_newlines  = (flags & W_NEWLINES) != 0;
-  boolean end_newline     = (flags & W_LINE) != 0;
-  boolean allow_colors    = (flags & W_COLOR) != 0;
-  boolean mask_midchars   = (flags & W_MASK_MIDCHARS) && !chr_offset;
+  boolean allow_tabs      = (flags & WR_TAB) != 0;
+  boolean allow_newlines  = (flags & WR_NEWLINE) != 0;
+  boolean end_newline     = (flags & WR_LINE) != 0;
+  boolean allow_colors    = (flags & WR_COLOR) != 0;
+  boolean mask_midchars   = (flags & WR_MASK) != 0;
 
   write_string_intl(str, x, y, color, allow_tabs, allow_newlines,
    end_newline, allow_colors, mask_midchars, chr_offset, color_offset);

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -101,8 +101,8 @@ enum default_video_layers
 
 enum write_string_flags
 {
-  W_ALLOW_TAB     = (1 << 0), /* If set, tab will draw 5 spaces. */
-  W_ALLOW_NEWLINE = (1 << 1), /* If set, \n will act line a newline. */
+  W_TABS          = (1 << 0), /* If set, tab will draw 5 spaces. */
+  W_NEWLINES      = (1 << 1), /* If set, \n will act line a newline. */
   W_LINE          = (1 << 2), /* If set, stop if \n is encountered. */
   W_COLOR         = (1 << 3), /* If set, allow ~@ color codes. */
   W_MASK_MIDCHARS = (1 << 4), /* If set, use the protected charset for 32-126. */

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -101,11 +101,14 @@ enum default_video_layers
 
 enum write_string_flags
 {
-  W_TABS          = (1 << 0), /* If set, tab will draw 5 spaces. */
-  W_NEWLINES      = (1 << 1), /* If set, \n will act line a newline. */
-  W_LINE          = (1 << 2), /* If set, stop if \n is encountered. */
-  W_COLOR         = (1 << 3), /* If set, allow ~@ color codes. */
-  W_MASK_MIDCHARS = (1 << 4), /* If set, use the protected charset for 32-126. */
+  WR_NONE     = 0,
+  WR_TAB      = (1 << 0), /* If set, tab will draw 5 spaces. */
+  WR_NEWLINE  = (1 << 1), /* If set, \n will act line a newline. */
+  WR_LINE     = (1 << 2), /* If set, stop if \n is encountered. */
+  WR_COLOR    = (1 << 3), /* If set, allow ~@ color codes. */
+  WR_MASK     = (1 << 4)  /* If set, use the protected charset for 32-126
+                           * and use the user charset for all other chars.
+                           * Overrides the provided chars offset. */
 };
 
 struct graphics_data;

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -319,10 +319,6 @@ void color_string_ext(const char *string, unsigned int x, unsigned int y,
  uint8_t color, boolean allow_newline, unsigned int chr_offset, unsigned int color_offset);
 void color_string_ext_special(const char *string, unsigned int x, unsigned int y,
  uint8_t *color, boolean allow_newline, unsigned int chr_offset, unsigned int color_offset);
-void write_line_ext(const char *string, unsigned int x, unsigned int y,
- uint8_t color, boolean tab_allowed, unsigned int chr_offset, unsigned int color_offset);
-void write_line_mask(const char *str, unsigned int x, unsigned int y,
- uint8_t color, boolean tab_allowed);
 void fill_line_ext(unsigned int length, unsigned int x, unsigned int y,
  uint8_t chr, uint8_t color, unsigned int chr_offset, unsigned int color_offset);
 

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -99,6 +99,15 @@ enum default_video_layers
   NUM_DEFAULT_LAYERS  = 4
 };
 
+enum write_string_flags
+{
+  W_ALLOW_TAB     = (1 << 0), /* If set, tab will draw 5 spaces. */
+  W_ALLOW_NEWLINE = (1 << 1), /* If set, \n will act line a newline. */
+  W_LINE          = (1 << 2), /* If set, stop if \n is encountered. */
+  W_COLOR         = (1 << 3), /* If set, allow ~@ color codes. */
+  W_MASK_MIDCHARS = (1 << 4), /* If set, use the protected charset for 32-126. */
+};
+
 struct graphics_data;
 struct video_layer;
 
@@ -216,7 +225,7 @@ struct graphics_data
 CORE_LIBSPEC void color_string(const char *string, unsigned int x,
  unsigned int y, uint8_t color);
 CORE_LIBSPEC void write_string(const char *string, unsigned int x,
- unsigned int y, uint8_t color, boolean tab_allowed);
+ unsigned int y, uint8_t color, int flags);
 CORE_LIBSPEC void write_number(int number, uint8_t color, unsigned int x,
  unsigned int y, int minlen, boolean rightalign, int base);
 CORE_LIBSPEC void color_line(unsigned int length, unsigned int x,
@@ -229,9 +238,7 @@ CORE_LIBSPEC void erase_area(unsigned int x, unsigned int y,
  unsigned int x2, unsigned int y2);
 
 CORE_LIBSPEC void write_string_ext(const char *str, unsigned int x, unsigned int y,
- uint8_t color, boolean tab_allowed, unsigned int chr_offset, unsigned int color_offset);
-CORE_LIBSPEC void write_string_mask(const char *str, unsigned int x, unsigned int y,
- uint8_t color, boolean tab_allowed);
+ uint8_t color, int flags, unsigned int chr_offset, unsigned int color_offset);
 CORE_LIBSPEC void draw_char_ext(uint8_t chr, uint8_t color, unsigned int x,
  unsigned int y, unsigned int chr_offset, unsigned int color_offset);
 CORE_LIBSPEC void draw_char_bleedthru_ext(uint8_t chr, uint8_t color,

--- a/src/intake.c
+++ b/src/intake.c
@@ -110,7 +110,7 @@ int intake(struct world *mzx_world, char *string, int max_len,
 
   do
   {
-    int flags = use_mask ? W_MASK_MIDCHARS : 0;
+    int flags = use_mask ? WR_MASK : 0;
     write_string_ext(string, x, y, color, flags, 0, 16);
 
     fill_line(max_len + 1 - curr_len, x + curr_len, y, 32, color);

--- a/src/intake.c
+++ b/src/intake.c
@@ -110,10 +110,8 @@ int intake(struct world *mzx_world, char *string, int max_len,
 
   do
   {
-    if(use_mask)
-      write_string_mask(string, x, y, color, false);
-    else
-      write_string_ext(string, x, y, color, false, 0, 16);
+    int flags = use_mask ? W_MASK_MIDCHARS : 0;
+    write_string_ext(string, x, y, color, flags, 0, 16);
 
     fill_line(max_len + 1 - curr_len, x + curr_len, y, 32, color);
 

--- a/src/robot.c
+++ b/src/robot.c
@@ -2537,7 +2537,7 @@ static void display_robot_line(struct world *mzx_world, char *program,
       // On the off-chance something actually relies on this bug...
       int flags = 0;
       if((mzx_world->version >= VERSION_PORT) && (mzx_world->version < V291))
-        flags |= W_ALLOW_TAB;
+        flags |= W_TABS;
 
       tr_msg(mzx_world, program + 3, id, ibuff);
       ibuff[64] = 0; // Clip

--- a/src/robot.c
+++ b/src/robot.c
@@ -2535,12 +2535,13 @@ static void display_robot_line(struct world *mzx_world, char *program,
     case ROBOTIC_CMD_MESSAGE_BOX_LINE: // Normal message
     {
       // On the off-chance something actually relies on this bug...
-      boolean allow_tabs =
-       ((mzx_world->version >= VERSION_PORT) && (mzx_world->version < V291));
+      int flags = 0;
+      if((mzx_world->version >= VERSION_PORT) && (mzx_world->version < V291))
+        flags |= W_ALLOW_TAB;
 
       tr_msg(mzx_world, program + 3, id, ibuff);
       ibuff[64] = 0; // Clip
-      write_string_ext(ibuff, 8, y, scroll_base_color, allow_tabs, 0, 0);
+      write_string_ext(ibuff, 8, y, scroll_base_color, flags, 0, 0);
       break;
     }
 

--- a/src/robot.c
+++ b/src/robot.c
@@ -2537,7 +2537,7 @@ static void display_robot_line(struct world *mzx_world, char *program,
       // On the off-chance something actually relies on this bug...
       int flags = 0;
       if((mzx_world->version >= VERSION_PORT) && (mzx_world->version < V291))
-        flags |= W_TABS;
+        flags |= WR_TAB;
 
       tr_msg(mzx_world, program + 3, id, ibuff);
       ibuff[64] = 0; // Clip

--- a/src/scrdisp.c
+++ b/src/scrdisp.c
@@ -41,7 +41,7 @@ static const char scr_nm_strs[5][12] =
 static int scroll_draw_flags(struct world *mzx_world, boolean mask_chars,
  boolean mask_colors)
 {
-  int flags = W_ALLOW_TAB | W_LINE;
+  int flags = W_LINE;
 
   if(mask_chars)
     flags |= W_MASK_MIDCHARS;

--- a/src/scrdisp.c
+++ b/src/scrdisp.c
@@ -38,6 +38,21 @@
 static const char scr_nm_strs[5][12] =
  { "  Scroll   ", "   Sign    ", "Edit Scroll", "   Help    ", "" };
 
+static int scroll_draw_flags(struct world *mzx_world, boolean mask_chars,
+ boolean mask_colors)
+{
+  int flags = W_ALLOW_TAB | W_LINE;
+
+  if(mask_chars)
+    flags |= W_MASK_MIDCHARS;
+
+  if(!mask_colors)
+    if(mzx_world->version < V200 || mzx_world->version >= V293)
+      flags |= W_COLOR;
+
+  return flags;
+}
+
 static void scroll_frame(struct world *mzx_world, struct scroll *scroll,
  int pos, boolean mask_chars, boolean mask_colors)
 {
@@ -49,6 +64,7 @@ static void scroll_frame(struct world *mzx_world, struct scroll *scroll,
   char *where;
   int scroll_base_color = mzx_world->scroll_base_color;
   int c_offset = 16;
+  int flags = scroll_draw_flags(mzx_world, mask_chars, mask_colors);
 
   where = scroll->mesg;
 
@@ -65,11 +81,7 @@ static void scroll_frame(struct world *mzx_world, struct scroll *scroll,
 
   // Display center line
   fill_line_ext(64, 8, 12, 32, scroll_base_color, 0, c_offset);
-
-  if(mask_chars)
-    write_line_mask(where + pos, 8, 12, scroll_base_color, true);
-  else
-    write_line_ext(where + pos, 8, 12, scroll_base_color, true, 0, c_offset);
+  write_string_ext(where + pos, 8, 12, scroll_base_color, flags, 0, c_offset);
 
   // Display lines above center line
   for(t1 = 11; t1 >= 6; t1--)
@@ -87,14 +99,11 @@ static void scroll_frame(struct world *mzx_world, struct scroll *scroll,
         } while((where[pos] != '\n') && (where[pos] != 1));
         // At start of prev. line -1. Display.
         pos++;
-        if(mask_chars)
-          write_line_mask(where + pos, 8, t1, scroll_base_color, true);
-        else
-          write_line_ext(where + pos, 8, t1, scroll_base_color, true, 0, c_offset);
+        write_string_ext(where + pos, 8, t1, scroll_base_color, flags, 0, c_offset);
       }
     }
-    // Next line...
   }
+
   // Display lines below center line
   pos = old_pos;
   for(t1 = 13; t1 <= 18; t1++)
@@ -103,16 +112,10 @@ static void scroll_frame(struct world *mzx_world, struct scroll *scroll,
     if(where[pos] == 0) continue;
     // Go forward to next line
     while(where[pos] != '\n') pos++;
-    // At end of current. If next is a 0, don't show nuthin'.
+    // At end of current. If next is a 0, it's the end of the scroll.
     pos++;
     if(where[pos])
-    {
-      if(mask_chars)
-        write_line_mask(where + pos, 8, t1, scroll_base_color, true);
-      else
-        write_line_ext(where + pos, 8, t1, scroll_base_color, true, 0, c_offset);
-    }
-    // Next line...
+      write_string_ext(where + pos, 8, t1, scroll_base_color, flags, 0, c_offset);
   }
 
   select_layer(UI_LAYER);
@@ -471,13 +474,13 @@ void scroll_edging_ext(struct world *mzx_world, int type, boolean mask)
   draw_char_ext(16, scroll_pointer_color, 6, 12, offset, c_offset);
   draw_char_ext(17, scroll_pointer_color, 73, 12, offset, c_offset);
   // Write title
-  write_string_ext(scr_nm_strs[type], 34, 4, scroll_title_color, 0,
+  write_string_ext(scr_nm_strs[type], 34, 4, scroll_title_color, false,
    offset, c_offset);
   // Write key reminders
   if(type == 2)
   {
     write_string_ext("\x12\x1d: Move cursor   Alt+C: Character "
-     "  Esc: Done editing", 13, 20, scroll_corner_color, 0,
+     "  Esc: Done editing", 13, 20, scroll_corner_color, false,
      offset, c_offset);
   }
   else
@@ -485,7 +488,7 @@ void scroll_edging_ext(struct world *mzx_world, int type, boolean mask)
   if(type < 2)
   {
     write_string_ext("\x12: Scroll text   Esc/Enter: End reading",
-     21, 20, scroll_corner_color, 0, offset, c_offset);
+     21, 20, scroll_corner_color, false, offset, c_offset);
   }
   else
 
@@ -493,15 +496,15 @@ void scroll_edging_ext(struct world *mzx_world, int type, boolean mask)
   {
     write_string_ext("\x12:Scroll text  Esc:Exit help"
      "  Enter:Select  Alt+P:Print", 13, 20,
-     scroll_corner_color, 0, offset, c_offset);
+     scroll_corner_color, false, offset, c_offset);
     write_string_ext("F1:Help on Help "
      " Alt+F1:Table of Contents", 20, 21,
-     scroll_corner_color, 0, offset, c_offset);
+     scroll_corner_color, false, offset, c_offset);
   }
   else
   {
     write_string_ext("\x12:Scroll text  Esc:Exit "
-     "  Enter:Select", 21, 20, scroll_corner_color, 0, offset, c_offset);
+     "  Enter:Select", 21, 20, scroll_corner_color, false, offset, c_offset);
   }
   select_layer(UI_LAYER);
   update_screen();

--- a/src/scrdisp.c
+++ b/src/scrdisp.c
@@ -41,14 +41,14 @@ static const char scr_nm_strs[5][12] =
 static int scroll_draw_flags(struct world *mzx_world, boolean mask_chars,
  boolean mask_colors)
 {
-  int flags = W_LINE;
+  int flags = WR_LINE;
 
   if(mask_chars)
-    flags |= W_MASK_MIDCHARS;
+    flags |= WR_MASK;
 
   if(!mask_colors)
     if(mzx_world->version < V200 || mzx_world->version >= V293)
-      flags |= W_COLOR;
+      flags |= WR_COLOR;
 
   return flags;
 }
@@ -474,13 +474,13 @@ void scroll_edging_ext(struct world *mzx_world, int type, boolean mask)
   draw_char_ext(16, scroll_pointer_color, 6, 12, offset, c_offset);
   draw_char_ext(17, scroll_pointer_color, 73, 12, offset, c_offset);
   // Write title
-  write_string_ext(scr_nm_strs[type], 34, 4, scroll_title_color, false,
+  write_string_ext(scr_nm_strs[type], 34, 4, scroll_title_color, WR_NONE,
    offset, c_offset);
   // Write key reminders
   if(type == 2)
   {
     write_string_ext("\x12\x1d: Move cursor   Alt+C: Character "
-     "  Esc: Done editing", 13, 20, scroll_corner_color, false,
+     "  Esc: Done editing", 13, 20, scroll_corner_color, WR_NONE,
      offset, c_offset);
   }
   else
@@ -488,23 +488,21 @@ void scroll_edging_ext(struct world *mzx_world, int type, boolean mask)
   if(type < 2)
   {
     write_string_ext("\x12: Scroll text   Esc/Enter: End reading",
-     21, 20, scroll_corner_color, false, offset, c_offset);
+     21, 20, scroll_corner_color, WR_NONE, offset, c_offset);
   }
   else
 
   if(type == 3)
   {
-    write_string_ext("\x12:Scroll text  Esc:Exit help"
-     "  Enter:Select  Alt+P:Print", 13, 20,
-     scroll_corner_color, false, offset, c_offset);
-    write_string_ext("F1:Help on Help "
-     " Alt+F1:Table of Contents", 20, 21,
-     scroll_corner_color, false, offset, c_offset);
+    write_string_ext(
+     "\x12:Scroll text  Esc:Exit help  Enter:Select  Alt+P:Print\n"
+     "\t  F1:Help on Help  Alt+F1:Table of Contents",
+     13, 20, scroll_corner_color, WR_TAB | WR_NEWLINE, offset, c_offset);
   }
   else
   {
-    write_string_ext("\x12:Scroll text  Esc:Exit "
-     "  Enter:Select", 21, 20, scroll_corner_color, false, offset, c_offset);
+    write_string_ext("\x12:Scroll text  Esc:Exit  Enter:Select",
+     21, 20, scroll_corner_color, WR_NONE, offset, c_offset);
   }
   select_layer(UI_LAYER);
   update_screen();


### PR DESCRIPTION
Cleans up the five (5!) string drawing loops in graphics.c and replaces them with one. `write_string` and `write_string_ext` now take a flags field instead of `boolean tab_allowed`. This allows a) the mask and line variants of these functions to be removed and b) scrolls to be able to display color codes with less if/else spaghetti and without adding more functions to graphics.c.

The scroll color displaying functionality is limited to 1.x and >=2.93 worlds. Since neither are actually supported right now outside of unmerged branches, this means it doesn't do anything, but it can be verified by modifying the version check!