### PR TITLE
Add --host config.sh option and CROSS_COMPILE Makefile variable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ PEFIX   ?= true
 
 CHMOD   ?= chmod
 CP      ?= cp
-LOCAL_CC?= gcc
+HOST_CC ?= gcc
 LN      ?= ln
 MKDIR   ?= mkdir
 MV      ?= mv
@@ -441,7 +441,7 @@ PEFIX   := @${PEFIX}
 
 CHMOD   := @${CHMOD}
 CP      := @${CP}
-LOCAL_CC:= @${LOCAL_CC}
+HOST_CC := @${HOST_CC}
 LN      := @${LN}
 MKDIR   := @${MKDIR}
 MV      := @${MV}
@@ -478,7 +478,7 @@ build/${TARGET}src:
 #
 # * SUPPRESS_CC_TARGETS prevents "mzx", etc from being added to "all".
 # * SUPPRESS_BUILD_TARGETS suppresses "build".
-# * SUPPRESS_LOCAL_TARGETS suppresses "assets/help.fil", "test", etc.
+# * SUPPRESS_HOST_TARGETS suppresses "assets/help.fil", "test", etc.
 #
 ifneq (${SUPPRESS_ALL_TARGETS},1)
 
@@ -621,7 +621,7 @@ distclean: clean
 	@rm -f src/config.h
 	@echo "PLATFORM=none" > platform.inc
 
-ifneq (${SUPPRESS_LOCAL_TARGETS},1)
+ifneq (${SUPPRESS_HOST_TARGETS},1)
 
 assets/help.fil: ${txt2hlp} docs/WIPHelp.txt
 	$(if ${V},,@echo "  txt2hlp " $@)
@@ -648,7 +648,7 @@ else
 	@${SHELL} testworlds/run.sh ${PLATFORM}
 endif
 
-endif # !SUPPRESS_LOCAL_TARGETS
+endif # !SUPPRESS_HOST_TARGETS
 
 test_clean:
 	@rm -rf testworlds/log

--- a/arch/3ds/Makefile.in
+++ b/arch/3ds/Makefile.in
@@ -30,10 +30,13 @@ EXTRA_LICENSES += ${LICENSE_MPL2} ${LICENSE_NEWLIB}
 #
 # 3DS target rules
 #
-STRIP  = /bin/true
 
+# Block --host, which will break things.
+CROSS_COMPILE =
+# Don't strip when generating debug symbols.
+NO_STRIP_IN_DEBUGLINK ?= 1
 # Disable rules that require target code to run natively.
-SUPPRESS_HOST_TARGETS ?= 1
+SUPPRESS_LOCAL_TARGETS ?= 1
 
 #
 # Override library paths.

--- a/arch/3ds/Makefile.in
+++ b/arch/3ds/Makefile.in
@@ -36,7 +36,7 @@ CROSS_COMPILE =
 # Don't strip when generating debug symbols.
 NO_STRIP_IN_DEBUGLINK ?= 1
 # Disable rules that require target code to run natively.
-SUPPRESS_LOCAL_TARGETS ?= 1
+SUPPRESS_HOST_TARGETS ?= 1
 
 #
 # Override library paths.

--- a/arch/3ds/Makefile.in
+++ b/arch/3ds/Makefile.in
@@ -90,6 +90,8 @@ arch/3ds/%.shbin: arch/3ds/%.v.pica arch/3ds/%.g.pica
 arch/3ds/%.shbin.o: arch/3ds/%.shbin arch/3ds/%_shbin.h
 	$(if ${V},,@echo "  AS      " $<)
 	@bin2s $< > $<.S
+	@# Shut up the assembler since bin2s doesn't emit a trailing newline:
+	@echo '' >> $<.S
 	$(AS) $<.S -o $@
 
 arch/3ds/%_shbin.h: arch/3ds/%.shbin

--- a/arch/amiga/Makefile.in
+++ b/arch/amiga/Makefile.in
@@ -2,9 +2,9 @@
 # amiga makefile generics
 #
 
-CC      = ppc-amigaos-gcc -mcrt=clib2 -I${PREFIX}/clib2/include
-CXX     = ppc-amigaos-g++ -mcrt=clib2 -I${PREFIX}/clib2/include
-STRIP   = ppc-amigaos-strip --strip-unneeded
+CROSS_COMPILE ?= ppc-amigaos-
+CC      = gcc -mcrt=clib2 -I${PREFIX}/clib2/include
+CXX     = g++ -mcrt=clib2 -I${PREFIX}/clib2/include
 OBJCOPY = true
 CHMOD   = true
 

