### PR TITLE
Implement vio.c virtual filesystem and file caching support.

### DIFF
--- a/src/io/path.c
+++ b/src/io/path.c
@@ -97,7 +97,8 @@ char *path_reverse_tokenize(char **_base, size_t *_base_len)
     if(isslash(*pos))
     {
       if(_base_len)
-        *_base_len = pos - base - 1;
+        *_base_len = (pos > base) ? pos - base - 1 : 0;
+
       *pos = '\0';
       return pos + 1;
     }

--- a/src/io/path.c
+++ b/src/io/path.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2004 Gilead Kutnick <exophase@adelphia.net>
  * Copyright (C) 2008 Alistair John Strachan <alistair@devzero.co.uk>
- * Copyright (C) 2012, 2020 Alice Rowan <petrifiedrowan@gmail.com>
+ * Copyright (C) 2012, 2020-2023 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -60,6 +60,54 @@ char *path_tokenize(char **next)
       *next = NULL;
   }
   return src;
+}
+
+/**
+ * Similar to `path_tokenize`, but strips one path token off of the end of the
+ * provided path.
+ *
+ * This function is not aware of absolute paths; if the token returned is a
+ * root, the directory separator portion of the root will be replaced with nul.
+ *
+ * @param  base       Pointer to the path to reverse tokenize. If there is only
+ *                    one token in this path, NULL will be stored to *`base`.
+ *                    Otherwise, this value will not be modified.
+ * @param  base_len   Pointer to the current length of the path pointed to by
+ *                    `base`. If there is only one token in the path, 0 will be
+ *                    stored to *`base_len`. This field MUST be initialized
+ *                    properly if provided. If not provided, each call will
+ *                    perform one `strlen` call.
+ * @return            A pointer to the token removed from *`base`, or NULL if
+ *                    *`base` is NULL or `base` is NULL.
+ */
+char *path_reverse_tokenize(char **_base, size_t *_base_len)
+{
+  size_t base_len;
+  char *base;
+  char *pos;
+  if(!_base || !*_base)
+    return NULL;
+
+  base = *_base;
+  base_len = _base_len ? *_base_len : strlen(base);
+  pos = base + base_len;
+
+  while(pos >= base)
+  {
+    if(isslash(*pos))
+    {
+      if(_base_len)
+        *_base_len = pos - base - 1;
+      *pos = '\0';
+      return pos + 1;
+    }
+    pos--;
+  }
+
+  *_base = NULL;
+  if(_base_len)
+    *_base_len = 0;
+  return base;
 }
 
 /**
@@ -388,6 +436,43 @@ boolean path_get_directory_and_filename(char *d_dest, size_t d_len,
 }
 
 /**
+ * Get the parent directory of a provided path string if the path string
+ * contains a parent component.
+ *
+ * @param  dest       Destination buffer for the parent.
+ * @param  dest_len   Size of the destination buffer.
+ * @return            Length of the parent string, -1 if the path string is
+ *                    invalid or doesn't fit in the provided buffer, or 0
+ *                    if the path contains no parent directory.
+ */
+ssize_t path_get_parent(char *dest, size_t dest_len, const char *path)
+{
+  ssize_t path_len;
+  ssize_t i;
+  if(!path || !path[0])
+    return -1;
+
+  // Find last slash without respect to vstat.
+  path_len = strlen(path);
+  for(i = path_len - 1; i >= 0; i--)
+    if(isslash(path[i]))
+      break;
+  // Include the separator.
+  i++;
+
+  if((size_t)i >= dest_len)
+    return -1;
+
+  dest[i] = '\0';
+  if(i > 0)
+  {
+    memcpy(dest, path, i);
+    i = path_clean_slashes(dest, dest_len);
+  }
+  return i;
+}
+
+/**
  * Clean duplicate directory separators out of a path and normalize them to
  * the correct slash for the current platform.
  *
@@ -681,24 +766,27 @@ static ssize_t path_navigate_internal(char *path, size_t path_len, const char *t
     else      next++;
 
     // . does nothing, .. goes back one level
-    if(current_char == '.')
+    if(current_char == '.' && (current[1] == '\0' || isslash(current[1])))
     {
-      if(current[1] == '.')
-      {
-        // Skip the rightmost separator (current level) and look for the
-        // previous separator. If found, truncate the path to it.
-        char *pos = buffer + len - 1;
-        do
-        {
-          pos--;
-        }
-        while(pos >= buffer && !isslash(*pos));
+      // current directory, don't do anything.
+    }
+    else
 
-        if(pos >= buffer)
-        {
-          pos[1] = '\0';
-          len = strlen(buffer);
-        }
+    if(current_char == '.' && current[1] == '.')
+    {
+      // Skip the rightmost separator (current level) and look for the
+      // previous separator. If found, truncate the path to it.
+      char *pos = buffer + len - 1;
+      do
+      {
+        pos--;
+      }
+      while(pos >= buffer && !isslash(*pos));
+
+      if(pos >= buffer)
+      {
+        pos[1] = '\0';
+        len = strlen(buffer);
       }
     }
     else

--- a/src/io/path.c
+++ b/src/io/path.c
@@ -773,7 +773,8 @@ static ssize_t path_navigate_internal(char *path, size_t path_len, const char *t
     }
     else
 
-    if(current_char == '.' && current[1] == '.')
+    if(current_char == '.' && current[1] == '.' &&
+     (current[2] == '\0' || isslash(current[2])))
     {
       // Skip the rightmost separator (current level) and look for the
       // previous separator. If found, truncate the path to it.

--- a/src/io/path.h
+++ b/src/io/path.h
@@ -58,6 +58,7 @@ static inline boolean isslash(const char chr)
 }
 
 UTILS_LIBSPEC char *path_tokenize(char **next);
+UTILS_LIBSPEC char *path_reverse_tokenize(char **base, size_t *base_len);
 
 UTILS_LIBSPEC boolean path_force_ext(char *path, size_t buffer_len, const char *ext);
 UTILS_LIBSPEC ssize_t path_get_ext_offset(const char *path);
@@ -73,6 +74,8 @@ UTILS_LIBSPEC ssize_t path_get_filename(char *dest, size_t dest_len,
  const char *path);
 UTILS_LIBSPEC boolean path_get_directory_and_filename(char *d_dest, size_t d_len,
  char *f_dest, size_t f_len, const char *path);
+UTILS_LIBSPEC ssize_t path_get_parent(char *dest, size_t dest_len,
+ const char *path);
 
 UTILS_LIBSPEC size_t path_clean_slashes(char *path, size_t path_len);
 UTILS_LIBSPEC size_t path_clean_slashes_copy(char *dest, size_t dest_len,

--- a/src/io/vfile.h
+++ b/src/io/vfile.h
@@ -35,6 +35,9 @@ typedef struct vfilesystem vfilesystem;
 struct memfile;
 struct stat;
 
+/* Dummy device for stat on a virtual file. */
+#define VFS_MZX_DEVICE (('M'<<24u) | ('Z'<<16u) | ('X'<<8u) | ('V'))
+
 __M_END_DECLS
 
 #endif /* __IO_VFILE_H */

--- a/src/io/vfs.h
+++ b/src/io/vfs.h
@@ -78,6 +78,7 @@ UTILS_LIBSPEC int vfs_open_if_exists(vfilesystem *vfs,
  const char *path, boolean is_write, uint32_t *inode);
 UTILS_LIBSPEC int vfs_close(vfilesystem *vfs, uint32_t inode);
 UTILS_LIBSPEC int vfs_truncate(vfilesystem *vfs, uint32_t inode);
+UTILS_LIBSPEC ssize_t vfs_filelength(vfilesystem *vfs, uint32_t inode);
 UTILS_LIBSPEC int vfs_lock_file_read(vfilesystem *vfs, uint32_t inode,
  const unsigned char **data, size_t *data_length);
 UTILS_LIBSPEC int vfs_unlock_file_read(vfilesystem *vfs, uint32_t inode);
@@ -108,6 +109,7 @@ UTILS_LIBSPEC int vfs_cache_file_callback(vfilesystem *vfs, const char *path,
  size_t (*readfn)(void * RESTRICT, size_t, void * RESTRICT),
  void *priv, size_t data_length);
 UTILS_LIBSPEC size_t vfs_get_cache_total_size(vfilesystem *vfs);
+UTILS_LIBSPEC size_t vfs_get_total_memory_usage(vfilesystem *vfs);
 UTILS_LIBSPEC void vfs_set_timestamps_enabled(vfilesystem *vfs, boolean enable);
 
 #else /* !VIRTUAL_FILESYSTEM */
@@ -119,6 +121,7 @@ static inline int vfs_open_if_exists(vfilesystem *v,
  const char *p, boolean w, uint32_t *i) { return -1; }
 static inline int vfs_close(vfilesystem *v, uint32_t i) { return -1; }
 static inline int vfs_truncate(vfilesystem *v, uint32_t i) { return -1; }
+static inline ssize_t vfs_filelength(vfilesystem *v, uint32_t i) { return -1; }
 static inline int vfs_lock_file_read(vfilesystem *v, uint32_t i,
  const unsigned char **d, size_t *l) { return -1; }
 static inline int vfs_unlock_file_read(vfilesystem *v, uint32_t i) { return -1; }
