### PR TITLE
Replace audio extension checks with format filter functions.

### DIFF
--- a/src/audio/audio.c
+++ b/src/audio/audio.c
@@ -263,6 +263,16 @@ void init_audio(struct config_info *conf)
   init_vorbis(conf);
 #endif
 
+#ifdef CONFIG_REALITY
+  init_reality(conf);
+#endif
+
+  // Generic module players may misidentify files due to the ambiguity of
+  // formats like Soundtracker MOD, so register them last.
+#ifdef CONFIG_XMP
+  init_xmp(conf);
+#endif
+
 #ifdef CONFIG_MODPLUG
   init_modplug(conf);
 #endif
@@ -271,16 +281,8 @@ void init_audio(struct config_info *conf)
   init_mikmod(conf);
 #endif
 
-#ifdef CONFIG_XMP
-  init_xmp(conf);
-#endif
-
 #ifdef CONFIG_OPENMPT
   init_openmpt(conf);
-#endif
-
-#ifdef CONFIG_REALITY
-  init_reality(conf);
 #endif
 
   audio_set_music_volume(conf->music_volume);

--- a/src/audio/audio_openmpt.c
+++ b/src/audio/audio_openmpt.c
@@ -255,6 +255,7 @@ static struct audio_stream *construct_openmpt_stream(vfile *vf,
   {
     openmpt_module_destroy(open_file);
     free(omp_stream);
+    free(row_tbl);
     return NULL;
   }
 

--- a/src/audio/audio_openmpt.c
+++ b/src/audio/audio_openmpt.c
@@ -28,6 +28,7 @@
 
 #include "../const.h"
 #include "../util.h"
+#include "../io/path.h"
 #include "../io/vio.h"
 
 #include <libopenmpt/libopenmpt.h>
@@ -229,91 +230,103 @@ static const struct openmpt_stream_callbacks omp_callbacks =
   omp_tell_fn
 };
 
