### PR TITLE
Mobile display improvements for most HTML documentation.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -305,6 +305,8 @@ DEVELOPERS
 + Updated Android SDL to 2.28.2. (asie)
 + Updated Android NDK to r23c. (asie)
 + Fixed Android build system handling of missing libraries.
++ Improved fileform.html, joystick.html, keycodes.html, and
+  platform_matrix.html readability on small/mobile displays.
 - String values are now allocated separately from the string
   struct and name. This may make strings very slightly slower,
   but means string pointers are now stable through an entire

--- a/docs/fileform.html
+++ b/docs/fileform.html
@@ -20,6 +20,7 @@
 <head>
 <meta charset="UTF-8">
 <title>MegaZeux File Formats</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="title" content="MegaZeux File Format Reference">
 <meta name="description" content="Information about various file formats defined by MegaZeux.">
 <meta name="twitter:card" content="summary">
@@ -28,33 +29,33 @@
 <style>
   #container
   {
-    width: 800px;
+    max-width: 780px;
     margin: auto;
-    padding: 0px 24px;
+    padding: 0px;
   }
 
   header, section
   {
-    margin: 8px;
+    margin: 4px;
     margin-bottom: 16px;
   }
 
   header, section.contents
   {
-    padding: 16px;
+    padding: 8px 4px;
   }
 
   section.main
   {
-    padding: 16px;
-    padding-bottom: 96px;
+    padding: 8px 4px;
+    padding-bottom: 72px;
   }
 
   section.inner
   {
     background-color: #F4F4F4;
     border-radius: 5px;
-    padding: 4px 24px 16px;
+    padding: 2px 16px 8px;
   }
 
   code
@@ -76,19 +77,27 @@
     background-color: #555;
     font-size: .95em;
     color: #fff;
