### PR TITLE
Patch Opal envelope, KSL bugs; add player compatibility for broken RAD v2 KSL.

### DIFF
--- a/contrib/rad/README.md
+++ b/contrib/rad/README.md
@@ -19,6 +19,13 @@ This is a modified version of the RAD 2.x player for MegaZeux. Included:
   will ignore processing an entire note when it encounters a line that would
   play a MIDI instrument, causing it to ignore effects and riffs.
 * Some -pedantic warning fixes.
+* Opal bugfixes from OpenMPT/libADLMIDI by JP Cimalando have been ported over:
+  * Fixed wrong KSL (key scale shift) values.
+  * Cases where attack/decay/release are not applied should not prevent envelope
+    state changes.
+  * Registers Ax/Bx should affect both channels in 4op mode. This issue does not
+    affect RAD since RAD implements its 4op algorithms that support detune in
+    2op mode.
 
 As the RAD player code is public domain, so are these modifications. If you find this
 useful, go ahead and use it.

--- a/contrib/rad/player20.cpp
+++ b/contrib/rad/player20.cpp
@@ -176,6 +176,7 @@ class RADPlayer {
         void                Init10(const void *tune);
         bool                UnpackNote10(uint8_t *&s);
         uint8_t *           SkipToLine10(uint8_t *trk, uint8_t linenum);
+        uint8_t             FixRadv21KSLVolume(uint8_t val);
         int                 LastPatternOrder;
         bool                Is10;
 
@@ -341,8 +342,11 @@ void RADPlayer::Init(const void *tune, void (*opl3)(void *, uint16_t, uint8_t), 
 
             for (int i = 0; i < 4; i++) {
                 uint8_t *op = inst.Operators[i];
-                for (int j = 0; j < 5; j++)
-                    op[j] = *s++;
+                op[0] = *s++;
+                op[1] = FixRadv21KSLVolume(*s++);
+                op[2] = *s++;
+                op[3] = *s++;
+                op[4] = *s++;
             }
 
         } else {
@@ -1485,6 +1489,19 @@ uint8_t *RADPlayer::SkipToLine10(uint8_t *trk, uint8_t linenum)
         }
     }
     return 0;
+}
+
+
+
+//==================================================================================================
+// KSL is handled different between RAD v1 / DOS RAD v2.1 and Windows/Mac RAD v2.1.
+// In DOS, since these are passed directly to the OPL3, KSL 1 is 3dB and KSL 2 is 1.5dB.
+// With Opal, these were originally reversed, so flip the KSL bits when loading RAD v2s.
+// -Lachesis
+//==================================================================================================
+uint8_t RADPlayer::FixRadv21KSLVolume(uint8_t val)
+{
+    return ((val & 0x80) >> 1) | ((val & 0x40) << 1) | (val & 0x3F);
 }
 
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -241,6 +241,7 @@ DEVELOPERS
   find_function_counter.
 + _FILE_OFFSET_BITS=64 is now used for 64-bit fseeko, ftello,
   readdir, and stat/fstat support for 32-bit Linux builds.
++ Applied various Opal fixes from OpenMPT.
 
 
 November 22nd, 2020 - MZX 2.92f


### PR DESCRIPTION
This patch ports fixes for Opal support for KSL (and a couple other things), which in turn fixes KSL in RAD v1 modules. RAD v2 modules are loaded with the KSL bits swapped to emulate Opal's broken KSL, so they work the same as before.

There's no correct way to handle KSL for RAD v2—DOS builds don't use Opal, so they produce modules with the KSL bits in the correct order. The official RAD v2s seem to have been made in the Windows or Mac ports because they rely on the wrong order.