### PR TITLE
Add a MemorySanitizer action + required improvements/fixes.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -201,6 +201,37 @@ jobs:
       - name: Run tests
         run: $MZX_MAKE test
 
+  # Note: requires all non-system/libc calls to be from instrumented libraries.
+  # For the regression tests, MZX can get away with just zlib.
+  #
+  # - actions/checkout will delete the work directory(!?), do it first.
+  # - The MSan zlib needs to be built static to prevent linking the system zlib.
+  # - ZLIB_LDFLAGS needs to be overridden to prevent linking the system zlib.
+  MemorySanitizer:
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+      CXX: clang++
+      ZLIB_LDFLAGS: DEPS/lib/libz.a
+    steps:
+      - uses: actions/checkout@v2
+      - name: 🙄
+        run: sudo sed -i '/deb-src/s/^# //' /etc/apt/sources.list
+      - name: Fetch dependency sources
+        run: mkdir DEPS && sudo apt update && apt source zlib
+      - name: Build zlib
+        run: |
+          (cd zlib-*;
+          CC=clang CXX=clang++ CFLAGS="-O3 -fsanitize=memory -g -fPIC -Wno-pointer-sign" LDFLAGS="-fsanitize=memory" \
+            ./configure --prefix "$(pwd)/../DEPS" --static;
+          $MZX_MAKE && make install)
+      - name: Configure
+        run: ./config.sh --platform unix-devel --prefix DEPS --enable-msan --disable-sdl --disable-libpng --disable-vorbis --disable-x11
+      - name: Build
+        run: $MZX_MAKE V=1
+      - name: Run tests
+        run: $MZX_MAKE V=1 test
+
   UndefinedBehaviorSanitizer:
     runs-on: ubuntu-latest
     env:

--- a/Makefile
+++ b/Makefile
@@ -235,11 +235,11 @@ DEBUG_CFLAGS := -fsanitize=thread -O2 -fno-omit-frame-pointer -fPIE
 ARCH_EXE_LDFLAGS += -pie
 endif
 ifeq (${SANITIZER},memory)
-# FIXME I don't think there's a way to make this one work properly right now.
-# SDL_Init generates an error immediately and if sanitize-recover is used it
-# seems to get stuck printing endless errors.
-DEBUG_CFLAGS := -fsanitize=memory -O1 -fno-omit-frame-pointer -fPIE \
- -fsanitize-recover=memory -fsanitize-memory-track-origins
+# Note: to be useful, this requires a fairly special build with most
+# external libraries turned off or re-built with instrumentation.
+# This sanitizer is only implemented by clang.
+DEBUG_CFLAGS := -fsanitize=memory -O1 -fno-omit-frame-pointer -fPIC \
+ -fsanitize-recover=memory -fsanitize-memory-track-origins=2
 ARCH_EXE_LDFLAGS += -pie
 endif
 

--- a/config.sh
+++ b/config.sh
@@ -707,23 +707,9 @@ echo "LICENSEDIR=$LICENSEDIR" >> platform.inc
 #
 # Platform-specific libraries, or SDL?
 #
-if [ "$PLATFORM" = "wii" ]; then
-	echo "#define CONFIG_WII" >> src/config.h
-	echo "BUILD_WII=1" >> platform.inc
-	LIBSDL2="false"
-
-	echo "Force-disabling stack protector on Wii."
-	STACK_PROTECTOR="false"
-fi
-
 if [ "$PLATFORM" = "3ds" ] || [ "$PLATFORM" = "nds" ]; then
 	echo "Disabling SDL ($PLATFORM)."
 	SDL="false"
-fi
-
-if [ "$PLATFORM" = "pandora" ]; then
-	echo "#define CONFIG_PANDORA" >> src/config.h
-	echo "BUILD_PANDORA=1" >> platform.inc
 fi
 
 #
@@ -731,8 +717,7 @@ fi
 #
 if [ "$SDL" = "false" ]; then
 	echo "Force-disabling SDL dependent components:"
-	echo " -> SOFTWARE, SOFTSCALE, OVERLAY"
-	SOFTWARE="false"
+	echo " -> SOFTSCALE, OVERLAY"
 	SOFTSCALE="false"
 	OVERLAY="false"
 	LIBSDL2="false"
