### PR TITLE
Add Robotic debugger watchpoint improvements.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -206,6 +206,11 @@ USERS
 + Added disable_screensaver configuration option. MegaZeux now
   leaves the screensaver enabled by default (fixes regression
   caused by SDL 2.0.2+).
++ Improved the performance of Robotic debugger watchpoints,
+  especially for non-built-in counters and non-spliced strings.
++ Robotic debugger watchpoints can now watch for particular
+  counter or string values. Leaving the value field blank will
+  still check for any value.
 + editor_show_thing_toggles is now enabled by default.
 - board_editor_hide_help and robot_editor_hide_help are no
   longer enabled by default for accessibility.
@@ -248,6 +253,10 @@ DEVELOPERS
 + _FILE_OFFSET_BITS=64 is now used for 64-bit fseeko, ftello,
   readdir, and stat/fstat support for 32-bit Linux builds.
 + Applied various Opal fixes from OpenMPT.
+- String values are now allocated separately from the string
+  struct and name. This may make strings very slightly slower,
+  but means string pointers are now stable through an entire
+  gameplay session.
 
 
 November 22nd, 2020 - MZX 2.92f

--- a/src/core.c
+++ b/src/core.c
@@ -1266,6 +1266,7 @@ int (*debug_robot_break)(context *ctx, struct robot *cur_robot,
 int (*debug_robot_watch)(context *ctx, struct robot *cur_robot,
  int id, int lines_run);
 void (*debug_robot_config)(struct world *mzx_world);
+void (*debug_robot_reset)(struct world *mzx_world);
 
 // Network external function pointers (NULL by default).
 

--- a/src/core.h
+++ b/src/core.h
@@ -295,6 +295,7 @@ CORE_LIBSPEC extern int (*debug_robot_break)(context *ctx,
 CORE_LIBSPEC extern int (*debug_robot_watch)(context *ctx,
  struct robot *cur_robot, int id, int lines_run);
 CORE_LIBSPEC extern void (*debug_robot_config)(struct world *mzx_world);
+CORE_LIBSPEC extern void (*debug_robot_reset)(struct world *mzx_world);
 
 // Network external function pointers.
 

--- a/src/counter.h
+++ b/src/counter.h
@@ -35,6 +35,8 @@ __M_BEGIN_DECLS
 CORE_LIBSPEC void counter_fsg(void);
 CORE_LIBSPEC int match_function_counter(const char *dest, const char *src);
 CORE_LIBSPEC int get_counter(struct world *mzx_world, const char *name, int id);
+CORE_LIBSPEC const struct counter *get_counter_pointer(struct world *mzx_world,
+ const char *name, int id);
 CORE_LIBSPEC void set_counter(struct world *mzx_world, const char *name,
  int value, int id);
 CORE_LIBSPEC void new_counter(struct world *mzx_world, const char *name,

--- a/src/counter_struct.h
+++ b/src/counter_struct.h
@@ -55,12 +55,13 @@ struct counter_list
 #endif
 };
 
-// Name and storage share space. It's messy, but fast and
-// space efficient.
+// Like counters, string names are allocated as part of the struct.
+// The storage space is ALWAYS allocated separately from the rest
+// of the string in normal strings, which allows string struct
+// pointers to remain stable throughout their entire lifetime.
+// The storage space must always be allocated for normal strings.
 
-// The storage space doesn't actually have to have anything,
-// however (in fact, neither does name). Strings can
-// be used as pointers to hold intermediate or immediate
+// Strings can also be used as pointers to hold intermediate or immediate
 // values. For instance, string literals and spliced
 // strings. Anyone who uses strings in this way has a few
 // responsibilities, however:
@@ -90,10 +91,6 @@ struct string
   uint32_t length;
   uint32_t allocated_length;
 
-  // Back reference to the string's position in the main list, mandatory as
-  // a hash table search needs to be able to determine this value.
-  uint32_t list_ind;
-
 #ifdef CONFIG_COUNTER_HASH_TABLES
   uint32_t hash;
 #endif
@@ -103,9 +100,9 @@ struct string
   uint8_t unused2;
 
   /**
-   * This struct will be allocated with extra space to contain the string name
-   * and string value. This field MUST be at least 4-aligned and must be the
-   * last field in the struct (any extra padding after it will be used).
+   * This struct will be allocated with extra space to contain the entire
+   * string name, null-terminated. This field MUST be at least 4-aligned and
+   * it must be the last field (any extra padding after it will be used).
    */
   char name[1];
 };

--- a/src/editor/debug.c
+++ b/src/editor/debug.c
@@ -1104,22 +1104,14 @@ static void write_var(struct world *mzx_world, struct debug_var *v, int int_val,
     {
       //set string -- int_val is the length here
       char buffer[ROBOT_MAX_TR];
-      int list_index;
-
       struct string temp;
+
       memset(&temp, '\0', sizeof(struct string));
       temp.length = int_val;
       temp.value = char_val;
 
-      // This may reallocate the string, so we want to save the list index.
-      // We also want to back up the name so its pointer doesn't get changed
-      // in the middle of setting the string.
       memcpy(buffer, v->data.string->name, v->data.string->name_length + 1);
-      list_index = v->data.string->list_ind;
-
       set_string(mzx_world, buffer, &temp, 0);
-
-      v->data.string = mzx_world->string_list.strings[list_index];
       break;
     }
 

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -3464,7 +3464,7 @@ static boolean editor_key(context *ctx, int *key)
           send_robot_def(mzx_world, 0, LABEL_JUSTENTERED);
           send_robot_def(mzx_world, 0, LABEL_JUSTLOADED);
 
-          reset_robot_debugger();
+          debug_robot_reset(mzx_world);
 
           play_game(ctx, NULL);
         }
@@ -3939,6 +3939,7 @@ void editor_init(void)
   debug_robot_break = __debug_robot_break;
   debug_robot_watch = __debug_robot_watch;
   debug_robot_config = __debug_robot_config;
+  debug_robot_reset = __debug_robot_reset;
   load_editor_charsets();
 }
 

