### PR TITLE
nds-blocksds: Clean up/update Makefile, add GitHub CI support.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -228,6 +228,23 @@ jobs:
       - name: Package NDS .zip
         run: make archive
 
+  ARM-NDS-BlocksDS:
+    runs-on: ubuntu-latest
+    container: skylyrac/blocksds:slim-latest
+    steps:
+      - name: Install dependencies
+        run: apt update && apt install -y --no-install-recommends $MZXDEPS_DEBIAN_CROSS
+      - name: Install target dependencies
+        run: wf-pacman -Syu --noconfirm && wf-pacman -S --noconfirm toolchain-gcc-arm-none-eabi-zlib
+      - run: echo "BLOCKSDS=/opt/blocksds/core" >> $GITHUB_ENV
+      - uses: actions/checkout@v3
+      - name: Configure NDS/BlocksDS
+        run: arch/nds-blocksds/CONFIG.NDS
+      - name: Build NDS/BlocksDS
+        run: $MZX_MAKE
+      - name: Package NDS/BlocksDS .zip
+        run: make archive
+
   PowerPC-Wii:
     runs-on: ubuntu-latest
     container: devkitpro/devkitppc

--- a/arch/nds-blocksds/Makefile.in
+++ b/arch/nds-blocksds/Makefile.in
@@ -34,16 +34,15 @@ EXTRA_INCLUDES := $(foreach path,$(EXTRA_LIBS_DIRS),-I$(path)/include)
 EXTRA_LIBS := $(foreach path,$(EXTRA_LIBS_DIRS),-L$(path)/lib) \
               -Wl,--start-group $(EXTRA_LIBS_NAMES) -Wl,--end-group
 
-ARCH_CFLAGS   += -marm -mthumb-interwork -mcpu=arm946e-s+nofp
-ARCH_CFLAGS   += ${EXTRA_INCLUDES} -DARM9 -D__NDS__ -Iarch/nds -ffunction-sections -fdata-sections
-ARCH_CXXFLAGS += ${ARCH_CFLAGS}
+ARCH_CFLAGS   += -marm -mcpu=arm946e-s+nofp
+ARCH_CFLAGS   += ${EXTRA_INCLUDES} -Iarch/nds -ffunction-sections -fdata-sections
 
-ARCH_LDFLAGS  += -marm -mthumb-interwork -mcpu=arm946e-s+nofp
-ARCH_LDFLAGS  += -Wl,--defsym=vfprintf=__i_vfprintf -Wl,--defsym=vfscanf=__i_vfscanf
-ARCH_LDFLAGS  += -Wl,--no-warn-rwx-segments -Wl,--use-blx
-ARCH_LDFLAGS  += $(BLOCKSDS)/sys/crts/ds_arm9_crt0.o ${EXTRA_LIBS} -Wl,--gc-sections -nostdlib \
-                   -T$(BLOCKSDS)/sys/crts/ds_arm9.mem \
-                   -T$(BLOCKSDS)/sys/crts/ds_arm9.ld
+ARCH_LDFLAGS  += -marm -mcpu=arm946e-s+nofp
+ARCH_LDFLAGS  += ${EXTRA_LIBS}
+
+ARCH_CFLAGS   += -DPICOLIBC_LONG_LONG_PRINTF_SCANF -specs=$(BLOCKSDS)/sys/crts/ds_arm9.specs
+ARCH_LDFLAGS  += -DPICOLIBC_LONG_LONG_PRINTF_SCANF -specs=$(BLOCKSDS)/sys/crts/ds_arm9.specs
+ARCH_CXXFLAGS += ${ARCH_CFLAGS}
 
 ARM7_BINARY := arch/nds-blocksds/megazeux.arm7.elf
 
@@ -81,17 +80,14 @@ ARM7_LIBS := $(foreach path,$(ARM7_LIBS_DIRS),-L$(path)/lib) \
 
 $(ARM7_BINARY): $(ARM7_OBJECT_FILES)
 	$(if ${V},,@echo "  LD.7    " $@)
-	${CC} -o $@ $< $(BLOCKSDS)/sys/crts/ds_arm7_crt0.o \
-		-mthumb -mthumb-interwork -Wl,--gc-sections -nostdlib \
-		-T$(BLOCKSDS)/sys/crts/ds_arm7.ld \
-		-Wl,--start-group $(ARM7_LIBS) -Wl,--end-group \
-		-Wl,--no-warn-rwx-segments
+	${CC} -o $@ $< -mthumb -specs=$(BLOCKSDS)/sys/crts/ds_arm7.specs \
+		-Wl,--start-group $(ARM7_LIBS) -Wl,--end-group
 
 arch/nds/arm7/source/%.c.o: arch/nds/arm7/source/%.c
 	$(if ${V},,@echo "  CC.7    " $<)
-	${CC} -MD -Os -std=gnu11 -D__NDS__ -DARM7 \
+	${CC} -MD -Os -std=gnu11 -specs=$(BLOCKSDS)/sys/crts/ds_arm7.specs \
 		-Wall -Wno-unused-macros -mcpu=arm7tdmi \
-		-mthumb -mthumb-interwork $(ARM7_INCLUDES) \
+		-mthumb $(ARM7_INCLUDES) \
 		-ffunction-sections -fdata-sections -fomit-frame-pointer \
 		-c $< -o $@
 #


### PR DESCRIPTION
Builds the same code, just in a somewhat more future-proof and cleaner manner.

Also added a regression test, as the BlocksDS target is faster-moving.