### PR TITLE
SDL3 preparation (event_sdl.c).

### DIFF
--- a/arch/switch/pad.config
+++ b/arch/switch/pad.config
@@ -27,11 +27,11 @@
 # Buttons 17-24 are directional axis "buttons" ignored by MZX because MZX does
 # its own internal analog-to-digital conversion.
 
-# Because the Switch uses SDL2, MZX can generate mappings automatically with
-# the SDL_GameController API. However, this API is based on XInput and has
+# Because the Switch uses SDL, MZX can generate mappings automatically with
+# the SDL gamepad API. However, this API is based on XInput and has
 # the face buttons inverted from where they'd be expected on a Nintendo system.
 
-gamecontroller.a = act_b
-gamecontroller.b = act_a
-gamecontroller.x = act_y
-gamecontroller.y = act_x
+gamepad.a = act_b
+gamepad.b = act_a
+gamepad.x = act_y
+gamepad.y = act_x

--- a/config.txt
+++ b/config.txt
@@ -650,47 +650,47 @@
 # joystick number 'X' can be substituted with a range '[Z,W]', which will
 # assign the control for all joysticks numbered Z through W (inclusive).
 
-# Automatic mapping for actions is handled using SDL 2's game controller API.
-# Supported controllers should generally "just work" when they're plugged in.
+# Automatic mapping for actions is handled using SDL's gamepad API.
+# Supported gamepads should generally "just work" when they're plugged in.
 # This setting can be used to globally disable the automatic mapping feature
 # entirely. If 1, it will be enabled (default). If 0, it will be disabled.
 
-# gamecontroller_enable = 1
+# gamepad_enable = 1
 
-# Controllers that aren't supported can be fixed by adding SDL mapping strings.
+# Gamepads that aren't supported can be fixed by adding SDL mapping strings.
 # This config option adds a new mapping string and can be used multiple times;
 # each line adds a new mapping. See docs/joystick.html for more information.
 
-# gamecontroller_add =
+# gamepad_add =
 
 # The following settings can be used to globally customize the automated
 # joystick mappings generated from SDL mapping strings.
 # See docs/joystick.html for more information.
 
-# gamecontroller.a = act_a
-# gamecontroller.b = act_b
-# gamecontroller.x = act_x
-# gamecontroller.y = act_y
-# gamecontroller.back = act_select
-# gamecontroller.start = act_start
-# gamecontroller.leftstick = act_lstick
-# gamecontroller.rightstick = act_rstick
-# gamecontroller.leftshoulder = act_lshoulder
-# gamecontroller.rightshoulder = act_rshoulder
-# gamecontroller.dpup = act_up
-# gamecontroller.dpdown = act_down
-# gamecontroller.dpleft = act_left
-# gamecontroller.dpright = act_right
-# gamecontroller.-leftx = act_l_left
-# gamecontroller.+leftx = act_l_right
-# gamecontroller.-lefty = act_l_up
-# gamecontroller.+lefty = act_l_down
-# gamecontroller.-rightx = act_r_left
-# gamecontroller.+rightx = act_r_right
-# gamecontroller.-righty = act_r_up
-# gamecontroller.+righty = act_r_down
-# gamecontroller.lefttrigger = act_ltrigger
-# gamecontroller.righttrigger = act_rtrigger
+# gamepad.a = act_a
+# gamepad.b = act_b
+# gamepad.x = act_x
+# gamepad.y = act_y
+# gamepad.back = act_select
+# gamepad.start = act_start
+# gamepad.leftstick = act_lstick
+# gamepad.rightstick = act_rstick
+# gamepad.leftshoulder = act_lshoulder
+# gamepad.rightshoulder = act_rshoulder
+# gamepad.dpup = act_up
+# gamepad.dpdown = act_down
+# gamepad.dpleft = act_left
+# gamepad.dpright = act_right
+# gamepad.-leftx = act_l_left
+# gamepad.+leftx = act_l_right
+# gamepad.-lefty = act_l_up
+# gamepad.+lefty = act_l_down
+# gamepad.-rightx = act_r_left
+# gamepad.+rightx = act_r_right
+# gamepad.-righty = act_r_up
+# gamepad.+righty = act_r_down
+# gamepad.lefttrigger = act_ltrigger
+# gamepad.righttrigger = act_rtrigger
 
 
 # Misc Options

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -5,6 +5,8 @@ FREAD/FREADn bugfixes, as the old behavior was unusably buggy.
 
 USERS
 
++ All "gamecontroller[...]" config.txt options have been renamed
+  to "gamepad[...]". The old names are still supported.
 + HTML5: fixed the poor performance of FREADn and other features
   that rely on calculating the length of an open file.
 + Setting a string offset, limit, or splice to FREADn now

--- a/docs/joystick.html
+++ b/docs/joystick.html
@@ -648,7 +648,7 @@
       </p>
 
       <code class="example" style="word-wrap: break-word">
