### PR TITLE
Fix misc. clang and MinGW warnings.

### DIFF
--- a/src/about.c
+++ b/src/about.c
@@ -328,7 +328,7 @@ static char **load_license(const char *filename, int *_lines)
         }
       }
       total += sz;
-      if(sz > MAX_LICENSE)
+      if(total > MAX_LICENSE)
         break;
 
       arr[lines] = (char *)malloc(sz);

--- a/src/audio/audio_openmpt.c
+++ b/src/audio/audio_openmpt.c
@@ -248,6 +248,8 @@ static struct audio_stream *construct_openmpt_stream(vfile *vf,
     return NULL;
 
   row_tbl_size = openmpt_module_get_num_orders(open_file) + 1;
+  if(row_tbl_size < 1)
+    row_tbl_size = 1;
 
   omp_stream = (struct openmpt_stream *)malloc(sizeof(struct openmpt_stream));
   row_tbl = (uint32_t *)malloc(row_tbl_size * sizeof(uint32_t));
@@ -263,11 +265,11 @@ static struct audio_stream *construct_openmpt_stream(vfile *vf,
   omp_stream->row_tbl = row_tbl;
   omp_stream->row_tbl_size = row_tbl_size;
 
-  for(i = 0, row_pos = 0; i < row_tbl_size; i++)
+  for(i = 0, row_pos = 0; i < (uint32_t)row_tbl_size; i++)
   {
     row_tbl[i] = row_pos;
     ord = openmpt_module_get_order_pattern(open_file, i);
-    if(i < row_tbl_size - 1)
+    if(i < (uint32_t)row_tbl_size - 1)
       row_pos += openmpt_module_get_pattern_num_rows(open_file, ord);
   }
 

--- a/src/io/fsafeopen.c
+++ b/src/io/fsafeopen.c
@@ -36,6 +36,11 @@
 #define SLOW_FILESYSTEM_HACKS
 #endif
 
+#ifndef _WIN32
+#define ENABLE_DOS_COMPAT_TRANSLATIONS
+#endif
+
+#ifdef ENABLE_DOS_COMPAT_TRANSLATIONS
 #if defined(SLOW_FILESYSTEM_HACKS) || defined(_WIN32) || defined(CONFIG_DJGPP)
 // Skip the extra all caps/lower case checks, either because the current
 // platform will always be case-insensitive, or because they are slower than
@@ -43,11 +48,6 @@
 #define NO_EXTRA_CASE_CHECKS
 #endif
 
-#ifndef _WIN32
-#define ENABLE_DOS_COMPAT_TRANSLATIONS
-#endif
-
-#ifdef ENABLE_DOS_COMPAT_TRANSLATIONS
 enum sfn_type
 {
   NOT_AN_SFN,

--- a/src/io/vio.c
+++ b/src/io/vio.c
@@ -1133,7 +1133,7 @@ static inline boolean virt_writeback(vfile *vf)
 static inline boolean virt_read(vfile *vf)
 {
   const unsigned char *tmp;
-  size_t len;
+  size_t len = 0;
   int ret = -1;
   if(!vf->inode)
     return false;


### PR DESCRIPTION
* Fix clang `total` unused warning in about.c.
* Fix clang `len` used uninitialized false positive warning in
  vio.c when compiled without VFS support.
* Fix MinGW `NO_EXTRA_CASE_CHECKS` unused macro warning in fsafeopen.c.
* Fix -Wsign-compare in audio_openmpt.c.