### PR TITLE
Enable save slots by default on consoles.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -255,6 +255,7 @@ USERS
   FWRITE_APPEND) is now stored in save files. This fixes a bug
   where the output file would be reopened in the wrong mode (ab)
   when reloading a saved game.
++ save_slots is now enabled by default for consoles. (Spectere)
 + editor_show_thing_toggles is now enabled by default.
 - board_editor_hide_help and robot_editor_hide_help are no
   longer enabled by default for accessibility.

--- a/src/configure.c
+++ b/src/configure.c
@@ -52,6 +52,7 @@
 #ifdef CONFIG_NDS
 #define VIDEO_OUTPUT_DEFAULT "nds"
 #define VIDEO_RATIO_DEFAULT RATIO_CLASSIC_4_3
+#define SAVE_SLOTS true
 #endif
 
 #ifdef CONFIG_DREAMCAST
@@ -61,6 +62,7 @@
 #ifdef CONFIG_GP2X
 #define VIDEO_OUTPUT_DEFAULT "gp2x"
 #define AUDIO_BUFFER_SAMPLES 128
+#define SAVE_SLOTS true
 #endif
 
 #ifdef CONFIG_PSP
@@ -68,6 +70,7 @@
 #define FULLSCREEN_HEIGHT_DEFAULT 363
 #define FORCE_BPP_DEFAULT 8
 #define FULLSCREEN_DEFAULT 1
+#define SAVE_SLOTS true
 #endif
 
 #ifdef CONFIG_PSVITA
@@ -84,6 +87,7 @@
 #define FULLSCREEN_DEFAULT 1
 #define GL_VSYNC_DEFAULT 1
 #define VIDEO_RATIO_DEFAULT RATIO_CLASSIC_4_3
+#define SAVE_SLOTS true
 #ifdef CONFIG_SDL
 #define VIDEO_OUTPUT_DEFAULT "software"
 #define FULLSCREEN_WIDTH_DEFAULT 640
@@ -102,6 +106,7 @@
 #define FULLSCREEN_WIDTH_DEFAULT 1280
 #define FULLSCREEN_HEIGHT_DEFAULT 720
 #define FULLSCREEN_DEFAULT 1
+#define SAVE_SLOTS true
 #endif
 
 #ifdef CONFIG_SWITCH
@@ -109,6 +114,7 @@
 #define FULLSCREEN_WIDTH_DEFAULT 1920
 #define FULLSCREEN_HEIGHT_DEFAULT 1080
 #define FULLSCREEN_DEFAULT 1
+#define SAVE_SLOTS true
 #endif
 
 #ifdef ANDROID
@@ -198,6 +204,10 @@
 
 #ifndef AUTO_DECRYPT_WORLDS
 #define AUTO_DECRYPT_WORLDS true
+#endif
+
+#ifndef SAVE_SLOTS
+#define SAVE_SLOTS false
 #endif
 
 #ifdef CONFIG_UPDATER
@@ -293,7 +303,7 @@ static const struct config_info user_conf_default =
   false,                        // no_titlescreen
   false,                        // system_mouse
   false,                        // grab_mouse
-  false,                        // save_slots
+  SAVE_SLOTS,                   // save_slots
   "%w.",                        // save_slots_name
   ".sav",                       // save_slots_ext
 

--- a/src/configure.c
+++ b/src/configure.c
@@ -52,17 +52,18 @@
 #ifdef CONFIG_NDS
 #define VIDEO_OUTPUT_DEFAULT "nds"
 #define VIDEO_RATIO_DEFAULT RATIO_CLASSIC_4_3
-#define SAVE_SLOTS true
+#define SAVE_SLOTS_DEFAULT true
 #endif
 
 #ifdef CONFIG_DREAMCAST
 #define VIDEO_OUTPUT_DEFAULT "dreamcast"
+#define SAVE_SLOTS_DEFAULT true
 #endif
 
 #ifdef CONFIG_GP2X
 #define VIDEO_OUTPUT_DEFAULT "gp2x"
 #define AUDIO_BUFFER_SAMPLES 128
-#define SAVE_SLOTS true
+#define SAVE_SLOTS_DEFAULT true
 #endif
 
 #ifdef CONFIG_PSP
@@ -70,7 +71,7 @@
 #define FULLSCREEN_HEIGHT_DEFAULT 363
 #define FORCE_BPP_DEFAULT 8
 #define FULLSCREEN_DEFAULT 1
-#define SAVE_SLOTS true
+#define SAVE_SLOTS_DEFAULT true
 #endif
 
 #ifdef CONFIG_PSVITA
@@ -80,6 +81,7 @@
 #define FULLSCREEN_DEFAULT 1
 #define VFS_ENABLE_DEFAULT true
 #define VFS_MAX_CACHE_SIZE_DEFAULT (1 << 27) /* 128 MiB */
+#define SAVE_SLOTS_DEFAULT true
 #endif
 
 #ifdef CONFIG_WII
@@ -87,7 +89,7 @@
 #define FULLSCREEN_DEFAULT 1
 #define GL_VSYNC_DEFAULT 1
 #define VIDEO_RATIO_DEFAULT RATIO_CLASSIC_4_3
-#define SAVE_SLOTS true
+#define SAVE_SLOTS_DEFAULT true
 #ifdef CONFIG_SDL
 #define VIDEO_OUTPUT_DEFAULT "software"
 #define FULLSCREEN_WIDTH_DEFAULT 640
@@ -100,13 +102,14 @@
 #define VIDEO_RATIO_DEFAULT RATIO_CLASSIC_4_3
 #define VFS_ENABLE_DEFAULT true
 #define VFS_MAX_CACHE_SIZE_DEFAULT (1 << 25) /* 32 MiB */
+#define SAVE_SLOTS_DEFAULT true
 #endif
 
 #ifdef CONFIG_WIIU
 #define FULLSCREEN_WIDTH_DEFAULT 1280
 #define FULLSCREEN_HEIGHT_DEFAULT 720
 #define FULLSCREEN_DEFAULT 1
-#define SAVE_SLOTS true
+#define SAVE_SLOTS_DEFAULT true
 #endif
 
 #ifdef CONFIG_SWITCH
@@ -114,7 +117,7 @@
 #define FULLSCREEN_WIDTH_DEFAULT 1920
 #define FULLSCREEN_HEIGHT_DEFAULT 1080
 #define FULLSCREEN_DEFAULT 1
-#define SAVE_SLOTS true
+#define SAVE_SLOTS_DEFAULT true
 #endif
 
 #ifdef ANDROID
@@ -206,8 +209,8 @@
 #define AUTO_DECRYPT_WORLDS true
 #endif
 
-#ifndef SAVE_SLOTS
-#define SAVE_SLOTS false
+#ifndef SAVE_SLOTS_DEFAULT
+#define SAVE_SLOTS_DEFAULT false
 #endif
 
 #ifdef CONFIG_UPDATER
@@ -303,7 +306,7 @@ static const struct config_info user_conf_default =
   false,                        // no_titlescreen
   false,                        // system_mouse
   false,                        // grab_mouse
-  SAVE_SLOTS,                   // save_slots
+  SAVE_SLOTS_DEFAULT,           // save_slots
   "%w.",                        // save_slots_name
   ".sav",                       // save_slots_ext
 


### PR DESCRIPTION
New PR since I can't rebase an archived branch. Closes #222.

Original description:
> Enables save slots on NDS, GP2X, PSP, Wii, 3DS, and Switch. It defaults to false on everything else, including Android and Emscripten.

Changes:
* Also enabled it for Dreamcast, PS Vita, and Wii U.
* Macro name tweak (attempt at consistency...).