@@ -144,8 +147,12 @@ static inline int vfs_invalidate_all(vfilesystem *v) { return -1; }
 static inline int vfs_cache_directory(vfilesystem *v, const char *p,
  const struct stat *st) { return -1; }
 static inline int vfs_cache_file(vfilesystem *v, const char *p,
- unsigned char *d, size_t l) { return -1; }
+ const void *d, size_t l) { return -1; }
+static inline int vfs_cache_file_callback(vfilesystem *v, const char *p,
+ size_t (*r)(void * RESTRICT, size_t, void * RESTRICT),
+ void *pr, size_t l) { return -1; }
 static inline size_t vfs_get_cache_total_size(vfilesystem *v) { return 0; }
+static inline size_t vfs_get_total_memory_usage(vfilesystem *vfs) { return 0; }
 static inline void vfs_set_timestamps_enabled(vfilesystem *v, boolean e) { }
 
 #endif /* !VIRTUAL_FILESYSTEM */

--- a/src/io/vfs.h
+++ b/src/io/vfs.h
@@ -33,7 +33,7 @@ __M_BEGIN_DECLS
 #include <stdlib.h>
 #include "vfile.h"
 
-#ifdef CONFIG_VFS
+#if defined(CONFIG_VFS) && !defined(NO_VIRTUAL_FILESYSTEM)
 #define VIRTUAL_FILESYSTEM
 #endif
 

