### PR TITLE
Sample the system time at most once per Robotic command.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -166,6 +166,10 @@ USERS
   and >>> will return 0 if the left operand is positive or -1 if
   the left operand is negative. The old behavior of the bitshift
   operators for these shift values was architecture dependent.
++ The date and time for the Robotic date and time counters is
+  now sampled once per command maximum. When multiple date/time
+  counters are read in the same command, they are guaranteed to
+  represent the same time.
 + libxmp playback improvements for GDM, AMF, and OctaMED modules
   as well as general stability improvements.
 + ccv and png2smzx now both support the following image formats:
@@ -219,6 +223,9 @@ DEVELOPERS
 + Updated libxmp to 4.5.0.
 + Relicensed ccv from GPL 3 to GPL 2+ to match the rest of MZX.
   (Lancer-X)
++ If available, GetSystemTimePreciseAsFileTime and clock_gettime
+  are now used to calculate the system clock time.
++ If available, SDL_GetTicks64 is now used by get_ticks().
 
 
 November 22nd, 2020 - MZX 2.92f

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -113,6 +113,7 @@ core_cobjs := \
   ${core_obj}/legacy_robot.o      \
   ${core_obj}/legacy_world.o      \
   ${core_obj}/mzm.o               \
+  ${core_obj}/platform_time.o     \
   ${core_obj}/render.o            \
   ${core_obj}/robot.o             \
   ${core_obj}/run_robot.o         \

--- a/src/counter.c
+++ b/src/counter.c
@@ -29,12 +29,6 @@
 #include <limits.h>
 #include <time.h>
 
-#ifdef _MSC_VER
-#include "win32time.h"
-#else
-#include <sys/time.h>
-#endif /* _MSC_VER */
-
 #include "board.h"
 #include "configure.h"
 #include "counter.h"
@@ -46,6 +40,7 @@
 #include "graphics.h"
 #include "idarray.h"
 #include "idput.h"
+#include "platform.h"
 #include "rasm.h"
 #include "robot.h"
 #include "sprite.h"
@@ -1292,66 +1287,68 @@ static void timereset_write(struct world *mzx_world,
   mzx_world->current_board->time_limit = CLAMP(value, 0, 32767);
 }
 