-    margin: 24px;
-    padding: 0px 32px 16px;
+    margin: 20px 8px;
+    padding: 0px 20px 16px;
+    overflow: auto;
     white-space: pre;
   }
 
   div.image-wrapper
   {
-    margin: 16px;
+    max-width: 640px;
+    margin: 0 auto;
+    overflow: auto;
+  }
+
+  div.scroll-wrapper
+  {
+    overflow: auto;
   }
 
   table
   {
-    width: 100%;
+    width: 99%;
     margin: 24px 2px 40px;
     border: 1px solid #aaa;
     font-size: small;
@@ -129,6 +138,7 @@
   {
     font-family: monospace;
     white-space: pre;
+    overflow: auto;
   }
 
   li
@@ -296,6 +306,8 @@
     <h3>MegaZeux 2.92f &mdash; November 22nd, 2020</h3>
     <p>
       This guide contains specifications for most MegaZeux file formats.
+      This is a table-dense document and should be displayed in a window/viewport
+      at least 640px wide to reduce table overflow.
     </p>
   </header>
 
@@ -461,7 +473,7 @@
 |---------|-----|
 | Binary  | `00101010`
 | Hex     | `2A`
-| Decimal | <code class="block">(128 * 0) + (64 * 0) + (32 * 1) + (16 * 0) +<br>(8 * 1) + (4 * 0) + (2 * 1) + (1 * 0) = 42.</code>
+| Decimal | <code class="block">  (128 * 0) <br> + (64 * 0) <br> + (32 * 1) <br> + (16 * 0) <br> +  (8 * 1) <br> +  (4 * 0) <br> +  (2 * 1) <br> +  (1 * 0) = 42 </code>
       </div>
     </section>
 
@@ -500,7 +512,7 @@
 | Quaternary | `1130`
 | Binary     | `01011100`
 | Hex        | `5C`
-| Decimal    | <code class="block">(64 * 1) + (16 * 1) + (4 * 3) + (1 * 0) = 92</code>
+| Decimal    | <code class="block">   (64 * 1) <br> + (16 * 1) <br> +  (4 * 3) <br> +  (1 * 0) = 92 </code>
       </div>
     </section>
   </section>
@@ -529,8 +541,8 @@
 
       <h4>Examples</h4>
       <div class="markdown">
-| Color         | R   | G   | B   | Hex representation in-file: |
-|---------------|-----|-----|-----|-----------------------------|
+| Color         | R   | G   | B   | Hex in-file: |
+|---------------|-----|-----|-----|--------------|
 | Black         | 0   | 0   | 0   | `00 00 00`
 | Dark Blue     | 0   | 0   | 42  | `00 00 2A`
 | Dark Green    | 0   | 42  | 0   | `00 2A 00`
@@ -1773,13 +1785,13 @@ while(i &lt; size)
           MegaZeux 2.80+ ignores this field and uses the plane dimensions to
           to determine the board size.
           <div class="markdown">
-| Board Mode | Max. Width | Max. Height |
-|------------|------------|-------------|
-| `0`        | 60         | 166         |
-| `1`        | 80         | 125         |
-| `2`        | 100        | 100         |
-| `3`        | 200        | 50          |
-| `4`        | 400        | 25          |
+| Board Mode | Width | Height |
+|------------|-------|--------|
+| `0`        | 60    | 166    |
+| `1`        | 80    | 125    |
+| `2`        | 100   | 100    |
+| `3`        | 200   | 50     |
+| `4`        | 400   | 25     |
           </div>
         </li>
         <li id="board200note2">
@@ -2449,7 +2461,7 @@ while(i &lt; size)
 | `0x0012` | ID Chars bullet colors               | array(b * 3)            |
 | `0x0013` | ID Chars block 3 (damage)            | array(b * 128)          |
 
-| `0x0018` | Status counters                      | Properties (2.93+)<br>array(s15 with \0 * 6) |
+| `0x0018` | Status counters                      | Properties (2.93+)<br>array(s15&nbsp;with&nbsp;\0&nbsp;*&nbsp;6) |
 
 | `0x0020` | Edge color                           | int(b)
 | `0x0021` | First board #                        | int(b)
@@ -2466,7 +2478,7 @@ while(i &lt; size)
 | `0x002C` | Health limit                         | int(w)
 | `0x002D` | Enemies' bullets hurt other enemies  | int(b)
 | `0x002E` | Clear messages/projectiles on exit   | int(b)
-| `0x002F` | Can only play world from a <code>SWAP WORLD</code>| int(b)
+| `0x002F` | Can only play world from <code>SWAP WORLD</code>| int(b)
 
 | `0x8030` | SMZX mode (0: disabled)              | int(b)                  | Save-only before 2.91
 | `0x8031` | Vlayer width                         | int(w)                  | Save-only before 2.91
@@ -2478,7 +2490,7 @@ while(i &lt; size)
 | `0x8042` | MZX speed is locked?                 | int(b)                  | Save-only
 | `0x8043` | Commands per cycle                   | int(ds)                 | Save-only
 | `0x8044` | Commands per cycle breakpoint limit  | int(ds)                 | Save-only
-| `0x8048` | Saved positions                      | array((w + w + b) * 8)  | Save-only
+| `0x8048` | Saved positions                      | array((w&nbsp;+&nbsp;w&nbsp;+&nbsp;b)&nbsp;*&nbsp8)  | Save-only
 | `0x8049` | Under player ID/param/color          | array(b * 3)            | Save-only
 | `0x804A` | Player restart X                     | int(w)                  | Save-only
 | `0x804B` | Player restart Y                     | int(w)                  | Save-only

--- a/docs/joystick.html
+++ b/docs/joystick.html
@@ -20,6 +20,7 @@
 <head>
   <meta charset="UTF-8">
   <title>MegaZeux Joystick Support</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="title" content="MegaZeux Joystick Support Guide">
   <meta name="description" content="Guide for configuring gamepad support for games and standard console gamepad layouts.">
   <meta name="twitter:card" content="summary">
@@ -29,33 +30,33 @@
   <style>
     #container
     {
-      width: 800px;
+      max-width: 780px;
       margin: auto;
-      padding: 0px 24px;
+      padding: 0px;
     }
 
     header, section
     {
-      margin: 8px;
+      margin: 4px;
       margin-bottom: 16px;
     }
 
     header, section.contents
     {
-      padding: 16px;
+      padding: 8px 4px;
     }
 
     section.main
     {
-      padding: 16px;
-      padding-bottom: 96px;
+      padding: 8px 4px;
+      padding-bottom: 72px;
     }
 
     section.inner
     {
       background-color: #F4F4F4;
       border-radius: 5px;
-      padding: 4px 24px 16px;
+      padding: 2px 16px 8px;
     }
 
     code
@@ -72,26 +73,34 @@
       background-color: #555;
       font-size: .95em;
       color: #fff;
-      margin: 24px;
-      padding: 0px 32px 16px;
+      margin: 20px 8px;
+      padding: 0px 20px 16px;
+      overflow: auto;
       white-space: pre-line;
     }
 
     div.image-wrapper
     {
-      margin: 16px;
+      max-width: 640px;
+      margin: 0 auto;
+      overflow: auto;
+    }
+
+    div.scroll-wrapper
+    {
+      overflow: auto;
     }
 
     table
     {
-      width: 100%;
+      width: 99%;
       margin: 24px 2px 40px;
       border: 1px solid #aaa;
     }
 
     td
     {
-      padding: 1px 10px;
+      padding: 1px 6px;
       border: 4px solid transparent;
     }
 