--- a/src/io/vio.c
+++ b/src/io/vio.c
@@ -1,6 +1,6 @@
 /* MegaZeux
  *
- * Copyright (C) 2019 Alice Rowan <petrifiedrowan@gmail.com>
+ * Copyright (C) 2019-2023 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -19,13 +19,16 @@
 
 #include <assert.h>
 #include <dirent.h>
+#include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <sys/stat.h>
 
 #include "../util.h"
 #include "memfile.h"
+#include "path.h"
 #include "vio.h"
+#include "vfs.h"
 //#include "zip.h"
 
 #ifdef __WIN32__
@@ -42,6 +45,9 @@
 #define VFILE_LARGE_BUFFER_SIZE 32768
 #endif
 
+// If 0 is provided as a cache maximum size, use this value instead.
+#define DEFAULT_MAX_SIZE (1<<22)
+
 struct vfile
 {
   FILE *fp;
@@ -53,6 +59,11 @@ struct vfile
   // External copy of pointer/size of expandable vfile buffer.
   void **external_buffer;
   size_t *external_buffer_size;
+  // Virtual file--inode and position.
+  size_t *v_length;
+  size_t position;
+  size_t position_writeback;
+  uint32_t inode;
 
   // vungetc buffer for memory files.
   int tmp_chr;
@@ -60,6 +71,383 @@ struct vfile
   // To avoid arithmetic on NULL...
   char dummy[1];
 };
+
+
+/************************************************************************
+ * Virtual filesystem support functions.
+ */
+
+// Letting the optimizer deal with this is cleaner than macros everywhere...
+#ifdef VIRTUAL_FILESYSTEM
+static vfilesystem *vfs_base = NULL;
+#else
+#define vfs_base ((vfilesystem *)NULL)
+#endif
+static size_t vfs_max_size = 0;
+static size_t vfs_max_auto_cache_file_size = 0;
+static boolean vfs_enable_auto_cache = false;
+
+/**
+ * Recursively cache the provided directory path if it doesn't exist in
+ * the cache, including the root. This function will cache as much of `path`
+ * as possible, starting from the root and working down the directory tree.
+ * Returns true if the directory is already in the VFS or if the entire
+ * path is successfully cached.
+ */
+static boolean vio_cache_directory_recursively(vfilesystem *vfs, const char *path)
+{
+  char tmp[MAX_PATH];
+  char *next;
+  struct stat st;
+  ssize_t len;
+  int ret;
+
+  // Does it already exist in the VFS?
+  ret = vfs_stat(vfs, path, &st);
+  if(ret == 0 || ret == -VFS_ERR_IS_CACHED)
+    return true;
+
+/*
+  // Is it a real directory?
+  ret = platform_stat(path, &st);
+  if(ret < 0 || !S_ISDIR(st.st_mode))
+    return false;
+*/
+
+  // Initialize root.
+  path_clean_slashes_copy(tmp, MAX_PATH, path);
+  next = tmp;
+  len = path_is_absolute(tmp);
+  if(tmp[0] != '/' && len)
+  {
+    // Last character of the root should be /, next to last :.
+    if(len < 3 || tmp[len - 2] != ':')
+      return false;
+
+    path_tokenize(&next);
+    tmp[len - 2] = '\0';
+
+    ret = vfs_make_root(vfs, tmp);
+    if(ret != 0 && ret != -EEXIST)
+      return false;
+
+    // Repair current fragment.
+    tmp[len - 2] = ':';
+    tmp[len - 1] = DIR_SEPARATOR_CHAR;
+  }
+  else
+
+  if(tmp[0] == '/')
+    next++;
+
+  // Initialize directories.
+  while(next)
+  {
+    path_tokenize(&next);
+
+    ret = platform_stat(tmp, &st);
+    if(ret < 0 || !S_ISDIR(st.st_mode))
+      return false;
+
+    ret = vfs_cache_directory(vfs, tmp, &st);
+    if(ret != 0 && ret != -EEXIST)
+      return false;
+
+    // Repair current fragment.
+    if(next)
+      next[-1] = DIR_SEPARATOR_CHAR;
+  }
+  return true;
+}
+
+/**
+ * Get the parent directory from the provided path and cache it recursively,
+ * including the root. The parent must successfully stat. If there is no parent
+ * component of the path, this function automatically succeeds.
+ */
+static boolean vio_cache_parent_recursively(vfilesystem *vfs, const char *path)
+{
+  char parent[MAX_PATH];
+
+  // If there is no parent component, there's nothing else to do here.
+  if(path_get_parent(parent, MAX_PATH, path) <= 0)
+    return true;
+
+  return vio_cache_directory_recursively(vfs, parent);
+}
+
+static size_t cache_file_read_fn(void * RESTRICT dest, size_t nbytes,
+ void * RESTRICT priv)
+{
+  FILE *fp = (FILE *)priv;
+  return fread(dest, 1, nbytes, fp);
+}
+
+/**
+ * Cache the file at the provided path and its parent directory (recursively).
+ * The file should already be opened with stdio.
+ */
+static boolean vio_cache_file_and_parent(vfilesystem *vfs, const char *path,
+ FILE *fp, int flags)
+{
+  struct stat st;
+  int64_t len;
+  int64_t pos;
+  int ret;
+
+  // Already cached...
+  if(vfs_stat(vfs, path, &st) == 0 && S_ISREG(st.st_mode))
+    return true;
+
+  len = platform_filelength(fp);
+  if(len < 0 || (size_t)len >= SIZE_MAX)
+    return false;
+
+  // Can't cache files over the individual file size limit.
+  if((size_t)len >= vfs_max_auto_cache_file_size && (~flags & V_FORCE_CACHE))
+    return false;
+
+  // If there isn't enough space, try to free some.
+  if(vfs_max_size)
+  {
+    size_t current = vfs_get_cache_total_size(vfs);
+    size_t avail = vfs_max_size > current ? vfs_max_size - current : 0;
+    size_t to_free = (size_t)len > avail ? len - avail : 0;
+
+    if(to_free)
+      vfs_invalidate_at_least(vfs, &to_free);
+
+    // If it wasn't able to free enough space, just fail.
+    if(to_free && (~flags & V_FORCE_CACHE))
+      return false;
+  }
+
+  if(!vio_cache_parent_recursively(vfs, path))
+    return false;
+
+  pos = platform_ftell(fp);
+  ret = vfs_cache_file_callback(vfs, path, cache_file_read_fn, fp, len);
+  platform_fseek(fp, pos, SEEK_SET);
+  return ret == 0;
+}
+
+/**
+ * Given a relative or absolute path, convert it to an absolute path if the
+ * current working directory is virtual. This is necessary because the current
+ * real directory is desyncronized from the current VFS directory (the current
+ * VFS directory does not exist in the real filesystem). This function will
+ * always clobber the contents of the provided buffer.
+ *
+ * TODO: if a platform needs chdir/getcwd emulation, this would be a good
+ * place to insert relative path conversion for that too, since all functions
+ * which take paths need to use this when the VFS is enabled.
+ */
+static const char *vio_normalize_virtual_path(vfilesystem *vfs,
+ char *buffer, size_t buffer_len, const char *path)
+{
+  // Cached current directory will return -VFS_ERR_IS_CACHED instead.
+  if(vfs_getcwd(vfs, buffer, buffer_len) == 0)
+  {
+    path_navigate_no_check(buffer, buffer_len, path);
+    return buffer;
+  }
+  return path;
+}
+
+/**
+ * Enables the virtual filesystem for all vio.c functions. The virtual
+ * filesystem provides virtual files and file caching. This function
+ * is not thread-safe. If the virtual filesystem is already initialized,
+ * this function will update the cache settings.
+ *
+ * @param max_size            soft limit for the maximum total size of cached
+ *                            files in the VFS. In some cases, the total size
+ *                            may be allowed exceed this value. If 0 is provided
+ *                            a default maximum size will be used instead.
+ * @param max_file_size       maximum size of files allowed to be automatically
+ *                            cached, if enabled. If 0 is provided, this will
+ *                            default to `max_size`.
+ * @param enable_auto_cache   if `true`, files will be automatically cached.
+ * @return                    `true` on success, otherwise `false`.
+ */
+boolean vio_filesystem_init(size_t max_size, size_t max_file_size,
+ boolean enable_auto_cache)
+{
+  char tmp[MAX_PATH];
+
+  if(!vfs_base)
+  {
+#ifdef VIRTUAL_FILESYSTEM
+    vfs_base = vfs_init();
+#endif
+    if(!vfs_base)
+      return false;
+  }
+
+  // Synchronize the current working directory.
+  if(!getcwd(tmp, MAX_PATH))
+    goto err;
+  if(!vio_cache_directory_recursively(vfs_base, tmp))
+    goto err;
+  if(vfs_chdir(vfs_base, tmp) != -VFS_ERR_IS_CACHED)
+    goto err;
+
+  // Immediately purge the cache if it has been disabled.
+  if(vfs_enable_auto_cache && !enable_auto_cache)
+    vfs_invalidate_all(vfs_base);
+
+  vfs_max_size = max_size ? max_size : DEFAULT_MAX_SIZE;
+  vfs_max_auto_cache_file_size = max_file_size ? max_file_size : vfs_max_size;
+  vfs_enable_auto_cache = enable_auto_cache;
+
+  return true;
+
+err:
+#ifdef VIRTUAL_FILESYSTEM
+  vfs_free(vfs_base);
+  vfs_base = NULL;
+#endif
+  return false;
+}
+
+/**
+ * Disable the virtual filesystem for all vio.c functions and free all memory
+ * associated with it. This function is not thread-safe and should be called
+ * only when all other threads are finished using vio.c functions.
+ *
+ * @return                    `true` on success.
+ */
+boolean vio_filesystem_exit(void)
+{
+#ifdef VIRTUAL_FILESYSTEM
+  if(vfs_base)
+    vfs_free(vfs_base);
+
+  vfs_base = NULL;
+#endif
+  return true;
+}
+
+/**
+ * Get the total memory usage for the contents of cached files ONLY
+ * the vio.c virtual filesystem.
+ *
+ * @return                    the total amount of memory used.
+ */
+size_t vio_filesystem_total_cached_usage(void)
+{
+  if(vfs_base)
+    return vfs_get_cache_total_size(vfs_base);
+  return 0;
+}
+
+/**
+ * Get the total memory usage of the vio.c virtual filesystem,
+ * INCLUDING cached files.
+ *
+ * @return                    the total amount of memory used.
+ */
+size_t vio_filesystem_total_memory_usage(void)
+{
+  if(vfs_base)
+    return vfs_get_total_memory_usage(vfs_base);
+  return 0;
+}
+
+/**
+ * Create a virtual file in the VFS which is not backed by a physical file.
+ * If a physical file exists at the provided path, it will be masked.
+ * If the file already exists in the virtual filesystem, this function will
+ * return true.
+ *
+ * The parent directory of the path must be a real directory or an existing
+ * virtual directory.
+ *
+ * @param                     path to create a new file at.
+ * @return                    `true` on success, otherwise `false`.
+ */
+boolean vio_virtual_file(const char *path)
+{
+  int err;
+  if(!vfs_base)
+    return false;
+
+  if(!vio_cache_parent_recursively(vfs_base, path))
+    return false;
+
+  err = vfs_create_file_at_path(vfs_base, path);
+  if(err != 0 && err != -EEXIST)
+    return false;
+
+  return true;
+}
+
+/**
+ * Create a virtual directory in the VFS which is not backed by a physical file.
+ * If a physical file exists at the provided path, it will be masked.
+ * If the directory already exists in the virtual filesystem, this function
+ * will return true.
+ *
+ * The parent directory of the path must be a real directory or an existing
+ * virtual directory.
+ *
+ * @param                     path to create a new directory at.
+ * @return                    `true` on success, otherwise `false`.
+ */
+boolean vio_virtual_directory(const char *path)
+{
+  int err;
+  if(!vfs_base)
+    return false;
+
+  if(!vio_cache_parent_recursively(vfs_base, path))
+    return false;
+
+  err = vfs_mkdir(vfs_base, path, 0755);
+  if(err != 0 && err != -EEXIST)
+    return false;
+
+  return true;
+}
+
+/**
+ * Invalidate and purge cached files in the VFS until at least
+ * the amount of memory pointed to by `amount_to_free` has been invalided.
+ */
+boolean vio_invalidate_at_least(size_t *amount_to_free)
+{
+  int err;
+  if(!vfs_base || !amount_to_free)
+    return false;
+
+  err = vfs_invalidate_at_least(vfs_base, amount_to_free);
+  if(err)
+    return false;
+
+  if(*amount_to_free > 0)
+    return false;
+
+  return true;
+}
+
+/**
+ * Invalidate and purge ALL cached files in the VFS.
+ */
+boolean vio_invalidate_all(void)
+{
+  if(!vfs_base)
+    return false;
+
+  if(vfs_invalidate_all(vfs_base) < 0)
+    return false;
+
+  return true;
+}
+
+
+/************************************************************************
+ * vfile functions and stdio/unistd wrappers.
+ */
 
 /**
  * Parse vfile mode flags from a standard fopen mode string.
@@ -112,50 +500,116 @@ int vfile_get_mode_flags(const char *mode)
 }
 
 /**
+ * Diagnostic function to get the internal flags of a vfile.
+ * Doesn't have much use outside of the unit tests.
+ *
+ * @param  vf     vfile handle.
+ * @return        the internal flags of the provided vfile.
+ */
+int vfile_get_flags(vfile *vf)
+{
+  return vf ? vf->flags : 0;
+}
+
+/**
+ * Internal function for opening a file from the VFS.
+ * filename should already have been normalized by the caller.
+ */
+static int vfopen_virtual(vfilesystem *vfs, vfile *vf, const char *filename,
+ int flags)
+{
+  uint32_t inode;
+  int ret;
+
+  ret = vfs_open_if_exists(vfs_base, filename, !!(flags & VF_WRITE), &inode);
+  if(ret != 0 && ret != -VFS_ERR_IS_CACHED)
+    return ret;
+
+  if(flags & VF_TRUNCATE)
+    vfs_truncate(vfs_base, inode);
+
+  vf->flags |= VF_MEMORY | VF_MEMORY_EXPANDABLE | VF_VIRTUAL;
+  vf->inode = inode;
+  vf->position = (flags & VF_APPEND) ? vfs_filelength(vfs, inode) : 0;
+  vf->position_writeback = vf->position;
+  return ret;
+}
+
+/**
  * Open a file for input or output with user-defined flags.
  */
 vfile *vfopen_unsafe_ext(const char *filename, const char *mode,
  int user_flags)
 {
+  char buffer[MAX_PATH];
   int flags = vfile_get_mode_flags(mode);
-  vfile *vf = NULL;
+  int ret;
+  vfile *vf;
+  FILE *fp;
 
   assert(filename && flags);
   flags |= (user_flags & VF_PUBLIC_MASK);
 
-  // TODO archive detection/memory file caching here
-  // TODO vf = vfscache_vfopen(filename, flags);
+  vf = (vfile *)calloc(1, sizeof(vfile));
+  vf->tmp_chr = EOF;
+  vf->flags = flags;
+
+  if(vfs_base)
+  {
+    filename = vio_normalize_virtual_path(vfs_base, buffer, MAX_PATH, filename);
+    ret = vfopen_virtual(vfs_base, vf, filename, flags);
+    // File is 100% virtual? Can exit now.
+    if(ret == 0)
+      return vf;
+    // TODO: optionally allow non-write cached to exit too, since
+    // stdio is just a rare fallback in that situation?
+  }
 
   // Open the vfile as a normal file.
-  if(!vf)
+  fp = platform_fopen_unsafe(filename, mode);
+  if(!fp)
   {
-    FILE *fp = platform_fopen_unsafe(filename, mode);
-
-    if(fp)
+    if(vfs_base && vf->inode)
     {
-      if((flags & VF_BINARY) && (!(flags & VF_READ) || !(flags & VF_WRITE)))
+      vfs_close(vfs_base, vf->inode);
+      vfs_invalidate_at_path(vfs_base, filename);
+    }
+    free(vf);
+    return NULL;
+  }
+
+#ifndef VFILE_NO_SETVBUF
+  if((flags & VF_BINARY) && (!(flags & VF_READ) || !(flags & VF_WRITE)))
+  {
+    if(flags & V_LARGE_BUFFER)
+    {
+      setvbuf(fp, NULL, _IOFBF, VFILE_LARGE_BUFFER_SIZE);
+      flags &= ~V_SMALL_BUFFER;
+    }
+    else
+
+    if(flags & V_SMALL_BUFFER)
+      setvbuf(fp, NULL, _IOFBF, VFILE_SMALL_BUFFER_SIZE);
+  }
+  else
+#endif
+    flags &= ~(V_SMALL_BUFFER | V_LARGE_BUFFER);
+
+  vf->fp = fp;
+  vf->flags |= VF_FILE;
+
+  if(vfs_base && !vf->inode)
+  {
+    if(vfs_enable_auto_cache || (flags & V_FORCE_CACHE))
+    {
+      if(vio_cache_file_and_parent(vfs_base, filename, fp, flags))
       {
-        if(flags & V_LARGE_BUFFER)
-        {
-          setvbuf(fp, NULL, _IOFBF, VFILE_LARGE_BUFFER_SIZE);
-          flags &= ~V_SMALL_BUFFER;
-        }
-        else
-
-        if(flags & V_SMALL_BUFFER)
-          setvbuf(fp, NULL, _IOFBF, VFILE_SMALL_BUFFER_SIZE);
+        // In the rare case this fails, the vfile will just fall back to stdio.
+        vfopen_virtual(vfs_base, vf, filename, flags);
       }
-      else
-        flags &= ~(V_SMALL_BUFFER | V_LARGE_BUFFER);
-
-      vf = (vfile *)ccalloc(1, sizeof(vfile));
-      vf->fp = fp;
-      vf->tmp_chr = EOF;
-      vf->flags = flags | VF_FILE;
-      return vf;
     }
   }
-  return NULL;
+  return vf;
 }
 
 /**
@@ -267,6 +721,65 @@ vfile *vtempfile(size_t initial_size)
 }
 
 /**
+ * Force an open vfile entirely into RAM. This function will ALWAYS rewind.
+ * If this is a regular vfile in READ mode, attempt to copy it into RAM.
+ * If this is a cached vfile in READ mode, just close the FILE if it's open.
+ * If this is a memory or virtual vfile, nothing needs to be done.
+ * Returns false if the vfile can not be moved to memory or is in write mode.
+ */
+boolean vfile_force_to_memory(vfile *vf)
+{
+  assert(vf);
+  vrewind(vf);
+  // This only works in read mode--write mode needs to be able to write
+  // back, unless it's a virtual file, in which case
+  if(~vf->flags & VF_FILE)
+  {
+    // Already entirely in memory.
+    if(vf->flags & VF_MEMORY)
+      return true;
+    // Broken handle :(
+    return false;
+  }
+  // If there's an underlying FILE, it can only be closed in read mode.
+  if(vf->flags & VF_WRITE)
+    return false;
+
+  // FILE and memory -> cached, close the underlying FILE.
+  // If there is no memory, it needs to be loaded to memory first.
+  if(~vf->flags & VF_MEMORY)
+  {
+    int64_t len = vfilelength(vf, false);
+    void *buffer;
+
+    if(len < 0 || (size_t)len >= SIZE_MAX)
+      return false;
+
+    buffer = malloc(len);
+    if(!buffer)
+      return false;
+
+    if(!vfread(buffer, len, 1, vf))
+    {
+      free(buffer);
+      return false;
+    }
+
+    mfopen(buffer, len, &(vf->mf));
+    vf->mf.seek_past_end = true;
+    vf->tmp_chr = EOF;
+    vf->flags |= VF_MEMORY | VF_MEMORY_FREE;
+    vf->local_buffer = buffer;
+    vf->local_buffer_size = len;
+  }
+
+  fclose(vf->fp);
+  vf->flags &= ~VF_FILE;
+  vf->fp = NULL;
+  return true;
+}
+
+/**
  * Close a file. The file pointer should not be used after using this function.
  */
 int vfclose(vfile *vf)