-        gamecontroller_add = 030000005e0400008e02000000007801,XInput Controller,a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b10,leftshoulder:b4,leftstick:b8,lefttrigger:a2,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b9,righttrigger:a5,rightx:a3,righty:a4,start:b7,x:b2,y:b3,platform:Windows,
+        gamepad_add = 030000005e0400008e02000000007801,XInput Controller,a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b10,leftshoulder:b4,leftstick:b8,lefttrigger:a2,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b9,righttrigger:a5,rightx:a3,righty:a4,start:b7,x:b2,y:b3,platform:Windows,
       </code>
 
       <p>
@@ -667,9 +667,9 @@
       </p>
 
       <code class="example">
-        gamecontroller.SDLBUTTON = act_NAME
-        gamecontroller.+SDLAXIS = act_NAME
-        gamecontroller.-SDLAXIS = act_NAME
+        gamepad.SDLBUTTON = act_NAME
+        gamepad.+SDLAXIS = act_NAME
+        gamepad.-SDLAXIS = act_NAME
       </code>
 
       <p>
@@ -687,7 +687,7 @@
       </p>
 
       <code class="example">
-        gamecontroller_enable = 0
+        gamepad_enable = 0
       </code>
     </section>
 
@@ -1151,10 +1151,10 @@
       </p>
 
       <code class="example">
-        gamecontroller.a = act_b
-        gamecontroller.b = act_a
-        gamecontroller.x = act_y
-        gamecontroller.y = act_x
+        gamepad.a = act_b
+        gamepad.b = act_a
+        gamepad.x = act_y
+        gamepad.y = act_x
       </code>
 
       <p>

--- a/src/configure.c
+++ b/src/configure.c
@@ -290,7 +290,7 @@ static const struct config_info user_conf_default =
   true,                         // pc_speaker_on
 
   // Event options
-  true,                         // allow_gamecontroller
+  true,                         // allow_gamepad
   false,                        // pause_on_unfocus
   1,                            // num_buffered_events
 