@@ -750,6 +735,9 @@ fi
 if [ "$EGL" = "true" ]; then
 	echo "#define CONFIG_EGL" >> src/config.h
 	echo "BUILD_EGL=1" >> platform.inc
+
+	echo "Force-disabling software renderer (EGL)."
+	SOFTWARE="false"
 
 	echo "Force-enabling OpenGL ES support (EGL)."
 	GLES="true"
@@ -853,11 +841,36 @@ if [ "$PLATFORM" = "3ds" ]; then
 	echo "Building custom 3DS renderer."
 	SOFTWARE="false"
 
-	echo "Disabling utils on 3DS (silly)."
+	echo "Disabling utils on 3DS."
 	UTILS="false"
 
 	echo "Force-disabling IPv6 on 3DS (not implemented)."
 	IPV6="false"
+fi
+
+#
+# If the Wii arch is enabled, some code has to be compile time
+# enabled too.
+#
+if [ "$PLATFORM" = "wii" ]; then
+	echo "Enabling Wii-specific hacks."
+	echo "#define CONFIG_WII" >> src/config.h
+	echo "BUILD_WII=1" >> platform.inc
+
+	if [ "$SDL" = "false" ]; then
+		echo "Force-disabling software renderer on Wii."
+		echo "Building custom Wii renderers."
+		SOFTWARE="false"
+	fi
+
+	# No SDL 2 support currently.
+	LIBSDL2="false"
+
+	echo "Force-disabling utils on Wii."
+	UTILS="false"
+
+	echo "Force-disabling stack protector on Wii."
+	STACK_PROTECTOR="false"
 fi
 
 #
@@ -869,7 +882,7 @@ if [ "$PLATFORM" = "wiiu" ]; then
 	echo "#define CONFIG_WIIU" >> src/config.h
 	echo "BUILD_WIIU=1" >> platform.inc
 
-	echo "Disabling utils on Wii U (silly)."
+	echo "Disabling utils on Wii U."
 	UTILS="false"
 
 	# Doesn't seem to be fully populated on the Wii U.
@@ -885,7 +898,7 @@ if [ "$PLATFORM" = "switch" ]; then
 	echo "#define CONFIG_SWITCH" >> src/config.h
 	echo "BUILD_SWITCH=1" >> platform.inc
 
-	echo "Disabling utils on Switch (silly)."
+	echo "Disabling utils on Switch."
 	UTILS="false"
 
 	echo "Force-enabling OpenGL ES support (Switch)."
@@ -934,6 +947,15 @@ if [ "$PLATFORM" = "gp2x" ]; then
 
 	echo "Force-disabling Modplug audio."
 	MODPLUG="false"
+fi
+
+#
+# If the Pandora arch is enabled, some code has to be compile time
+# enabled too.
+#
+if [ "$PLATFORM" = "pandora" ]; then
+	echo "#define CONFIG_PANDORA" >> src/config.h
+	echo "BUILD_PANDORA=1" >> platform.inc
 fi
 
 #

--- a/src/error.c
+++ b/src/error.c
@@ -81,6 +81,7 @@ int error(const char *string, enum error_type type, unsigned int options,
     int scode = code ? (int)code : -1;
 
     fprintf(stderr, "%s%s\n", type_name, string);
+    fflush(stderr);
 
     // Attempt to automatically handle this error if possible.
     if(options & ERROR_OPT_EXIT) exit(scode);

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1776,7 +1776,11 @@ boolean has_video_initialized(void)
   // Dummy SDL driver should act as headless.
   const char *sdl_driver = SDL_GetCurrentVideoDriver();
   if(sdl_driver && !strcmp(sdl_driver, "dummy")) return false;
-#endif /* CONFIG_SDL */
+#elif defined(CONFIG_RENDER_SOFT)
+  // Non-SDL software renderer is always headless.
+  if(renderers[graphics.renderer_num].reg == render_soft_register)
+    return false;
+#endif /* CONFIG_RENDER_SOFT */
 
   return graphics_was_initialized;
 }

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -61,7 +61,6 @@
 #define CURSOR_BLINK_RATE 115
 
 __editor_maybe_static struct graphics_data graphics;