@@ -274,6 +787,14 @@ int vfclose(vfile *vf)
   int retval = 0;
 
   assert(vf);
+
+  if(vfs_base && vf->inode)
+  {
+    // Rewind to force writeback.
+    // TODO: kind of a crap way to do this, might need to add vfflush.
+    vrewind(vf);
+    vfs_close(vfs_base, vf->inode);
+  }
 
   if((vf->flags & VF_MEMORY) && (vf->flags & VF_MEMORY_FREE))
   {
@@ -303,7 +824,32 @@ int vfclose(vfile *vf)
  */
 int vchdir(const char *path)
 {
-  // TODO archive detection, etc
+  if(vfs_base)
+  {
+    char buffer[MAX_PATH];
+    int ret;
+
+    path = vio_normalize_virtual_path(vfs_base, buffer, MAX_PATH, path);
+    // If this is also a virtual path, this will succeed. The vfs_access
+    // call filters out cached directories, which vfs_chdir DOES work on.
+    if(vfs_access(vfs_base, path, R_OK) == 0 && vfs_chdir(vfs_base, path) == 0)
+      return 0;
+
+    // Special: the current directory must exist in the VFS.
+    vio_cache_directory_recursively(vfs_base, path);
+
+    // If this is a real path, this function will succeed, in which case
+    // the VFS current directory should also be updated.
+    ret = platform_chdir(path);
+    if(ret == 0)
+    {
+      ret = vfs_chdir(vfs_base, path);
+      assert(ret == -VFS_ERR_IS_CACHED);
+      ret = 0;
+    }
+
+    return ret;
+  }
   return platform_chdir(path);
 }
 
@@ -313,7 +859,13 @@ int vchdir(const char *path)
  */
 char *vgetcwd(char *buf, size_t size)
 {
-  // TODO archive detection, etc
+  if(vfs_base)
+  {
+    // If cwd is a virtual path, return the VFS cwd.
+    // Cached real cwds will return -VFS_ERR_IS_CACHED.
+    if(vfs_getcwd(vfs_base, buf, size) == 0)
+      return buf;
+  }
   return platform_getcwd(buf, size);
 }
 
@@ -322,7 +874,27 @@ char *vgetcwd(char *buf, size_t size)
  */
 int vmkdir(const char *path, int mode)
 {
-  // TODO archive detection, etc
+  if(vfs_base)
+  {
+    char buffer[MAX_PATH];
+    int ret;
+
+    path = vio_normalize_virtual_path(vfs_base, buffer, MAX_PATH, path);
+
+    // Special: this function prefers real mkdir over vfs_mkdir.
+    // Use vio_virtual_directory to force creation of virtual directories.
+    ret = platform_mkdir(path, mode);
+    if(ret == 0 || errno != ENOENT)
+      return ret;
+
+    ret = vfs_mkdir(vfs_base, path, mode);
+    if(ret < 0)
+    {
+      errno = -ret;
+      return -1;
+    }
+    return 0;
+  }
   return platform_mkdir(path, mode);
 }
 
@@ -331,7 +903,41 @@ int vmkdir(const char *path, int mode)
  */
 int vrename(const char *oldpath, const char *newpath)
 {
-  // TODO archive detection, etc
+  if(vfs_base)
+  {
+    char buffer1[MAX_PATH];
+    char buffer2[MAX_PATH];
+    int ret;
+
+    oldpath = vio_normalize_virtual_path(vfs_base, buffer1, MAX_PATH, oldpath);
+    newpath = vio_normalize_virtual_path(vfs_base, buffer2, MAX_PATH, newpath);
+
+    // Preemptively cache the destination parent.
+    vio_cache_parent_recursively(vfs_base, newpath);
+
+    // Attempt vfs_rename, which will handle virtual source files
+    // moving, replacing cached files, or replacing virtual files.
+    // No filesystem operation needs to be done in this case.
+    ret = vfs_rename(vfs_base, oldpath, newpath);
+    if(ret == 0)
+      return 0;
+
+    if(ret == -EBUSY || ret == -ENOTDIR || ret == -EISDIR || ret == -EEXIST)
+    {
+      errno = -ret;
+      return -1;
+    }
+
+    // Try a real rename...
+    ret = platform_rename(oldpath, newpath);
+    if(ret != 0)
+    {
+      // (Try to) roll back the vfs_rename.
+      // This unfortunately won't bring back the old dir/file at newpath.
+      vfs_rename(vfs_base, newpath, oldpath);
+    }
+    return ret;
+  }
   return platform_rename(oldpath, newpath);
 }
 
@@ -341,7 +947,28 @@ int vrename(const char *oldpath, const char *newpath)
  */
 int vunlink(const char *path)
 {
-  // TODO archive detection, cache, etc
+  if(vfs_base)
+  {
+    char buffer[MAX_PATH];
+    int ret;
+
+    path = vio_normalize_virtual_path(vfs_base, buffer, MAX_PATH, path);
+    ret = vfs_unlink(vfs_base, path);
+    if(ret == 0)
+      return 0;
+
+    // VFS inode exists and isn't cached, but there was an error.
+    if(ret == -EBUSY || ret == -EPERM)
+    {
+      errno = -ret;
+      return -1;
+    }
+
+    ret = platform_unlink(path);
+    if(ret == 0)
+      vfs_invalidate_at_path(vfs_base, path);
+    return ret;
+  }
   return platform_unlink(path);
 }
 
@@ -350,7 +977,28 @@ int vunlink(const char *path)
  */
 int vrmdir(const char *path)
 {
-  // TODO archive detection, etc
+  if(vfs_base)
+  {
+    char buffer[MAX_PATH];
+    int ret;
+
+    path = vio_normalize_virtual_path(vfs_base, buffer, MAX_PATH, path);
+    ret = vfs_rmdir(vfs_base, path);
+    if(ret == 0)
+      return 0;
+
+    // VFS inode exists and isn't cached, but there was an error.
+    if(ret == -EBUSY || ret == -ENOTDIR || ret == -ENOTEMPTY)
+    {
+      errno = -ret;
+      return -1;
+    }
+
+    ret = platform_rmdir(path);
+    if(ret == 0)
+      vfs_invalidate_at_path(vfs_base, path);
+    return ret;
+  }
   return platform_rmdir(path);
 }
 
@@ -364,7 +1012,23 @@ int vrmdir(const char *path)
  */
 int vaccess(const char *path, int mode)
 {
-  // TODO archive detection, etc
+  if(vfs_base)
+  {
+    char buffer[MAX_PATH];
+    int ret;
+
+    path = vio_normalize_virtual_path(vfs_base, buffer, MAX_PATH, path);
+    ret = vfs_access(vfs_base, path, mode);
+    if(ret == 0)
+      return 0;
+
+    // File exists and is virtual but permission was denied.
+    if(ret == -EACCES)
+    {
+      errno = -ret;
+      return -1;
+    }
+  }
   return platform_access(path, mode);
 }
 
@@ -373,8 +1037,23 @@ int vaccess(const char *path, int mode)
  */
 int vstat(const char *path, struct stat *buf)
 {
-  // TODO archive detection, cache, etc
-  // TODO custom struct for 64-bit file sizes, 64-bit timestamps.
+  if(vfs_base)
+  {
+    char buffer[MAX_PATH];
+    struct stat tmp;
+    int ret;
+
+    path = vio_normalize_virtual_path(vfs_base, buffer, MAX_PATH, path);
+    // Pass through success only.
+    // TODO: may be beneficial to pass through cached as success eventually, but
+    // everything that cares about performance already uses dirent d_type.
+    ret = vfs_stat(vfs_base, path, &tmp);
+    if(ret == 0)
+    {
+      memcpy(buf, &tmp, sizeof(struct stat));
+      return 0;
+    }
+  }
   return platform_stat(path, buf);
 }
 
@@ -382,6 +1061,147 @@ int vstat(const char *path, struct stat *buf)
 /************************************************************************
  * stdio function wrappers.
  */
+
+/* If virtual IO fails, close the VFS file (if applicable)
+ * and fall back to stdio. */
+static inline void vfile_cleanup_virtual(vfile *vf)
+{
+  if(vfs_base)
+    vfs_close(vfs_base, vf->inode);
+
+  vf->flags &= ~(VF_MEMORY | VF_VIRTUAL);
+  vf->inode = 0;
+
+  if(vf->fp)
+  {
+    size_t pos = vf->position;
+    int buf = vf->tmp_chr;
+    vrewind(vf);
+    vfseek(vf, pos, SEEK_SET);
+    if(buf >= 0)
+      vungetc(buf, vf);
+  }
+  else
+    vf->flags &= ~VF_FILE;
+}
+
+/* Perform a writeback for cached vfiles. This should be performed
+ * after the VFS file is read locked and the memfile is synchronized.
+ * Returns true on success or if no writeback was required. */
+static inline boolean virt_writeback(vfile *vf)
+{
+  size_t count;
+  size_t avail;
+  size_t out;
+  const unsigned char *src;
+
+  // Detached vfiles and read-only vfiles can't perform a writeback operation.
+  if(!vf->inode || !vf->fp || (~vf->flags & VF_WRITE))
+    return true;
+
+  if(vf->position_writeback == vf->position)
+    return true;
+
+  // fseek to write position (also allows switching to write mode).
+  if(platform_fseek(vf->fp, vf->position_writeback, SEEK_SET) != 0)
+    return false;
+
+  // This shouldn't be able to happen--all backwards seeks call here.
+  assert(vf->position_writeback < vf->position);
+
+  // Attempt write...
+  src = vf->mf.start + vf->position_writeback;
+  if(src >= vf->mf.end)
+    return false;
+
+  avail = vf->mf.end - src;
+  count = vf->position - vf->position_writeback;
+  avail = MIN(avail, count);
+  out = fwrite(src, 1, avail, vf->fp);
+  fflush(vf->fp);
+
+  if(out < count)
+    return false;
+
+  return true;
+}
+
+/**
+ * Begin a read or write operation on a VFS vfile.
+ * This synchronizes the internal memfile and, if the VFS is no longer
+ * available, attempts to fall back to FILE io.
+ */
+static inline boolean virt_read(vfile *vf)
+{
+  const unsigned char *tmp;
+  size_t len;
+  int ret = -1;
+  if(!vf->inode)
+    return false;
+
+  assert(vf->flags & VF_MEMORY);
+  if(vfs_base)
+    ret = vfs_lock_file_read(vfs_base, vf->inode, &tmp, &len);
+  if(ret != 0)
+  {
+    vfile_cleanup_virtual(vf);
+    return false;
+  }
+  mfopen(tmp, len, &(vf->mf));
+  vf->mf.seek_past_end = true;
+  mfseek(&(vf->mf), vf->position, SEEK_SET);
+  virt_writeback(vf);
+  return true;
+}
+
+static inline void virt_read_end(vfile *vf)
+{
+  if(!vfs_base || !vf->inode)
+    return;
+
+  assert(vf->flags & VF_MEMORY);
+  vfs_unlock_file_read(vfs_base, vf->inode);
+  vf->position = mftell(&(vf->mf));
+  vf->position_writeback = vf->position;
+}
+
+static inline boolean virt_write(vfile *vf)
+{
+  int ret = -1;
+  if(!vf->inode)
+    return false;
+
+  assert(vf->flags & VF_MEMORY);
+  if(vfs_base)
+  {
+    ret = vfs_lock_file_write(vfs_base, vf->inode,
+     (unsigned char ***)&vf->external_buffer,
+     &vf->v_length, &vf->external_buffer_size);
+  }
+  if(ret != 0)
+  {
+    vfile_cleanup_virtual(vf);
+    return false;
+  }
+  vf->local_buffer = *vf->external_buffer;
+  vf->local_buffer_size = *vf->external_buffer_size;
+  mfopen_wr(vf->local_buffer, *vf->v_length, &(vf->mf));
+  vf->mf.seek_past_end = true;
+  mfseek(&(vf->mf), vf->position, SEEK_SET);
+  return true;
+}
+
+static inline void virt_write_end(vfile *vf)
+{
+  if(!vfs_base || !vf->inode)
+    return;
+
+  assert(vf->flags & VF_MEMORY);
+
+  *(vf->v_length) = vf->mf.end - vf->mf.start;
+  vfs_unlock_file_write(vfs_base, vf->inode);
+  vf->position = mftell(&(vf->mf));
+}
 
 /**
  * Ensure an amount of space exists in a memory vfile or expand the vfile
@@ -464,17 +1284,23 @@ boolean vfile_get_memfile_block(vfile *vf, size_t length, struct memfile *dest)
 int vfgetc(vfile *vf)
 {
   assert(vf);
-  assert(vf->flags & VF_STORAGE_MASK);
   assert(vf->flags & VF_READ);
 
-  if(vf->flags & VF_MEMORY)
+  if(virt_read(vf) || (vf->flags & VF_MEMORY))
   {
-    int tmp = vf->tmp_chr;
-    vf->tmp_chr = EOF;
-    if(tmp != EOF)
-      return tmp;
+    int character = EOF;
+    if(vf->tmp_chr != EOF)
+    {
+      character = vf->tmp_chr;
+      vf->tmp_chr = EOF;
+    }
+    else
 
-    return mfhasspace(1, &(vf->mf)) ? mfgetc(&(vf->mf)) : EOF;
+    if(mfhasspace(1, &(vf->mf)))
+      character = mfgetc(&(vf->mf));
+
+    virt_read_end(vf);
+    return character;
   }
 
   if(vf->flags & VF_FILE)
@@ -489,22 +1315,26 @@ int vfgetc(vfile *vf)
 int vfgetw(vfile *vf)
 {
   assert(vf);
-  assert(vf->flags & VF_STORAGE_MASK);
   assert(vf->flags & VF_READ);
 
-  if(vf->flags & VF_MEMORY)
+  if(virt_read(vf) || (vf->flags & VF_MEMORY))
   {
-    int tmp = vf->tmp_chr;
-    if(tmp != EOF)
+    int character = EOF;
+    if(vf->tmp_chr != EOF)
     {
-      if(!mfhasspace(1, &(vf->mf)))
-        return EOF;
-
-      vf->tmp_chr = EOF;
-      return tmp | (mfgetc(&(vf->mf)) << 8);
+      if(mfhasspace(1, &(vf->mf)))
+      {
+        character = vf->tmp_chr | (mfgetc(&(vf->mf)) << 8);
+        vf->tmp_chr = EOF;
+      }
     }
+    else
 
-    return mfhasspace(2, &(vf->mf)) ? mfgetw(&(vf->mf)) : EOF;
+    if(mfhasspace(2, &(vf->mf)))
+      character = mfgetw(&(vf->mf));
+
+    virt_read_end(vf);
+    return character;
   }
 
   if(vf->flags & VF_FILE)
@@ -525,22 +1355,28 @@ int vfgetw(vfile *vf)
 int vfgetd(vfile *vf)
 {
   assert(vf);
-  assert(vf->flags & VF_STORAGE_MASK);
   assert(vf->flags & VF_READ);
 
-  if(vf->flags & VF_MEMORY)
+  if(virt_read(vf) || (vf->flags & VF_MEMORY))
   {
-    int tmp = vf->tmp_chr;
-    if(tmp != EOF)
+    int character = EOF;
+    if(vf->tmp_chr != EOF)
     {
-      if(!mfhasspace(3, &(vf->mf)))
-        return EOF;
-
-      vf->tmp_chr = EOF;
-      return tmp | (mfgetc(&(vf->mf)) << 8) | (mfgetw(&(vf->mf)) << 16);
+      if(mfhasspace(3, &(vf->mf)))
+      {
+        character = vf->tmp_chr |
+         (mfgetc(&(vf->mf)) << 8) |
+         (mfgetw(&(vf->mf)) << 16);
+        vf->tmp_chr = EOF;
+      }
     }
+    else
 
-    return mfhasspace(4, &(vf->mf)) ? mfgetd(&(vf->mf)) : EOF;
+    if(mfhasspace(4, &(vf->mf)))
+      character = mfgetd(&(vf->mf));
+
+    virt_read_end(vf);
+    return character;
   }
 
   if(vf->flags & VF_FILE)
@@ -566,24 +1402,29 @@ int vfgetd(vfile *vf)
 int64_t vfgetq(vfile *vf)
 {
   assert(vf);
-  assert(vf->flags & VF_STORAGE_MASK);
   assert(vf->flags & VF_READ);
 
-  if(vf->flags & VF_MEMORY)
+  if(virt_read(vf) || (vf->flags & VF_MEMORY))
   {
-    int tmp = vf->tmp_chr;
-    if(tmp != EOF)
+    int64_t character = EOF;
+    if(vf->tmp_chr != EOF)
     {
-      if(!mfhasspace(7, &(vf->mf)))
-        return EOF;
-
-      vf->tmp_chr = EOF;
-      return tmp | (mfgetc(&(vf->mf)) << 8) |
-       ((uint64_t)mfgetw(&(vf->mf)) << 16) |
-       ((uint64_t)mfgetud(&(vf->mf)) << 32);
+      if(mfhasspace(7, &(vf->mf)))
+      {
+        character = vf->tmp_chr |
+         ((int64_t)mfgetc(&(vf->mf)) << 8) |
+         ((int64_t)mfgetw(&(vf->mf)) << 16) |
+         ((int64_t)mfgetud(&(vf->mf)) << 32);
+        vf->tmp_chr = EOF;
+      }
     }
+    else
 
-    return mfhasspace(8, &(vf->mf)) ? mfgetq(&(vf->mf)) : EOF;
+    if(mfhasspace(8, &(vf->mf)))
+      character = mfgetq(&(vf->mf));
+
+    virt_read_end(vf);
+    return character;
   }
 
   if(vf->flags & VF_FILE)
@@ -615,15 +1456,17 @@ int64_t vfgetq(vfile *vf)
 int vfputc(int character, vfile *vf)
 {
   assert(vf);
-  assert(vf->flags & VF_STORAGE_MASK);
   assert(vf->flags & VF_WRITE);
 
-  if(vf->flags & VF_MEMORY)
+  if(virt_write(vf) || (vf->flags & VF_MEMORY))
   {
-    if(!vfile_ensure_space(1, vf))
-      return EOF;
+    if(vfile_ensure_space(1, vf))
+      character = mfputc(character, &(vf->mf));
+    else
+      character = EOF;
 
-    return mfputc(character, &(vf->mf));
+    virt_write_end(vf);
+    return character;
   }
 
   if(vf->flags & VF_FILE)
@@ -638,15 +1481,16 @@ int vfputc(int character, vfile *vf)
 int vfputw(int character, vfile *vf)
 {
   assert(vf);
-  assert(vf->flags & VF_STORAGE_MASK);
   assert(vf->flags & VF_WRITE);
 
-  if(vf->flags & VF_MEMORY)
+  if(virt_write(vf) || (vf->flags & VF_MEMORY))
   {
-    if(!vfile_ensure_space(2, vf))
-      return EOF;
+    if(vfile_ensure_space(2, vf))
+      mfputw(character, &(vf->mf));
+    else
+      character = EOF;
 
-    mfputw(character, &(vf->mf));
+    virt_write_end(vf);
     return character;
   }
 
@@ -667,15 +1511,16 @@ int vfputw(int character, vfile *vf)
 int vfputd(int character, vfile *vf)
 {
   assert(vf);
-  assert(vf->flags & VF_STORAGE_MASK);
   assert(vf->flags & VF_WRITE);
 
-  if(vf->flags & VF_MEMORY)
+  if(virt_write(vf) || (vf->flags & VF_MEMORY))
   {
-    if(!vfile_ensure_space(4, vf))
-      return EOF;
+    if(vfile_ensure_space(4, vf))
+      mfputd(character, &(vf->mf));
+    else
+      character = EOF;
 
-    mfputd(character, &(vf->mf));
+    virt_write_end(vf);
     return character;
   }
 
@@ -702,15 +1547,16 @@ int vfputd(int character, vfile *vf)
 int64_t vfputq(int64_t character, vfile *vf)
 {
   assert(vf);
-  assert(vf->flags & VF_STORAGE_MASK);
   assert(vf->flags & VF_WRITE);
 
-  if(vf->flags & VF_MEMORY)
+  if(virt_write(vf) || (vf->flags & VF_MEMORY))
   {
-    if(!vfile_ensure_space(8, vf))
-      return EOF;
+    if(vfile_ensure_space(8, vf))
+      mfputq(character, &(vf->mf));
+    else
+      character = EOF;
 
-    mfputq(character, &(vf->mf));
+    virt_write_end(vf);
     return character;
   }
 
@@ -743,10 +1589,9 @@ size_t vfread(void *dest, size_t size, size_t count, vfile *vf)
 {
   assert(vf);
   assert(dest);
-  assert(vf->flags & VF_STORAGE_MASK);
   assert(vf->flags & VF_READ);
 
-  if(vf->flags & VF_MEMORY)
+  if(virt_read(vf) || (vf->flags & VF_MEMORY))
   {
     if(size && count && vf->tmp_chr != EOF)
     {
@@ -755,15 +1600,22 @@ size_t vfread(void *dest, size_t size, size_t count, vfile *vf)
       if(size > 1)
       {
         if(!mfread(d, size - 1, 1, &(vf->mf)))
+        {
+          virt_read_end(vf);
           return 0;
+        }
 
         d += size - 1;
       }
       vf->tmp_chr = EOF;
-      return (count > 1) ? mfread(d, size, count - 1, &(vf->mf)) + 1 : 1;
+      if(count > 1)
+        count = mfread(d, size, count - 1, &(vf->mf)) + 1;
     }
+    else
+      count = mfread(dest, size, count, &(vf->mf));
 
-    return mfread(dest, size, count, &(vf->mf));
+    virt_read_end(vf);
+    return count;
   }
 
   if(vf->flags & VF_FILE)
@@ -779,15 +1631,17 @@ size_t vfwrite(const void *src, size_t size, size_t count, vfile *vf)
 {
   assert(vf);
   assert(src);
-  assert(vf->flags & VF_STORAGE_MASK);
   assert(vf->flags & VF_WRITE);
 
-  if(vf->flags & VF_MEMORY)
+  if(virt_write(vf) || (vf->flags & VF_MEMORY))
   {
-    if(!vfile_ensure_space(size * count, vf))
-      return 0;
+    if(vfile_ensure_space(size * count, vf))
+      count = mfwrite(src, size, count, &(vf->mf));
+    else
+      count = 0;
 
-    return mfwrite(src, size, count, &(vf->mf));
+    virt_write_end(vf);
+    return count;
   }
 
   if(vf->flags & VF_FILE)
@@ -805,10 +1659,9 @@ char *vfsafegets(char *dest, int size, vfile *vf)
   assert(vf);
   assert(dest);
   assert(size > 1);
-  assert(vf->flags & VF_STORAGE_MASK);
   assert(vf->flags & VF_READ);
 
-  if(vf->flags & VF_MEMORY)
+  if(virt_read(vf) || (vf->flags & VF_MEMORY))
   {
     if(size && vf->tmp_chr != EOF)
     {
@@ -820,14 +1673,19 @@ char *vfsafegets(char *dest, int size, vfile *vf)
         if(tmp == '\r' && (mfhasspace(1, &(vf->mf)) && vf->mf.current[0] == '\n'))
           vf->mf.current++;
         dest[0] = '\0';
-        return dest;
       }
-      dest[0] = tmp;
-      dest[1] = '\0';
-      mfsafegets(dest + 1, size - 1, &(vf->mf));
-      return dest;
+      else
+      {
+        dest[0] = tmp;
+        dest[1] = '\0';
+        mfsafegets(dest + 1, size - 1, &(vf->mf));
+      }
     }
-    return mfsafegets(dest, size, &(vf->mf));
+    else
+      dest = mfsafegets(dest, size, &(vf->mf));
+
+    virt_read_end(vf);
+    return dest;
   }
 
   if(vf->flags & VF_FILE)
@@ -859,7 +1717,6 @@ int vfputs(const char *src, vfile *vf)
 
   assert(vf);
   assert(src);
-  assert(vf->flags & VF_STORAGE_MASK);
   assert(vf->flags & VF_WRITE);
 
   len = strlen(src);
@@ -894,10 +1751,9 @@ int vf_vprintf(vfile *vf, const char *fmt, va_list args)
 {
   assert(vf);
   assert(fmt);
-  assert(vf->flags & VF_STORAGE_MASK);
   assert(vf->flags & VF_WRITE);
 
-  if(vf->flags & VF_MEMORY)
+  if(virt_write(vf) || (vf->flags & VF_MEMORY))
   {
     // Get the expected output length from the format string and args.
     // This requires a duplicate arglist so vsnprintf can be called twice.
@@ -915,7 +1771,10 @@ int vf_vprintf(vfile *vf, const char *fmt, va_list args)
     // This shouldn't happen since only MinGW and MSVC 2015+ are supported.
     // Alternatively, some errors cause it to return -1.
     if(length < 0)
-      return -1;
+    {
+      length = -1;
+      goto err;
+    }
 
     // Write to a temporary buffer to avoid null terminators overwriting data
     // and potential side effects of allocating extra vfile space. This is a
@@ -924,7 +1783,10 @@ int vf_vprintf(vfile *vf, const char *fmt, va_list args)
     {
       buffer = malloc(length + 1);
       if(!buffer)
-        return -1;
+      {
+        length = -1;
+        goto err;
+      }
     }
     else
       buffer = _buffer;
@@ -941,6 +1803,8 @@ int vf_vprintf(vfile *vf, const char *fmt, va_list args)
     if(buffer != _buffer)
       free(buffer);
 
+  err:
+    virt_write_end(vf);
     return length;
   }
 
@@ -959,7 +1823,6 @@ int vf_vprintf(vfile *vf, const char *fmt, va_list args)
 int vungetc(int chr, vfile *vf)
 {
   assert(vf);
-  assert(vf->flags & VF_STORAGE_MASK);
 
   // Note: MSVCRT &255s non-EOF values so this may not be 100% accurate to stdio.
   // If this somehow breaks something it can be reverted later.
@@ -987,11 +1850,14 @@ int vungetc(int chr, vfile *vf)
 int vfseek(vfile *vf, int64_t offset, int whence)
 {
   assert(vf);
-  assert(vf->flags & VF_STORAGE_MASK);
   vf->tmp_chr = EOF;
 
-  if(vf->flags & VF_MEMORY)
-    return mfseek(&(vf->mf), offset, whence);
+  if(virt_read(vf) || (vf->flags & VF_MEMORY))
+  {
+    int ret = mfseek(&(vf->mf), offset, whence);
+    virt_read_end(vf);
+    return ret;
+  }
 
   if(vf->flags & VF_FILE)
     return platform_fseek(vf->fp, offset, whence);
@@ -1005,9 +1871,8 @@ int vfseek(vfile *vf, int64_t offset, int whence)
 int64_t vftell(vfile *vf)
 {
   assert(vf);
-  assert(vf->flags & VF_STORAGE_MASK);
 
-  if(vf->flags & VF_MEMORY)
+  if(virt_read(vf) || (vf->flags & VF_MEMORY))
   {
     long res = mftell(&(vf->mf));
     /**
@@ -1016,8 +1881,9 @@ int64_t vftell(vfile *vf)
      * cursor is at position 0 the return value of this operation is undefined.
      */
     if((vf->tmp_chr != EOF) && (vf->flags & VF_BINARY) && res > 0)
-      return res - 1;
+      res--;
 
+    virt_read_end(vf);
     return res;
   }
 