--- a/arch/amiga/Makefile.in
+++ b/arch/amiga/Makefile.in
@@ -2,9 +2,9 @@
 # amiga makefile generics
 #
 
-CROSS_COMPILE ?= ppc-amigaos-
-CC      = gcc -mcrt=clib2 -I${PREFIX}/clib2/include
-CXX     = g++ -mcrt=clib2 -I${PREFIX}/clib2/include
+CC      = ppc-amigaos-gcc -mcrt=clib2 -I${PREFIX}/clib2/include
+CXX     = ppc-amigaos-g++ -mcrt=clib2 -I${PREFIX}/clib2/include
+STRIP   = ppc-amigaos-strip
 OBJCOPY = true
 CHMOD   = true
 
@@ -15,6 +15,9 @@ DSOPRE     = lib
 DSOPOST    = .so
 DSORPATH   = -Wl,-rpath,${LIBDIR}
 DSOSONAME  = -Wl,-soname,
+
+# Block --host, which will break things.
+CROSS_COMPILE =
 
 ifeq (${BUILD_MODULAR},1)
 ARCH_CFLAGS   += -fPIC

--- a/arch/android/Makefile.in
+++ b/arch/android/Makefile.in
@@ -30,7 +30,7 @@ endif
 # Block --host, which will break things.
 CROSS_COMPILE =
 # Disable rules that require target code to run natively.
-SUPPRESS_LOCAL_TARGETS ?= 1
+SUPPRESS_HOST_TARGETS ?= 1
 
 #
 # Determine ${TOOLCHAIN} (the common NDK toolchain path) if not provided.

--- a/arch/android/Makefile.in
+++ b/arch/android/Makefile.in
@@ -27,6 +27,11 @@ ifeq (${NDK_PATH},)
 $(error "Must define $$NDK_PATH!")
 endif
 
+# Block --host, which will break things.
+CROSS_COMPILE =
+# Disable rules that require target code to run natively.
+SUPPRESS_LOCAL_TARGETS ?= 1
+
 #
 # Determine ${TOOLCHAIN} (the common NDK toolchain path) if not provided.
 # Requires determining ${HOST} since currently the NDK toolchain path relies on it.
@@ -171,7 +176,6 @@ else
 #
 SUPPRESS_CC_TARGETS ?= 1
 SUPPRESS_BUILD_TARGETS ?= 1
-SUPPRESS_HOST_TARGETS ?= 1
 all: dist
 archive build: apk
 

--- a/arch/compat.inc
+++ b/arch/compat.inc
@@ -9,11 +9,16 @@
 #
 COMPILER := ${shell \
  compiler="gcc"; \
+ command -v ${CC} >/dev/null || compiler="error"; \
  tmp=`${CC} --version`; \
  echo $$tmp | grep -qi "clang version" && compiler="clang"; \
  echo $$tmp | grep -qi "LLVM version" && compiler="clang"; \
  echo $$tmp | grep -qi "emcc" && compiler="clang"; \
  echo $$compiler; }
+
+ifeq (${COMPILER},error)
+$(error CC not found: ${CC})
+endif
 
 #
 # Get compiler version (GCC).

--- a/arch/darwin/Makefile.in
+++ b/arch/darwin/Makefile.in
@@ -8,8 +8,6 @@ DSOPOST    = .dylib
 DSORPATH   =
 DSOSONAME  = -install_name ${LIBDIR}/
 
-STRIP   ?= strip
-
 #
 # darwin specific recipes.
 # Enable 'make install' and 'make uninstall' for darwin builds.

--- a/arch/djgpp/Makefile.in
+++ b/arch/djgpp/Makefile.in
@@ -2,14 +2,7 @@
 # DJGPP Makefile
 #
 
-DJGPPBASE ?= i586-pc-msdosdjgpp
-CC = ${DJGPPBASE}-gcc
-CXX = ${DJGPPBASE}-g++
-AS = ${DJGPPBASE}-as
-AR = ${DJGPPBASE}-ar
-OBJCOPY = ${DJGPPBASE}-objcopy
-STRIP = ${DJGPPBASE}-strip
-
+CROSS_COMPILE ?= i586-pc-msdosdjgpp
 BINEXT = .exe
 
 EXTRA_LICENSES += ${LICENSE_DJGPP} ${LICENSE_LGPL2}

