### PR TITLE
Implement semaphores and standardize synchronization return values.

### DIFF
--- a/arch/dreamcast/thread.h
+++ b/arch/dreamcast/thread.h
@@ -33,13 +33,23 @@ __M_BEGIN_DECLS
 
 typedef condvar_t platform_cond;
 typedef mutex_t platform_mutex;
+typedef semaphore_t platform_sem;
 typedef kthread_t *platform_thread;
 typedef kthread_t *platform_thread_id;
 typedef void *(*platform_thread_fn)(void *);
 
-static inline void platform_mutex_init(platform_mutex *mutex)
+static inline boolean platform_mutex_init(platform_mutex *mutex)
 {
-  mutex_init(mutex, MUTEX_TYPE_NORMAL);
+  if(mutex_init(mutex, MUTEX_TYPE_NORMAL))
+    return false;
+  return true;
+}
+
+static inline boolean platform_mutex_destroy(platform_mutex *mutex)
+{
+  if(mutex_destroy(mutex))
+    return false;
+  return true;
 }
 
 static inline bool platform_mutex_lock(platform_mutex *mutex)
@@ -56,19 +66,18 @@ static inline bool platform_mutex_unlock(platform_mutex *mutex)
   return true;
 }
 
-static inline bool platform_mutex_destroy(platform_mutex *mutex)
+static inline boolean platform_cond_init(platform_cond *cond)
 {
+  if(cond_init(cond))
+    return false;
   return true;
 }
 
-static inline void platform_cond_init(platform_cond *cond)
+static inline boolean platform_cond_destroy(platform_cond *cond)
 {
-  cond_init(cond);
-}
-
-static inline void platform_cond_destroy(platform_cond *cond)
-{
-  cond_destroy(cond);
+  if(cond_destroy(cond))
+    return false;
+  return true;
 }
 
 static inline boolean platform_cond_wait(platform_cond *cond,
@@ -101,19 +110,51 @@ static inline boolean platform_cond_broadcast(platform_cond *cond)
   return true;
 }
 