@@ -1033,12 +1899,12 @@ int64_t vftell(vfile *vf)
 void vrewind(vfile *vf)
 {
   assert(vf);
-  assert(vf->flags & VF_STORAGE_MASK);
   vf->tmp_chr = EOF;
 
-  if(vf->flags & VF_MEMORY)
+  if(virt_read(vf) || (vf->flags & VF_MEMORY))
   {
     mfseek(&(vf->mf), 0, SEEK_SET);
+    virt_read_end(vf);
     return;
   }
 
@@ -1062,14 +1928,18 @@ int64_t vfilelength(vfile *vf, boolean rewind)
   int64_t size = -1;
 
   assert(vf);
-  assert(vf->flags & VF_STORAGE_MASK);
 
-  if(vf->flags & VF_MEMORY)
+  if(vfs_base && vf->inode)
+  {
+    size = vfs_filelength(vfs_base, vf->inode);
+  }
+
+  if((vf->flags & VF_MEMORY) && size < 0)
   {
     size = vf->mf.end - vf->mf.start;
   }
 
-  if(vf->flags & VF_FILE)
+  if((vf->flags & VF_FILE) && size < 0)
   {
     // fstat (and maybe _filelength) rely on the copy on-disk being up to date.
     // The SEEK_END hack works without this, since fseek also flushes the file.
@@ -1103,9 +1973,11 @@ int64_t vfilelength(vfile *vf, boolean rewind)
 struct vdir
 {
   struct dir_handle dh;
+  struct vfs_dir virt;
   long position;
   long num_total;
   long num_real;
+  boolean has_real;
 #ifdef PLATFORM_NO_REWINDDIR
   // Path for dirent implementations with no working rewinddir.
   char path[1];
@@ -1117,31 +1989,58 @@ struct vdir
  */
 vdir *vdir_open(const char *path)
 {
+  char buffer[MAX_PATH];
+  boolean virt_okay = false;
+  vdir *dir;
+
 #ifdef PLATFORM_NO_REWINDDIR
 
-  size_t pathlen = strlen(path);
-  vdir *dir = (vdir *)malloc(sizeof(vdir) + pathlen);
+  ssize_t pathlen = -1;
+
+  // Make path absolute so this directory can be located more reliably.
+  if(vgetcwd(buffer, MAX_PATH))
+  {
+    pathlen = path_navigate_no_check(buffer, MAX_PATH, path);
+    if(pathlen >= 0)
+      path = buffer;
+  }
+  if(pathlen < 0)
+    pathlen = strlen(path);
+
+  dir = (vdir *)calloc(1, sizeof(vdir) + pathlen);
   if(dir)
     memcpy(dir->path, path, pathlen + 1);
 
 #else
-  vdir *dir = (vdir *)malloc(sizeof(vdir));
+  dir = (vdir *)calloc(1, sizeof(vdir));
+
+  // Path needs to be made absolute only for VFS operations.
+  if(vfs_base)
+    path = vio_normalize_virtual_path(vfs_base, buffer, MAX_PATH, path);
 #endif
 
   if(dir)
   {
-    dir->position = 0;
-    dir->num_total = 0;
-    dir->num_real = 0;
+    // There may be virtual files in this directory, or this directory
+    // may also be virtual. Both real and virtual files need to be listed.
+    // TODO: overlaid files should replace the real file somehow? ugh
+    if(vfs_base && vfs_readdir(vfs_base, path, &dir->virt) == 0)
+    {
+      virt_okay = true;
+      dir->num_total += dir->virt.num_files;
+    }
 
-    // TODO archive detection, etc
-    if(!platform_opendir(&(dir->dh), path))
+    if(platform_opendir(&(dir->dh), path))
+    {
+      // Get total real files.
+      dir->has_real = true;
+      while(platform_readdir(dir->dh, NULL, 0, NULL))
+        dir->num_real++;
+    }
+    else
+
+    if(!virt_okay)
       goto err;
-
-    // Get total real files.
-    // TODO get total virtual files with no real backing.
-    while(platform_readdir(dir->dh, NULL, 0, NULL))
-      dir->num_real++;
 
     dir->num_total += dir->num_real;
     vdir_rewind(dir);
@@ -1156,10 +2055,15 @@ err:
 /**
  * Close a directory.
  */
-void vdir_close(vdir *dir)
+int vdir_close(vdir *dir)
 {
-  platform_closedir(dir->dh);
+  int ret = 0;
+  if(dir->has_real)
+    ret = platform_closedir(dir->dh);
+
+  vfs_readdir_free(&dir->virt);
   free(dir);
+  return ret;
 }
 
 /**
@@ -1173,10 +2077,28 @@ boolean vdir_read(vdir *dir, char *buffer, size_t len, enum vdir_type *type)
   if(dir->position >= dir->num_total)
     return false;
 
-/*
-  // TODO virtual files with no real backing.
+  /* Return a virtual file. */
   if(dir->position >= dir->num_real)
-*/
+  {
+    size_t i = dir->position - dir->num_real;
+    struct vfs_dir_file *f = dir->virt.files[i];
+    size_t sz;
+    // Shouldn't happen.
+    if(!f)
+      return false;
+
+    if(buffer)
+    {
+      sz = snprintf(buffer, len, "%s", f->name);
+      if(sz >= len)
+        return false;
+    }
+    if(type)
+      *type = f->type;
+
+    dir->position++;
+    return true;
+  }
 
   if(!platform_readdir(dir->dh, buffer, len, &dirent_type))
     return false;
@@ -1241,7 +2163,8 @@ boolean vdir_rewind(vdir *dir)
 
 #ifdef PLATFORM_NO_REWINDDIR
   platform_closedir(dir->dh);
-  // TODO archive detection, etc
+
+  // Virtual files are still valid, only the real dir needs to be reopened.
   if(!platform_opendir(&(dir->dh), dir->path))
   {
     dir->num_total -= dir->num_real;

--- a/src/io/vio_no_vfs.c
+++ b/src/io/vio_no_vfs.c
@@ -1,0 +1,22 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2023 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/* Hack so the utilities can build without SDL threading functions. */
+#define NO_VIRTUAL_FILESYSTEM
+#include "vio.c"

--- a/src/io/vio_posix.h
+++ b/src/io/vio_posix.h
@@ -135,9 +135,9 @@ static inline boolean platform_opendir(struct dir_handle *dh, const char *path)
   return dh->dir != NULL;
 }
 
-static inline void platform_closedir(struct dir_handle dh)
+static inline int platform_closedir(struct dir_handle dh)
 {
-  closedir(dh.dir);
+  return closedir(dh.dir);
 }
 
 static inline boolean platform_readdir(struct dir_handle dh, char *buffer,

--- a/src/io/vio_win32.h
+++ b/src/io/vio_win32.h
@@ -272,16 +272,13 @@ static inline boolean platform_opendir(struct dir_handle *dh, const char *path)
   return dh->dir != NULL;
 }
 
-static inline void platform_closedir(struct dir_handle dh)
+static inline int platform_closedir(struct dir_handle dh)
 {
 #ifdef WIDE_PATHS
   if(dh.wdir)
-  {
-    _wclosedir(dh.wdir);
-    return;
-  }
+    return _wclosedir(dh.wdir);
 #endif
-  closedir(dh.dir);
+  return closedir(dh.dir);
 }
 
 static inline boolean platform_readdir(struct dir_handle dh, char *buffer,

--- a/src/utils/Makefile.in
+++ b/src/utils/Makefile.in
@@ -16,7 +16,7 @@ utils_obj = src/utils/.build
 # Define UTILS_LIBSPEC so these properly link.
 utils_cflags := ${LIBPNG_CFLAGS} ${PTHREAD_CFLAGS} -DUTILS_LIBSPEC=
 
-zip_objs  := ${io_obj}/vio.o ${io_obj}/zip.o ${io_obj}/zip_stream.o
+zip_objs  := ${io_obj}/path.o ${io_obj}/vio_no_vfs.o ${io_obj}/zip.o ${io_obj}/zip_stream.o
 img_objs  := ${utils_obj}/image_file.o ${utils_obj}/image_gif.o
 img_flags :=
 
@@ -27,7 +27,7 @@ endif
 checkres := ${utils_src}/checkres${BINEXT}
 checkres_objs := ${utils_obj}/checkres.o \
                  ${io_obj}/fsafeopen.o \
-                 ${io_obj}/path.o ${zip_objs}
+                 ${zip_objs}
 checkres_ldflags := ${ZLIB_LDFLAGS}
 
 downver := ${utils_src}/downver${BINEXT}

--- a/unit/io/path.cpp
+++ b/unit/io/path.cpp
@@ -47,14 +47,14 @@ UNITTEST(Init)
   vfclose(vf);
 }
 
+struct path_tokenize_result
+{
+  const char *input;
+  const char *expected[8];
+};
+
 UNITTEST(path_tokenize)
 {
-  struct path_tokenize_result
-  {
-    const char *input;
-    const char *expected[8];
-  };
-
   static const path_tokenize_result data[] =
   {
     { nullptr,        { nullptr }},
@@ -93,6 +93,81 @@ UNITTEST(path_tokenize)
       pos++;
     }
     ASSERTEQ(current, d.expected[pos], "%s : %d", d.input, pos);
+  }
+}
+
+UNITTEST(path_reverse_tokenize)
+{
+  static constexpr path_tokenize_result data[] =
+  {
+    { nullptr,          { nullptr }},
+    { "",               { "" }},
+    { "abcde",          { "abcde" }},
+    { "path1/path2",    { "path2", "path1" }},
+    { "p1\\p2\\p3",     { "p3", "p2", "p1" }},
+    { "m1/m2\\m3/m4",   { "m4", "m3", "m2", "m1" }},
+    { "clean///first",  { "first", "", "", "clean" }},
+    { "../duhh/./",     { "", ".", "duhh", ".." }},
+    { "/",              { "", "" }},
+    { "/dir",           { "dir", "" }},
+    { "/dir1/dir2",     { "dir2", "dir1", "" }},
+    { "C:\\",           { "", "C:" }},
+    { "C:\\WINDOWS",    { "WINDOWS", "C:" }},
+    { "C:\\a\\b",       { "b", "a", "C:" }},
+    { "sdcard:/butt",   { "butt", "sdcard:" }},
+    {
+      u8"/home/\u00C8śŚ/megazeux/DE/saved.sav",
+      { "saved.sav", "DE", "megazeux", u8"\u00C8śŚ", "home", "" }
+    },
+  };
+
+  size_t base_length;
+  char *base;
+  char *token;
+
+  token = path_reverse_tokenize(nullptr, nullptr);
+  ASSERTEQ(token, nullptr, "");
+  token = path_reverse_tokenize(nullptr, &base_length);
+  ASSERTEQ(token, nullptr, "");
+
+  for(auto &d : data)
+  {
+    char buffer[256];
+    int pos = 0;
+
+    const auto &init = [&]()
+    {
+      if(d.input)
+      {
+        base_length = snprintf(buffer, sizeof(buffer), "%s", d.input);
+        base = buffer;
+        ASSERT(base_length < sizeof(buffer), "");
+      }
+      else
+      {
+        base_length = 0xbaad; // Some junk, should be ignored.
+        base = nullptr;
+      }
+      pos = 0;
+    };
+
+    init();
+    while((token = path_reverse_tokenize(&base, &base_length)))
+    {
+      ASSERTCMP(token, d.expected[pos], "%s : %d", d.input, pos);
+      pos++;
+    }
+    ASSERTEQ(token, d.expected[pos], "%s : %d", d.input, pos);
+
+    // Should work identically without base_length, it's just slower.
+    init();
+    while((token = path_reverse_tokenize(&base, nullptr)))
+    {
+      ASSERT(d.expected[pos], "%s : %d", d.input, pos);
+      ASSERTCMP(token, d.expected[pos], "%s : %d", d.input, pos);
+      pos++;
+    }
+    ASSERTEQ(token, d.expected[pos], "%s : %d", d.input, pos);
   }
 }
 
@@ -617,6 +692,42 @@ UNITTEST(path_split_functions)
       16,
       true
     },
+    {
+      "/",
+      "/",
+      "\\",
+      "",
+      1,
+      0,
+      true
+    },
+    {
+      "C:\\",
+      "C:/",
+      "C:\\",
+      "",
+      3,
+      0,
+      true
+    },
+    {
+      "/sdfjklfdjdskfdsfgdfsggdfgdfgfdgsgdfgfdgfgg",
+      "/",
+      "\\",
+      "sdfjklfdjdskfdsfgdfsggdfgdfgfdgsgdfgfdgfgg",
+      1,
+      42,
+      true
+    },
+    {
+      "C:\\sdfjklfdjdskfdsfgdfsggdfgdfgfdgsgdfgfdgfgg",
+      "C:/",
+      "C:\\",
+      "sdfjklfdjdskfdsfgdfsggdfgdfgfdgsgdfgfdgfgg",
+      3,
+      42,
+      true
+    },
     // Internally all of these functions may stat the provided directory to
     // determine how much of it is/isn't a path. These paths all assume that
     // a directory stat succeeds for the input path.
@@ -719,6 +830,33 @@ UNITTEST(path_split_functions)
         if(d.filename)
           ASSERTCMP(file_buffer, d.filename, "%s", d.path);
       }
+    }
+  }
+
+  SECTION(path_get_parent)
+  {
+    for(auto &d : data)
+    {
+      // Special: the tests that expect stat() are different.
+      if(!strcmp(d.path, PATH_DIR_EXISTS))
+      {
+        result = path_get_parent(dir_buffer, MAX_PATH, PATH_DIR_EXISTS);
+        ASSERTEQ(result, 0, "%s", PATH_DIR_EXISTS);
+        continue;
+      }
+      if(!strcmp(d.path, PATH_DIR_EXISTS_2))
+      {
+        result = path_get_parent(dir_buffer, MAX_PATH, PATH_DIR_EXISTS_2);
+        ASSERTEQ(result, strlen(PATH_DIR_EXISTS), "%s", PATH_DIR_EXISTS_2);
+        ASSERTCMP(dir_buffer, PATH_DIR_EXISTS, "%s", PATH_DIR_EXISTS_2);
+        continue;
+      }
+
+      // The rest behave exactly like path_get_directory.
+      result = path_get_parent(dir_buffer, MAX_PATH, d.path);
+      ASSERTEQ(result, d.dir_return_value, "%s", d.path);
+      if(result >= 0 && d.SPLIT_DIRECTORY)
+        ASSERTCMP(dir_buffer, d.SPLIT_DIRECTORY, "%s", d.path);
     }
   }
 }
@@ -1140,6 +1278,13 @@ UNITTEST(path_navigate)
       "\\skdlfjlskdjfklsd\\i\\am\\someone\\on\\this",
       38
     },
+    {
+      "/.yeah/.actually/.dotfiles/.should/.work",
+      "../../.work",
+      "/.yeah/.actually/.dotfiles/.work",
+      "\\.yeah\\.actually\\.dotfiles\\.work",
+      32
+    }
   };
   static const path_target_output with_check[] =
   {

--- a/unit/io/path.cpp
+++ b/unit/io/path.cpp
@@ -1284,7 +1284,14 @@ UNITTEST(path_navigate)
       "/.yeah/.actually/.dotfiles/.work",
       "\\.yeah\\.actually\\.dotfiles\\.work",
       32
-    }
+    },
+    {
+      "look/more/nonsense",
+      ".../lol",
+      "look/more/nonsense/.../lol",
+      "look\\more\\nonsense\\...\\lol",
+      26
+    },
   };
   static const path_target_output with_check[] =
   {


### PR DESCRIPTION
Adds support for virtual files and file caching to the vio.c stdio/unistd/dirent wrapper functions. Currently there is no way to enable this in MegaZeux itself; it is only enabled in the unit tests.