--- a/arch/djgpp/Makefile.in
+++ b/arch/djgpp/Makefile.in
@@ -2,7 +2,7 @@
 # DJGPP Makefile
 #
 
-CROSS_COMPILE ?= i586-pc-msdosdjgpp
+CROSS_COMPILE ?= i586-pc-msdosdjgpp-
 BINEXT = .exe
 
 EXTRA_LICENSES += ${LICENSE_DJGPP} ${LICENSE_LGPL2}

--- a/arch/dreamcast/Makefile.in
+++ b/arch/dreamcast/Makefile.in
@@ -14,11 +14,18 @@ endif
 
 EXTRA_LICENSES += ${LICENSE_NEWLIB}
 
-CC      := kos-cc
-CXX     := kos-c++
-AR      := kos-ar
-OBJCOPY := kos-objcopy
-STRIP   := kos-strip
+#
+# Dreamcast target rules
+#
+
+CROSS_COMPILE = kos-
+
+# Disable rules that require target code to run natively.
+SUPPRESS_LOCAL_TARGETS ?= 1
+
+#
+# Override library paths
+#
 
 SDL_CFLAGS := -I"${KOS_PORTS}"/SDL/inst/include
 SDL_LDFLAGS := -L"${KOS_PORTS}"/SDL/inst/lib -lSDL

--- a/arch/dreamcast/Makefile.in
+++ b/arch/dreamcast/Makefile.in
@@ -21,7 +21,7 @@ EXTRA_LICENSES += ${LICENSE_NEWLIB}
 CROSS_COMPILE = kos-
 
 # Disable rules that require target code to run natively.
-SUPPRESS_LOCAL_TARGETS ?= 1
+SUPPRESS_HOST_TARGETS ?= 1
 
 #
 # Override library paths

--- a/arch/emscripten/Makefile.in
+++ b/arch/emscripten/Makefile.in
@@ -4,8 +4,10 @@ AR      = emar
 OBJCOPY = /bin/true
 STRIP   = /bin/true
 
+# Block --host, which will break things.
+CROSS_COMPILE =
 # Disable rules that require target code to run natively.
-SUPPRESS_HOST_TARGETS ?= 1
+SUPPRESS_LOCAL_TARGETS ?= 1
 
 SDL_CFLAGS = -s USE_SDL=2
 SDL_LDFLAGS = -s USE_SDL=2

--- a/arch/emscripten/Makefile.in
+++ b/arch/emscripten/Makefile.in
@@ -7,7 +7,7 @@ STRIP   = /bin/true
 # Block --host, which will break things.
 CROSS_COMPILE =
 # Disable rules that require target code to run natively.
-SUPPRESS_LOCAL_TARGETS ?= 1
+SUPPRESS_HOST_TARGETS ?= 1
 
 SDL_CFLAGS = -s USE_SDL=2
 SDL_LDFLAGS = -s USE_SDL=2

--- a/arch/gp2x/Makefile.in
+++ b/arch/gp2x/Makefile.in
@@ -3,7 +3,6 @@
 #
 
 CROSS_COMPILE ?= arm-open2x-linux-
-
 BINEXT = .gpe
 
 # Disable rules that require target code to run natively.

--- a/arch/gp2x/Makefile.in
+++ b/arch/gp2x/Makefile.in
@@ -2,15 +2,12 @@
 # gp2x makefile generics
 #
 
-CC      = arm-open2x-linux-gcc
-CXX     = arm-open2x-linux-g++
-STRIP   = arm-open2x-linux-strip --strip-unneeded
-OBJCOPY = arm-open2x-linux-objcopy
+CROSS_COMPILE ?= arm-open2x-linux-
 
 BINEXT = .gpe
 
 # Disable rules that require target code to run natively.
-SUPPRESS_HOST_TARGETS ?= 1
+SUPPRESS_LOCAL_TARGETS ?= 1
 
 #
 # GP2X binaries must be statically linked.

--- a/arch/gp2x/Makefile.in
+++ b/arch/gp2x/Makefile.in
@@ -6,7 +6,7 @@ CROSS_COMPILE ?= arm-open2x-linux-
 BINEXT = .gpe
 
 # Disable rules that require target code to run natively.
-SUPPRESS_LOCAL_TARGETS ?= 1
+SUPPRESS_HOST_TARGETS ?= 1
 
 #
 # GP2X binaries must be statically linked.

--- a/arch/mingw/Makefile.in
+++ b/arch/mingw/Makefile.in
@@ -55,12 +55,12 @@ pefix := arch/mingw/pefix
 -include arch/mingw/pefix.d
 
 arch/mingw/pefix.o: arch/mingw/pefix.c
