### PR TITLE
Performance tweaks for Robotic execution.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -232,6 +232,8 @@ DEVELOPERS
 + If available, GetSystemTimePreciseAsFileTime and clock_gettime
   are now used to calculate the system clock time.
 + If available, SDL_GetTicks64 is now used by get_ticks().
++ Minor performance improvements for run_robot, is_string, and
+  find_function_counter.
 
 
 November 22nd, 2020 - MZX 2.92f

--- a/src/counter.c
+++ b/src/counter.c
@@ -40,6 +40,7 @@
 #include "graphics.h"
 #include "idarray.h"
 #include "idput.h"
+#include "memcasecmp.h"
 #include "platform.h"
 #include "rasm.h"
 #include "robot.h"
@@ -2841,7 +2842,7 @@ int match_function_counter(const char *dest, const char *src)
 static const struct function_counter *find_function_counter(const char *name)
 {
   const struct function_counter *base = builtin_counters;
-  int first_letter = tolower((int)name[0]) * 2;
+  int first_letter = memtolower((unsigned char)name[0]) * 2;
   int bottom, top, middle;
   int cmpval;
 

--- a/src/str.c
+++ b/src/str.c
@@ -1465,30 +1465,6 @@ void dec_string_int(struct world *mzx_world, const char *name, int value,
   }
 }
 
-boolean is_string(char *buffer)
-{
-  size_t namelen, i;
-
-  // String doesn't start with $, that's an immediate reject
-  if(buffer[0] != '$')
-    return false;
-
-  // We need to stub out any part of the buffer that describes a
-  // string offset or size constraint. This is because after the
-  // offset or size characters, there may be an expression which
-  // may use the .length operator on the same (or different)
-  // string. We must not consider such composites to be invalid.
-  namelen = strcspn(buffer, "#+");
-
-  // For something to be a string it must not have a . in its name
-  for(i = 0; i < namelen; i++)
-    if(buffer[i] == '.')
-      return false;
-
-  // Valid string
-  return true;
-}
-
 static boolean wildcard_char_is_escapable(unsigned char c)
 {
   return (c == '%') || (c == '?') || (c == '\\');

--- a/src/str.h
+++ b/src/str.h
@@ -37,13 +37,32 @@ __M_BEGIN_DECLS
 // Strings cannot be longer than 4M (orig 1M)
 #define MAX_STRING_LEN (1 << 22)
 
+static inline boolean is_string(const char *buffer)
+{
+  size_t namelen;
+
+  // String identifiers always begin with '$'.
+  if(buffer[0] != '$')
+    return false;
+
+  /* String identifiers can contain three different delimiters:
+   * '+' indicates a string offset, which has a string value.
+   * '#' indicates a string length limit, which has a string value.
+   * '.' indicates a string subscript or length, which has a numeric value.
+   *     A subscript may be followed by a '#' to indicate integer width.
+   *
+   * If a '.' is the first delimiter found, the identifier is not a string.
+   */
+  namelen = strcspn(buffer, "#+.");
+  return buffer[namelen] != '.';
+}
+
 CORE_LIBSPEC int get_string(struct world *mzx_world, char *name_buffer,
  struct string *dest, int id);
 CORE_LIBSPEC int set_string(struct world *mzx_world, char *name_buffer,
  struct string *src, int id);
 CORE_LIBSPEC struct string *new_string(struct world *mzx_world,
  const char *name, size_t length, int id);
-CORE_LIBSPEC boolean is_string(char *buffer);
 CORE_LIBSPEC void sort_string_list(struct string_list *string_list);
 CORE_LIBSPEC void string_list_size(struct string_list *string_list,
  size_t *list_size, size_t *table_size, size_t *strings_size);


### PR DESCRIPTION
* Replaced tolower() usage in find_function_counter() with the faster memtolower() from memcasecmp.h.
* Optimized is_string() check for '.' by including it into the strcspn call. The new smaller is_string() is now inlineable.
* Revised the run_robot() hang detection improvement from 9ca3c82. It now masks lines_run by 0xffff, which is somehow faster!
* Partially reverted the debugger changes from 9ca3c82 since they didn't help that much or possibly made things slower.