### PR TITLE
Preparation for SDL3 support.

### DIFF
--- a/arch/msvc/config.h
+++ b/arch/msvc/config.h
@@ -4,7 +4,7 @@
 #define CONFDIR "./"
 #define CONFFILE "config.txt"
 #define SHAREDIR "./"
-#define CONFIG_SDL
+#define CONFIG_SDL 2
 #define CONFIG_EDITOR
 #define CONFIG_HELPSYS
 #define CONFIG_RENDER_SOFT

--- a/arch/xcode/MegaZeux.xcodeproj/project.pbxproj
+++ b/arch/xcode/MegaZeux.xcodeproj/project.pbxproj
@@ -65,7 +65,7 @@
 		BF6058EC216B3725001B738C /* core.h in Headers */ = {isa = PBXBuildFile; fileRef = BF6058C9216B3722001B738C /* core.h */; };
 		BF6058ED216B3725001B738C /* game_update_board.c in Sources */ = {isa = PBXBuildFile; fileRef = BF6058CA216B3722001B738C /* game_update_board.c */; };
 		BF6058EE216B3725001B738C /* world_struct.h in Headers */ = {isa = PBXBuildFile; fileRef = BF6058CB216B3722001B738C /* world_struct.h */; };
-		BF6058EF216B3725001B738C /* compat_sdl.h in Headers */ = {isa = PBXBuildFile; fileRef = BF6058CC216B3722001B738C /* compat_sdl.h */; };
+		BF6058EF216B3725001B738C /* SDLmzx.h in Headers */ = {isa = PBXBuildFile; fileRef = BF6058CC216B3722001B738C /* SDLmzx.h */; };
 		BF6058F0216B3725001B738C /* renderers.h in Headers */ = {isa = PBXBuildFile; fileRef = BF6058CD216B3723001B738C /* renderers.h */; };
 		BF6058F1216B3725001B738C /* caption.c in Sources */ = {isa = PBXBuildFile; fileRef = BF6058CE216B3723001B738C /* caption.c */; };
 		BF6058F2216B3725001B738C /* game_ops.c in Sources */ = {isa = PBXBuildFile; fileRef = BF6058CF216B3723001B738C /* game_ops.c */; };
@@ -448,7 +448,7 @@
 		BF6058C9216B3722001B738C /* core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = core.h; path = ../../src/core.h; sourceTree = "<group>"; };
 		BF6058CA216B3722001B738C /* game_update_board.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = game_update_board.c; path = ../../src/game_update_board.c; sourceTree = "<group>"; };
 		BF6058CB216B3722001B738C /* world_struct.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = world_struct.h; path = ../../src/world_struct.h; sourceTree = "<group>"; };
-		BF6058CC216B3722001B738C /* compat_sdl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = compat_sdl.h; path = ../../src/compat_sdl.h; sourceTree = "<group>"; };
+		BF6058CC216B3722001B738C /* SDLmzx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SDLmzx.h; path = ../../src/SDLmzx.h; sourceTree = "<group>"; };
 		BF6058CD216B3723001B738C /* renderers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = renderers.h; path = ../../src/renderers.h; sourceTree = "<group>"; };
 		BF6058CE216B3723001B738C /* caption.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = caption.c; path = ../../src/caption.c; sourceTree = "<group>"; };
 		BF6058CF216B3723001B738C /* game_ops.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = game_ops.c; path = ../../src/game_ops.c; sourceTree = "<group>"; };
@@ -885,7 +885,7 @@
 				BF6058CE216B3723001B738C /* caption.c */,
 				BF6058C8216B3721001B738C /* caption.h */,
 				BF6058BD216B3720001B738C /* compat.h */,
-				BF6058CC216B3722001B738C /* compat_sdl.h */,
+				BF6058CC216B3722001B738C /* SDLmzx.h */,
 				BFFF164E1FCDC64800BDEC58 /* configure.c */,
 				BFFF165A1FCDC64A00BDEC58 /* configure.h */,
 				BF6058D7216B3724001B738C /* const.h */,