-static struct audio_stream *construct_openmpt_stream(char *filename,
- uint32_t frequency, unsigned int volume, boolean repeat)
+static struct audio_stream *construct_openmpt_stream(vfile *vf,
+ const char *filename, uint32_t frequency, unsigned int volume, boolean repeat)
 {
-  vfile *input_file;
+  struct openmpt_stream *omp_stream;
+  struct sampled_stream_spec s_spec;
+  struct audio_stream_spec a_spec;
+  uint32_t *row_tbl;
   uint32_t row_pos;
   uint32_t ord;
   uint32_t i;
+  int row_tbl_size;
 
-  input_file = vfopen_unsafe(filename, "rb");
+  openmpt_module *open_file = openmpt_module_create2(omp_callbacks, vf,
+   &omp_log, NULL, NULL, NULL, NULL, NULL, NULL);
+  if(!open_file)
+    return NULL;
 
-  if(input_file)
+  row_tbl_size = openmpt_module_get_num_orders(open_file) + 1;
+
+  omp_stream = (struct openmpt_stream *)malloc(sizeof(struct openmpt_stream));
+  row_tbl = (uint32_t *)malloc(row_tbl_size * sizeof(uint32_t));
+  if(!omp_stream || !row_tbl)
   {
-    openmpt_module *open_file = openmpt_module_create2(omp_callbacks, input_file,
-     &omp_log, NULL, NULL, NULL, NULL, NULL, NULL);
-
-    vfclose(input_file);
-
-    if(open_file)
-    {
-      struct openmpt_stream *omp_stream = cmalloc(sizeof(struct openmpt_stream));
-      struct sampled_stream_spec s_spec;
-      struct audio_stream_spec a_spec;
-      omp_stream->module_data = open_file;
-
-      omp_stream->row_tbl_size = openmpt_module_get_num_orders(open_file) + 1;
-      omp_stream->row_tbl = malloc(sizeof(uint32_t) * omp_stream->row_tbl_size);
-
-      for(i = 0, row_pos = 0; i < omp_stream->row_tbl_size; i++)
-      {
-        omp_stream->row_tbl[i] = row_pos;
-        ord = openmpt_module_get_order_pattern(open_file, i);
-        if(i < omp_stream->row_tbl_size - 1)
-          row_pos += openmpt_module_get_pattern_num_rows(open_file, ord);
-      }
-
-      openmpt_module_set_render_param(omp_stream->module_data,
-       OPENMPT_MODULE_RENDER_INTERPOLATIONFILTER_LENGTH,
-       omp_get_resample_mode());
-
-      openmpt_module_set_repeat_count(omp_stream->module_data, -1);
-
-      memset(&a_spec, 0, sizeof(struct audio_stream_spec));
-      a_spec.mix_data     = omp_mix_data;
-      a_spec.set_volume   = omp_set_volume;
-      a_spec.set_repeat   = omp_set_repeat;
-      a_spec.set_order    = omp_set_order;
-      a_spec.set_position = omp_set_position;
-      a_spec.get_order    = omp_get_order;
-      a_spec.get_position = omp_get_position;
-      a_spec.get_length   = omp_get_length;
-      a_spec.destruct     = omp_destruct;
-
-      memset(&s_spec, 0, sizeof(struct sampled_stream_spec));
-      s_spec.set_frequency = omp_set_frequency;
-      s_spec.get_frequency = omp_get_frequency;
-
-      initialize_sampled_stream((struct sampled_stream *)omp_stream, &s_spec,
-       frequency, 2, false);
-
-      initialize_audio_stream((struct audio_stream *)omp_stream, &a_spec,
-       volume, repeat);
-
-      return (struct audio_stream *)omp_stream;
-    }
+    openmpt_module_destroy(open_file);
+    free(omp_stream);
+    return NULL;
   }
-  return NULL;
+
+  omp_stream->module_data = open_file;
+  omp_stream->row_tbl = row_tbl;
+  omp_stream->row_tbl_size = row_tbl_size;
+
+  for(i = 0, row_pos = 0; i < row_tbl_size; i++)
+  {
+    row_tbl[i] = row_pos;
+    ord = openmpt_module_get_order_pattern(open_file, i);
+    if(i < row_tbl_size - 1)
+      row_pos += openmpt_module_get_pattern_num_rows(open_file, ord);
+  }
+
+  openmpt_module_set_render_param(omp_stream->module_data,
+   OPENMPT_MODULE_RENDER_INTERPOLATIONFILTER_LENGTH,
+   omp_get_resample_mode());
+
+  openmpt_module_set_repeat_count(omp_stream->module_data, -1);
+
+  memset(&a_spec, 0, sizeof(struct audio_stream_spec));
+  a_spec.mix_data     = omp_mix_data;
+  a_spec.set_volume   = omp_set_volume;
+  a_spec.set_repeat   = omp_set_repeat;
+  a_spec.set_order    = omp_set_order;
+  a_spec.set_position = omp_set_position;
+  a_spec.get_order    = omp_get_order;
+  a_spec.get_position = omp_get_position;
+  a_spec.get_length   = omp_get_length;
+  a_spec.destruct     = omp_destruct;
+
+  memset(&s_spec, 0, sizeof(struct sampled_stream_spec));
+  s_spec.set_frequency = omp_set_frequency;
+  s_spec.get_frequency = omp_get_frequency;
+
+  initialize_sampled_stream((struct sampled_stream *)omp_stream, &s_spec,
+   frequency, 2, false);
+
+  initialize_audio_stream((struct audio_stream *)omp_stream, &a_spec,
+   volume, repeat);
+
+  vfclose(vf);
+  return (struct audio_stream *)omp_stream;
+}
+
+static boolean test_openmpt_stream(vfile *vf, const char *filename)
+{
+  /* TODO: OpenMPT doesn't have a way to whitelist individual formats yet,
+   * and having to add Symphonie/etc. support to libxmp because a package
+   * maintainer liked OpenMPT better doesn't sound fun, so filter by extension.
+   * This is not foolproof.
+   */
+  static const char * const ext_list[] =
+  {
+    "669", "amf", "dsm", "far", "gdm", "it", "med", "mod", "mtm",
+    "nst", "oct", "okt", "s3m", "stm", "ult", "wow", "xm"
+  };
+  ssize_t ext_pos = path_get_ext_offset(filename);
+  size_t i;
+  if(ext_pos < 0)
+    return false;
+
+  for(i = 0; i < ARRAY_SIZE(ext_list); i++)
+  {
+    if(!strcasecmp(filename + ext_pos + 1, ext_list[i]))
+      return true;
+  }
+  return false;
 }
 
 void init_openmpt(struct config_info *conf)
 {
-  audio_ext_register("669", construct_openmpt_stream);
-  audio_ext_register("amf", construct_openmpt_stream);
-  audio_ext_register("dsm", construct_openmpt_stream);
-  audio_ext_register("far", construct_openmpt_stream);
-  audio_ext_register("gdm", construct_openmpt_stream);
-  audio_ext_register("it", construct_openmpt_stream);
-  audio_ext_register("med", construct_openmpt_stream);
-  audio_ext_register("mod", construct_openmpt_stream);
-  audio_ext_register("mtm", construct_openmpt_stream);
-  audio_ext_register("nst", construct_openmpt_stream);
-  audio_ext_register("oct", construct_openmpt_stream);
-  audio_ext_register("okt", construct_openmpt_stream);
-  audio_ext_register("s3m", construct_openmpt_stream);
-  audio_ext_register("stm", construct_openmpt_stream);
-  audio_ext_register("ult", construct_openmpt_stream);
-  audio_ext_register("wow", construct_openmpt_stream);
-  audio_ext_register("xm", construct_openmpt_stream);
+  audio_ext_register(test_openmpt_stream, construct_openmpt_stream);
 }