@@ -178,7 +187,8 @@
       </p>
 
       <div class="image-wrapper">
-      <svg width="640" height="400">
+      <svg width="640" height="400" role="img">
+        <title>Diagram of a typical XInput-like controller with buttons and axes labeled.</title>
         <style>
           .label { font: bold 16px monospace; }
         </style>
@@ -286,6 +296,7 @@
         The available joystick actions, their UI behavior, and their default
         gameplay keybindings are:
       </p>
+      <div class="scroll-wrapper">
       <table>
         <thead>
           <td>Name</td>
@@ -297,28 +308,28 @@
         <tr>
           <td><code>up</code></td>
           <td></td>
-          <td>Element/cursor up</td>
+          <td>Element/&#x200b;cursor up</td>
           <td><code>key_up</code> (movement)</td>
         </tr>
 
         <tr>
           <td><code>down</code></td>
           <td></td>
-          <td>Element/cursor down</td>
+          <td>Element/&#x200b;cursor down</td>
           <td><code>key_down</code> (movement)</td>
         </tr>
 
         <tr>
           <td><code>left</code></td>
           <td></td>
-          <td>Element/cursor left</td>
+          <td>Element/&#x200b;cursor left</td>
           <td><code>key_left</code> (movement)</td>
         </tr>
 
         <tr>
           <td><code>right</code></td>
           <td></td>
-          <td>Element/cursor right</td>
+          <td>Element/&#x200b;cursor right</td>
           <td><code>key_right</code> (movement)</td>
         </tr>
 
@@ -406,6 +417,7 @@
           <td></td>
         </tr>
       </table>
+      </div>
 
       <p>
         The following actions are available only through Robotic or are mostly
@@ -414,7 +426,7 @@
 
       <table>
         <thead>
-          <td style="min-width:256px">Name</td>
+          <td style="min-width:40%">Name</td>
           <td>Description</td>
         </thead>
 
@@ -922,7 +934,8 @@
       </p>
 
       <div class="image-wrapper">
-      <svg width="640" height="560">
+      <svg width="640" height="560" role="img">
+        <title>Diagram resembling an NDS or 3DS, with buttons and axes labeled.</title>
         <svg x="5%" y="1%" width="90%" height="98%">
           <style>
             .label { font: bold 16px monospace; }
@@ -1027,7 +1040,8 @@
       </p>
 
       <div class="image-wrapper">
-      <svg width="640" height="280">
+      <svg width="640" height="280" role="img">
+        <title>Diagram resembling a PSP, with buttons and axes labeled.</title>
         <style>
           .label { font: bold 16px monospace; }
         </style>
@@ -1142,7 +1156,8 @@
       </p>
 
       <div class="image-wrapper">
-      <svg width="640" height="320">
+      <svg width="640" height="320" role="img">
+        <title>Diagram resembling a Switch with buttons and axes labeled.</title>
         <style>
           .label { font: bold 16px monospace; }
         </style>
@@ -1290,7 +1305,8 @@
         </p>
 
         <div class="image-wrapper">
-        <svg width="640" height="200">
+        <svg width="640" height="200" role="img">
+          <title>Diagram resembling a Wii Remote with buttons labeled.</title>
           <style>
             .label { font: bold 16px monospace; }
           </style>
