### PR TITLE
Update unix .desktop files and install the icon to the correct place.

### DIFF
--- a/arch/install.inc
+++ b/arch/install.inc
@@ -19,8 +19,8 @@ install = install
 endif
 
 ifneq (${V},1)
-install = @${install}
-gzip    = @${gzip}
+install := @${install}
+gzip    := @${gzip}
 endif
 
 #

--- a/arch/unix/Makefile.in
+++ b/arch/unix/Makefile.in
@@ -18,13 +18,13 @@ include arch/install.inc
 
 # linux os specific install files
 install-arch: install-check
-	@${install} -m 0755 -d \
+	${install} -m 0755 -d \
 		${DESTDIR}${SHAREDIR} \
-		${DESTDIR}${SHAREDIR}/icons \
-		${DESTDIR}${SHAREDIR}/applications && \
-	 ${install} -m 0644 contrib/icons/quantump.png \
-		${DESTDIR}${SHAREDIR}/icons/megazeux.png && \
-	 ${install} -m 0644 arch/unix/megazeux.desktop \
+		${DESTDIR}${SHAREDIR}/icons/hicolor/128x128/apps \
+		${DESTDIR}${SHAREDIR}/applications
+	${install} -m 0644 contrib/icons/quantump.png \
+		${DESTDIR}${SHAREDIR}/icons/hicolor/128x128/apps/megazeux.png
+	${install} -m 0644 arch/unix/megazeux.desktop \
 		${DESTDIR}${SHAREDIR}/applications/megazeux.desktop
 ifeq (${BUILD_MZXRUN},1)
 	@${install} -m 0644 arch/unix/mzxrun.desktop \
@@ -34,7 +34,7 @@ endif
 # linux os specific install files
 uninstall-arch: install-check
 	@${RM} -f \
-		${DESTDIR}${SHAREDIR}/icons/megazeux.png \
+		${DESTDIR}${SHAREDIR}/icons/hicolor/128x128/apps/megazeux.png \
 		${DESTDIR}${SHAREDIR}/applications/megazeux.desktop
 ifeq (${BUILD_MZXRUN},1)
 	@${RM} -f \

--- a/arch/unix/megazeux.desktop
+++ b/arch/unix/megazeux.desktop
@@ -5,3 +5,5 @@ Icon=megazeux
 Terminal=false
 Type=Application
 Categories=Game;
+GenericName=Game Creation System
+Comment=A simple, cross-platform game creation system.

--- a/arch/unix/mzxrun.desktop
+++ b/arch/unix/mzxrun.desktop
@@ -5,3 +5,5 @@ Icon=megazeux
 Terminal=false
 Type=Application
 Categories=Game;
+GenericName=Game Creation System
+Comment=A simple, cross-platform game creation system. This executable does not load the game editor.

--- a/config.sh
+++ b/config.sh
@@ -1576,7 +1576,7 @@ if [ "$ICON" = "true" ]; then
 		if [ "$SHAREDIR" = "." ]; then
 			ICONFILE="contrib/icons/quantump.png"
 		else
-			ICONFILE="$SHAREDIR/icons/megazeux.png"
+			ICONFILE="$SHAREDIR/icons/hicolor/128x128/apps/megazeux.png"
 		fi
 		echo "#define ICONFILE \"$ICONFILE\"" >> src/config.h
 	fi


### PR DESCRIPTION
Turns out you can't just dump an icon in /usr/share/icons! This is needed for flatpak specifically but is a good idea to fix in general.