### PR TITLE
nds: avoid reading main RAM cell data multiple times, saving ~2-10% C…

### DIFF
--- a/arch/nds/render.c
+++ b/arch/nds/render.c
@@ -533,12 +533,16 @@ static void nds_render_graph_scaled(struct graphics_data *graphics)
     if(graph_cache[chars] != key)
     {
       graph_cache[chars] = key;
+      // Avoid reading from RAM to cache twice.
+      chr = key & 0x1FF;
+      bg  = (key >> 16) & 0x0F;
+      fg  = (key >> 24) & 0x0F;
 #else
     {
-#endif
       chr = (*text_cell).char_value & 0x1FF;
       bg  = (*text_cell).bg_color   & 0x0F;
       fg  = (*text_cell).fg_color   & 0x0F;
+#endif
 
       // Construct a table mapping charset two-bit pairs to palette entries.
       if(chr & 0x100) // Protected palette


### PR DESCRIPTION
…PU time

I do not understand why this helps as much as it does. Alas, it does save ~2% CPU usage in this function in melonDS and a staggering ~10% CPU usage on a real NDS.