### PR TITLE
Disable SDL 1.2 IKEY_UNICODE handling for SDL 2.0, fix keys.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -170,6 +170,9 @@ USERS
 + Scrolls can now display standard message ~@ color codes.
 + Creating a new world using N from the title screen or Alt+R
   in the editor now clears the extended character sets.
++ Fixed PrintScreen/SysRq and Menu/"Right Click" keycodes.
++ Unsupported keys no longer return a KEY_PRESSED value of 1
+  for SDL 2 builds.
 - Removed GL4ES from the GLSL blacklist.
 - Removed 3DS CIA support. (asie)
 

--- a/docs/keycodes.html
+++ b/docs/keycodes.html
@@ -516,10 +516,10 @@
    <tr>
 
     <td>
-     <div class="bad">
+     <div class="warn">
       SysRq
-      <b class="badkey">n/a</b>
-      <p class="badkey">1</p>
+      <b>55</b>
+      <p>317</p>
       <span class="keyname">key_sysreq</span>
      </div>
     </td>
@@ -1386,10 +1386,10 @@
     </td>
 
     <td class="wide">
-     <div class="bad">
-      R.&nbsp;Click
-      <b class="badkey">n/a</b>
-      <p class="badkey">1</p>
+     <div class="warn">
+      Menu
+      <b>93</b>
+      <p>319</p>
       <span class="keyname">key_menu</span>
      </div>
     </td>

--- a/src/event_sdl.c
+++ b/src/event_sdl.c
@@ -159,6 +159,11 @@ static enum keycode convert_SDL_internal(SDL_Keycode key)
     case SDLK_SYSREQ: return IKEY_SYSREQ;
     case SDLK_PAUSE: return IKEY_BREAK;
     case SDLK_MENU: return IKEY_MENU;
+#if SDL_VERSION_ATLEAST(2,0,0)
+    // SDL 2.0 leaves the old keysyms around but doesn't use them?
+    case SDLK_PRINTSCREEN: return IKEY_SYSREQ;
+    case SDLK_APPLICATION: return IKEY_MENU;
+#endif
 #ifdef __WIN32__
 #if SDL_VERSION_ATLEAST(2,0,6) && !SDL_VERSION_ATLEAST(2,0,10)
     // Dumb hack for a Windows virtual keycode bug. TODO remove.
@@ -1199,10 +1204,10 @@ static boolean process_event(SDL_Event *event)
       if(!ckey)
       {
 #if !SDL_VERSION_ATLEAST(2,0,0)
-        if(!event->key.keysym.unicode)
-          break;
-#endif
         ckey = IKEY_UNICODE;
+        if(!event->key.keysym.unicode)
+#endif
+          break;
       }
 
 #if !SDL_VERSION_ATLEAST(2,0,0)
@@ -1309,10 +1314,10 @@ static boolean process_event(SDL_Event *event)
       if(!ckey)
       {
 #if !SDL_VERSION_ATLEAST(2,0,0)
-        if(!status->keymap[IKEY_UNICODE])
-          break;
-#endif
         ckey = IKEY_UNICODE;
+        if(!status->keymap[IKEY_UNICODE])
+#endif
+          break;
       }
 
       if(ckey == IKEY_NUMLOCK)


### PR DESCRIPTION
The `IKEY_UNICODE` handling for SDL 1.2 builds (which combine text/unicode events into key events) was incorrectly handled for SDL 2.0 (which uses separate events), causing it to generate key presses with `IKEY_UNICODE` for unsupported keys instead of just ignoring them.

Also fixes PrintScreen/SysRq and Menu/"Right Click", which were the normal US layout keys that still produced this behavior. SDL 2.0 added new keycode enum values for these but didn't get rid of the old ones, hence them getting overlooked before.