### PR TITLE
Fix glslscale bug when binding a framebuffer before gl_swap_buffers.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -7,6 +7,9 @@ USERS
 
 + All "gamecontroller[...]" config.txt options have been renamed
   to "gamepad[...]". The old names are still supported.
++ Fixed blank screen bugs that occur with the glslscale renderer
+  in conjunction with Intel HD Graphics 2500 graphics drivers
+  and possibly some other old drivers.
 + The softscale renderer now respects disable_screensaver.
 + HTML5: fixed the poor performance of FREADn and other features
   that rely on calculating the length of an open file.


### PR DESCRIPTION
Using the Intel HD Graphics 2500 driver for Windows 10 and possibly some other old graphics drivers (the [SDL documentation cites macOS](https://wiki.libsdl.org/SDL2/SDL_GL_SwapWindow)), swapping to a framebuffer other than 0 prior to calling SDL_GL_SwapWindow can cause the screen to flicker or not display at all. This was occurring in the GLSL renderer, though for some reason only with `glslscale` (and not `glsl`).