-static struct tm *system_time(void)
+static void refresh_time(struct world *mzx_world)
 {
-  static struct tm err;
-  struct timeval tv;
-  time_t e_time;
-  struct tm *t;
+  if(!(mzx_world->command_cache & COMMAND_CACHE_CURRENT_TIME))
+  {
+    mzx_world->command_cache |= COMMAND_CACHE_CURRENT_TIME;
 
-  if(!gettimeofday(&tv, NULL))
-    e_time = tv.tv_sec;
-  else
-    e_time = time(NULL);
+    memset(&(mzx_world->current_time), 0, sizeof(mzx_world->current_time));
+    mzx_world->current_time_epoch = 0;
+    mzx_world->current_time_nano = 0;
 
-  // If localtime returns NULL, return a tm with all zeros instead of crashing.
-  t = localtime(&e_time);
-  return t ? t : &err;
+    platform_system_time(&(mzx_world->current_time),
+     &(mzx_world->current_time_epoch), &(mzx_world->current_time_nano));
+  }
 }
 
 static int date_day_read(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int id)
 {
-  return system_time()->tm_mday;
+  refresh_time(mzx_world);
+  return mzx_world->current_time.tm_mday;
 }
 
 static int date_year_read(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int id)
 {
-  return system_time()->tm_year + 1900;
+  refresh_time(mzx_world);
+  return mzx_world->current_time.tm_year + 1900;
 }
 
 static int date_month_read(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int id)
 {
-  return system_time()->tm_mon + 1;
+  refresh_time(mzx_world);
+  return mzx_world->current_time.tm_mon + 1;
 }
 
 static int time_hours_read(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int id)
 {
-  return system_time()->tm_hour;
+  refresh_time(mzx_world);
+  return mzx_world->current_time.tm_hour;
 }
 
 static int time_minutes_read(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int id)
 {
-  return system_time()->tm_min;
+  refresh_time(mzx_world);
+  return mzx_world->current_time.tm_min;
 }
 
 static int time_seconds_read(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int id)
 {
-  return system_time()->tm_sec;
+  refresh_time(mzx_world);
+  return mzx_world->current_time.tm_sec;
 }
 
 static int time_millis_read(struct world *mzx_world,
  const struct function_counter *counter, const char *name, int id)
 {
-  struct timeval tv;
-  if(!gettimeofday(&tv, NULL))
-    return (tv.tv_usec / 1000) % 1000;
-  return 0;
+  refresh_time(mzx_world);
+  return mzx_world->current_time_nano / 1000000;
 }
 
 static int random_seed_read(struct world *mzx_world,

--- a/src/platform.h
+++ b/src/platform.h
@@ -65,11 +65,14 @@ int real_main(int argc, char *argv[]);
 #endif
 
 #include <stdint.h>
+#include <time.h>
 
 CORE_LIBSPEC void delay(uint32_t ms);
 CORE_LIBSPEC uint64_t get_ticks(void);
 CORE_LIBSPEC boolean platform_init(void);
 CORE_LIBSPEC void platform_quit(void);
+CORE_LIBSPEC boolean platform_system_time(struct tm *tm,
+ int64_t *epoch, int32_t *nano);
 
 __M_END_DECLS
 

--- a/src/platform_sdl.c
+++ b/src/platform_sdl.c
@@ -53,7 +53,11 @@ void delay(uint32_t ms)
 
 uint64_t get_ticks(void)
 {
+#if SDL_VERSION_ATLEAST(2,0,18)
+  return SDL_GetTicks64();
+#else
   return SDL_GetTicks();
+#endif
 }
 
 #ifdef __WIN32__

--- a/src/platform_time.c
+++ b/src/platform_time.c
@@ -1,0 +1,187 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2023 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "platform.h"
+#include "util.h"
+
+#include <time.h>
+
+#ifndef _MSC_VER
+#include <unistd.h> /* _POSIX_TIMERS */
+#include <sys/time.h> /* gettimeofday */
+#endif
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <SDL.h>
+
+#define WINDOWS_TO_UNIX_SECONDS 11644473600LL
+#define WINDOWS_TO_UNIX_100NS   10000000LL
+
+static void convert_timestamp(int64_t *epoch, int32_t *nano,
+ DWORD high, DWORD low)
+{
+  uint64_t full = ((uint64_t)high << 32) | (uint64_t)low;
+
+  *epoch = (full / WINDOWS_TO_UNIX_100NS) - WINDOWS_TO_UNIX_SECONDS;
+  *nano = (full % WINDOWS_TO_UNIX_100NS) * 100;
+}
+
+/**
+ * Get the system timestamp using Win32 function calls directly.
+ */
+static boolean system_time_win32(int64_t *epoch, int32_t *nano)
+{
+  static void (WINAPI *_GetSystemTimePreciseAsFileTime)(LPFILETIME) = NULL;
+  static boolean init = false;
+  FILETIME ft;
+
+  if(!init)
+  {
+    void *dll = SDL_LoadObject("Kernel32.dll");
+    if(dll)
+    {
+      union dso_fn_ptr_ptr tmp;
+      tmp.in = (dso_fn **)&_GetSystemTimePreciseAsFileTime;
+      *(tmp.value) = SDL_LoadFunction(dll, "GetSystemTimePreciseAsFileTime");
+      SDL_UnloadObject(dll);
+    }
+    init = true;
+  }
+
+  if(_GetSystemTimePreciseAsFileTime)
+  {
+    /* Windows 8, precise to 100ns. */
+    _GetSystemTimePreciseAsFileTime(&ft);
+  }
+  else
+  {
+    /* Windows 95, NT 3.5; precision not well defined. */
+    GetSystemTimeAsFileTime(&ft);
+  }
+
+  convert_timestamp(epoch, nano, ft.dwHighDateTime, ft.dwLowDateTime);
+  return true;
+}
+#endif /* _WIN32 */
+
+/**
+ * Get the system timestamp via `clock_gettime(CLOCK_REALTIME)`.
+ * Disable for MinGW (implemented by winpthread); not supported by MSVC.
+ */
+static boolean system_time_clock_gettime(int64_t *epoch, int32_t *nano)
+{
+#if !defined(_WIN32) && defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0
+  struct timespec tp;
+
+  if(clock_gettime(CLOCK_REALTIME, &tp))
+    return false;
+
+  *epoch = tp.tv_sec;
+  *nano = (unsigned long)tp.tv_nsec % 1000000000;
+  return true;
+#else
+  return false;
+#endif
+}
+
+/**
+ * Get the system timestamp via `gettimeofday`, which exists in most libc
+ * implementations. Safe for MinGW (implemented by MinGW), not for MSVC.
+ */
+static boolean system_time_gettimeofday(int64_t *epoch, int32_t *nano)
+{
+#ifndef _MSC_VER
+  struct timeval tv;
+
+  if(gettimeofday(&tv, NULL))
+    return false;
+
+  *epoch = tv.tv_sec;
+  *nano = ((unsigned long)tv.tv_usec % 1000000) * 1000;
+  return true;
+#else
+  return false;
+#endif
+}
+
+/**
+ * Use `time` as a fallback :(. Modern implementations, even for 32-bit
+ * platforms, typically use a 64-bit `time_t` now.
+ */
+static void system_time_fallback(int64_t *epoch, int32_t *nano)
+{
+  *epoch = time(NULL);
+  *nano = 0;
+}
+
+/**
+ * Get the system clock time in the system clock timezone.
+ * All parameters must be present and will be written to.
+ *
+ * @param tm    destination for `localtime` info. May be 0-filled on failure.
+ * @param epoch destination for seconds since Jan 1 1970.
+ * @param nano  destination for nanoseconds since Jan 1 1970.
+ * @return      `true` if all fields are filled and have microsecond precision,
+ *              otherwise `false`. Nanosecond precision is not reliable.
+ */
+boolean platform_system_time(struct tm *tm, int64_t *epoch, int32_t *nano)
+{
+  struct tm *local;
+  boolean ret;
+  time_t tmp;
+
+#ifdef _WIN32
+  if(system_time_win32(epoch, nano))
+  {
+    ret = true;
+  }
+  else
+#endif
+
+  if(system_time_clock_gettime(epoch, nano))
+  {
+    ret = true;
+  }
+  else
+
+  if(system_time_gettimeofday(epoch, nano))
+  {
+    ret = true;
+  }
+  else
+  {
+    system_time_fallback(epoch, nano);
+    ret = false;
+  }
+
+  tmp = *epoch;
+  local = localtime(&tmp);
+  if(local)
+  {
+    memcpy(tm, local, sizeof(struct tm));
+    return ret;
+  }
+  else
+  {
+    memset(tm, 0, sizeof(struct tm));
+    return false;
+  }
+}

--- a/src/robot.c
+++ b/src/robot.c
@@ -2532,6 +2532,7 @@ static void display_robot_line(struct world *mzx_world, char *program,
   char *next;
   int scroll_base_color = mzx_world->scroll_base_color;
   int scroll_arrow_color = mzx_world->scroll_arrow_color;
+  mzx_world->command_cache = 0;
 
   switch(program[1])
   {

--- a/src/world_struct.h
+++ b/src/world_struct.h
@@ -25,6 +25,8 @@
 __M_BEGIN_DECLS
 
 #include <stdio.h>
+#include <stdint.h>
+#include <time.h>
 
 #include "board_struct.h"
 #include "robot_struct.h"
@@ -33,6 +35,8 @@ __M_BEGIN_DECLS
 
 #include "io/vfile.h"
 #include "audio/sfx.h"
+
+#define COMMAND_CACHE_CURRENT_TIME (1 << 0)
 
 enum change_game_state_value
 {
@@ -196,6 +200,8 @@ struct world
   int mid_prefix;
   // 1-3 normal 5-7 is 1-3 but from a REL LAST cmd
   int last_prefix;
+  // Flags for data that persists during a command (keep in the prefix cache line).
+  int command_cache;
 
   // Lets the get counter routines indiciate to the caller
   // that the result is not a typical counter but something
@@ -233,6 +239,11 @@ struct world
   // An array for game2.cpp
   char *update_done;
   int update_done_size;
+
+  // Cached time for the current robot command.
+  struct tm current_time;
+  int64_t current_time_epoch;
+  int32_t current_time_nano;
 };
 
 __M_END_DECLS


### PR DESCRIPTION
* The system time is now stored for the duration of the current Robotic command the first time it is requested. This makes usage of multiple date/time counters in the same command atomic, fixing rare bugs when combining multiple counters.
* System time sampling has been moved to platform_time.c.
* If available at runtime, all Windows builds now use `GetSystemTimePreciseAsFileTime` to get the system time. If not, they directly poll `GetSystemTimeAsFileTime` instead of `gettimeofday`.
* If available at compile time, all POSIX builds now use `clock_gettime` to get the system time. If not, they fall back to `gettimeofday` or `time`.
* If available at compile time, all SDL builds now use `SDL_GetTicks64` to get the ticks since initialization count. If not, they fall back to `SDL_GetTicks`.
* Very small performance improvements in `run_robot`.

Tentatively marking the system time atomicity bug as having a DOS introduction since each counter access is an individual `getdate` or `gettime` call. MegaZeux 2.80 similarly started the use of `time`+`localtime` for each counter call, which is most likely affected as well but less observable.