--- a/src/editor/robo_debug.h
+++ b/src/editor/robo_debug.h
@@ -27,13 +27,13 @@ __M_BEGIN_DECLS
 #include "../core.h"
 
 EDITOR_LIBSPEC void __debug_robot_config(struct world *mzx_world);
+EDITOR_LIBSPEC void __debug_robot_reset(struct world *mzx_world);
 
 EDITOR_LIBSPEC int __debug_robot_break(context *ctx,
  struct robot *cur_robot, int id, int lines_run);
 EDITOR_LIBSPEC int __debug_robot_watch(context *ctx,
  struct robot *cur_robot, int id, int lines_run);
 
-EDITOR_LIBSPEC void reset_robot_debugger(void);
 EDITOR_LIBSPEC void free_breakpoints(void);
 
 void update_watchpoint_last_values(struct world *mzx_world);

--- a/src/str.h
+++ b/src/str.h
@@ -59,6 +59,8 @@ static inline boolean is_string(const char *buffer)
 
 CORE_LIBSPEC int get_string(struct world *mzx_world, char *name_buffer,
  struct string *dest, int id);
+CORE_LIBSPEC const struct string *get_string_pointer(struct world *mzx_world,
+ const char *name, int id);
 CORE_LIBSPEC int set_string(struct world *mzx_world, char *name_buffer,
  struct string *src, int id);
 CORE_LIBSPEC struct string *new_string(struct world *mzx_world,

--- a/src/world.c
+++ b/src/world.c
@@ -3294,6 +3294,10 @@ void clear_global_data(struct world *mzx_world)
   // Clear all strings out of the string list
   clear_string_list(&(mzx_world->string_list));
 
+  // This needs to be done whenever the counters/strings are cleared.
+  if(debug_robot_reset)
+    debug_robot_reset(mzx_world);
+
   for(i = 0; i < MAX_SPRITES; i++)
   {
     free(sprite_list[i]);


### PR DESCRIPTION
+ Improved the general performance of watchpoints (each watchpoint was calling snprintf once regardless of whether or not it matched).
+ Improved the performance of non-built-in counter and non-splice string watchpoints by caching counter and string pointers.
- String values are no longer allocated as part of the string struct. This was required to stabilize string pointers through the lifetime of the strings list.