-	$(if ${V},,@echo "  LOC.CC  " $<)
-	${LOCAL_CC} -MD ${CFLAGS} -c $< -o $@
+	$(if ${V},,@echo "  HOSTCC  " $<)
+	${HOST_CC} -MD ${CFLAGS} -c $< -o $@
 
 ${pefix}: arch/mingw/pefix.o
-	$(if ${V},,@echo "  LOC.LINK" ${pefix})
-	${LOCAL_CC} arch/mingw/pefix.o -o ${pefix}
+	$(if ${V},,@echo "  HOSTLINK" ${pefix})
+	${HOST_CC} arch/mingw/pefix.o -o ${pefix}
 
 all: ${pefix}
 

--- a/arch/mingw/Makefile.in
+++ b/arch/mingw/Makefile.in
@@ -2,14 +2,7 @@
 # mingw makefile generics
 #
 
-CC      = ${MINGWBASE}gcc
-CXX     = ${MINGWBASE}g++
-AR      = ${MINGWBASE}ar
-OBJCOPY = ${MINGWBASE}objcopy
-STRIP   = ${MINGWBASE}strip --strip-unneeded
-WINDRES = ${MINGWBASE}windres
 PEFIX   = ${pefix}
-
 BINEXT  = .exe
 
 DSOLDFLAGS = -shared
@@ -62,12 +55,12 @@ pefix := arch/mingw/pefix
 -include arch/mingw/pefix.d
 
 arch/mingw/pefix.o: arch/mingw/pefix.c
-	$(if ${V},,@echo "  HOSTCC  " $<)
-	${HOST_CC} -MD ${CFLAGS} -c $< -o $@
+	$(if ${V},,@echo "  LOC.CC  " $<)
+	${LOCAL_CC} -MD ${CFLAGS} -c $< -o $@
 
 ${pefix}: arch/mingw/pefix.o
-	$(if ${V},,@echo "  HOSTLINK" ${pefix})
-	${HOST_CC} arch/mingw/pefix.o -o ${pefix}
+	$(if ${V},,@echo "  LOC.LINK" ${pefix})
+	${LOCAL_CC} arch/mingw/pefix.o -o ${pefix}
 
 all: ${pefix}
 

--- a/arch/nds-blocksds/Makefile.in
+++ b/arch/nds-blocksds/Makefile.in
@@ -15,12 +15,10 @@ EXTRA_LICENSES += ${LICENSE_CC0} ${LICENSE_MPL2} ${LICENSE_NEWLIB}
 #
 WONDERFUL_TOOLCHAIN	?= /opt/wonderful
 ARM_NONE_EABI_PATH	?= $(WONDERFUL_TOOLCHAIN)/toolchain/gcc-arm-none-eabi/bin/
-CROSS_PREFIX	:= arm-none-eabi-
-CC		:= $(ARM_NONE_EABI_PATH)$(CROSS_PREFIX)gcc
-CXX		:= $(ARM_NONE_EABI_PATH)$(CROSS_PREFIX)g++
-OBJDUMP		:= $(ARM_NONE_EABI_PATH)$(CROSS_PREFIX)objdump
-STRIP		:= /bin/true
+CROSS_COMPILE := ${ARM_NONE_EABI_PATH}arm-none-eabi-
 
+# Don't strip when generating debug symbols.
+NO_STRIP_IN_DEBUGLINK ?= 1
 # Disable rules that require target code to run natively.
 SUPPRESS_HOST_TARGETS ?= 1
 

--- a/arch/nds/Makefile.in
+++ b/arch/nds/Makefile.in
@@ -62,6 +62,8 @@ arch/nds/render.o: arch/nds/protected_palette.bin.o
 arch/nds/%.bin.o arch/nds/%_bin.h : arch/nds/%.bin
 	$(if ${V},,@echo "  AS      " $<)
 	@bin2s -a 32 -H arch/nds/`(echo $(<F) | tr . _)`.h $< > $<.S
