### PR TITLE
Enable screensaver by default and add disable_screensaver setting.

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -191,6 +191,12 @@
 
 # fullscreen = 1
 
+# Whether MZX should disable the screensaver (or similar) while running.
+# By default, MZX will instruct SDL to leave the screensaver on. This setting
+# currently only affects SDL 2+ ports.
+
+# disable_screensaver = 0
+
 # MZX can optionally display the text cursor to hint at the currently selected
 # UI element when applicable. Valid settings are 0 or "off" (doesn't display
 # or update the cursor position), 1 or "hidden" (doesn't display, but updates

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -203,6 +203,9 @@ USERS
   where the aforementioned files could break the zip format's
   internal field bounds.
 + Fixed loading of world/save/counters files over 4 GB.
++ Added disable_screensaver configuration option. MegaZeux now
+  leaves the screensaver enabled by default (fixes regression
+  caused by SDL 2.0.2+).
 - Removed GL4ES from the GLSL blacklist.
 - Removed 3DS CIA support. (asie)
 

--- a/src/configure.c
+++ b/src/configure.c
@@ -224,6 +224,7 @@ static const struct config_info user_conf_default =
   "",                           // opengl default scaling shader
   "",                           // sdl_render_driver
   CURSOR_MODE_HINT,             // cursor_hint_mode
+  SCREENSAVER_ENABLE,           // disable_screensaver
   true,                         // allow screenshots
 
   // Audio options
@@ -359,6 +360,13 @@ static const struct config_enum system_mouse_values[] =
 {
   { "0", 0 },
   { "1", 1 }
+};
+
+static const struct config_enum screensaver_disable_values[] =
+{
+  { "0", SCREENSAVER_ENABLE },
+  { "1", SCREENSAVER_DISABLE },
+  //{ "ingame", SCREENSAVER_DISABLE_IN_GAME }
 };
 
 #ifdef CONFIG_NETWORK
@@ -694,6 +702,14 @@ static void config_grab_mouse(struct config_info *conf, char *name,
  char *value, char *extended_data)
 {
   config_boolean(&conf->grab_mouse, value);
+}
+
+static void config_disable_screensaver(struct config_info *conf, char *name,
+ char *value, char *extended_data)
+{
+  int result;
+  if(config_enum(&result, value, screensaver_disable_values))
+    conf->disable_screensaver = result;
 }
 
 static void config_save_slots(struct config_info *conf, char *name,
@@ -1107,6 +1123,7 @@ static const struct config_entry config_options[] =
   { "audio_sample_rate", config_set_audio_freq, false },
   { "auto_decrypt_worlds", config_set_auto_decrypt_worlds, false },
   { "dialog_cursor_hints", config_set_dialog_cursor_hints, false },
+  { "disable_screensaver", config_disable_screensaver, false },
   { "enable_oversampling", config_enable_oversampling, false },
   { "enable_resizing", config_enable_resizing, false },
   { "force_bpp", config_force_bpp, false },

--- a/src/configure.h
+++ b/src/configure.h
@@ -72,6 +72,14 @@ enum cursor_mode_types
   NUM_CURSOR_MODE_TYPES
 };
 
+enum screensaver_disable_mode
+{
+  SCREENSAVER_ENABLE,
+  SCREENSAVER_DISABLE,
+  SCREENSAVER_DISABLE_IN_GAME,
+  NUM_SCREENSAVER_MODES
+};
+
 enum allow_cheats_type
 {
   ALLOW_CHEATS_NEVER,
@@ -116,6 +124,7 @@ struct config_info
   char gl_scaling_shader[32];
   char sdl_render_driver[16];
   enum cursor_mode_types cursor_hint_mode;
+  enum screensaver_disable_mode disable_screensaver;
   boolean allow_screenshots;
 
   // Audio options

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1684,6 +1684,7 @@ boolean init_video(struct config_info *conf, const char *caption)
   graphics.cursor_flipflop = 1;
   graphics.system_mouse = conf->system_mouse;
   graphics.grab_mouse = conf->grab_mouse;
+  graphics.disable_screensaver = conf->disable_screensaver;
 
   memset(&(graphics.text_video_layer), 0, sizeof(struct video_layer));
   graphics.text_video_layer.w = SCREEN_W;

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -215,6 +215,7 @@ struct graphics_data
   int gl_vsync;
   char gl_scaling_shader[32];
   char sdl_render_driver[16];
+  enum screensaver_disable_mode disable_screensaver;
 
   uint8_t default_charset[CHAR_SIZE * CHARSET_SIZE];
 

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -28,6 +28,17 @@
 
 CORE_LIBSPEC Uint32 sdl_window_id;
 
+#if SDL_VERSION_ATLEAST(2,0,0)
+static void sdl_set_screensaver_enabled(boolean enable)
+{
+  debug("SDL %s screensaver.\n", enable ? "enabling" : "disabling");
+  if(enable)
+    SDL_EnableScreenSaver();
+  else
+    SDL_DisableScreenSaver();
+}
+#endif
+
 int sdl_flags(int depth, boolean fullscreen, boolean fullscreen_windowed,
  boolean resize)
 {
@@ -460,6 +471,7 @@ boolean sdl_set_video_mode(struct graphics_data *graphics, int width,
   }
 
   sdl_window_id = SDL_GetWindowID(render_data->window);
+  sdl_set_screensaver_enabled(graphics->disable_screensaver == SCREENSAVER_ENABLE);
 
 #else // !SDL_VERSION_ATLEAST(2,0,0)
 
@@ -554,6 +566,7 @@ boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
   }
 
   sdl_window_id = SDL_GetWindowID(render_data->window);
+  sdl_set_screensaver_enabled(graphics->disable_screensaver == SCREENSAVER_ENABLE);
 
 #else // !SDL_VERSION_ATLEAST(2,0,0)
 

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -118,6 +118,12 @@ constexpr resample_mode INVALID<resample_mode>()
 }
 
 template<>
+constexpr screensaver_disable_mode INVALID<screensaver_disable_mode>()
+{
+  return NUM_SCREENSAVER_MODES;
+}
+
+template<>
 constexpr allow_cheats_type INVALID<allow_cheats_type>()
 {
   return NUM_ALLOW_CHEATS_TYPES;
@@ -678,6 +684,20 @@ UNITTEST(Settings)
   SECTION(grab_mouse)
   {
     TEST_ENUM("grab_mouse", conf->grab_mouse, boolean_data);
+  }
+
+  SECTION(disable_screensaver)
+  {
+    constexpr screensaver_disable_mode DEFAULT = INVALID<screensaver_disable_mode>();
+    static const config_test_single data[] =
+    {
+      { "0", SCREENSAVER_ENABLE },
+      { "1", SCREENSAVER_DISABLE },
+      { "ingame", DEFAULT },
+      { "fgdjiogjf", DEFAULT },
+      { "", DEFAULT },
+    };
+    TEST_ENUM("disable_screensaver", conf->disable_screensaver, data);
   }
 
   SECTION(save_slots)


### PR DESCRIPTION
* MegaZeux now leaves the screensaver enabled by default, same as 2.84X and under. SDL 2.0.2 and up disabled the screensaver by default, preventing Windows et al. from starting a screensaver or putting monitors to sleep.
* Added a new config option `disable_screensaver` which can be used to disable the screensaver, if that behavior is preferred.

Should close #367.