### PR TITLE
Fix building with MinGW on Fedora.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ arch/dreamcast/*.o
 arch/emscripten/web/mzxrun_web.js
 arch/emscripten/web/node_modules
 arch/emscripten/web/package-lock.json
+arch/mingw/pefix
 arch/mingw/pefix.d
 arch/mingw/pefix.exe
 arch/mingw/pefix.o

--- a/Makefile
+++ b/Makefile
@@ -366,14 +366,20 @@ endif # PLATFORM=mingw
 
 #
 # The stack protector is optional and is generally only built for Linux/BSD and
-# Mac OS X. Windows and most embedded platforms currently disable this.
+# Mac OS X. It also works on Windows. GCC's -fstack-protector-strong is
+# preferred when available due to better performance.
 #
 ifeq (${BUILD_STACK_PROTECTOR},1)
+ifeq (${HAS_F_STACK_PROTECTOR_STRONG},1)
+CFLAGS   += -fstack-protector-strong
+CXXFLAGS += -fstack-protector-strong
+else
 ifeq (${HAS_F_STACK_PROTECTOR},1)
 CFLAGS   += -fstack-protector-all
 CXXFLAGS += -fstack-protector-all
 else
 $(warning stack protector not supported, ignoring.)
+endif
 endif
 endif
 

--- a/arch/compat.inc
+++ b/arch/compat.inc
@@ -92,6 +92,11 @@ ifeq ($(GCC_VER_GE_4_6),0)
 HAS_W_NO_UNUSED_BUT_SET_VARIABLE ?= 1
 endif
 
+GCC_VER_GE_4_9   := ${shell test ${GCC_VER} -ge 40900; echo $$?}
+ifeq (${GCC_VER_GE_4_9},0)
+HAS_F_STACK_PROTECTOR_STRONG ?= 1
+endif
+
 GCC_VER_GE_7     := ${shell test ${GCC_VER} -ge 70000; echo $$?}
 ifeq ($(GCC_VER_GE_7),0)
 HAS_W_NO_FORMAT_TRUNCATION ?= 1
@@ -134,4 +139,9 @@ CLANG_VER_GE_3_3 := ${shell test "${CLANG_VER}" -ge 30300; echo $$?}
 ifeq (${CLANG_VER_GE_3_3},0)
 HAS_CXX_11 ?= 1
 endif
+
+CLANG_VER_GE_3_5 := ${shell test "${CLANG_VER}" -ge 30500; echo $$?}
+ifeq (${CLANG_VER_GE_3_3},0)
+HAS_F_STACK_PROTECTOR_STRONG ?= 1
 endif
+endif # clang

--- a/arch/mingw/Makefile.in
+++ b/arch/mingw/Makefile.in
@@ -33,6 +33,10 @@ ARCH_LDFLAGS += -static-libstdc++ -static-libgcc
 LINK_STATIC_IF_MIXED  ?= -Wl,-Bstatic
 LINK_DYNAMIC_IF_MIXED ?= -Wl,-Bdynamic
 
+# In Fedora, libmingwex dirent is compiled with stack protector now, so
+# libssp must manually be linked (and therefore libmingwex too).
+ARCH_LIBS += ${LINK_STATIC_IF_MIXED} -lmingwex -lssp
+
 # OpenGL must be linked to MZX
 core_ldflags += -lopengl32
 

--- a/config.sh
+++ b/config.sh
@@ -769,16 +769,6 @@ if [ "$SDL" = "false" ] && [ "$EGL" = "false" ]; then
 fi
 
 #
-# The stack protector may cause issues with various C++ features (platform
-# matrix claims it breaks exceptions) in some versions of MinGW. This hasn't
-# been verified (and MZX doesn't use exceptions), but for now just disable it.
-#
-if [ "$PLATFORM" = "mingw" ]; then
-	echo "Force-disabling stack protector on Windows."
-	STACK_PROTECTOR="false"
-fi
-
-#
 # Force-disable features unnecessary on Emscripten.
 #
 if [ "$PLATFORM" = "emscripten" ]; then

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -453,7 +453,7 @@ core_target := ${DSOPRE}core${DSOPOST}
 ${core_target}: ${core_objs}
 	$(if ${V},,@echo "  LINK    " $@)
 	${LINK_CC} ${DSOLDFLAGS} -o $@ ${core_objs} ${LDFLAGS} \
-	  ${DSOSONAME}$@ ${core_ldflags}
+	  ${DSOSONAME}$@ ${core_ldflags} ${ARCH_LIBS}
 
 core_target_clean:
 	$(if ${V},,@echo "  RM      " ${core_target} ${core_target}.debug)
@@ -488,11 +488,11 @@ ${mzx}: ${core_target} ${editor_target} ${mzx_objs}
 ifeq (${BUILD_MODULAR},1)
 	${LINK_CC} ${mzx_objs} -o ${mzx} ${ARCH_EXE_LDFLAGS} ${LDFLAGS} \
 	  ${DSORPATH} -L. -lcore -leditor \
-	  ${mzx_ldflags}
+	  ${mzx_ldflags} ${ARCH_LIBS}
 else
 	${LINK_CC} ${mzx_objs} ${core_target} ${editor_target} \
 	  -o ${mzx} ${ARCH_EXE_LDFLAGS} ${LDFLAGS} \
-	  ${core_ldflags} ${editor_ldflags}
+	  ${core_ldflags} ${editor_ldflags} ${ARCH_LIBS}
 endif
 
 mzx_clean: editor_clean
@@ -523,10 +523,10 @@ ${mzxrun}: ${core_target} ${mzxrun_objs}
 	$(if ${V},,@echo "  LINK    " ${mzxrun})
 ifeq (${BUILD_MODULAR},1)
 	${LINK_CC} ${mzxrun_objs} -o ${mzxrun} ${ARCH_EXE_LDFLAGS} ${LDFLAGS} \
-	  ${DSORPATH} -L. -lcore ${mzxrun_ldflags}
+	  ${DSORPATH} -L. -lcore ${mzxrun_ldflags} ${ARCH_LIBS}
 else
 	${LINK_CC} ${mzxrun_objs} ${core_target} \
-	  -o ${mzxrun} ${ARCH_EXE_LDFLAGS} ${LDFLAGS} ${core_ldflags}
+	  -o ${mzxrun} ${ARCH_EXE_LDFLAGS} ${LDFLAGS} ${core_ldflags} ${ARCH_LIBS}
 endif
 
 else

--- a/src/editor/Makefile.in
+++ b/src/editor/Makefile.in
@@ -97,7 +97,7 @@ editor_target := ${DSOPRE}editor${DSOPOST}
 ${editor_target}: ${editor_objs} ${core_target}
 	$(if ${V},,@echo "  LINK    " $@)
 	${CC} ${DSOLDFLAGS} -o $@ ${editor_objs} ${editor_ldflags} \
-	  ${LDFLAGS} ${DSOSONAME}$@ ${DSORPATH} $(LINK_DYNAMIC_IF_MIXED) -L. -lcore
+	  ${LDFLAGS} ${DSOSONAME}$@ ${DSORPATH} $(LINK_DYNAMIC_IF_MIXED) -L. -lcore ${ARCH_LIBS}
 
 editor_target_clean:
 	$(if ${V},,@echo "  RM      " ${editor_target} ${editor_target}.debug)

--- a/src/utils/Makefile.in
+++ b/src/utils/Makefile.in
@@ -73,42 +73,42 @@ ${utils_obj}/%.o: ${utils_src}/%.c src/config.h
 ${checkres}: ${checkres_objs}
 	$(if ${V},,@echo "  LINK    " ${checkres})
 	${CC} ${checkres_objs} -o ${checkres} \
-	  ${ARCH_EXE_LDFLAGS} ${LDFLAGS} ${checkres_ldflags}
+	  ${ARCH_EXE_LDFLAGS} ${LDFLAGS} ${checkres_ldflags} ${ARCH_LIBS}
 
 ${downver}: ${downver_objs}
 	$(if ${V},,@echo "  LINK    " ${downver})
 	${CC} ${downver_objs} -o ${downver} \
-	  ${ARCH_EXE_LDFLAGS} ${LDFLAGS} ${downver_ldflags}
+	  ${ARCH_EXE_LDFLAGS} ${LDFLAGS} ${downver_ldflags} ${ARCH_LIBS}
 
 ${hlp2html}: ${hlp2html_objs}
 	$(if ${V},,@echo "  LINK    " ${hlp2html})
 	${CC} ${hlp2html_objs} -o ${hlp2html} \
-	  ${ARCH_EXE_LDFLAGS} ${LDFLAGS}
+	  ${ARCH_EXE_LDFLAGS} ${LDFLAGS} ${ARCH_LIBS}
 
 ${hlp2txt}: ${hlp2txt_objs}
 	$(if ${V},,@echo "  LINK    " ${hlp2txt})
 	${CC} ${hlp2txt_objs} -o ${hlp2txt} \
-	  ${ARCH_EXE_LDFLAGS} ${LDFLAGS}
+	  ${ARCH_EXE_LDFLAGS} ${LDFLAGS} ${ARCH_LIBS}
 
 ${txt2hlp}: ${txt2hlp_objs}
 	$(if ${V},,@echo "  LINK    " ${txt2hlp})
 	${CC} ${txt2hlp_objs} -o ${txt2hlp} \
-	  ${ARCH_EXE_LDFLAGS} ${LDFLAGS}
+	  ${ARCH_EXE_LDFLAGS} ${LDFLAGS} ${ARCH_LIBS}
 
 ${png2smzx}: ${png2smzx_objs}
 	$(if ${V},,@echo "  LINK    " ${png2smzx})
 	${CC} ${png2smzx_objs} -o ${png2smzx} \
-	  ${ARCH_EXE_LDFLAGS} ${LDFLAGS} ${png2smzx_ldflags}
+	  ${ARCH_EXE_LDFLAGS} ${LDFLAGS} ${png2smzx_ldflags} ${ARCH_LIBS}
 
 ${y4m2smzx}: ${y4m2smzx_objs}
 	$(if ${V},,@echo "  LINK    " ${y4m2smzx})
 	${CC} ${y4m2smzx_objs} -o ${y4m2smzx} \
-	  ${ARCH_EXE_LDFLAGS} ${LDFLAGS}
+	  ${ARCH_EXE_LDFLAGS} ${LDFLAGS} ${ARCH_LIBS}
 
 ${ccv}: ${ccv_objs}
 	$(if ${V},,@echo "  LINK    " ${ccv})
 	${CC} ${ccv_objs} -o ${ccv} \
-	  ${ARCH_EXE_LDFLAGS} ${LDFLAGS} ${ccv_ldflags}
+	  ${ARCH_EXE_LDFLAGS} ${LDFLAGS} ${ccv_ldflags} ${ARCH_LIBS}
 
 utils: $(filter-out $(wildcard ${utils_obj}), ${utils_obj})
 

--- a/src/utils/Makefile.in
+++ b/src/utils/Makefile.in
@@ -14,7 +14,7 @@ utils_obj = src/utils/.build
 
 # Some core objects are required for file format purposes.
 # Define UTILS_LIBSPEC so these properly link.
-utils_cflags := ${LIBPNG_CFLAGS} -DUTILS_LIBSPEC=
+utils_cflags := ${LIBPNG_CFLAGS} ${PTHREAD_CFLAGS} -DUTILS_LIBSPEC=
 
 zip_objs  := ${io_obj}/vio.o ${io_obj}/zip.o ${io_obj}/zip_stream.o
 img_objs  := ${utils_obj}/image_file.o ${utils_obj}/image_gif.o
@@ -50,6 +50,10 @@ png2smzx_ldflags := ${img_flags}
 
 y4m2smzx := ${utils_src}/y4m2smzx${BINEXT}
 y4m2smzx_objs := ${utils_obj}/y4m2smzx.o ${utils_obj}/smzxconv.o ${utils_obj}/y4m.o
+y4m2smzx_ldflags :=
+ifeq (${PTHREAD},1)
+y4m2smzx_ldflags += ${PTHREAD_LDFLAGS}
+endif
 
 ccv := ${utils_src}/ccv${BINEXT}
 ccv_objs := ${utils_obj}/ccv.o
@@ -103,7 +107,7 @@ ${png2smzx}: ${png2smzx_objs}
 ${y4m2smzx}: ${y4m2smzx_objs}
 	$(if ${V},,@echo "  LINK    " ${y4m2smzx})
 	${CC} ${y4m2smzx_objs} -o ${y4m2smzx} \
-	  ${ARCH_EXE_LDFLAGS} ${LDFLAGS} ${ARCH_LIBS}
+	  ${ARCH_EXE_LDFLAGS} ${LDFLAGS} ${y4m2smzx_ldflags} ${ARCH_LIBS}
 
 ${ccv}: ${ccv_objs}
 	$(if ${V},,@echo "  LINK    " ${ccv})

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -126,6 +126,12 @@ unit_cflags  += ${LIBPNG_CFLAGS}
 unit_ldflags += ${LIBPNG_LDFLAGS}
 endif
 
+# Required for threading test.
+ifeq (${PTHREAD},1)
+unit_cflags  += ${PTHREAD_CFLAGS}
+unit_ldflags += ${PTHREAD_LDFLAGS}
+endif
+
 # System libs need to be last in the search order.
 unit_ldflags += ${ARCH_LIBS}
 

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -126,6 +126,9 @@ unit_cflags  += ${LIBPNG_CFLAGS}
 unit_ldflags += ${LIBPNG_LDFLAGS}
 endif
 
+# System libs need to be last in the search order.
+unit_ldflags += ${ARCH_LIBS}
+
 ifneq (${HAS_CXX_11},1)
 
 unit unittest:


### PR DESCRIPTION
libmingwex and several prebuilt dependencies as packaged by Fedora requires libssp. MinGW doesn't automatically link statically it (:

Also adds -fstack-protector-strong support, enables the stack protector for MinGW, and fixes some missing pthread flags.