--- a/src/audio/audio_vorbis.c
+++ b/src/audio/audio_vorbis.c
@@ -234,106 +234,120 @@ static const ov_callbacks vorbis_callbacks =
   vorbis_tell_fn,
 };
 
-static struct audio_stream *construct_vorbis_stream(char *filename,
- uint32_t frequency, unsigned int volume, boolean repeat)
+static void get_loopstart_loopend(struct vorbis_stream *v_stream,
+ OggVorbis_File *open_file)
 {
-  vfile *input_file;
   vorbis_comment *comment;
   int loopstart = -1;
   int looplength = -1;
   int loopend = -1;
   int i;
 
-  // Using a large file buffer at minimum is pretty much mandatory for OGGs to
-  // work on the 3DS and Wii U. Since 32k isn't much to ask for most platforms
-  // that can support OGGs in the first place, just unconditionally use it.
-  // TODO: VFS full file caching (useful for 3DS/Wii U, mandatory for DJGPP).
-  input_file = vfopen_unsafe_ext(filename, "rb", V_LARGE_BUFFER);
+  comment = ov_comment(open_file, -1);
+  if(!comment)
+    return;
 
-  if(input_file)
+  for(i = 0; i < comment->comments; i++)
   {
-    OggVorbis_File open_file;
+    if(!strncasecmp("loopstart=", comment->user_comments[i], 10))
+      loopstart = atoi(comment->user_comments[i] + 10);
+    else
 
-    if(!ov_open_callbacks(input_file, &open_file, NULL, 0, vorbis_callbacks))
-    {
-      vorbis_info *vorbis_file_info = ov_info(&open_file, -1);
+    if(!strncasecmp("loopend=", comment->user_comments[i], 8))
+      loopend = atoi(comment->user_comments[i] + 8);
+    else
 
-      // Surround OGGs not supported yet..
-      if(vorbis_file_info->channels <= 2)
-      {
-        struct vorbis_stream *v_stream = cmalloc(sizeof(struct vorbis_stream));
-        struct sampled_stream_spec s_spec;
-        struct audio_stream_spec a_spec;
-
-        v_stream->vorbis_file_handle = open_file;
-        v_stream->vorbis_file_info = vorbis_file_info;
-        v_stream->input_file = input_file;
-
-        v_stream->loop_start = 0;
-        v_stream->loop_end = 0;
-
-        comment = ov_comment(&open_file, -1);
-        if(comment)
-        {
-          for(i = 0; i < comment->comments; i++)
-          {
-            if(!strncasecmp("loopstart=", comment->user_comments[i], 10))
-              loopstart = atoi(comment->user_comments[i] + 10);
-            else
-
-            if(!strncasecmp("loopend=", comment->user_comments[i], 8))
-              loopend = atoi(comment->user_comments[i] + 8);
-            else
-
-            if(!strncasecmp("looplength=", comment->user_comments[i], 11))
-              looplength = atoi(comment->user_comments[i] + 11);
-          }
-
-          if(loopstart >= 0 && (looplength > 0 || loopend > loopstart))
-          {
-            v_stream->loop_start = loopstart;
-
-            // looplength takes priority since it's older and more "standard"
-            if(looplength > 0)
-              v_stream->loop_end = loopstart + looplength;
-            else
-              v_stream->loop_end = loopend;
-          }
-        }
-
-        memset(&a_spec, 0, sizeof(struct audio_stream_spec));
-        a_spec.mix_data       = vorbis_mix_data;
-        a_spec.set_volume     = vorbis_set_volume;
-        a_spec.set_repeat     = vorbis_set_repeat;
-        a_spec.set_position   = vorbis_set_position;
-        a_spec.set_loop_start = vorbis_set_loop_start;
-        a_spec.set_loop_end   = vorbis_set_loop_end;
-        a_spec.get_position   = vorbis_get_position;
-        a_spec.get_length     = vorbis_get_length;
-        a_spec.get_loop_start = vorbis_get_loop_start;
-        a_spec.get_loop_end   = vorbis_get_loop_end;
-        a_spec.destruct       = vorbis_destruct;
-
-        memset(&s_spec, 0, sizeof(struct sampled_stream_spec));
-        s_spec.set_frequency = vorbis_set_frequency;
-        s_spec.get_frequency = vorbis_get_frequency;
-
-        initialize_sampled_stream((struct sampled_stream *)v_stream, &s_spec,
-         frequency, v_stream->vorbis_file_info->channels, true);
-
-        initialize_audio_stream((struct audio_stream *)v_stream, &a_spec,
-         volume, repeat);
-
-        return (struct audio_stream *)v_stream;
-      }
-      ov_clear(&open_file);
-    }
-    vfclose(input_file);
+    if(!strncasecmp("looplength=", comment->user_comments[i], 11))
+      looplength = atoi(comment->user_comments[i] + 11);
   }
-  return NULL;
+
+  if(loopstart >= 0 && (looplength > 0 || loopend > loopstart))
+  {
+    v_stream->loop_start = loopstart;
+
+    // looplength takes priority since it's older and more "standard"
+    if(looplength > 0)
+      v_stream->loop_end = loopstart + looplength;
+    else
+      v_stream->loop_end = loopend;
+  }
+}
+
+static struct audio_stream *construct_vorbis_stream(vfile *vf,
+ const char *filename, uint32_t frequency, unsigned int volume, boolean repeat)
+{
+  struct vorbis_stream *v_stream;
+  struct sampled_stream_spec s_spec;
+  struct audio_stream_spec a_spec;
+  vorbis_info *vorbis_file_info;
+
+  OggVorbis_File open_file;
+
+  // FIXME: the vfile must be forced into memory for DJGPP so that filesystem
+  // operations will not occur during the audio interrupt.
+
+  if(ov_open_callbacks(vf, &open_file, NULL, 0, vorbis_callbacks) != 0)
+    return NULL;
+
+  // Surround OGGs not supported yet..
+  vorbis_file_info = ov_info(&open_file, -1);
+  if(!vorbis_file_info || vorbis_file_info->channels > 2)
+  {
+    ov_clear(&open_file);
+    return NULL;
+  }
+
+  v_stream = (struct vorbis_stream *)malloc(sizeof(struct vorbis_stream));
+  if(!v_stream)
+  {
+    ov_clear(&open_file);
+    return NULL;
+  }
+
+  v_stream->vorbis_file_handle = open_file;
+  v_stream->vorbis_file_info = vorbis_file_info;
+  v_stream->input_file = vf;
+
+  v_stream->loop_start = 0;
+  v_stream->loop_end = 0;
+  get_loopstart_loopend(v_stream, &open_file);
+
+  memset(&a_spec, 0, sizeof(struct audio_stream_spec));
+  a_spec.mix_data       = vorbis_mix_data;
+  a_spec.set_volume     = vorbis_set_volume;
+  a_spec.set_repeat     = vorbis_set_repeat;
+  a_spec.set_position   = vorbis_set_position;
+  a_spec.set_loop_start = vorbis_set_loop_start;
+  a_spec.set_loop_end   = vorbis_set_loop_end;
+  a_spec.get_position   = vorbis_get_position;
+  a_spec.get_length     = vorbis_get_length;
+  a_spec.get_loop_start = vorbis_get_loop_start;
+  a_spec.get_loop_end   = vorbis_get_loop_end;
+  a_spec.destruct       = vorbis_destruct;
+
+  memset(&s_spec, 0, sizeof(struct sampled_stream_spec));
+  s_spec.set_frequency = vorbis_set_frequency;
+  s_spec.get_frequency = vorbis_get_frequency;
+
+  initialize_sampled_stream((struct sampled_stream *)v_stream, &s_spec,
+   frequency, v_stream->vorbis_file_info->channels, true);
+
+  initialize_audio_stream((struct audio_stream *)v_stream, &a_spec,
+   volume, repeat);
+
+  return (struct audio_stream *)v_stream;
+}
+
+static boolean test_vorbis_stream(vfile *vf, const char *filename)
+{
+  char buf[4];
+  if(!vfread(buf, 4, 1, vf))
+    return false;
+
+  return memcmp(buf, "OggS", 4) == 0;
 }
 
 void init_vorbis(struct config_info *conf)
 {
-  audio_ext_register("ogg", construct_vorbis_stream);
+  audio_ext_register(test_vorbis_stream, construct_vorbis_stream);
 }

