### PR TITLE
Fix message box newline, color string length calculation bugs.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -173,6 +173,11 @@ USERS
   stdin using the input filename "-".
 + Fixed bugs caused by missing validation in the Import SFX
   feature in the editor.
++ The Robotic message box commands now properly display char 10.
++ The Robotic command ? now correctly accounts for color codes
+  in its length bounding.
++ Fixed crashes in the & Robotic command caused by bad color
+  string length calculations.
 + Scrolls can now display standard message ~@ color codes.
 + Creating a new world using N from the title screen or Alt+R
   in the editor now clears the extended character sets.

--- a/src/robot.c
+++ b/src/robot.c
@@ -2496,30 +2496,34 @@ static int robot_box_up(char *program, int pos, int count)
   return pos;
 }
 
-static int num_ccode_chars(char *str)
+static void clip_color_string(char *buf, size_t len, size_t pos)
 {
-  char current_char = *str;
-  char *str_pos = str;
-  int count = 0;
+  size_t idx = 0;
 
-  while(current_char)
+  while(idx < len)
   {
+    char current_char = buf[idx];
+    if(current_char == '\0')
+      break;
+
     if((current_char == '~') || (current_char == '@'))
     {
-      count++;
-
-      if(isxdigit((int)str_pos[1]))
+      idx++;
+      if(idx < len && isxdigit((uint8_t)buf[idx]))
       {
-        count++;
-        str_pos++;
+        idx++;
+        continue;
       }
     }
 
-    str_pos++;
-    current_char = *str_pos;
+    if(pos == 0) // Clip here
+    {
+      buf[idx] = '\0';
+      return;
+    }
+    pos--;
+    idx++;
   }
-
-  return count;
 }
 
 static void display_robot_line(struct world *mzx_world, char *program,
@@ -2551,8 +2555,8 @@ static void display_robot_line(struct world *mzx_world, char *program,
       // next is pos of string
       next = next_param_pos(program + 2);
       tr_msg(mzx_world, next + 1, id, ibuff);
-      ibuff[62] = 0; // Clip
-      color_string_ext(ibuff, 10, y, scroll_base_color, true, 0, 0);
+      clip_color_string(ibuff, ROBOT_MAX_TR, 62); // Clip
+      color_string_ext(ibuff, 10, y, scroll_base_color, false, 0, 0);
       draw_char_ext('\x10', scroll_arrow_color, 8, y, 0, 0);
       break;
     }
@@ -2568,8 +2572,8 @@ static void display_robot_line(struct world *mzx_world, char *program,
         next = next_param_pos(program + 2);
         next = next_param_pos(next);
         tr_msg(mzx_world, next + 1, id, ibuff);
-        ibuff[62] = 0; // Clip
-        color_string_ext(ibuff, 10, y, scroll_base_color, true, 0, 0);
+        clip_color_string(ibuff, ROBOT_MAX_TR, 62); // Clip
+        color_string_ext(ibuff, 10, y, scroll_base_color, false, 0, 0);
         draw_char_ext('\x10', scroll_arrow_color, 8, y, 0, 0);
       }
       break;
@@ -2578,8 +2582,8 @@ static void display_robot_line(struct world *mzx_world, char *program,
     case ROBOTIC_CMD_MESSAGE_BOX_COLOR_LINE: // Colored message
     {
       tr_msg(mzx_world, program + 3, id, ibuff);
-      ibuff[64 + num_ccode_chars(ibuff)] = 0; // Clip
-      color_string_ext(ibuff, 8, y, scroll_base_color, true, 0, 0);
+      clip_color_string(ibuff, ROBOT_MAX_TR, 64); // Clip
+      color_string_ext(ibuff, 8, y, scroll_base_color, false, 0, 0);
       break;
     }
 
@@ -2587,10 +2591,11 @@ static void display_robot_line(struct world *mzx_world, char *program,
     {
       int length, x_position;
       tr_msg(mzx_world, program + 3, id, ibuff);
-      ibuff[64 + num_ccode_chars(ibuff)] = 0; // Clip
+      clip_color_string(ibuff, ROBOT_MAX_TR, 64); // Clip
       length = strlencolor(ibuff);
       x_position = 40 - (length / 2);
-      color_string_ext(ibuff, x_position, y, scroll_base_color, true, 0, 0);
+      assert(x_position >= 0);
+      color_string_ext(ibuff, x_position, y, scroll_base_color, false, 0, 0);
       break;
     }
   }

--- a/src/scrdisp.c
+++ b/src/scrdisp.c
@@ -841,7 +841,7 @@ ex:
 int strlencolor(char *str)
 {
   int len = 0;
-  char cur_char = *str;\
+  char cur_char = *str;
 
   while(cur_char != 0)
   {
@@ -859,7 +859,7 @@ int strlencolor(char *str)
           return len;
 
         // If the next isn't hex, count as one
-        if(!isxdigit((int)cur_char))
+        if(!isxdigit((uint8_t)cur_char))
         {
           len++;
         }


### PR DESCRIPTION
* `\n` no longer emits a line break in robot message box color printing lines (introduced in 2.81X). It now prints as char 10.
* Bad termination for the centered color string `&` command combined with the X position calculation no longer causes `color_string_ext` to crash (introduced in 2.84, but hard to reproduce prior to 2.90 for some reason).
* Fixed termination for the option `?` commands that didn't take color codes into account (has existed in some form forever).