@@ -1367,7 +1383,8 @@
         </p>
 
         <div class="image-wrapper">
-        <svg width="640" height="500">
+        <svg width="640" height="500" role="img">
+          <title>Diagram resembling a Wii Remote and nunchuck, with buttons and axes labeled.</title>
           <style>
             .label { font: bold 16px monospace; }
           </style>
@@ -1473,7 +1490,8 @@
         </p>
 
         <div class="image-wrapper">
-        <svg width="640" height="320">
+        <svg width="640" height="320" role="img">
+          <title>Diagram resembling a Wii Classic Controller with buttons and axes labeled.</title>
           <style>
             .label { font: bold 16px monospace; }
           </style>
@@ -1598,7 +1616,8 @@
       </p>
 
       <div class="image-wrapper">
-      <svg width="640" height="360">
+      <svg width="640" height="360" role="img">
+        <title>Diagram resembling a GP2X with buttons and axes labeled.</title>
         <style>
           .label { font: bold 16px monospace; }
         </style>
@@ -1696,7 +1715,7 @@
     <h2>License</h2>
     <section class="inner">
       <p>
-        Copyright &copy; 2019, 2020 Lachesis &mdash;
+        Copyright &copy; 2019-2023 Lachesis &mdash;
         <a href="https://github.com/AliceLR/megazeux/">
           https://github.com/AliceLR/megazeux/
         </a>

--- a/docs/keycodes.html
+++ b/docs/keycodes.html
@@ -20,6 +20,7 @@
  <head>
   <title>MegaZeux Keycodes Guide</title>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="title" content="MegaZeux Keycodes Guide">
   <meta name="description" content="Diagram of MegaZeux keycodes for the US keyboard layout.">
   <meta name="twitter:card" content="summary">
@@ -28,9 +29,8 @@
   <style>
    body
    {
-    /* The keyboard starts to visually break apart around ~824px. */
-    min-width: 832px;
     max-width: 1260px;
+    font-family: Arial, sans;
    }
 
    /* Browsers that don't support flexboxes should ignore these settings and
@@ -39,6 +39,10 @@
    {
     display: flex;
     flex-flow: row-reverse;
+    /* The keyboard starts to visually break apart around ~824px. */
+    /* It breaks closer to 860px in Firefox/Linux. */
+    min-width: 860px;
+    overflow: auto;
    }
 
    #keyboardmaincontainer
@@ -48,6 +52,13 @@
     /* This div is also a separate flexbox */
     display: flex;
     flex-flow: column;
+   }
+
+   #keyboardkey
+   {
+    /* See keyboardcontainer */
+    min-width: 860px;
+    overflow: auto;
    }
 
    table, tbody, tr, td, div, p, b
@@ -207,6 +218,11 @@
     z-index: 1;
    }
 
+   table.keyboard.key td div
+   {
+    height: 80px;
+   }
+
    div:before, b:before, p:before
    {
     font-size: 60%;
@@ -237,7 +253,7 @@
    }
    table.bypass th
    {
-    border: 1px solid #000;
+    border: 1px solid #555;
     font-weight: bold;
     text-align: left;
     padding-right: 16px;
@@ -246,7 +262,9 @@
    }
    table.bypass td
    {
-    padding-left: 10px;
+    border-top: 1px solid #aaa;
+    border-bottom: 1px solid #aaa;
+    padding: 5px 0px 5px 10px;
     font-weight: normal;
    }
    var
@@ -379,7 +397,7 @@
 
     <td>
      <div class="warn">
-      7<sup> Home</sup>
+      7<sup>&nbsp;Home</sup>
       <b>71</b>
       <p>263</p>
       <span class="keyname">key_kp7</span>
@@ -388,7 +406,7 @@
 
     <td>
      <div class="warn">
-       8<sup> &#x25b2;</sup>
+       8<sup>&nbsp;&#x25b2;</sup>
       <b>72</b>
       <p>264</p>
       <span class="keyname">key_kp8</span>
@@ -397,7 +415,7 @@
 
     <td>
      <div class="warn">