@@ -957,16 +957,23 @@ static void config_set_joy_axis_threshold(struct config_info *conf, char *name,
 
 #ifdef CONFIG_SDL
 #if SDL_VERSION_ATLEAST(2,0,0)
-#define GC_ENUM "%15[-+0-9A-Za-z_]"
+#define GAMEPAD_ENUM "%15[-+0-9A-Za-z_]"
 
-static void config_sdl_gc_set(struct config_info *conf, char *name,
+static void config_gamepad_set(struct config_info *conf, char *name,
  char *value, char *extended_data)
 {
-  char gc_sym[16];
+  char gamepad_sym[16];
   char key[16];
   int read = 0;
 
-  if(sscanf(name, "gamecontroller." GC_ENUM "%n", gc_sym, &read) != 1
+  // Option may be either "gamepad.[enum]" or "gamecontroller.[enum]".
+  if(!strncmp(name, "gamepad.", 7))
+    name += 7;
+  else
+  if(!strncmp(name, "gamecontroller", 14))
+    name += 14;
+
+  if(sscanf(name, "." GAMEPAD_ENUM "%n", gamepad_sym, &read) != 1
    || (name[read] != 0))
     return;
 
@@ -974,19 +981,19 @@ static void config_sdl_gc_set(struct config_info *conf, char *name,
   if(sscanf(value, JOY_ENUM "%n", key, &read) != 1 || (value[read] != 0))
     return;
 
-  gamecontroller_map_sym(gc_sym, key);
+  gamepad_map_sym(gamepad_sym, key);
 }
 
-static void config_sdl_gc_add(struct config_info *conf, char *name,
+static void config_gamepad_add(struct config_info *conf, char *name,
  char *value, char *extended_data)
 {
-  gamecontroller_add_mapping(value);
+  gamepad_add_mapping(value);
 }
 
-static void config_sdl_gc_enable(struct config_info *conf, char *name,
+static void config_gamepad_enable(struct config_info *conf, char *name,
  char *value, char *extended_data)
 {
-  config_boolean(&conf->allow_gamecontroller, value);
+  config_boolean(&conf->allow_gamepad, value);
 }
 
 #endif // SDL_VERSION_ATLEAST(2,0,0)
@@ -1231,9 +1238,12 @@ static const struct config_entry config_options[] =
   { "fullscreen_windowed", config_set_fullscreen_windowed, false },
 #ifdef CONFIG_SDL
 #if SDL_VERSION_ATLEAST(2,0,0)
-  { "gamecontroller.*", config_sdl_gc_set, false },
-  { "gamecontroller_add", config_sdl_gc_add, false },
-  { "gamecontroller_enable", config_sdl_gc_enable, false },
+  { "gamecontroller.*", config_gamepad_set, false },
+  { "gamecontroller_add", config_gamepad_add, false },
+  { "gamecontroller_enable", config_gamepad_enable, false },
+  { "gamepad.*", config_gamepad_set, false },
+  { "gamepad_add", config_gamepad_add, false },
+  { "gamepad_enable", config_gamepad_enable, false },
 #endif
 #endif
   { "gl_filter_method", config_set_gl_filter_method, false },

--- a/src/configure.c
+++ b/src/configure.c
@@ -967,7 +967,7 @@ static void config_gamepad_set(struct config_info *conf, char *name,
   int read = 0;
 
   // Option may be either "gamepad.[enum]" or "gamecontroller.[enum]".
-  if(!strncmp(name, "gamepad.", 7))
+  if(!strncmp(name, "gamepad", 7))
     name += 7;
   else
   if(!strncmp(name, "gamecontroller", 14))

--- a/src/configure.h
+++ b/src/configure.h
@@ -141,7 +141,7 @@ struct config_info
   boolean pc_speaker_on;
 
   // Event options
-  boolean allow_gamecontroller;
+  boolean allow_gamepad;
   boolean pause_on_unfocus;
   int num_buffered_events;
 

--- a/src/event.h
+++ b/src/event.h
@@ -207,8 +207,8 @@ void __wait_event(void);
 void __warp_mouse(int x, int y);
 
 // "Driver" functions currently only supported by SDL.
-void gamecontroller_map_sym(const char *sym, const char *value);
-void gamecontroller_add_mapping(const char *mapping);
+void gamepad_map_sym(const char *sym, const char *value);
+void gamepad_add_mapping(const char *mapping);
 
 #ifdef CONFIG_NDS
 const struct buffered_status *load_status(void);

--- a/src/event_sdl.c
+++ b/src/event_sdl.c
@@ -962,8 +962,17 @@ err_invalid:
 static boolean process_event(SDL_Event *event)
 {
   struct buffered_status *status = store_status();
-  static boolean unicode_fallback = true;
   enum keycode ckey;
+
+#if SDL_VERSION_ATLEAST(2,0,0)
+  /* Enable converting keycodes to fake unicode presses when text input isn't
+   * active. Enabling text input also enables an onscreen keyboard in some
+   * ports, so it isn't always desired. */
+  boolean unicode_fallback = !SDL_IsTextInputActive();
+#else
+  /* SDL 1.2 might also need this (Pandora? doesn't generate unicode presses). */
+  static boolean unicode_fallback = true;
+#endif
 
   /* SDL's numlock keyboard modifier handling seems to be broken on X11,
    * and it will only get numlock's status right on application init. We

--- a/src/platform_sdl.c
+++ b/src/platform_sdl.c
@@ -153,15 +153,20 @@ boolean platform_init(void)
   }
 
 #if SDL_VERSION_ATLEAST(2,0,0)
-/**
- * TODO: Don't enable SDL_TEXTINPUT events on Android for now. They seem to
- * cause more issues than they solve. Enabling these on Android also seems
- * to assume that the onscreen keyboard should be opened, which usually
- * covers whatever part of the MZX screen is being typed into.
- */
-#if !defined(ANDROID)
-  SDL_StartTextInput();
-#endif
+  /* Most platforms want text input events always on so they can generate
+   * convenient unicode text values, but in Android this causes some problems:
+   *
+   * - On older versions the navigation bar will ALWAYS display, regardless
+   *   of whether or not there's an attached keyboard.
+   * - Holding the space key no longer works, breaking built-in shooting (as
+   *   recent as Android 10).
+   * - The onscreen keyboard Android pops up can be moved but not collapsed.
+   *
+   * TODO: Instead, enable text input on demand at text prompts.
+   * TODO: this probably redundant with behavior already in SDL.
+   */
+  if(!SDL_HasScreenKeyboardSupport())
+    SDL_StartTextInput();
 #else
   SDL_EnableUNICODE(1);
 #endif

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -624,9 +624,14 @@ UNITTEST(Settings)
 
 #ifdef CONFIG_SDL
 #if SDL_VERSION_ATLEAST(2,0,0)
-  SECTION(allow_gamecontroller)
+  SECTION(gamecontroller_enable)
   {
-    TEST_ENUM("gamecontroller_enable", conf->allow_gamecontroller, boolean_data);
+    TEST_ENUM("gamecontroller_enable", conf->allow_gamepad, boolean_data);
+  }
+
+  SECTION(gamepad_enable)
+  {
+    TEST_ENUM("gamepad_enable", conf->allow_gamepad, boolean_data);
   }
 #endif
 #endif


### PR DESCRIPTION
* Most references to "gamecontrollers" in code and config settings are now "gamepad", which is half the length, less annoying to type and look at, and also matches SDL3's current renaming of their API. The old "gamecontroller" config settings still work, but config.txt now only contains references to "gamepad".
* The SDL event unicode fallback behavior now only triggers when text events are disabled in SDL2+. This should allow text input events if the onscreen keyboard is active in the Android port, but still allow the unicode fallback to work when it's hidden. Text input is now disabled whenever a platform supports an onscreen keyboard instead of being excluded by Android specifically.
* SDL joystick GUIDs are now derived from the `SDL_Joystick *` rather than the SDL device index. The SDL device index is now only used for initializing the `SDL_Joystick` and `SDL_Gamepad` and getting the mapping string, which should make it easier to support SDL2 and SDL3 at the same time.