@@ -1151,7 +1151,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BF6058FB216B3725001B738C /* keysym.h in Headers */,
-				BF6058EF216B3725001B738C /* compat_sdl.h in Headers */,
+				BF6058EF216B3725001B738C /* SDLmzx.h in Headers */,
 				BFFF17CE1FCDCCF300BDEC58 /* mdataio.h in Headers */,
 				BFD5B0422465AFAE00BC91E9 /* zip_deflate64.h in Headers */,
 				BF6058EA216B3725001B738C /* settings.h in Headers */,

--- a/arch/xcode/config.h
+++ b/arch/xcode/config.h
@@ -5,7 +5,7 @@
 #define USERCONFFILE ".megazeux-config"
 #define SHAREDIR "../Resources"
 #define LICENSEDIR "../Resources"
-#define CONFIG_SDL
+#define CONFIG_SDL 2
 #define CONFIG_EDITOR
 #define CONFIG_HELPSYS
 #define CONFIG_RENDER_SOFT

--- a/config.sh
+++ b/config.sh
@@ -806,7 +806,7 @@ else
 		SDL="2"
 	fi
 	echo "Enabling SDL $SDL.x."
-	echo "#define CONFIG_SDL" >> src/config.h
+	echo "#define CONFIG_SDL $SDL" >> src/config.h
 	echo "BUILD_SDL=$SDL" >> platform.inc
 fi
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -28,6 +28,9 @@ USERS
 
 DEVELOPERS
 
++ Renamed "compat_sdl.h" to "SDLmzx.h". This header is now used
+  to abstract ALL trivial includes of SDL headers. This makes
+  supporting the future release of SDL 3 cleaner.
 + The version of SDL to build with is now determined by the
   config.sh options:
     --enable-sdl (enables the default SDL version, usually 2);
@@ -35,6 +38,7 @@ DEVELOPERS
     --enable-sdl1 (enables SDL 1.2.x);
     --disable-sdl (disables SDL).
   For compatibility, "--disable-libsdl2" is still recognized.
++ Added SDL 2 and SDL 1.2 support to the 3DS port. (asie)
 + -Og is now the default debug optimization level (was -O0).
 + Added --enable-lto to enable link-time optimizations.
 + The sanitizer config.sh options can now be used with release

--- a/src/SDLmzx.h
+++ b/src/SDLmzx.h
@@ -30,7 +30,9 @@ __M_BEGIN_DECLS
 #if defined(CONFIG_SDL)
 
 #include <SDL.h>
+#if defined(_WIN32) || defined(CONFIG_X11)
 #include <SDL_syswm.h>
+#endif
 
 #if !SDL_VERSION_ATLEAST(2,0,0)
 
@@ -40,6 +42,8 @@ __M_BEGIN_DECLS
 // Data types
 
 typedef SDLKey SDL_Keycode;
+typedef int (*SDL_ThreadFunction)(void *);
+typedef Uint32 SDL_threadID;
 // Use a macro because sdl1.2-compat typedefs SDL_Window...
 #define SDL_Window void
 
@@ -67,11 +71,13 @@ typedef SDLKey SDL_Keycode;
 
 #define SDL_SetEventFilter(filter, userdata) SDL_SetEventFilter(filter)
 
+#ifdef CONFIG_X11
 static inline SDL_bool SDL_GetWindowWMInfo(SDL_Window *window,
                                            SDL_SysWMinfo *info)
 {
   return SDL_GetWMInfo(info) == 1 ? SDL_TRUE : SDL_FALSE;
 }