-static inline int platform_thread_create(platform_thread *thread,
+static inline boolean platform_sem_init(platform_sem *sem, unsigned init_value)
+{
+  if(sem_init(sem, init_value))
+    return false;
+  return true;
+}
+
+static inline boolean platform_sem_destroy(platform_sem *sem)
+{
+  if(sem_destroy(sem))
+    return false;
+  return true;
+}
+
+static inline boolean platform_sem_wait(platform_sem *sem)
+{
+  if(sem_wait(sem))
+    return false;
+  return true;
+}
+
+static inline boolean platform_sem_post(platform_sem *sem)
+{
+  if(sem_signal(sem))
+    return false;
+  return true;
+}
+
+static inline boolean platform_thread_create(platform_thread *thread,
  platform_thread_fn start_function, void *data)
 {
   platform_thread ret = thd_create(0, start_function, data);
-  *thread = ret;
   if(ret)
-    return 0;
-  return -1;
+  {
+    *thread = ret;
+    return true;
+  }
+  return false;
 }
 
-static inline void platform_thread_join(platform_thread *thread)
+static inline boolean platform_thread_join(platform_thread *thread)
 {
-  thd_join(*thread, NULL);
+  if(thd_join(*thread, NULL))
+    return false;
+  return true;
 }
 
 static inline platform_thread_id platform_get_thread_id(void)

--- a/src/network/DNS.cpp
+++ b/src/network/DNS.cpp
@@ -160,7 +160,7 @@ static void create_dns_thread(struct dns_data *data)
 
   LOCK(data);
 
-  if(platform_thread_create(&(data->thread),
+  if(!platform_thread_create(&(data->thread),
    (platform_thread_fn)run_dns_thread, (void *)data))
   {
     UNLOCK(data);

--- a/src/platform.h
+++ b/src/platform.h
@@ -53,8 +53,10 @@ int real_main(int argc, char *argv[]);
 #include "../arch/djgpp/thread.h"
 #elif defined(CONFIG_DREAMCAST)
 #include "../arch/dreamcast/thread.h"
-#elif defined(CONFIG_SDL)
+#elif defined(CONFIG_SDL) && !defined(SKIP_SDL)
 #include "thread_sdl.h"
+#elif defined(_WIN32) /* Fallback, prefer SDL when possible. */
+#include "thread_win32.h"
 #else
 #if defined(CONFIG_NDS)
 #define THREAD_DUMMY_ALLOW_MUTEX

--- a/src/thread_dummy.h
+++ b/src/thread_dummy.h
@@ -52,6 +52,7 @@ __M_BEGIN_DECLS
 
 typedef int platform_cond;
 typedef int platform_mutex;
+typedef int platform_sem;
 typedef int platform_thread;
 typedef int platform_thread_id;
 typedef THREAD_RES (*platform_thread_fn)(void *);
@@ -63,14 +64,16 @@ typedef THREAD_RES (*platform_thread_fn)(void *);
  * without a proper threading/synchronization implementation.
  */
 #ifdef THREAD_DUMMY_ALLOW_MUTEX
-static inline void platform_mutex_init(platform_mutex *mutex)
+static inline boolean platform_mutex_init(platform_mutex *mutex)
 {
   *mutex = 1;
+  return true;
 }
 
-static inline void platform_mutex_destroy(platform_mutex *mutex)
+static inline boolean platform_mutex_destroy(platform_mutex *mutex)
 {
   *mutex = 0;
+  return true;
 }
 
 static inline boolean platform_mutex_lock(platform_mutex *mutex)
@@ -84,10 +87,10 @@ static inline boolean platform_mutex_unlock(platform_mutex *mutex)
 }
 #else
 THREAD_ERROR
-void platform_mutex_init(platform_mutex *mutex);
+boolean platform_mutex_init(platform_mutex *mutex);
 
 THREAD_ERROR
-void platform_mutex_destroy(platform_mutex *mutex);
+boolean platform_mutex_destroy(platform_mutex *mutex);
 
 THREAD_ERROR
 boolean platform_mutex_lock(platform_mutex *mutex);
@@ -97,10 +100,10 @@ boolean platform_mutex_unlock(platform_mutex *mutex);
 #endif
 
 THREAD_ERROR
-void platform_cond_init(platform_cond *cond);
+boolean platform_cond_init(platform_cond *cond);
 
 THREAD_ERROR
-void platform_cond_destroy(platform_cond *cond);
+boolean platform_cond_destroy(platform_cond *cond);
 
 THREAD_ERROR
 boolean platform_cond_wait(platform_cond *cond, platform_mutex *mutex);
@@ -116,11 +119,23 @@ THREAD_ERROR
 boolean platform_cond_broadcast(platform_cond *cond);
 
 THREAD_ERROR
-int platform_thread_create(platform_thread *thread,
+boolean platform_sem_init(platform_sem *sem, unsigned init_value);
+
+THREAD_ERROR
+boolean platform_sem_destroy(platform_sem *sem);
+
+THREAD_ERROR
+boolean platform_sem_wait(platform_sem *sem);
+
+THREAD_ERROR
+boolean platform_sem_post(platform_sem *sem);
+
+THREAD_ERROR
+boolean platform_thread_create(platform_thread *thread,
  platform_thread_fn start_function, void *data);
 
 THREAD_ERROR
-void platform_thread_join(platform_thread *thread);
+boolean platform_thread_join(platform_thread *thread);
 
 /**
  * Safe to use with no thread implementation (required by util.c).
@@ -138,9 +153,6 @@ static inline boolean platform_is_same_thread(platform_thread_id a,
 {
   return true;
 }
-
-THREAD_ERROR
-void platform_yield(void);
 
 __M_END_DECLS
 

--- a/src/thread_win32.h
+++ b/src/thread_win32.h
@@ -1,7 +1,6 @@
 /* MegaZeux
  *
- * Copyright (C) 2008 Alan Williams <mralert@gmail.com>
- * Copyright (C) 2009 Alistair John Strachan <alistair@devzero.co.uk>
+ * Copyright (C) 2023 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -18,130 +17,120 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __THREAD_PTHREAD_H
-#define __THREAD_PTHREAD_H
+/**
+ * Fallback Windows threading implementation. This uses Win32 function calls
+ * which should work all the way back to Windows 95. Since Win32 didn't have
+ * condition variables until Vista, this is pretty hacky and terrible!
+ * Only use this when SDL isn't available, e.g. for the utils.
+ */
+
+#ifndef __THREAD_WIN32_H
+#define __THREAD_WIN32_H
 
 #include "compat.h"
 
 __M_BEGIN_DECLS
 
-#include <sched.h>
-#include <semaphore.h>
-#include <time.h>
-#include "pthread.h"
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 
-#define THREAD_RES void *
-#define THREAD_RETURN do { return NULL; } while(0)
+#define THREAD_RES DWORD WINAPI
+#define THREAD_RETURN do { return 0; } while(0)
 
-typedef pthread_cond_t platform_cond;
-typedef pthread_mutex_t platform_mutex;
-typedef sem_t platform_sem;
-typedef pthread_t platform_thread;
-typedef pthread_t platform_thread_id;
+typedef DWORD platform_cond;
+typedef CRITICAL_SECTION platform_mutex;
+typedef HANDLE platform_sem;
+typedef HANDLE platform_thread;
+typedef DWORD platform_thread_id;
 typedef THREAD_RES (*platform_thread_fn)(void *);
 
 static inline boolean platform_mutex_init(platform_mutex *mutex)
 {
-  if(pthread_mutex_init(mutex, NULL))
-    return false;
+  InitializeCriticalSection(mutex);
   return true;
 }
 
 static inline boolean platform_mutex_destroy(platform_mutex *mutex)
 {
-  if(pthread_mutex_destroy(mutex))
-    return false;
+  DeleteCriticalSection(mutex);
   return true;
 }
 
 static inline boolean platform_mutex_lock(platform_mutex *mutex)
 {
-  if(pthread_mutex_lock(mutex))
-    return false;
+  EnterCriticalSection(mutex);
   return true;
 }
 
 static inline boolean platform_mutex_unlock(platform_mutex *mutex)
 {
-  if(pthread_mutex_unlock(mutex))
-    return false;
+  LeaveCriticalSection(mutex);
   return true;
 }
 
+// TODO: Dynamically link Vista condvars or approximate with semaphores...
 static inline boolean platform_cond_init(platform_cond *cond)
 {
-  if(pthread_cond_init(cond, NULL))
-    return false;
-  return true;
+  return false;
 }
 
 static inline boolean platform_cond_destroy(platform_cond *cond)
 {
-  if(pthread_cond_destroy(cond))
-    return false;
-  return true;
+  return false;
+}
+
+static inline boolean platform_cond_timedwait(platform_cond *cond,
+ platform_mutex *mutex, unsigned time)
+{
+  abort();
+  return false;
 }
 
 static inline boolean platform_cond_wait(platform_cond *cond,
  platform_mutex *mutex)
 {
-  if(pthread_cond_wait(cond, mutex))
-    return false;
-  return true;
-}
-
-static inline boolean platform_cond_timedwait(platform_cond *cond,
- platform_mutex *mutex, unsigned int timeout_ms)
-{
-  struct timespec timeout;
-
-  clock_gettime(CLOCK_REALTIME, &timeout);
-  timeout.tv_sec  += (timeout_ms / 1000);
-  timeout.tv_nsec += (timeout_ms % 1000) * 1000000;
-
-  if(pthread_cond_timedwait(cond, mutex, &timeout))
-    return false;
-  return true;
+  abort();
+  return false;
 }
 
 static inline boolean platform_cond_signal(platform_cond *cond)
 {
-  if(pthread_cond_signal(cond))
-    return false;
-  return true;
+  abort();
+  return false;
 }
 
 static inline boolean platform_cond_broadcast(platform_cond *cond)
 {
-  if(pthread_cond_broadcast(cond))
-    return false;
-  return true;
+  abort();
+  return false;
 }
 
 static inline boolean platform_sem_init(platform_sem *sem, unsigned init_value)
 {
-  if(sem_init(sem, 0, init_value))
-    return false;
-  return true;
+  HANDLE s = CreateSemaphore(NULL, init_value, LONG_MAX, NULL);
+  if(s)
+  {
+    *sem = s;
+    return true;
+  }
+  return false;
 }
 
 static inline boolean platform_sem_destroy(platform_sem *sem)
 {
-  if(sem_destroy(sem))
-    return false;
-  return true;
+  return CloseHandle(*sem);
 }
 
 static inline boolean platform_sem_wait(platform_sem *sem)
 {
-  if(sem_wait(sem))
+  if(WaitForSingleObject(*sem, INFINITE) != WAIT_OBJECT_0)
     return false;
   return true;
 }
 
 static inline boolean platform_sem_post(platform_sem *sem)
 {
-  if(sem_post(sem))
+  if(ReleaseSemaphore(*sem, 1, NULL) == 0)
     return false;
   return true;
 }
@@ -149,34 +138,33 @@ static inline boolean platform_sem_post(platform_sem *sem)
 static inline boolean platform_thread_create(platform_thread *thread,
  platform_thread_fn start_function, void *data)
 {
-  if(pthread_create(thread, NULL, start_function, data))
-    return false;
-  return true;
+  HANDLE t = CreateThread(NULL, 0, start_function, data, 0, NULL);
+  if(t)
+  {
+    *thread = t;
+    return true;
+  }
+  return false;
 }
 
 static inline boolean platform_thread_join(platform_thread *thread)
 {
-  if(pthread_join(*thread, NULL))
+  if(WaitForSingleObject(*thread, INFINITE) != WAIT_OBJECT_0)
     return false;
   return true;
 }
 
 static inline platform_thread_id platform_get_thread_id(void)
 {
-  return pthread_self();
+  return GetCurrentThreadId();
 }
 
 static inline boolean platform_is_same_thread(platform_thread_id a,
  platform_thread_id b)
 {
-  return pthread_equal(a, b) != 0;
-}
-
-static inline void platform_yield(void)
-{
-  sched_yield();
+  return a == b;
 }
 
 __M_END_DECLS
 
-#endif // __THREAD_PTHREAD_H
+#endif /* __THREAD_WIN32_H */

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -58,6 +58,11 @@ unit_objs += \
 
 endif
 
+ifeq (${PLATFORM},mingw)
+unit_objs += \
+  ${unit_obj}/thread_win32${unit_ext}
+endif
+
 #
 # Some unit tests only work with modular builds. The reason is usually
 # that the component(s) being tested are far too dependent on other
@@ -68,6 +73,7 @@ ifneq (${BUILD_MODULAR},)
 unit_objs += \
   ${unit_obj}/configure${unit_ext}     \
   ${unit_obj}/intake${unit_ext}        \
+  ${unit_obj}/thread${unit_ext}        \
   ${unit_obj}/world${unit_ext}         \
 
 unit_ldflags += -L. -lcore
@@ -109,9 +115,10 @@ DEBUG_CFLAGS ?= -O0
 #
 unit_cflags ?= ${CXXFLAGS} ${DEBUG_CFLAGS} -UDEBUG -UNDEBUG
 unit_cflags += -fexceptions -funsigned-char -std=gnu++11
+unit_ldflags += ${DEBUG_CFLAGS}
 
 unit_cflags += ${SDL_CFLAGS} -Umain
-unit_ldflags += ${ZLIB_LDFLAGS}
+unit_ldflags += ${SDL_LDFLAGS} ${ZLIB_LDFLAGS}
 
 # Required for image_file test.
 ifneq (${LIBPNG},)

--- a/unit/thread.cpp
+++ b/unit/thread.cpp
@@ -1,0 +1,26 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2023 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * Perform thread tests with whichever thread.h implementation is used by the
+ * MegaZeux executable (possibly including SDL).
+ */
+
+#include "Unit.hpp"
+#include "thread.hpp"

--- a/unit/thread.hpp
+++ b/unit/thread.hpp
@@ -1,0 +1,438 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2023 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * Lazy tests to verify thread.h wrappers are implemented correctly.
+ * This needs to be in a header so the full test (SDL, pthread, etc.) and the
+ * limited Win32 test (utils only) can include different headers.
+ */
+
+#include "Unit.hpp"
+
+#ifndef WIN32_FALLBACK_TEST
+#undef SKIP_SDL
+#endif
+
+#include "../src/platform.h"
+#include "../src/util.h"
+
+#define NUM_THREADS 3
+#define REPEAT_TIMES 100
+
+static THREAD_RES thread_basic_fn(void *opaque)
+{
+  boolean *it_worked = reinterpret_cast<boolean *>(opaque);
+  *it_worked = true;
+  THREAD_RETURN;
+}
+
+UNITTEST(Thread)
+{
+  platform_thread thread;
+  boolean check = false;
+  boolean ret;
+
+  ret = platform_thread_create(&thread, thread_basic_fn, &check);
+  ASSERT(ret, "thread create failed");
+  platform_thread_join(&thread);
+
+  ASSERTEQ(check, true, "thread failed to run or thread join failed");
+}
+
+
+struct mutex_data
+{
+  platform_mutex lock;
+  boolean lock_ret_false;
+  boolean unlock_ret_false;
+  boolean bad_value;
+  int check;
+};
+
+static THREAD_RES mutex_fn(void *opaque)
+{
+  struct mutex_data *d = reinterpret_cast<struct mutex_data *>(opaque);
+
+  for(int i = 0; i < REPEAT_TIMES; i++)
+  {
+    if(!platform_mutex_lock(&(d->lock)))
+      d->lock_ret_false = true;
+
+    // nonatomic without mutex
+    int tmp = d->check;
+    if((++d->check) != (tmp + 1))
+      d->bad_value = true;
+
+    if(!platform_mutex_unlock(&(d->lock)))
+      d->unlock_ret_false = true;
+  }
+  THREAD_RETURN;
+}
+
+UNITTEST(Mutex)
+{
+  platform_thread threads[NUM_THREADS];
+  struct mutex_data d{};
+  boolean ret;
+  int i;
+
+  ret = platform_mutex_init(&(d.lock));
+  ASSERT(ret, "failed to init lock");
+
+  for(i = 0; i < NUM_THREADS; i++)
+  {
+    ret = platform_thread_create(&threads[i], mutex_fn, &d);
+    ASSERT(ret, "thread %d", i);
+  }
+  for(i = 0; i < NUM_THREADS; i++)
+    platform_thread_join(&threads[i]);
+
+  platform_mutex_destroy(&(d.lock));
+
+  ASSERTEQ(d.lock_ret_false, false, "lock() returned false");
+  ASSERTEQ(d.unlock_ret_false, false, "unlock() returned false");
+  ASSERTEQ(d.bad_value, false, "race condition in increment");
+  ASSERTEQ(d.check, NUM_THREADS * REPEAT_TIMES, "incorrect final value");
+}
+
+
+struct cond_data
+{
+  platform_mutex lock;
+  platform_cond cond;
+
+  uint8_t buffer[277];
+  unsigned sum[NUM_THREADS];
+  unsigned expected;
+  unsigned iter_read[NUM_THREADS];
+  unsigned iter_write;
+  unsigned iter_max;
+  unsigned num_readers;
+  unsigned thread_idx;
+  boolean is_write;
+
+  boolean lock_ret_false;
+  boolean unlock_ret_false;
+  boolean wait_ret_false;
+  boolean broadcast_ret_false;
+};
+
+static THREAD_RES cond_read_fn(void *opaque)
+{
+  struct cond_data *d = reinterpret_cast<struct cond_data *>(opaque);
+  size_t i;
+  int num;
+
+  if(!platform_mutex_lock(&(d->lock)))
+    d->lock_ret_false = true;
+
+  num = d->thread_idx;
+  d->thread_idx++;
+
+  while(d->iter_read[num] < d->iter_max)
+  {
+    while(d->is_write || d->iter_read[num] >= d->iter_write)
+    {
+      if(!platform_cond_wait(&(d->cond), &(d->lock)))
+        d->wait_ret_false = true;
+    }
+    d->num_readers++;
+
+    if(!platform_mutex_unlock(&(d->lock)))
+      d->unlock_ret_false = true;
+
+    for(i = 0; i < ARRAY_SIZE(d->buffer); i++)
+      d->sum[num] += d->buffer[i];
+
+    if(!platform_mutex_lock(&(d->lock)))
+      d->lock_ret_false = true;
+
+    d->iter_read[num]++;
+    d->num_readers--;
+
+    if(!platform_cond_broadcast(&(d->cond)))
+      d->broadcast_ret_false = true;
+  }
+  platform_mutex_unlock(&(d->lock));
+  THREAD_RETURN;
+}
+
+static THREAD_RES cond_write_fn(void *opaque)
+{
+  struct cond_data *d = reinterpret_cast<struct cond_data *>(opaque);
+  unsigned current = 0;
+  size_t i;
+
+  if(!platform_mutex_lock(&(d->lock)))
+    d->lock_ret_false = true;
+
+  while(d->iter_write < d->iter_max)
+  {
+    while(d->num_readers)
+    {
+      if(!platform_cond_wait(&(d->cond), &(d->lock)))
+        d->wait_ret_false = true;
+    }
+    boolean up_to_date = true;
+    for(i = 0; i < NUM_THREADS; i++)
+      if(d->iter_read[i] < d->iter_write)
+        up_to_date = false;
+
+    if(!up_to_date)
+    {
+      if(!platform_cond_wait(&(d->cond), &(d->lock)))
+        d->wait_ret_false = true;
+      continue;
+    }
+    d->is_write = true;
+
+    if(!platform_mutex_unlock(&(d->lock)))
+      d->unlock_ret_false = true;
+
+    for(i = 0; i < ARRAY_SIZE(d->buffer); i++)
+    {
+      d->buffer[i] = (current++);
+      d->expected += d->buffer[i];
+    }
+
+    if(!platform_mutex_lock(&(d->lock)))
+      d->lock_ret_false = true;
+
+    d->iter_write++;
+    d->is_write = false;
+
+    if(!platform_cond_broadcast(&(d->cond)))
+      d->broadcast_ret_false = true;
+  }
+  platform_mutex_unlock(&(d->lock));
+  THREAD_RETURN;
+}
+
+UNITTEST(Cond)
+{
+  platform_thread workers[NUM_THREADS];
+  platform_thread ctrl;
+  struct cond_data d{};
+  boolean ret;
+  int i;
+
+#if defined(_WIN32) && defined(SKIP_SDL)
+  // Not currently implemented.
+  SKIP();
+#endif
+
+  d.iter_max = REPEAT_TIMES;
+
+  ret = platform_mutex_init(&(d.lock));
+  ASSERT(ret, "failed to init lock");
+  ret = platform_cond_init(&(d.cond));
+  ASSERT(ret, "failed to init cond");
+
+  ret = platform_thread_create(&ctrl, cond_write_fn, &d);
+  ASSERT(ret, "ctrl");
+
+  for(i = 0; i < NUM_THREADS; i++)
+  {
+    ret = platform_thread_create(&workers[i], cond_read_fn, &d);
+    ASSERT(ret, "worker %d", i);
+  }
+
+  platform_thread_join(&ctrl);
+  for(i = 0; i < NUM_THREADS; i++)
+    platform_thread_join(&workers[i]);
+
+  platform_cond_destroy(&(d.cond));
+  platform_mutex_destroy(&(d.lock));
+
+  for(i = 0; i < NUM_THREADS; i++)
+    ASSERTEQ(d.sum[i], d.expected, "incorrect value");
+
+  ASSERTEQ(d.lock_ret_false, false, "lock() returned false");
+  ASSERTEQ(d.unlock_ret_false, false, "unlock() returned false");
+  ASSERTEQ(d.wait_ret_false, false, "wait() returned false");
+  ASSERTEQ(d.broadcast_ret_false, false, "broadcast() returned false");
+}
+
+
+#define NUM_WORK (NUM_THREADS) * 2
+struct semaphore_data
+{
+  platform_mutex lock;
+  platform_sem worker_sem;
+  platform_sem ctrl_sem;
+
+  boolean ready[NUM_WORK];
+  int buffer[NUM_WORK];
+  int next_idx;
+  int input_idx;
+  boolean need_exit;
+
+  boolean lock_ret_false;
+  boolean unlock_ret_false;
+  boolean wait_ret_false;
+  boolean post_ret_false;
+};
+
+static THREAD_RES semaphore_worker_fn(void *opaque)
+{
+  struct semaphore_data *d = reinterpret_cast<struct semaphore_data *>(opaque);
+  int i;
+  for(;;)
+  {
+    if(!platform_sem_wait(&(d->worker_sem)))
+      d->wait_ret_false = true;
+
+    if(!platform_mutex_lock(&(d->lock)))
+      d->lock_ret_false = true;
+
+    if(d->need_exit)
+    {
+      platform_mutex_unlock(&(d->lock));
+      THREAD_RETURN;
+    }
+
+    int idx = d->next_idx;
+    d->next_idx++;
+    if(d->next_idx >= NUM_WORK)
+      d->next_idx = 0;
+
+    if(!platform_mutex_unlock(&(d->lock)))
+      d->unlock_ret_false = true;
+
+    // Do "work"
+    for(i = 0; i < REPEAT_TIMES; i++)
+      d->buffer[idx]++;
+
+    if(!platform_mutex_lock(&(d->lock)))
+      d->lock_ret_false = true;
+
+    d->ready[idx] = true;
+
+    if(!platform_mutex_unlock(&(d->lock)))
+      d->unlock_ret_false = true;
+
+    if(!platform_sem_post(&(d->ctrl_sem)))
+      d->post_ret_false = true;
+  }
+}
+
+static THREAD_RES semaphore_ctrl_fn(void *opaque)
+{
+  struct semaphore_data *d = reinterpret_cast<struct semaphore_data *>(opaque);
+  int pending = 0;
+  int i;
+
+  for(i = 0; i < NUM_WORK * REPEAT_TIMES; i++)
+  {
+    if(!platform_sem_wait(&(d->ctrl_sem)))
+      d->wait_ret_false = true;
+
+    // Consume finished work in-order (y4m2smzx does this)
+    pending++;
+    while(pending > 0)
+    {
+      if(!platform_mutex_lock(&(d->lock)))
+        d->lock_ret_false = true;
+
+      boolean ready = d->ready[d->input_idx];
+
+      if(!platform_mutex_unlock(&(d->lock)))
+        d->unlock_ret_false = true;
+
+      if(!ready)
+        break;
+
+      // Consume and prepare new "work"
+      d->buffer[d->input_idx]++;
+      d->ready[d->input_idx] = false;
+      d->input_idx++;
+      if(d->input_idx >= NUM_WORK)
+        d->input_idx = 0;
+
+      if(!platform_sem_post(&(d->worker_sem)))
+        d->post_ret_false = true;
+
+      pending--;
+    }
+  }
+  // Wait for all workers to finish.
+  for(i = 0; i < NUM_WORK; i++)
+  {
+    if(!platform_sem_wait(&(d->ctrl_sem)))
+      d->wait_ret_false = true;
+  }
+
+  if(!platform_mutex_lock(&(d->lock)))
+    d->lock_ret_false = true;
+  d->need_exit = true;
+  if(!platform_mutex_unlock(&(d->lock)))
+    d->unlock_ret_false = true;
+
+  for(i = 0; i < NUM_THREADS; i++)
+  {
+    if(!platform_sem_post(&(d->worker_sem)))
+      d->post_ret_false = true;
+  }
+  THREAD_RETURN;
+}
+
+UNITTEST(Semaphore)
+{
+  platform_thread workers[NUM_THREADS];
+  platform_thread ctrl;
+  struct semaphore_data d{};
+  boolean ret;
+  int i;
+
+  ret = platform_mutex_init(&(d.lock));
+  ASSERT(ret, "failed to init lock");
+  ret = platform_sem_init(&(d.worker_sem), 0);
+  ASSERT(ret, "failed to init worker semaphore");
+  ret = platform_sem_init(&(d.ctrl_sem), NUM_WORK);
+  ASSERT(ret, "failed to init ctrl semaphore");
+
+  for(i = 0; i < NUM_THREADS; i++)
+  {
+    ret = platform_thread_create(&workers[i], semaphore_worker_fn, &d);
+    ASSERT(ret, "worker %d", i);
+  }
+  for(i = 0; i < NUM_WORK; i++)
+  {
+    ASSERTEQ(d.buffer[i], 0, "worker did not block");
+    d.ready[i] = true;
+  }
+  ret = platform_thread_create(&ctrl, semaphore_ctrl_fn, &d);
+  ASSERT(ret, "ctrl");
+
+  platform_thread_join(&ctrl);
+  for(i = 0; i < NUM_THREADS; i++)
+    platform_thread_join(&workers[i]);
+
+  platform_sem_destroy(&(d.worker_sem));
+  platform_sem_destroy(&(d.ctrl_sem));
+  platform_mutex_destroy(&(d.lock));
+
+  for(i = 0; i < NUM_WORK; i++)
+    ASSERTEQ(d.buffer[i], REPEAT_TIMES * (REPEAT_TIMES + 1), "incorrect value");
+
+  ASSERTEQ(d.lock_ret_false, false, "lock() returned false");
+  ASSERTEQ(d.unlock_ret_false, false, "unlock() returned false");
+  ASSERTEQ(d.wait_ret_false, false, "wait() returned false");
+  ASSERTEQ(d.post_ret_false, false, "post() returned false");
+}

--- a/unit/thread_win32.cpp
+++ b/unit/thread_win32.cpp
@@ -1,0 +1,27 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2023 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * Perform thread tests with the Win32 fallback implementation for utils.
+ */
+
+#define WIN32_FALLBACK_TEST
+
+#include "Unit.hpp"
+#include "thread.hpp"


### PR DESCRIPTION
* Added semaphores to all thread.h implementations that support them.
* Added boolean return values to the following functions: platform_mutex_init, platform_mutex_destroy, platform_cond_init, platform_cond_destroy, platform_thread_create, platform_thread_join.
* Minor style/function order tidying.
* Added a Win32-based thread.h implementation for utilities on Windows, which do not link SDL. This should be used for utilities only as it does not support condition variables and its semaphores are slow.
* Added a set of unit tests for thread.h which are probably very bad!