-      9<sup> PgUp</sup>
+      9<sup>&nbsp;PgUp</sup>
       <b>73</b>
       <p>265</p>
       <span class="keyname">key_kp9</span>
@@ -418,7 +436,7 @@
 
     <td>
      <div class="warn">
-       4<sup> &#x25c0;</sup>
+       4<sup>&nbsp;&#x25c0;</sup>
       <b>75</b>
       <p>260</p>
       <span class="keyname">key_kp4</span>
@@ -436,7 +454,7 @@
 
     <td>
      <div class="warn">
-       6<sup> &#x25b6;</sup>
+       6<sup>&nbsp;&#x25b6;</sup>
       <b>77</b>
       <p>262</p>
       <span class="keyname">key_kp6</span>
@@ -448,7 +466,7 @@
 
     <td>
      <div class="warn">
-      1<sup> End</sup>
+      1<sup>&nbsp;End</sup>
       <b>79</b>
       <p>257</p>
       <span class="keyname">key_kp1</span>
@@ -457,7 +475,7 @@
 
     <td>
      <div class="warn">
-       2<sup> &#x25bc;</sup>
+       2<sup>&nbsp;&#x25bc;</sup>
       <b>80</b>
       <p>258</p>
       <span class="keyname">key_kp2</span>
@@ -466,7 +484,7 @@
 
     <td>
      <div class="warn">
-      3<sup> PgDn</sup>
+      3<sup>&nbsp;PgDn</sup>
       <b>81</b>
       <p>259</p>
       <span class="keyname">key_kp3</span>
@@ -487,7 +505,7 @@
 
     <td colspan="2">
      <div class="warn">
-      0<sup> Insert</sup>
+      0<sup>&nbsp;Insert</sup>
       <b>82</b>
       <p>256</p>
       <span class="keyname">key_kp0</span>
@@ -1418,7 +1436,7 @@
 
   </div> <!-- #keyboardcontainer -->
 
-  <table class="keyboard key">
+  <table id="keyboardkey" class="keyboard key">
    <tr>
     <td class="spacebar">
      <div class="none">
@@ -1443,7 +1461,7 @@
     </td>
     <td class="double">
      <div class="game">
-      Game key&mdash;can be disabled via Robotic or other means.
+      Game key&mdash;can disable via Robotic or other means.
      </div>
     </td>
     <td class="space">
@@ -1629,7 +1647,7 @@
 
   <h3>License</h3>
   <p>
-    Copyright &copy; 2010-2020 Lachesis &mdash;
+    Copyright &copy; 2010-2023 Lachesis &mdash;
     <a href="https://github.com/AliceLR/megazeux/">
       https://github.com/AliceLR/megazeux/
     </a>

--- a/docs/platform_matrix.html
+++ b/docs/platform_matrix.html
@@ -3,6 +3,7 @@
 <head>
 <title>MegaZeux Platform Support Matrix</title>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="title" content="MegaZeux Platform Support Matrix">
 <meta name="description" content="Information about platforms supported by MegaZeux and their configuration/toolchain details.">
 <meta name="twitter:card" content="summary">
@@ -793,7 +794,6 @@ body {
 	font-family : "Verdana", "Bitstream Vera Sans";
 	margin-left : 1em;
 	margin-right : 1em;
-	font-size : 9pt;
 }
 
 p#legend {
@@ -807,6 +807,7 @@ table {
 	border-spacing : 0;
 	min-width : 1880px;
 	width : 98%;
+	font-size : 9pt;
 }
 
 td, th {
@@ -836,6 +837,7 @@ span.yes, span.no, span.no2, span.na, span.std {
 	border : 1px solid black;
 	padding-right : 1em;
 	padding-left : 1em;
+	white-space: nowrap;
 }
 
 .yes {
@@ -875,7 +877,7 @@ a {
 
 li {
 	padding : 2px;
-	width : 50%;
+	max-width: 960px;
 }
 </style>
 </head>


### PR DESCRIPTION
This improves the display of fileform.html, joystick.html, keycodes.html, and platform_matrix.html for mobile and other small displays. All four documents now have an HTML viewport tag, and I've made various CSS and content tweaks to each document to improve scalability of the text content and some (but not all) tables/figures.