### PR TITLE
Improve the handling of optimization flags, add --enable-lto.

### DIFF
--- a/arch/3ds/Makefile.in
+++ b/arch/3ds/Makefile.in
@@ -51,12 +51,10 @@ PORTLIBS_LIBS     := $(foreach dir, $(PORTLIBS), -L$(dir)/lib)
 EXTRA_INCLUDES := -isystem $(CTRULIB)/include ${PORTLIBS_INCLUDES}
 EXTRA_LIBS := -L$(CTRULIB)/lib ${PORTLIBS_LIBS}
 ifeq (${DEBUG},1)
-  ARCH_CFLAGS += -Og
-  EXTRA_LIBS += -lcitro3dd -lctrud -lpng16 -lz
+EXTRA_LIBS += -lcitro3dd -lctrud -lpng16 -lz
 else
-  OPTIMIZE_CFLAGS = -O3 -fomit-frame-pointer -ffunction-sections
-# OPTIMIZE_CFLAGS += -flto
-  EXTRA_LIBS += -lcitro3d -lctru -lpng16 -lz
+OPTIMIZE_FLAGS += -fomit-frame-pointer -ffunction-sections
+EXTRA_LIBS += -lcitro3d -lctru -lpng16 -lz
 endif
 
 MACHDEP = -march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft -mword-relocations

--- a/arch/emscripten/Makefile.in
+++ b/arch/emscripten/Makefile.in
@@ -49,13 +49,10 @@ ARCH_LDFLAGS += -g4 --source-map-base ${SOURCE_MAP_BASE}
 endif
 
 ifeq (${DEBUG},1)
-	ARCH_CFLAGS += -s ASSERTIONS=1 --profiling-funcs
-	ARCH_LDFLAGS += -s ASSERTIONS=1 --profiling-funcs
-	EMSCRIPTEN_FRONTEND_BUILD_PROFILE = build
+ARCH_LDFLAGS += -s ASSERTIONS=1 --profiling-funcs
+EMSCRIPTEN_FRONTEND_BUILD_PROFILE = build
 else
-	ARCH_LDFLAGS += -O3
-	OPTIMIZE_CFLAGS = -O3
-	EMSCRIPTEN_FRONTEND_BUILD_PROFILE = build-release
+EMSCRIPTEN_FRONTEND_BUILD_PROFILE = build-release
 endif
 
 clean:

--- a/arch/switch/Makefile.in
+++ b/arch/switch/Makefile.in
@@ -38,12 +38,12 @@ SUPPRESS_HOST_TARGETS ?= 1
 MACHDEP    := -D__SWITCH__ -march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE
 
 ifeq (${DEBUG},1)
-  #DRM_NOUVEAU := drm_nouveaud
-  NX := nxd
+#DRM_NOUVEAU := drm_nouveaud
+NX := nxd
 else
-  OPTIMIZE_CFLAGS := -O3 -ffunction-sections
-  #DRM_NOUVEAU := drm_nouveau
-  NX := nx
+OPTIMIZE_FLAGS += -ffunction-sections
+#DRM_NOUVEAU := drm_nouveau
+NX := nx
 endif
 
 MESA_LIBS :=

--- a/arch/wiiu/Makefile.in
+++ b/arch/wiiu/Makefile.in
@@ -36,10 +36,10 @@ SUPPRESS_HOST_TARGETS ?= 1
 MACHDEP    := -DESPRESSO -mcpu=750 -meabi -mhard-float
 
 ifeq (${DEBUG},1)
-  WUT := wutd
+WUT := wutd
 else
-  OPTIMIZE_CFLAGS := -O3 -ffunction-sections
-  WUT := wut
+OPTIMIZE_FLAGS += -ffunction-sections
+WUT := wut
 endif
 
 SDL_PREFIX := ${PORTLIBS_PATH}/wiiu

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -7,6 +7,10 @@ USERS
 
 DEVELOPERS
 
++ -Og is now the default debug optimization level (was -O0).
++ Added --enable-lto to enable link-time optimizations.
++ The sanitizer config.sh options can now be used with release
+  builds e.g. --enable-release --enable-asan.
 + Simplified the configuration of system directories for ports
   in config.sh, which now prints more information about them.
 + Fixed config.sh output of "/usr/bin/git" and the Git HEAD.

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -104,19 +104,20 @@ unit_common_objs += \
 endif
 
 #
-# This may already be set with sanitizer flags.
+# Build unit tests with debug optimizations and without link-time optimzations.
+# (Overrides these optimization flags from the global flags.)
 #
-DEBUG_CFLAGS ?= -O0
+UNIT_OPTIMIZE_FLAGS := -Og -fno-lto ${UNIT_OPTIMIZE_FLAGS}
 
 #
-# Use DEBUG_CFLAGS to override any optimization flags in the global flags.
 # Build without -DDEBUG to suppress debug messages,
 # build without -DNDEBUG to allow assert().
 # Turn on exceptions explicitly, since the global CXXFLAGS turn them off.
 #
-unit_cflags ?= ${CXXFLAGS} ${DEBUG_CFLAGS} -UDEBUG -UNDEBUG
+unit_cflags ?= ${CXXFLAGS}
+unit_cflags += ${UNIT_OPTIMIZE_FLAGS} -UDEBUG -UNDEBUG
 unit_cflags += -fexceptions -funsigned-char -std=gnu++11
-unit_ldflags += ${DEBUG_CFLAGS}
+unit_ldflags += ${UNIT_OPTIMIZE_FLAGS}
 
 unit_cflags += ${SDL_CFLAGS} -Umain
 unit_ldflags += ${SDL_LDFLAGS} ${ZLIB_LDFLAGS}


### PR DESCRIPTION
* Added --enable-lto for enabling link-time optimization.
* The default debug optimization level is now -Og.
* Sanitizer flags are now applied independently of release/debug.
* Removed redundant optimization flags from console ports.