-static boolean graphics_was_initialized;
 
 static const struct renderer_data renderers[] =
 {
@@ -1396,6 +1395,7 @@ static boolean set_graphics_output(struct config_info *conf)
 
   renderer->reg(&graphics.renderer);
   graphics.renderer_num = i;
+  graphics.renderer_is_headless = false;
 
   debug("Video: using '%s' renderer.\n", renderer->name);
   return true;
@@ -1758,7 +1758,7 @@ boolean init_video(struct config_info *conf, const char *caption)
   ec_clear_set();
   ec_load_mzx();
   init_palette();
-  graphics_was_initialized = true;
+  graphics.is_initialized = true;
   return true;
 }
 
@@ -1776,13 +1776,13 @@ boolean has_video_initialized(void)
   // Dummy SDL driver should act as headless.
   const char *sdl_driver = SDL_GetCurrentVideoDriver();
   if(sdl_driver && !strcmp(sdl_driver, "dummy")) return false;
-#elif defined(CONFIG_RENDER_SOFT)
-  // Non-SDL software renderer is always headless.
-  if(renderers[graphics.renderer_num].reg == render_soft_register)
-    return false;
-#endif /* CONFIG_RENDER_SOFT */
+#endif /* CONFIG_SDL */
 
-  return graphics_was_initialized;
+  // Renderers can also report as headless.
+  if(graphics.renderer_is_headless)
+    return false;
+
+  return graphics.is_initialized;
 }
 
 boolean set_video_mode(void)

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -162,6 +162,8 @@ struct graphics_data
   uint32_t current_intensity[SMZX_PAL_SIZE];
   uint32_t saved_intensity[SMZX_PAL_SIZE];
   uint32_t backup_intensity[SMZX_PAL_SIZE];
+  boolean is_initialized;
+  boolean renderer_is_headless;
   boolean default_smzx_loaded;
   boolean palette_dirty;
   boolean fade_status;

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -63,8 +63,9 @@ boolean sdl_get_fullscreen_resolution(int *width, int *height, boolean scaling)
 {
 #if SDL_VERSION_ATLEAST(2,0,0)
   SDL_DisplayMode display_mode;
-  int ret = -1;
+  boolean have_mode = false;
   int count;
+  int ret;
 
   if(scaling)
   {
@@ -77,6 +78,8 @@ boolean sdl_get_fullscreen_resolution(int *width, int *height, boolean scaling)
       if(count)
         ret = SDL_GetDisplayMode(0, 0, &display_mode);
     }
+    if(!ret)
+      have_mode = true;
   }
   else
   {
@@ -101,11 +104,12 @@ boolean sdl_get_fullscreen_resolution(int *width, int *height, boolean scaling)
       {
         min_size = mode.w * mode.h;
         display_mode = mode;
+        have_mode = true;
       }
     }
   }
 
