### PR TITLE
Fix serious framerate bug related to board edges/entrances.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -55,6 +55,9 @@ USERS
   positions, these can be configured with the config file option
   "vlayer_position#", and they work identically to board saved
   positions.
++ Fixed bug where the second cycle of a board when entering from
+  a board edge or entrance would be shortened due to incorrect
+  gameplay framerate timing introduced in 2.91g.
 + Fixed a crash bug when attempting to save MZMs over 4MB to an
   existing string.
 + Fixed a bug where, if a world's title screen music is set but

--- a/src/core.c
+++ b/src/core.c
@@ -1016,7 +1016,7 @@ void core_run(core_context *root)
   // this doesn't break MZX, this function stops once the number of contexts
   // on the stack has dropped below the initial value.
   int initial_stack_size = root->stack.size;
-  int start_ticks = get_ticks();
+  int start_ticks;
   int delta_ticks;
   int total_ticks;
   boolean need_update_screen = true;
@@ -1049,6 +1049,14 @@ void core_run(core_context *root)
       core_resume(root);
       continue;
     }
+
+    // Gameplay framerate timing starts immediately before the board update,
+    // which must be done in the draw function!
+    start_ticks = get_ticks();
+
+#ifdef CONFIG_FPS
+    update_fps(start_ticks);
+#endif
 
     need_update_screen = core_draw(root);
 
@@ -1132,12 +1140,6 @@ void core_run(core_context *root)
     joystick_set_legacy_loop_hacks(true);
     enable_f12_hack = conf->allow_screenshots;
     // FIXME end legacy loop hacks
-
-    start_ticks = get_ticks();
-
-#ifdef CONFIG_FPS
-    update_fps(start_ticks);
-#endif
 
     core_update(root);
   }


### PR DESCRIPTION
Due to the entrance/board edge `vquick_fadein` and entrance `vquick_fadeout` incorrectly being included in the gameplay framerate calculation, some frames could be severely truncated. For board edges this occurs on the second cycle of the board and is noticeable as the player appearing to jump over X=2 or Y=2, among other things. This was introduced as part of splitting up `update` way back in 2.91g.

sdfjksdlkfjsdlkfjdslkfjsdljkld