### PR TITLE
Revert editor hide help default settings, enable show thing toggles.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -206,6 +206,9 @@ USERS
 + Added disable_screensaver configuration option. MegaZeux now
   leaves the screensaver enabled by default (fixes regression
   caused by SDL 2.0.2+).
++ editor_show_thing_toggles is now enabled by default.
+- board_editor_hide_help and robot_editor_hide_help are no
+  longer enabled by default for accessibility.
 - Removed GL4ES from the GLSL blacklist.
 - Removed 3DS CIA support. (asie)
 

--- a/src/editor/configure.c
+++ b/src/editor/configure.c
@@ -37,12 +37,12 @@ static struct editor_config_info editor_conf_backup;
 static const struct editor_config_info editor_conf_default =
 {
   // Board editor options
-  true,                         // board_editor_hide_help
+  false,                        // board_editor_hide_help
   false,                        // editor_space_toggles
   false,                        // editor_tab_focuses_view
   false,                        // editor_load_board_assets
   true,                         // editor_thing_menu_places
-  false,                        // editor_show_thing_toggles
+  true,                         // editor_show_thing_toggles
   4,                            // editor_show_thing_blink_speed
   100,                          // Undo history size
 
@@ -84,7 +84,7 @@ static const struct editor_config_info editor_conf_default =
   1,                            // default_invalid_status
   true,                         // disassemble_extras
   10,                           // disassemble_base
-  true,                         // robot_editor_hide_help
+  false,                        // robot_editor_hide_help
 
   // Backup options
   3,                            // backup_count


### PR DESCRIPTION
Making the editor menu/help display by default again for accessibility reasons. Also, enabling show thing toggles by default because it's better than the legacy behavior in pretty much every way.