### PR TITLE
Free VFS cached files on check_alloc out-of-memory.

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -744,6 +744,31 @@
 # test_mode = 0
 # test_mode_start_board = 0
 
+# Set to 1 to enable MegaZeux's virtual filesystem (VFS). Currently, this
+# feature is used only to implement file caching in memory. This is disabled by
+# default for all platforms except 3DS and Vita. This feature is not available
+# on the NDS.
+
+# vfs_enable = 0
+
+# Set to 0 to disable file caching in memory when the VFS is active.
+# This will make MegaZeux use more memory. For platforms where the stdlib
+# memory allocation functions properly return NULL, MegaZeux will attempt to
+# reclaim memory from the file cache before an out of memory error occurs.
+# Enabled by default, but only takes effect if the VFS is also enabled.
+
+# vfs_enable_auto_cache = 1
+
+# This setting controls the total amount of memory that can be used by the
+# VFS file cache. This is a soft limit and can be exceeded in some situations.
+
+# vfs_max_cache_size = 16777216
+
+# This setting controls the largest size of an individual file that can be
+# cached within the VFS file cache. Larger files will not be cached to memory.
+
+# vfs_max_cache_file_size = 4194304
+
 
 ###################
 # NETWORK OPTIONS #

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -206,6 +206,12 @@ USERS
 + Added disable_screensaver configuration option. MegaZeux now
   leaves the screensaver enabled by default (fixes regression
   caused by SDL 2.0.2+).
++ Added virtual filesystem support to MegaZeux. Currently, this
+  is only used for caching files, and is only enabled by default
+  on platforms with slow or buggy file IO (3DS, Vita). This
+  feature may be optionally configured with the config options
+  vfs_enable, vfs_enable_auto_cache, vfs_max_cache_size, and
+  vfs_max_cache_file_size.
 + Improved the performance of Robotic debugger watchpoints,
   especially for non-built-in counters and non-spliced strings.
 + Robotic debugger watchpoints can now watch for particular

--- a/src/configure.c
+++ b/src/configure.c
@@ -114,8 +114,9 @@
 #define RESAMPLE_MODE_DEFAULT RESAMPLE_MODE_NONE
 #define MOD_RESAMPLE_MODE_DEFAULT RESAMPLE_MODE_NONE
 #define FULLSCREEN_DEFAULT 1
-#define VFS_ENABLE_DEFAULT true
-#define VFS_ENABLE_AUTO_CACHE_DEFAULT false
+// Uncomment if Ogg Vorbis files need to be forced into memory.
+//#define VFS_ENABLE_DEFAULT true
+//#define VFS_ENABLE_AUTO_CACHE_DEFAULT false
 #endif
 
 // End arch-specific config.
@@ -268,8 +269,8 @@ static const struct config_info user_conf_default =
   // Virtual filesystem options
   VFS_ENABLE_DEFAULT,           // vfs_enable
   VFS_ENABLE_AUTO_CACHE_DEFAULT,// vfs_enable_auto_cache
-  VFS_MAX_CACHE_SIZE_DEFAULT,   // vfs_max_cache_size_default
-  VFS_MAX_CACHE_FILE_SIZE_DEFAULT, // vfs_max_cache_file_size_default
+  VFS_MAX_CACHE_SIZE_DEFAULT,   // vfs_max_cache_size
+  VFS_MAX_CACHE_FILE_SIZE_DEFAULT, // vfs_max_cache_file_size
 
   // Game options
   "",                           // startup_path

--- a/src/io/vio.c
+++ b/src/io/vio.c
@@ -416,6 +416,9 @@ boolean vio_virtual_directory(const char *path)
  */
 boolean vio_invalidate_at_least(size_t *amount_to_free)
 {
+#ifdef DEBUG
+  size_t init = amount_to_free ? *amount_to_free : 0;
+#endif
   int err;
   if(!vfs_base || !amount_to_free)
     return false;
@@ -424,6 +427,7 @@ boolean vio_invalidate_at_least(size_t *amount_to_free)
   if(err)
     return false;
 
+  debug("vio_invalidate_at_least freed >= %zu buffered\n", init - *amount_to_free);
   if(*amount_to_free > 0)
     return false;
 
@@ -438,6 +442,7 @@ boolean vio_invalidate_all(void)
   if(!vfs_base)
     return false;
 
+  debug("vio_invalidate_all\n");
   if(vfs_invalidate_all(vfs_base) < 0)
     return false;
 


### PR DESCRIPTION
* The check_alloc functions now attempt to free cached files before displaying an out-of-memory error. This relies on operating systems or SDKs properly returning `NULL` from `malloc` et al.
* Added missing changelog entry and config.txt documentation for the VFS.