+#endif
 
 static inline SDL_Window *SDL_GetWindowFromID(Uint32 id)
 {

--- a/src/about.c
+++ b/src/about.c
@@ -28,7 +28,7 @@
 #include <zlib.h>
 
 #ifdef CONFIG_SDL
-#include <SDL.h>
+#include "SDLmzx.h"
 #endif
 #ifdef CONFIG_XMP
 #include <xmp.h>

--- a/src/audio/audio_sdl.c
+++ b/src/audio/audio_sdl.c
@@ -20,9 +20,9 @@
 #include "audio.h"
 #include "audio_struct.h"
 
+#include "../SDLmzx.h"
 #include "../util.h"
 
-#include <SDL.h>
 #include <stdlib.h>
 
 #ifdef __EMSCRIPTEN__

--- a/src/audio/audio_wav.c
+++ b/src/audio/audio_wav.c
@@ -30,14 +30,10 @@
 #include "ext.h"
 #include "sampled_stream.h"
 
+#include "../SDLmzx.h" // SDL WAV loader fallback
 #include "../util.h"
 #include "../io/path.h"
 #include "../io/vio.h"
-
-// For WAV loader fallback
-#ifdef CONFIG_SDL
-#include <SDL.h>
-#endif
 
 // If the WAV/SAM is larger than this, print a warning to the console.
 // (Right now only do this for debug builds because a lot more games than

--- a/src/audio/sampled_stream.cpp
+++ b/src/audio/sampled_stream.cpp
@@ -67,7 +67,7 @@ enum mixer_channels
 
 enum mixer_volume
 {
-  FIXED       = 0,
+  FULL        = 0,
   DYNAMIC     = 1
 };
 
@@ -223,8 +223,8 @@ static void mixer_function(struct sampled_stream *s_src,
 {
   switch(volume_mode)
   {
-    case FIXED:
-      mixer_function<CHANNELS, FIXED>(s_src, dest, write_len, src, volume, resample_mode);
+    case FULL:
+      mixer_function<CHANNELS, FULL>(s_src, dest, write_len, src, volume, resample_mode);
       break;
 
     case DYNAMIC:
@@ -323,7 +323,7 @@ void sampled_mix_data(struct sampled_stream *s_src,
     resample_mode = FLAT;
 
   if(!s_src->use_volume || volume == 256)
-    use_volume = FIXED;
+    use_volume = FULL;
 
   if(s_src->channels < 2)
     use_channels = MONO;

--- a/src/compat_sdl.h
+++ b/src/compat_sdl.h
@@ -121,35 +121,27 @@ static inline int SDL_GL_SetSwapInterval(int interval)
 }
 #endif
 
-#ifdef CONFIG_X11
-static inline XEvent *SDL_SysWMmsg_GetXEvent(SDL_SysWMmsg *msg)
+#ifdef _WIN32
+static inline HWND SDL_GetWindowProperty_HWND(SDL_Window *window)
 {
-  return &msg->event.xevent;
+  SDL_SysWMinfo info;
+  SDL_VERSION(&info.version);
+  SDL_GetWindowWMInfo(window, &info);
+  return info.window;
 }
-#endif /* CONFIG_X11 */
-
-#if defined(CONFIG_ICON) && defined(__WIN32__)
-static inline HWND SDL_SysWMinfo_GetWND(SDL_SysWMinfo *info)
-{
-  return info->window;
-}
-#endif /* CONFIG_ICON && __WIN32__ */
+#endif /* _WIN32 */
 
 #else /* SDL_VERSION_ATLEAST(2,0,0) */
 
-#ifdef CONFIG_X11
-static inline XEvent *SDL_SysWMmsg_GetXEvent(SDL_SysWMmsg *msg)
+#ifdef _WIN32
+static inline HWND SDL_GetWindowProperty_HWND(SDL_Window *window)
 {
-  return &msg->msg.x11.event;
+  SDL_SysWMinfo info;
+  SDL_VERSION(&info.version);
+  SDL_GetWindowWMInfo(window, &info);
+  return info.info.win.window;
 }
-#endif /* CONFIG_X11 */
-
-#if defined(CONFIG_ICON) && defined(__WIN32__)
-static inline HWND SDL_SysWMinfo_GetWND(SDL_SysWMinfo *info)
-{
-  return info->info.win.window;
-}
-#endif /* CONFIG_ICON && __WIN32__ */
+#endif /* _WIN32 */
 
 #endif /* SDL_VERSION_ATLEAST(2,0,0) */
 

--- a/src/configure.c
+++ b/src/configure.c
@@ -38,7 +38,7 @@
 #include "io/vio.h"
 
 #ifdef CONFIG_SDL
-#include <SDL_version.h>
+#include "SDLmzx.h"
 #endif
 
 #define MAX_INCLUDE_DEPTH 16

--- a/src/editor/clipboard_sdl2.c
+++ b/src/editor/clipboard_sdl2.c
@@ -22,9 +22,8 @@
 
 #include "clipboard.h"
 
+#include "../SDLmzx.h"
 #include "../util.h"
-
-#include <SDL.h>
 
 void copy_buffer_to_clipboard(char **buffer, int lines, int total_length)
 {

--- a/src/editor/clipboard_x11.c
+++ b/src/editor/clipboard_x11.c
@@ -25,7 +25,7 @@
 #include "clipboard.h"
 
 #if defined(CONFIG_SDL)
-#include "../compat_sdl.h"
+#include "../SDLmzx.h"
 #include "../render_sdl.h"
 #endif
 
@@ -34,7 +34,7 @@ static int copy_buffer_lines;
 static int copy_buffer_total_length;
 
 /* Forward declaration so the SDL parts can stay separate. */
-static int copy_buffer_to_X11_selection(Display *display, Window xwindow, Xevent *xevent);
+static int copy_buffer_to_X11_selection(Display *display, XEvent *xevent);
 
 #ifdef CONFIG_SDL
 #if SDL_VERSION_ATLEAST(1,2,0)
@@ -69,7 +69,7 @@ static inline int event_callback(const SDL_Event *event)
   SDL_Window *window = NULL;
 #endif
   Display *display;
-  Xevent *xevent;
+  XEvent *xevent;
   if(event->type != SDL_SYSWMEVENT)
     return 0;
 
@@ -79,13 +79,13 @@ static inline int event_callback(const SDL_Event *event)
 #if SDL_VERSION_ATLEAST(2,0,0)
   xevent = &(event->syswm.msg->msg.x11.event);
 #else
-  xevent = &(event->syswm.msg.event.xevent);
+  xevent = &(event->syswm.msg->event.xevent);
 #endif
 
   return copy_buffer_to_X11_selection(display, xevent);
 }
 
-static inline void set_X11_event_callback()
+static inline void set_X11_event_callback(void)
 {
   SDL_EventState(SDL_SYSWMEVENT, SDL_ENABLE);
   SDL_SetEventFilter(event_callback, SDL_GetWindowFromID(sdl_window_id));
@@ -95,7 +95,7 @@ static inline void set_X11_event_callback()
 #endif /* CONFIG_SDL */
 
 
-static int copy_buffer_to_X11_selection(Display *display, Xevent *xevent)
+static int copy_buffer_to_X11_selection(Display *display, XEvent *xevent)
 {
   XSelectionRequestEvent *request;
   char *dest_data, *dest_ptr;

--- a/src/editor/clipboard_x11.c
+++ b/src/editor/clipboard_x11.c
@@ -1,6 +1,7 @@
 /* MegaZeux
  *
  * Copyright (C) 2004 Gilead Kutnick <exophase@adelphia.net>
+ * Copyright (C) 2024 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -26,42 +27,84 @@
 #if defined(CONFIG_SDL)
 #include "../compat_sdl.h"
 #include "../render_sdl.h"
-#include <SDL_syswm.h>
 #endif
 
 static char **copy_buffer;
 static int copy_buffer_lines;
 static int copy_buffer_total_length;
 
+/* Forward declaration so the SDL parts can stay separate. */
+static int copy_buffer_to_X11_selection(Display *display, Window xwindow, Xevent *xevent);
+
+#ifdef CONFIG_SDL
+#if SDL_VERSION_ATLEAST(1,2,0)
+
+static inline boolean get_X11_display_and_window(SDL_Window *window,
+ Display **display, Window *xwindow)
+{
+  SDL_SysWMinfo info;
+  SDL_VERSION(&info.version);
+
+  if(!window)
+    window = SDL_GetWindowFromID(sdl_window_id);
+  if(!window || !SDL_GetWindowWMInfo(window, &info) || info.subsystem != SDL_SYSWM_X11)
+    return false;
+
+  if(display)
+    *display = info.info.x11.display;
+  if(window)
+    *xwindow = info.info.x11.window;
+  return true;
+}
+
 #if SDL_VERSION_ATLEAST(2,0,0)
-static int copy_buffer_to_X11_selection(void *userdata, SDL_Event *event)
+static inline int event_callback(void *userdata, SDL_Event *event)
 #else
-static int copy_buffer_to_X11_selection(const SDL_Event *event)
+static inline int event_callback(const SDL_Event *event)
 #endif
 {
-  XSelectionRequestEvent *request;
 #if SDL_VERSION_ATLEAST(2,0,0)
-  SDL_Window *window = userdata;
+  SDL_Window *window = (SDL_Window *)userdata;
 #else
   SDL_Window *window = NULL;
 #endif
-  char *dest_data, *dest_ptr;
-  XEvent response, *xevent;
-  SDL_SysWMinfo info;
-  int i, line_length;
   Display *display;
-
+  Xevent *xevent;
   if(event->type != SDL_SYSWMEVENT)
-    return 1;
+    return 0;
 
-  xevent = SDL_SysWMmsg_GetXEvent(event->syswm.msg);
+  if(!get_X11_display_and_window(window, &display, NULL))
+    return 0;
+
+#if SDL_VERSION_ATLEAST(2,0,0)
+  xevent = &(event->syswm.msg->msg.x11.event);
+#else
+  xevent = &(event->syswm.msg.event.xevent);
+#endif
+
+  return copy_buffer_to_X11_selection(display, xevent);
+}
+
+static inline void set_X11_event_callback()
+{
+  SDL_EventState(SDL_SYSWMEVENT, SDL_ENABLE);
+  SDL_SetEventFilter(event_callback, SDL_GetWindowFromID(sdl_window_id));
+}
+
+#endif /* SDL_VERSION_ATLEAST(1,2,0) */
+#endif /* CONFIG_SDL */
+
+
+static int copy_buffer_to_X11_selection(Display *display, Xevent *xevent)
+{
+  XSelectionRequestEvent *request;
+  char *dest_data, *dest_ptr;
+  XEvent response;
+  int i, line_length;
+
   if(xevent->type != SelectionRequest || !copy_buffer)
     return 0;
 
-  SDL_VERSION(&info.version);
-  SDL_GetWindowWMInfo(window, &info);
-
-  display = info.info.x11.display;
   dest_data = cmalloc(copy_buffer_total_length + 1);
   dest_ptr = dest_data;
 
@@ -78,7 +121,7 @@ static int copy_buffer_to_X11_selection(const SDL_Event *event)
   memcpy(dest_ptr, copy_buffer[i], line_length);
   dest_ptr[line_length] = 0;
 
-  request = &(SDL_SysWMmsg_GetXEvent(event->syswm.msg)->xselectionrequest);
+  request = &(xevent->xselectionrequest);
   response.xselection.type = SelectionNotify;
   response.xselection.display = request->display;
   response.xselection.selection = request->selection;
@@ -100,44 +143,33 @@ static int copy_buffer_to_X11_selection(const SDL_Event *event)
 
 void copy_buffer_to_clipboard(char **buffer, int lines, int total_length)
 {
-  SDL_Window *window = SDL_GetWindowFromID(sdl_window_id);
-  SDL_SysWMinfo info;
+  Display *display;
+  Window xwindow;
 
-  SDL_VERSION(&info.version);
-
-  if(!SDL_GetWindowWMInfo(window, &info) || (info.subsystem != SDL_SYSWM_X11))
+  if(!get_X11_display_and_window(NULL, &display, &xwindow))
     return;
 
   copy_buffer = buffer;
   copy_buffer_lines = lines;
   copy_buffer_total_length = total_length;
 
-  XSetSelectionOwner(info.info.x11.display, XA_PRIMARY,
-    info.info.x11.window, CurrentTime);
-
-  SDL_EventState(SDL_SYSWMEVENT, SDL_ENABLE);
-  SDL_SetEventFilter(copy_buffer_to_X11_selection, window);
+  XSetSelectionOwner(display, XA_PRIMARY, xwindow, CurrentTime);
+  set_X11_event_callback();
 }
 
 char *get_clipboard_buffer(void)
 {
-  SDL_Window *window = SDL_GetWindowFromID(sdl_window_id);
   int selection_format, ret_type;
   unsigned long int nbytes, overflow;
   unsigned char *src_data;
   char *dest_data = NULL;
   Window xwindow, owner;
   Atom selection_type;
-  SDL_SysWMinfo info;
   Display *display;
 
-  SDL_VERSION(&info.version);
-
-  if(!SDL_GetWindowWMInfo(window, &info) || (info.subsystem != SDL_SYSWM_X11))
+  if(!get_X11_display_and_window(NULL, &display, &xwindow))
     return NULL;
 
-  display = info.info.x11.display;
-  xwindow = info.info.x11.window;
   owner = XGetSelectionOwner(display, XA_PRIMARY);
 
   if((owner == None) || (owner == xwindow))

--- a/src/event_sdl.c
+++ b/src/event_sdl.c
@@ -19,14 +19,13 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "SDLmzx.h"
 #include "configure.h"
 #include "event.h"
 #include "graphics.h"
-#include "compat_sdl.h"
 #include "render_sdl.h"
 #include "util.h"
 
-#include <SDL.h>
 #include <ctype.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -48,10 +48,6 @@
 #endif
 
 #ifdef CONFIG_SDL
-#include <SDL.h>
-#ifdef CONFIG_ICON
-#include <SDL_syswm.h>
-#endif // CONFIG_ICON
 #include "compat_sdl.h"
 #include "render_sdl.h"
 #endif // CONFIG_SDL
@@ -1561,12 +1557,7 @@ static void set_window_icon(void)
     if(icon)
     {
       SDL_Window *window = SDL_GetWindowFromID(sdl_window_id);
-      SDL_SysWMinfo info;
-
-      SDL_VERSION(&info.version);
-      SDL_GetWindowWMInfo(window, &info);
-
-      SendMessage(SDL_SysWMinfo_GetWND(&info),
+      SendMessage(SDL_GetWindowProperty_HWND(window),
        WM_SETICON, ICON_BIG, (LPARAM)icon);
     }
   }

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -48,7 +48,7 @@
 #endif
 
 #ifdef CONFIG_SDL
-#include "compat_sdl.h"
+#include "SDLmzx.h"
 #include "render_sdl.h"
 #endif // CONFIG_SDL
 

--- a/src/network/Socket.cpp
+++ b/src/network/Socket.cpp
@@ -272,7 +272,7 @@ int Socket::poll(struct pollfd *fds, unsigned int nfds, int timeout_ms)
  */
 
 // For LoadObject/LoadFunction
-#include <SDL.h>
+#include "../SDLmzx.h"
 
 static struct
 {

--- a/src/network/server.cpp
+++ b/src/network/server.cpp
@@ -37,10 +37,10 @@ ${network_obj}/server.o: ${network_src}/server.cpp
 
 #include "HTTPHost.hpp"
 
+#include "../SDLmzx.h"
 #include "../const.h"
 #include "../util.h"
 
-#include <SDL.h>
 #include <assert.h>
 
 #define INBOUND_PORT 5656

--- a/src/old/render_sdl2accel.c
+++ b/src/old/render_sdl2accel.c
@@ -27,8 +27,7 @@
 // a significant FPS drop at speed 2. On top of that even just drawing chars to
 // a screen is much slower than MZX's software-based renderers right now.
 
-#include <SDL.h>
-
+#include "SDLmzx.h"
 #include "graphics.h"
 #include "platform.h"
 #include "render.h"

--- a/src/platform_endian.h
+++ b/src/platform_endian.h
@@ -1,6 +1,7 @@
 /* MegaZeux
  *
  * Copyright (C) 2008 Alistair John Strachan <alistair@devzero.co.uk
+ * Copyright (C) 2020, 2024 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -20,25 +21,12 @@
 #ifndef __ENDIAN_H
 #define __ENDIAN_H
 
-/* If SDL is available, include the header and use SDL's configured
- * endianness. If it's not available, use GCC/clang or a list of architectures
- * (both checks borrowed from SDL) to determine the endianness.
+/* Use GCC/clang or a list of architectures (both checks borrowed from SDL) to
+ * determine the endianness. If SDL is enabled, platform_sdl.c will check this.
  */
 
 #define PLATFORM_LIL_ENDIAN 0x1234
 #define PLATFORM_BIG_ENDIAN 0x4321
-
-#if defined(CONFIG_SDL) && !defined(SKIP_SDL)
-
-#include <SDL_endian.h>
-
-#if SDL_BYTEORDER == SDL_BIG_ENDIAN
-#define PLATFORM_BYTE_ORDER PLATFORM_BIG_ENDIAN
-#else
-#define PLATFORM_BYTE_ORDER PLATFORM_LIL_ENDIAN
-#endif
-
-#else // !CONFIG_SDL
 
 #if defined(__BIG_ENDIAN__)
 #define PLATFORM_BYTE_ORDER PLATFORM_BIG_ENDIAN
@@ -63,8 +51,6 @@
 #else
 #define PLATFORM_BYTE_ORDER PLATFORM_LIL_ENDIAN
 #endif
-
-#endif // CONFIG_SDL
 
 /* ModPlug and XMP both use this name to find out about endianness. It's not
  * too bad to pollute our namespace with it, so just do so here.

--- a/src/platform_sdl.c
+++ b/src/platform_sdl.c
@@ -19,11 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include "compat.h"
+#include "SDLmzx.h"
 #include "platform.h"
 #include "util.h"
-
-#include <SDL.h>
 
 #ifdef CONFIG_PSP
 #include <psppower.h>
@@ -36,6 +34,14 @@
 #ifdef CONFIG_WII
 #include <sys/iosupport.h>
 #include <fat.h>
+#endif
+
+/* Verify that SDL's endianness matches what platform_endian.h claims... */
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN && PLATFORM_BYTE_ORDER != PLATFORM_BIG_ENDIAN
+#error Endian mismatch: SDL detected big, but MZX detected little. Report this!
+#endif
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN && PLATFORM_BYTE_ORDER != PLATFORM_LIL_ENDIAN
+#error Endian mismatch: SDL detected little, but MZX detected big. Report this!
 #endif
 
 #ifdef __EMSCRIPTEN__
@@ -61,7 +67,9 @@ uint64_t get_ticks(void)
 }
 
 #ifdef __WIN32__
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 
 /**

--- a/src/platform_time.c
+++ b/src/platform_time.c
@@ -34,9 +34,11 @@
 #endif
 
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
-#include <SDL.h>
+#include "SDLmzx.h"
 
 #define WINDOWS_TO_UNIX_SECONDS 11644473600LL
 #define WINDOWS_TO_UNIX_100NS   10000000LL

--- a/src/render_gp2x.c
+++ b/src/render_gp2x.c
@@ -17,6 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "SDLmzx.h"
 #include "platform.h"
 #include "graphics.h"
 #include "render.h"
@@ -25,8 +26,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-
-#include <SDL.h>
 
 struct gp2x_render_data
 {

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -18,13 +18,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include "compat_sdl.h"
+#include "SDLmzx.h"
 #include "render_sdl.h"
 #include "util.h"
 
 #include <limits.h>
-
-#include <SDL.h>
 
 CORE_LIBSPEC Uint32 sdl_window_id;
 

--- a/src/render_sdl.h
+++ b/src/render_sdl.h
@@ -24,9 +24,8 @@
 
 __M_BEGIN_DECLS
 
+#include "SDLmzx.h"
 #include "graphics.h"
-
-#include <SDL.h>
 
 struct sdl_render_data
 {

--- a/src/render_soft.c
+++ b/src/render_soft.c
@@ -28,7 +28,7 @@
 #include "util.h"
 
 #ifdef CONFIG_SDL
-#include <SDL.h>
+#include "SDLmzx.h"
 #include "render_sdl.h"
 #endif
 

--- a/src/render_softscale.c
+++ b/src/render_softscale.c
@@ -33,9 +33,9 @@
  * nearest or linear scaling based on the scaling ratio and window size.
  */
 
-#include <SDL.h>
 #include <stdlib.h>
 
+#include "SDLmzx.h"
 #include "graphics.h"
 #include "render.h"
 #include "render_layer.h"

--- a/src/thread_sdl.h
+++ b/src/thread_sdl.h
@@ -24,14 +24,7 @@
 
 __M_BEGIN_DECLS
 
-#include <SDL_stdinc.h>
-#include <SDL_thread.h>
-#include <SDL_version.h>
-
-#if !SDL_VERSION_ATLEAST(2,0,0)
-typedef int (*SDL_ThreadFunction)(void *);
-typedef Uint32 SDL_threadID;
-#endif
+#include "SDLmzx.h"
 
 #define THREAD_RES int
 #define THREAD_RETURN do { return 0; } while(0)

--- a/src/utils/checkres.c
+++ b/src/utils/checkres.c
@@ -86,7 +86,6 @@
 #endif
 
 // Defines so checkres builds when MZX headers are included.
-#define SKIP_SDL
 #define CORE_LIBSPEC
 
 // From MZX itself:

--- a/src/utils/hlp2html.c
+++ b/src/utils/hlp2html.c
@@ -23,7 +23,6 @@
 #include <string.h>
 
 // Defines so hlp2html builds when this is included.
-#define SKIP_SDL
 #define CORE_LIBSPEC
 #include "../compat.h"
 #include "../hashtable.h"

--- a/src/utils/y4m2smzx.c
+++ b/src/utils/y4m2smzx.c
@@ -24,7 +24,9 @@
 #include "smzxconv.h"
 #include "y4m.h"
 
+#ifdef _WIN32
 #define SKIP_SDL
+#endif
 #include "../graphics.h"
 #include "../platform.h"
 #include "../util.h"


### PR DESCRIPTION
Changes due to how SDL3 includes its headers:

* Most SDL.h includes have been replaced with SDLmzx.h, formerly known as compat_sdl.h. Other includes have been optimized out or also replaced. The exceptions are main.c and render_sdl.h, which both require special handling in SDL3.
* `CONFIG_SDL` is now defined to be explicitly the major version number of SDL.

Changes due to the removal of SDL_syswm.h:

* `SDL_SysWMinfo_GetWND` has been replaced with `SDL_GetWindowProperty_HWND`, which now performs all SDL_syswm.h functionality internally. In SDL3 this is done by instead calling `SDL_GetProperty(SDL_GetWindowProperties(window), ...)`.
* `SDL_SysWMmsg_GetXEvent` has been removed entirely. This functionality has been integrated into the X11 clipboard handler instead.
* The X11 clipboard handler's SDL code has been separated from its X11 code. SDL3 support for listening to X11 events is handled completely differently.