--- a/src/audio/audio_xmp.c
+++ b/src/audio/audio_xmp.c
@@ -318,9 +318,9 @@ static struct audio_stream *construct_xmp_stream(vfile *vf,
   }
   xmp_stream->total_rows = row_pos;
 
-  // xmp tries to be clever and uses "sequences" to make certain mods loop
-  // to orders that aren't the start of the mod. This breaks legacy mods
-  // that rely on looping to the start, so zero all of their entry points.
+  // xmp uses sequences to make secondary loops in modules playable, but this
+  // breaks looping from the end of the module to the start. Since MZX doesn't
+  // use sequences and games rely on normal looping, zero all entry points.
   for(i = 0; i < info.num_sequences; i++)
   {
     info.seq_data[i].entry_point = 0;

--- a/src/audio/audio_xmp.c
+++ b/src/audio/audio_xmp.c
@@ -269,106 +269,90 @@ static struct xmp_callbacks xmp_callbacks =
   NULL
 };
 
-static struct audio_stream *construct_xmp_stream(char *filename,
- uint32_t frequency, unsigned int volume, boolean repeat)
+static struct audio_stream *construct_xmp_stream(vfile *vf,
+ const char *filename, uint32_t frequency, unsigned int volume, boolean repeat)
 {
+  struct xmp_stream *xmp_stream;
+  struct sampled_stream_spec s_spec;
+  struct audio_stream_spec a_spec;
   struct xmp_module_info info;
   xmp_context ctx;
   unsigned char ord;
   size_t row_pos;
+  int num_orders;
   int i;
 
-  vfile *vf = vfopen_unsafe_ext(filename, "rb", V_LARGE_BUFFER);
-  if(!vf)
+  ctx = xmp_create_context();
+  if(!ctx)
     return NULL;
 
-  ctx = xmp_create_context();
-  if(ctx)
+  xmp_set_player(ctx, XMP_PLAYER_DEFPAN, 50);
+
+  /* This function does not close the provided file pointer. */
+  if(xmp_load_module_from_callbacks(ctx, vf, xmp_callbacks) < 0)
   {
-    xmp_set_player(ctx, XMP_PLAYER_DEFPAN, 50);
-
-    /**
-     * This function does not close the provided file pointer.
-     */
-    if(!xmp_load_module_from_callbacks(ctx, vf, xmp_callbacks))
-    {
-      struct xmp_stream *xmp_stream = ccalloc(1, sizeof(struct xmp_stream));
-      struct sampled_stream_spec s_spec;
-      struct audio_stream_spec a_spec;
-      int num_orders;
-
-      xmp_stream->ctx = ctx;
-      xmp_start_player(ctx, audio.output_frequency, 0);
-      xmp_set_player(ctx, XMP_PLAYER_INTERP, get_xmp_resample_mode());
-
-      xmp_get_module_info(ctx, &info);
-      num_orders = info.mod->len;
-
-      for(i = 0, row_pos = 0; i < num_orders; i++)
-      {
-        xmp_stream->row_tbl[i] = row_pos;
-        ord = info.mod->xxo[i];
-        if(ord < info.mod->pat)
-          row_pos += info.mod->xxp[ord]->rows;
-      }
-      xmp_stream->total_rows = row_pos;
-
-      // xmp tries to be clever and uses "sequences" to make certain mods loop
-      // to orders that aren't the start of the mod. This breaks legacy mods
-      // that rely on looping to the start, so zero all of their entry points.
-      for(i = 0; i < info.num_sequences; i++)
-      {
-        info.seq_data[i].entry_point = 0;
-      }
-
-      memset(&a_spec, 0, sizeof(struct audio_stream_spec));
-      a_spec.mix_data     = audio_xmp_mix_data;
-      a_spec.set_volume   = audio_xmp_set_volume;
-      a_spec.set_repeat   = audio_xmp_set_repeat;
-      a_spec.set_order    = audio_xmp_set_order;
-      a_spec.set_position = audio_xmp_set_position;
-      a_spec.get_order    = audio_xmp_get_order;
-      a_spec.get_position = audio_xmp_get_position;
-      a_spec.get_length   = audio_xmp_get_length;
-      a_spec.get_sample   = audio_xmp_get_sample;
-      a_spec.destruct     = audio_xmp_destruct;
-
-      memset(&s_spec, 0, sizeof(struct sampled_stream_spec));
-      s_spec.set_frequency = audio_xmp_set_frequency;
-      s_spec.get_frequency = audio_xmp_get_frequency;
-
-      initialize_sampled_stream((struct sampled_stream *)xmp_stream, &s_spec,
-       frequency, 2, false);
-
-      initialize_audio_stream((struct audio_stream *)xmp_stream, &a_spec,
-       volume, repeat);
-
-      vfclose(vf);
-      return (struct audio_stream *)xmp_stream;
-    }
     xmp_free_context(ctx);
+    return NULL;
   }
+
+  xmp_stream = (struct xmp_stream *)ccalloc(1, sizeof(struct xmp_stream));
+  if(!xmp_stream)
+  {
+    xmp_free_context(ctx);
+    return NULL;
+  }
+
+  xmp_stream->ctx = ctx;
+  xmp_start_player(ctx, audio.output_frequency, 0);
+  xmp_set_player(ctx, XMP_PLAYER_INTERP, get_xmp_resample_mode());
+
+  xmp_get_module_info(ctx, &info);
+  num_orders = info.mod->len;
+
+  for(i = 0, row_pos = 0; i < num_orders; i++)
+  {
+    xmp_stream->row_tbl[i] = row_pos;
+    ord = info.mod->xxo[i];
+    if(ord < info.mod->pat)
+      row_pos += info.mod->xxp[ord]->rows;
+  }
+  xmp_stream->total_rows = row_pos;
+
+  // xmp tries to be clever and uses "sequences" to make certain mods loop
+  // to orders that aren't the start of the mod. This breaks legacy mods
+  // that rely on looping to the start, so zero all of their entry points.
+  for(i = 0; i < info.num_sequences; i++)
+  {
+    info.seq_data[i].entry_point = 0;
+  }
+
+  memset(&a_spec, 0, sizeof(struct audio_stream_spec));
+  a_spec.mix_data     = audio_xmp_mix_data;
+  a_spec.set_volume   = audio_xmp_set_volume;
+  a_spec.set_repeat   = audio_xmp_set_repeat;
+  a_spec.set_order    = audio_xmp_set_order;
+  a_spec.set_position = audio_xmp_set_position;
+  a_spec.get_order    = audio_xmp_get_order;
+  a_spec.get_position = audio_xmp_get_position;
+  a_spec.get_length   = audio_xmp_get_length;
+  a_spec.get_sample   = audio_xmp_get_sample;
+  a_spec.destruct     = audio_xmp_destruct;
+
+  memset(&s_spec, 0, sizeof(struct sampled_stream_spec));
+  s_spec.set_frequency = audio_xmp_set_frequency;
+  s_spec.get_frequency = audio_xmp_get_frequency;
+
+  initialize_sampled_stream((struct sampled_stream *)xmp_stream, &s_spec,
+   frequency, 2, false);
+
+  initialize_audio_stream((struct audio_stream *)xmp_stream, &a_spec,
+   volume, repeat);
+
   vfclose(vf);
-  return NULL;
+  return (struct audio_stream *)xmp_stream;
 }
 
 void init_xmp(struct config_info *conf)
 {
-  audio_ext_register("669", construct_xmp_stream);
-  audio_ext_register("amf", construct_xmp_stream);
-  //audio_ext_register("dsm", construct_xmp_stream);
-  audio_ext_register("far", construct_xmp_stream);
-  audio_ext_register("gdm", construct_xmp_stream);
-  audio_ext_register("it", construct_xmp_stream);
-  audio_ext_register("med", construct_xmp_stream);
-  audio_ext_register("mod", construct_xmp_stream);
-  audio_ext_register("mtm", construct_xmp_stream);
-  audio_ext_register("nst", construct_xmp_stream);
-  audio_ext_register("oct", construct_xmp_stream);
-  audio_ext_register("okt", construct_xmp_stream);
-  audio_ext_register("s3m", construct_xmp_stream);
-  audio_ext_register("stm", construct_xmp_stream);
-  audio_ext_register("ult", construct_xmp_stream);
-  audio_ext_register("wow", construct_xmp_stream);
-  audio_ext_register("xm", construct_xmp_stream);
+  audio_ext_register(NULL, construct_xmp_stream);
 }

