### PR TITLE
Fix poor HTML5 vfilelength performance.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -5,6 +5,8 @@ FREAD/FREADn bugfixes, as the old behavior was unusably buggy.
 
 USERS
 
++ HTML5: fixed the poor performance of FREADn and other features
+  that rely on calculating the length of an open file.
 + Setting a string offset, limit, or splice to FREADn now
   respects the provided limit. If n is larger than the limit,
   n total bytes will still be read (up to the maximum string

--- a/src/io/vio_posix.h
+++ b/src/io/vio_posix.h
@@ -189,6 +189,18 @@ static inline int64_t platform_ftell(FILE *fp)
 #endif
 }
 
+#if defined(__EMSCRIPTEN__)
+
+/**
+ * For unknown reasons, Emscripten fstat is much slower than the fallback.
+ */
+static inline int64_t platform_filelength(FILE *fp)
+{
+  return -1;
+}
+
+#else /* fstat */
+
 static inline int64_t platform_filelength(FILE *fp)
 {
   // Note: off_t, ino_t may cause issues unless _FILE_OFFSET_BITS=64 is defined.
@@ -206,6 +218,8 @@ static inline int64_t platform_filelength(FILE *fp)
 
   return st.st_size;
 }
+
+#endif /* fstat */
 
 __M_END_DECLS
 


### PR DESCRIPTION
Found via the mzvplay.txt conversion of the Mackey Mounse cartoon, which uses `FREADn` several times per frame. For some reason, each `FREADn` would take ~30ms per call (per Lancer-X), which I found is caused by the `fstat` used in POSIX `platform_filelength`. Due to the way frame delays are handled by mzvplay.txt, it would immediately try to load the next frame, causing hangs.