+	@# Shut up the assembler since bin2s doesn't emit a trailing newline:
+	@echo '' >> $<.S
 	$(AS) $<.S -o arch/nds/$(<F).o
 	@# Remove dkP's badly constructed macro (-Wundef):
 	@sed -i 's/^#if __cplusplus >= 201103L$$/#if 0/g' arch/nds/*_bin.h

--- a/arch/nds/Makefile.in
+++ b/arch/nds/Makefile.in
@@ -27,7 +27,7 @@ CROSS_COMPILE =
 # Don't strip when generating debug symbols.
 NO_STRIP_IN_DEBUGLINK ?= 1
 # Disable rules that require target code to run natively.
-SUPPRESS_LOCAL_TARGETS ?= 1
+SUPPRESS_HOST_TARGETS ?= 1
 
 #
 # Override library paths.

--- a/arch/nds/Makefile.in
+++ b/arch/nds/Makefile.in
@@ -21,10 +21,13 @@ EXTRA_LICENSES += ${LICENSE_CC0} ${LICENSE_MPL2} ${LICENSE_NEWLIB}
 #
 # NDS target rules
 #
-STRIP  = /bin/true
 
+# Block --host, which will break things.
+CROSS_COMPILE =
+# Don't strip when generating debug symbols.
+NO_STRIP_IN_DEBUGLINK ?= 1
 # Disable rules that require target code to run natively.
-SUPPRESS_HOST_TARGETS ?= 1
+SUPPRESS_LOCAL_TARGETS ?= 1
 
 #
 # Override library paths.

--- a/arch/nds/extmem.c
+++ b/arch/nds/extmem.c
@@ -63,14 +63,15 @@ static void nds_ext_print_info(void)
     info("Using extra VRAM for board storage.\n");
 #endif
 
+#ifdef CONFIG_NDS_BLOCKSDS
+#define SLOT2_NAME() peripheralSlot2GetName()
+#else
+#define SLOT2_NAME() ram_type_string()
+#endif
+
   if(nds_mspace_def[MSPACE_SLOT_2].start != 0)
     info("Using '%s' RAM expansion with capacity of %d (base %p).\n",
-#ifdef CONFIG_NDS_BLOCKSDS
-     peripheralSlot2GetName(),
-#else
-     ram_type_string(),
-#endif
-     slot2_capacity, (void *)slot2_base);
+     SLOT2_NAME(), slot2_capacity, (void *)slot2_base);
   else
     info("No RAM expansion detected.\n");
 }

--- a/arch/pandora/Makefile.in
+++ b/arch/pandora/Makefile.in
@@ -3,12 +3,6 @@ CROSS_COMPILE   ?= $(TOOLCHAIN)/bin/arm-none-linux-gnueabi-
 PANDORA_LIBPATH ?= $(PREFIX)/lib
 PANDORA_INCPATH ?= $(PREFIX)/include
 
-CC              = $(CROSS_COMPILE)gcc
-CXX             = $(CROSS_COMPILE)g++
-AR              = $(CROSS_COMPILE)ar
-OBJCOPY         = $(CROSS_COMPILE)objcopy
-STRIP           = $(CROSS_COMPILE)strip --strip-unneeded
-
 ARCH_CFLAGS     = -march=armv7-a -mtune=cortex-a8 -fPIC -I$(PANDORA_INCPATH)
 ARCH_CXXFLAGS   = $(ARCH_CFLAGS)
 

--- a/arch/psp/Makefile.in
+++ b/arch/psp/Makefile.in
@@ -14,7 +14,7 @@ CROSS_COMPILE = psp-
 # Don't strip when generating debug symbols.
 NO_STRIP_IN_DEBUGLINK ?= 1
 # Disable rules that require target code to run natively.
-SUPPRESS_LOCAL_TARGETS ?= 1
+SUPPRESS_HOST_TARGETS ?= 1
 
 # flag PSP build and link in c/psppower
 ARCH_CFLAGS   += -G0 -isystem ${PREFIX}/sdk/include -DPATH_MAX=4096

--- a/arch/psp/Makefile.in
+++ b/arch/psp/Makefile.in
@@ -9,14 +9,12 @@ EXTRA_LICENSES += ${LICENSE_NEWLIB}
 #
 # PSP toolchain overrides
 #
-CC      = psp-gcc
-CXX     = psp-g++
-AR      = psp-ar
-OBJCOPY = psp-objcopy
-STRIP   = /bin/true
+CROSS_COMPILE = psp-
 
+# Don't strip when generating debug symbols.
+NO_STRIP_IN_DEBUGLINK ?= 1
 # Disable rules that require target code to run natively.
-SUPPRESS_HOST_TARGETS ?= 1
+SUPPRESS_LOCAL_TARGETS ?= 1
 
 # flag PSP build and link in c/psppower
 ARCH_CFLAGS   += -G0 -isystem ${PREFIX}/sdk/include -DPATH_MAX=4096
@@ -44,7 +42,7 @@ LIBPNG_LDFLAGS = -lpng
 package: mzx
 	psp-fixup-imports ${mzxrun}
 	mksfo 'MegaZeux ${VERSION}' PARAM.SFO
-	psp-strip ${mzxrun} -o ${mzxrun}.strip
+	${STRIP} ${mzxrun} -o ${mzxrun}.strip
 	convert -scale 80x80 -border 32x0 -bordercolor transparent \
 	        contrib/icons/quantump.png ICON0.PNG
 	pack-pbp EBOOT.PBP PARAM.SFO ICON0.PNG NULL \

--- a/arch/psvita/Makefile.in
+++ b/arch/psvita/Makefile.in
@@ -1,10 +1,6 @@
 .PHONY: clean package build
 
-CC      = arm-vita-eabi-gcc
-CXX     = arm-vita-eabi-g++
-AR      = arm-vita-eabi-ar
-OBJCOPY = arm-vita-eabi-objcopy
-STRIP   = arm-vita-eabi-strip --strip-unneeded
+CROSS_COMPILE = arm-vita-eabi-
 
 VITA_TITLEID = VMZX00001
 VITA_TITLE = MegaZeux

--- a/arch/psvita/Makefile.in
+++ b/arch/psvita/Makefile.in
@@ -2,6 +2,9 @@
 
 CROSS_COMPILE = arm-vita-eabi-
 
+# Disable rules that require target code to run natively.
+SUPPRESS_HOST_TARGETS ?= 1
+
 VITA_TITLEID = VMZX00001
 VITA_TITLE = MegaZeux
 

--- a/arch/switch/Makefile.in
+++ b/arch/switch/Makefile.in
@@ -29,7 +29,7 @@ CROSS_COMPILE =
 # Don't strip when generating debug symbols.
 NO_STRIP_IN_DEBUGLINK ?= 1
 # Disable rules that require target code to run natively.
-SUPPRESS_LOCAL_TARGETS ?= 1
+SUPPRESS_HOST_TARGETS ?= 1
 
 #
 # Override library paths.

--- a/arch/switch/Makefile.in
+++ b/arch/switch/Makefile.in
@@ -24,10 +24,12 @@ APP_TITLE  := MegaZeux
 APP_AUTHOR := \"MegaZeux Developers\"
 APP_ICON   := arch/switch/icon.jpg
 
-STRIP      := /bin/true
-
+# Block --host, which will break things.
+CROSS_COMPILE =
+# Don't strip when generating debug symbols.
+NO_STRIP_IN_DEBUGLINK ?= 1
 # Disable rules that require target code to run natively.
-SUPPRESS_HOST_TARGETS ?= 1
+SUPPRESS_LOCAL_TARGETS ?= 1
 
 #
 # Override library paths.

--- a/arch/wii/Makefile.in
+++ b/arch/wii/Makefile.in
@@ -21,10 +21,13 @@ EXTRA_LICENSES += ${LICENSE_MPL2} ${LICENSE_NEWLIB}
 include $(DEVKITPPC)/wii_rules
 
 ELF2DOL := elf2dol
-STRIP   := /bin/true
 
+# Block --host, which will break things.
+CROSS_COMPILE =
+# Don't strip when generating debug symbols.
+NO_STRIP_IN_DEBUGLINK ?= 1
 # Disable rules that require target code to run natively.
-SUPPRESS_HOST_TARGETS ?= 1
+SUPPRESS_LOCAL_TARGETS ?= 1
 
 #
 # Override library paths

--- a/arch/wii/Makefile.in
+++ b/arch/wii/Makefile.in
@@ -27,7 +27,7 @@ CROSS_COMPILE =
 # Don't strip when generating debug symbols.
 NO_STRIP_IN_DEBUGLINK ?= 1
 # Disable rules that require target code to run natively.
-SUPPRESS_LOCAL_TARGETS ?= 1
+SUPPRESS_HOST_TARGETS ?= 1
 
 #
 # Override library paths

--- a/arch/wiiu/Makefile.in
+++ b/arch/wiiu/Makefile.in
@@ -27,7 +27,7 @@ PREFIX     := $(DEVKITPPC)
 # Block --host, which will break things.
 CROSS_COMPILE =
 # Disable rules that require target code to run natively.
-SUPPRESS_LOCAL_TARGETS ?= 1
+SUPPRESS_HOST_TARGETS ?= 1
 
 #
 # Override library paths.

--- a/arch/wiiu/Makefile.in
+++ b/arch/wiiu/Makefile.in
@@ -24,6 +24,11 @@ BINEXT     := .elf
 # overridden by base_tools include
 PREFIX     := $(DEVKITPPC)
 
+# Block --host, which will break things.
+CROSS_COMPILE =
+# Disable rules that require target code to run natively.
+SUPPRESS_LOCAL_TARGETS ?= 1
+
 #
 # Override library paths.
 #

--- a/config.sh
+++ b/config.sh
@@ -15,7 +15,7 @@ usage() {
 	echo "  --bindir       Where utilities should be installed. (/usr/bin)"
 	echo "  --sharedir     Where resources should be installed. (/usr/share)"
 	echo "  --licensedir   Where licenses should be installed. (/usr/share/doc)"
-	echo "  --host         Specify cross toolchain prefix for Unix et al. (none)"
+	echo "  --host         Specify cross toolchain prefix for Linux et al. (none)"
 	echo
 	echo "  Install directories can be disregarded for builds for platforms"
 	echo "  with a monolithic directory structure e.g. Windows."

--- a/config.sh
+++ b/config.sh
@@ -6,7 +6,7 @@ usage() {
 	echo "usage: ./config.sh --platform [platform] <--prefix [dir]> <--sysconfdir [dir]>"
 	echo "                                         <--gamesdir [dir]> <--bindir [dir]>"
 	echo "                                         <--sharedir [dir]> <--licensedir [dir]>"
-	echo "                                         <options..>"
+	echo "                                         <--host [name]> <options..>"
 	echo
 	echo "  --prefix       Install prefix and where dependencies should be found. (/usr)"
 	echo "  --sysconfdir   Where the config should be read from. (/etc)"
@@ -15,6 +15,7 @@ usage() {
 	echo "  --bindir       Where utilities should be installed. (/usr/bin)"
 	echo "  --sharedir     Where resources should be installed. (/usr/share)"
 	echo "  --licensedir   Where licenses should be installed. (/usr/share/doc)"
+	echo "  --host         Specify cross toolchain prefix for Unix et al. (none)"
 	echo
 	echo "  Install directories can be disregarded for builds for platforms"
 	echo "  with a monolithic directory structure e.g. Windows."
@@ -129,6 +130,7 @@ usage() {
 # Default settings for flags (used if unspecified)
 #
 PLATFORM=""
+TOOL_PREFIX=""
 PREFIX="/usr"
 PREFIX_IS_SET="false"
 SYSCONFDIR="/etc"
@@ -281,6 +283,12 @@ while [ "$1" != "" ]; do
 		shift
 		LICENSEDIR="$1"
 		LICENSEDIR_IS_SET="true"
+	fi
+
+	# e.g. --host arm-none-eabi
+	if [ "$1" = "--host" ]; then
+		shift
+		TOOL_PREFIX="$1"
 	fi
 
 	[ "$1" = "--as-needed-hack" ] && AS_NEEDED="true"
@@ -503,13 +511,12 @@ if [ "$PLATFORM" = "win32"   ] || [ "$PLATFORM" = "win64" ] ||
 
 	[ "$PLATFORM" = "win32" ] || [ "$PLATFORM" = "mingw32" ] && ARCHNAME=x86
 	[ "$PLATFORM" = "win64" ] || [ "$PLATFORM" = "mingw64" ] && ARCHNAME=x64
-	[ "$PLATFORM" = "mingw32" ] && MINGWBASE=i686-w64-mingw32-
-	[ "$PLATFORM" = "mingw64" ] && MINGWBASE=x86_64-w64-mingw32-
+	[ "$PLATFORM" = "mingw32" ] && [ "$TOOL_PREFIX" = "" ] && TOOL_PREFIX=i686-w64-mingw32
+	[ "$PLATFORM" = "mingw64" ] && [ "$TOOL_PREFIX" = "" ] && TOOL_PREFIX=x86_64-w64-mingw32
 	PLATFORM="mingw"
 	echo "#define PLATFORM \"windows-$ARCHNAME\"" > src/config.h
 	echo "SUBPLATFORM=windows-$ARCHNAME"         >> platform.inc
 	echo "PLATFORM=$PLATFORM"                    >> platform.inc
-	echo "MINGWBASE=$MINGWBASE"                  >> platform.inc
 elif [ "$PLATFORM" = "unix" ] || [ "$PLATFORM" = "unix-devel" ]; then
 	OS="$(uname -s)"
 	MACH="$(uname -m)"
@@ -605,6 +612,10 @@ else
 	LIBDIR="."
 fi
 
+if [ "$TOOL_PREFIX" != "" ]; then
+	echo "CROSS_COMPILE?=$TOOL_PREFIX-" >> platform.inc
+fi
+
 ### SYSTEM CONFIG DIRECTORY ###################################################
 
 if [ "$PLATFORM" = "unix" ] || [ "$PLATFORM" = "darwin" ]; then
@@ -622,6 +633,9 @@ fi
 echo "Building for platform:   $PLATFORM"
 echo "Using prefix:            $PREFIX"
 echo "Using sysconfdir:        $SYSCONFDIR"
+if [ "$TOOL_PREFIX" != "" ]; then
+echo "Using host:              $TOOL_PREFIX"
+fi
 echo
 
 ### GENERATE CONFIG.H HEADER ##################################################

--- a/contrib/icons/Makefile.in
+++ b/contrib/icons/Makefile.in
@@ -13,10 +13,6 @@ icons = ${icons_obj}/icons.o
 
 icons_objs = ${icons_obj}/quantump.o
 
-ifneq (${V},1)
-WINDRES := @${WINDRES}
-endif
-
 ${icons_obj}/%.o: ${icons_src}/%.rc
 	$(if ${V},,@echo "  WINDRES " $<)
 	${WINDRES} -i $< -o $@

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -309,6 +309,10 @@ DEVELOPERS
 + Fixed the DSO -Wstrict-aliasing warnings in Socket.cpp and the
   OpenGL renderers for GCC versions using -Wstrict-aliasing=2.
 + Updated libxmp to 4.6.0+ceb2d025.
++ Added --host config.sh option to manually specify a cross
+  compiler prefix. This is ignored or overriden by most ports
+  and is mainly just for Linux.
++ HOST_CC is now LOCAL_CC to avoid confusion with --host.
 + Relicensed ccv from GPL 3 to GPL 2+ to match the rest of MZX.
   (Lancer-X)
 + If available, GetSystemTimePreciseAsFileTime and clock_gettime

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -312,7 +312,6 @@ DEVELOPERS
 + Added --host config.sh option to manually specify a cross
   compiler prefix. This is ignored or overriden by most ports
   and is mainly just for Linux.
-+ HOST_CC is now LOCAL_CC to avoid confusion with --host.
 + Relicensed ccv from GPL 3 to GPL 2+ to match the rest of MZX.
   (Lancer-X)
 + If available, GetSystemTimePreciseAsFileTime and clock_gettime

--- a/src/configure.h
+++ b/src/configure.h
@@ -24,6 +24,8 @@
 
 __M_BEGIN_DECLS
 
+#include <stdint.h>
+
 #define OPTION_NAME_LEN 33
 
 enum config_type
@@ -148,8 +150,8 @@ struct config_info
   // Virtual filesystem options
   boolean vfs_enable;
   boolean vfs_enable_auto_cache;
-  long long vfs_max_cache_size;
-  long long vfs_max_cache_file_size;
+  int64_t vfs_max_cache_size;
+  int64_t vfs_max_cache_file_size;
 
   // Game options
   char startup_path[256];

--- a/src/io/vio.h
+++ b/src/io/vio.h
@@ -70,7 +70,7 @@ enum vdirflags
   VDIR_NO_SCAN          = (1<<0), // Don't scan the directory to get its length.
                                   // This will break seek, tell, and length.
   VDIR_FAST             = VDIR_NO_SCAN, // Enable all speed hacks.
-  VDIR_PUBLIC_MASK      = VDIR_NO_SCAN,
+  VDIR_PUBLIC_MASK      = VDIR_NO_SCAN
 };
 
 UTILS_LIBSPEC boolean vio_filesystem_init(size_t max_size, size_t max_file_size,


### PR DESCRIPTION
Adds `--host` to config.sh and its corresponding variable `CROSS_COMPILE` to the build system (previously only used by the Pandora port). This is mainly for Linux, but it also simplified the toolchain variables for several architectures. This required changing how the console ports override `STRIP` and moving `--strip-unneeded` from that variable.

Additionally, I fixed these warnings:
* 3DS, NDS: `as` would repeatedly complain about missing end-of-file newlines caused by `bin2s`.
* NDS: fixed `#ifdef` used inside of the macro `info()`.
* PSP: C++98 whining about `long long` and commas at the end of enum declarations.