--- a/src/audio/ext.h
+++ b/src/audio/ext.h
@@ -27,14 +27,16 @@
 __M_BEGIN_DECLS
 
 #include "audio.h"
+#include "../io/vfile.h"
 
-typedef struct audio_stream *(*construct_stream_fn)(char *,
- uint32_t, unsigned int, boolean);
+typedef boolean (*filter_stream_fn)(vfile *vf, const char *filename);
+typedef struct audio_stream *(*construct_stream_fn)(vfile *vf, const char *,
+ uint32_t frequency, unsigned int volume, boolean repeat);
 
-void audio_ext_register(const char *ext, construct_stream_fn constructor);
+void audio_ext_register(filter_stream_fn test, construct_stream_fn constructor);
 void audio_ext_free_registry(void);
 
-struct audio_stream *audio_ext_construct_stream(char *filename,
+struct audio_stream *audio_ext_construct_stream(const char *filename,
  uint32_t frequency, unsigned int volume, boolean repeat);
 
 __M_END_DECLS


### PR DESCRIPTION
Replaces the audio file extension checks in the audio loading system with a simple test function system. The old checks were prone to the issue that any variant extension, or lack thereof, would prevent the loading of otherwise valid files. This required adding new extensions to the list for multiple loaders every time a module format is added or a variant extension is found. This was not worth it, and extension filtering has been retained for OpenMPT builds only (as there is no other way to format filter).

To keep any added overhead minimal, the base loader now opens the input file immediately and reuses the same handle until a loader succeeds and claims/closes the handle, or until all loaders fail. This required refactoring most audio stream implementations due to the deeply nested nature of some of them.