-  if(!ret)
+  if(have_mode)
   {
     *width = display_mode.w;
     *height = display_mode.h;

--- a/src/render_soft.c
+++ b/src/render_soft.c
@@ -19,29 +19,88 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <stdlib.h>
+
 #include "graphics.h"
 #include "render.h"
-#include "render_sdl.h"
 #include "render_layer.h"
 #include "renderers.h"
 #include "util.h"
 
+#ifdef CONFIG_SDL
 #include <SDL.h>
+#include "render_sdl.h"
+#endif
 
-static SDL_Color sdlpal[SMZX_PAL_SIZE];
-
-static SDL_Surface *soft_get_screen_surface(struct sdl_render_data *render_data)
+struct soft_render_data
 {
+#ifdef CONFIG_SDL
+  struct sdl_render_data sdl;
+  SDL_Color sdlpal[SMZX_PAL_SIZE];
+#else
+  unsigned pitch;
+  unsigned bpp;
+  uint8_t buffer[SCREEN_PIX_W * SCREEN_PIX_H];
+#endif
+};
+
+#ifdef CONFIG_SDL
+
+static SDL_Surface *soft_get_screen_surface(struct soft_render_data *_render_data)
+{
+  struct sdl_render_data *render_data = &(_render_data->sdl);
   return render_data->shadow ? render_data->shadow : render_data->screen;
 }
+
+static void soft_lock_buffer(struct soft_render_data *render_data,
+ uint32_t **pixels, unsigned *pitch, unsigned *bpp, uint32_t *amask)
+{
+  SDL_Surface *screen = soft_get_screen_surface(render_data);
+
+  *pixels = (uint32_t *)screen->pixels;
+  *pitch = screen->pitch;
+  *bpp = screen->format->BytesPerPixel * 8;
+
+  *pixels += *pitch * ((screen->h - 350) / 8);
+  *pixels += (screen->w - 640) * *bpp / 64;
+
+  if(amask)
+    *amask = screen->format->Amask;
+
+  SDL_LockSurface(screen);
+}
+
+static void soft_unlock_buffer(struct soft_render_data *render_data)
+{
+  SDL_Surface *screen = soft_get_screen_surface(render_data);
+  SDL_UnlockSurface(screen);
+}
+
+#else /* !CONFIG_SDL */
+
+static void soft_lock_buffer(struct soft_render_data *render_data,
+ uint32_t **pixels, unsigned *pitch, unsigned *bpp, uint32_t *amask)
+{
+  *pixels = (uint32_t *)render_data->buffer;
+  *pitch = render_data->pitch;
+  *bpp = render_data->bpp;
+  if(amask)
+    *amask = 0;
+}
+
+static void soft_unlock_buffer(struct soft_render_data *render_data)
+{
+  // do nothing
+}
+
+#endif /* !CONFIG_SDL */
 
 static boolean soft_init_video(struct graphics_data *graphics,
  struct config_info *conf)
 {
-  static struct sdl_render_data render_data;
-
-  memset(&render_data, 0, sizeof(struct sdl_render_data));
-  graphics->render_data = &render_data;
+  struct soft_render_data *render_data =
+   (struct soft_render_data *)ccalloc(1, sizeof(struct soft_render_data));
+  graphics->render_data = render_data;
 
   graphics->allow_resize = 0;
   graphics->bits_per_pixel = 32;
@@ -66,16 +125,37 @@ static boolean soft_init_video(struct graphics_data *graphics,
 
 static void soft_free_video(struct graphics_data *graphics)
 {
+#ifdef CONFIG_SDL
   sdl_destruct_window(graphics);
+#endif
 
-  // Don't free render_data, it's static!
+  free(graphics->render_data);
   graphics->render_data = NULL;
+}
+
+static boolean soft_set_video_mode(struct graphics_data *graphics,
+ int width, int height, int depth, boolean fullscreen, boolean resize)
+{
+#ifdef CONFIG_SDL
+  return sdl_set_video_mode(graphics, width, height, depth, fullscreen, resize);
+#else
+
+  struct soft_render_data *render_data = graphics->render_data;
+
+  graphics->bits_per_pixel = 8;
+  render_data->pitch = (graphics->bits_per_pixel / 8) * SCREEN_PIX_W;
+  render_data->bpp = graphics->bits_per_pixel;
+
+  return true;
+
+#endif /* !CONFIG_SDL */
 }
 
 static void soft_update_colors(struct graphics_data *graphics,
  struct rgb_color *palette, unsigned int count)
 {
-  struct sdl_render_data *render_data = graphics->render_data;
+#ifdef CONFIG_SDL
+  struct soft_render_data *render_data = graphics->render_data;
   SDL_Surface *screen = soft_get_screen_surface(render_data);
 
   unsigned int i;
@@ -91,36 +171,36 @@ static void soft_update_colors(struct graphics_data *graphics,
   }
   else
   {
-    if (count > 256) count = 256;
+    if(count > 256)
+      count = 256;
+
     for(i = 0; i < count; i++)
     {
-      sdlpal[i].r = palette[i].r;
-      sdlpal[i].g = palette[i].g;
-      sdlpal[i].b = palette[i].b;
+      render_data->sdlpal[i].r = palette[i].r;
+      render_data->sdlpal[i].g = palette[i].g;
+      render_data->sdlpal[i].b = palette[i].b;
     }
 
 #if SDL_VERSION_ATLEAST(2,0,0)
-    SDL_SetPaletteColors(render_data->palette, sdlpal, 0, count);
+    SDL_SetPaletteColors(render_data->sdl.palette, render_data->sdlpal, 0, count);
 #else
-    SDL_SetColors(render_data->screen, sdlpal, 0, count);
+    SDL_SetColors(render_data->sdl.screen, render_data->sdlpal, 0, count);
 #endif
   }
+#endif /* CONFIG_SDL */
 }
 
 static void soft_render_graph(struct graphics_data *graphics)
 {
-  struct sdl_render_data *render_data = graphics->render_data;
-  SDL_Surface *screen = soft_get_screen_surface(render_data);
+  struct soft_render_data *render_data = graphics->render_data;
 
-  uint32_t *pixels = (uint32_t *)screen->pixels;
-  unsigned int pitch = screen->pitch;
-  unsigned int bpp = screen->format->BytesPerPixel * 8;
+  uint32_t *pixels;
+  unsigned int pitch;
+  unsigned int bpp;
   unsigned int mode = graphics->screen_mode;
 
-  pixels += pitch * ((screen->h - 350) / 8);
-  pixels += (screen->w - 640) * bpp / 64;
+  soft_lock_buffer(render_data, &pixels, &pitch, &bpp, NULL);
 
-  SDL_LockSurface(screen);
   if(bpp == 8)
   {
     render_graph8((uint8_t *)pixels, pitch, graphics, set_colors8[mode]);
@@ -155,22 +235,32 @@ static void soft_render_graph(struct graphics_data *graphics)
     *(pixels + (pitch/2) + 2) = 0xFFFF0000;
     */
   }
-  SDL_UnlockSurface(screen);
+  soft_unlock_buffer(render_data);
+}
+
+static void soft_render_layer(struct graphics_data *graphics,
+ struct video_layer *layer)
+{
+  struct soft_render_data *render_data = graphics->render_data;
+  uint32_t *pixels;
+  unsigned int pitch;
+  unsigned int bpp;
+
+  soft_lock_buffer(render_data, &pixels, &pitch, &bpp, NULL);
+  render_layer(pixels, bpp, pitch, graphics, layer);
+  soft_unlock_buffer(render_data);
 }
 
 static void soft_render_cursor(struct graphics_data *graphics, unsigned int x,
  unsigned int y, uint16_t color, unsigned int lines, unsigned int offset)
 {
-  struct sdl_render_data *render_data = graphics->render_data;
-  SDL_Surface *screen = soft_get_screen_surface(render_data);
-
-  uint32_t *pixels = (uint32_t *)screen->pixels;
-  unsigned int pitch = screen->pitch;
-  unsigned int bpp = screen->format->BytesPerPixel * 8;
+  struct soft_render_data *render_data = graphics->render_data;
+  uint32_t *pixels;
+  unsigned int pitch;
+  unsigned int bpp;
   uint32_t flatcolor;
 
-  pixels += pitch * ((screen->h - 350) / 8);
-  pixels += (screen->w - 640) * bpp / 64;
+  soft_lock_buffer(render_data, &pixels, &pitch, &bpp, NULL);
 
   if(bpp == 8)
   {
@@ -185,39 +275,33 @@ static void soft_render_cursor(struct graphics_data *graphics, unsigned int x,
   if(bpp == 16)
     flatcolor |= flatcolor << 16;
 
-  SDL_LockSurface(screen);
   render_cursor(pixels, pitch, bpp, x, y, flatcolor, lines, offset);
-  SDL_UnlockSurface(screen);
+  soft_unlock_buffer(render_data);
 }
 
 static void soft_render_mouse(struct graphics_data *graphics,
  unsigned int x, unsigned int y, unsigned int w, unsigned int h)
 {
-  struct sdl_render_data *render_data = graphics->render_data;
-  SDL_Surface *screen = soft_get_screen_surface(render_data);
-
-  uint32_t *pixels = (uint32_t *)screen->pixels;
-  unsigned int pitch = screen->pitch;
-  unsigned int bpp = screen->format->BytesPerPixel * 8;
+  struct soft_render_data *render_data = graphics->render_data;
+  uint32_t *pixels;
+  unsigned int pitch;
+  unsigned int bpp;
   uint32_t mask, amask;
 
-  pixels += pitch * ((screen->h - 350) / 8);
-  pixels += (screen->w - 640) * bpp / 64;
+  soft_lock_buffer(render_data, &pixels, &pitch, &bpp, &amask);
 
   if((bpp == 8) && !graphics->screen_mode)
     mask = 0x0F0F0F0F;
   else
     mask = 0xFFFFFFFF;
 
-  amask = screen->format->Amask;
-
-  SDL_LockSurface(screen);
   render_mouse(pixels, pitch, bpp, x, y, mask, amask, w, h);
-  SDL_UnlockSurface(screen);
+  soft_unlock_buffer(render_data);
 }
 
 static void soft_sync_screen(struct graphics_data *graphics)
 {
+#ifdef CONFIG_SDL
   struct sdl_render_data *render_data = graphics->render_data;
 
   if(render_data->shadow)
@@ -232,24 +316,7 @@ static void soft_sync_screen(struct graphics_data *graphics)
 #else
   SDL_Flip(render_data->screen);
 #endif
-}
-
-static void soft_render_layer(struct graphics_data *graphics,
- struct video_layer *layer)
-{
-  struct sdl_render_data *render_data = graphics->render_data;
-  SDL_Surface *screen = soft_get_screen_surface(render_data);
-
-  uint32_t *pixels = (uint32_t *)screen->pixels;
-  unsigned int pitch = screen->pitch;
-  unsigned int bpp = screen->format->BytesPerPixel * 8;
-
-  pixels += pitch * ((screen->h - 350) / 8);
-  pixels += (screen->w - 640) * bpp / 64;
-
-  SDL_LockSurface(screen);
-  render_layer(pixels, bpp, pitch, graphics, layer);
-  SDL_UnlockSurface(screen);
+#endif /* CONFIG_SDL */
 }
 
 void render_soft_register(struct renderer *renderer)
@@ -257,7 +324,7 @@ void render_soft_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = soft_init_video;
   renderer->free_video = soft_free_video;
-  renderer->set_video_mode = sdl_set_video_mode;
+  renderer->set_video_mode = soft_set_video_mode;
   renderer->update_colors = soft_update_colors;
   renderer->resize_screen = resize_screen_standard;
   renderer->get_screen_coords = get_screen_coords_centered;

--- a/src/render_soft.c
+++ b/src/render_soft.c
@@ -146,6 +146,7 @@ static boolean soft_set_video_mode(struct graphics_data *graphics,
   render_data->pitch = (graphics->bits_per_pixel / 8) * SCREEN_PIX_W;
   render_data->bpp = graphics->bits_per_pixel;
 
+  graphics->renderer_is_headless = true;
   return true;
 
 #endif /* !CONFIG_SDL */

--- a/src/run_robot.c
+++ b/src/run_robot.c
@@ -1562,7 +1562,11 @@ void run_robot(context *ctx, int id, int x, int y)
             if(is_string(src_buffer))
             {
               // Is it another string?
-              get_string(mzx_world, src_buffer, &dest, id);
+              if(!get_string(mzx_world, src_buffer, &dest, id))
+              {
+                dest.value = src_buffer;
+                src_buffer[0] = '\0';
+              }
             }
             else
             {

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -94,6 +94,8 @@ unit_common_objs += \
   ${io_obj}/zip.o         \
   ${io_obj}/zip_stream.o  \
 
+unit_ldflags += ${ZLIB_LDFLAGS}
+
 endif
 
 #


### PR DESCRIPTION
MemorySanitizer requires all dependencies to be instrumented to be of much use, which makes it particularly annoying out of the sanitizers to test for projects with dependencies (like MegaZeux).

* The software renderer was closely tied to SDL before, but will now build even with `--disable-sdl`. In this form it is headless and mainly only good for testing, but this change to the software renderer was pretty much going to happen anyway eventually for other reasons. The alternatives here: either get a working instrumented build of SDL (which I initially attempted but it seems messy), or add a separate dummy renderer (cleaner but more readily gives access to a headless renderer which might be frustrating/confusing to users).

* Non-modular builds couldn't build the tests in some cases due to missing `ZLIB_LDFLAGS`.

* There was a potential use of uninitialized value in `sdl_get_fullscreen_resolution` due to poor handling of the SDL return values.

* There was a use of uninitialized value in `force_string_move` in cases where a string is set to a non-existent string. This shouldn't actually have been a problem due to the source string having a zero length in this case, but I fixed it anyway.

* Finally cleaned up some config.sh architecture hacks that were in weird spots.