### PR TITLE
Explicitly define Android ndkVersion in app/build.gradle.

### DIFF
--- a/arch/android/README.md
+++ b/arch/android/README.md
@@ -58,7 +58,6 @@ The build process for the MegaZeux port is as follows:
   * For Android Studio users, this will be `/home/.../Android/Sdk/ndk-bundle/`
     Create the file `arch/android/project/local.properties` with the following lines:
 ```
-ndk.dir=[NDK path here]
 sdk.dir=[SDK path here]
 ```
 3. If you haven't done so already, use `./config.sh --platform android` (or use

--- a/arch/android/project/app/build.gradle
+++ b/arch/android/project/app/build.gradle
@@ -25,6 +25,8 @@ android {
             keyPassword keystoreProperties['keyPassword']
         }
     }
+    // TODO: Gradle automatically installs whatever version it wants unless this is specified.
+    ndkVersion "23.2.8568313"
     compileSdkVersion 31
     buildToolsVersion "30.0.3"
     defaultConfig {

--- a/arch/android/project/app/build.gradle
+++ b/arch/android/project/app/build.gradle
@@ -25,7 +25,6 @@ android {
             keyPassword keystoreProperties['keyPassword']
         }
     }
-    // TODO: Gradle automatically installs whatever version it wants unless this is specified.
     ndkVersion "23.2.8568313"
     compileSdkVersion 31
     buildToolsVersion "30.0.3"


### PR DESCRIPTION
For whatever reason, in my setup this is required so that Gradle doesn't choose to install whichever NDK versions it feels like during `make apk`.