### PR TITLE
Fix robot editor hangs when using Replace All on quotes/extras.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -42,6 +42,8 @@ USERS
   compilation warnings.
 + Fixed platform-dependent out-of-memory errors when loading
   robots from <=2.84 save files with corrupt stack sizes.
++ Fixed hangs in the robot editor caused by trying to use
+  Replace All to replace quotes or extra words with nothing.
 + Added compatibility for MegaZeux 1.x's reverse send behavior
   which allows robots to execute twice per cycle in some cases.
 


### PR DESCRIPTION
- [x] Does this actually fix the reported issue?
- [x] ~~Are there hangs with more than one replacement state in the loop?~~ There *shouldn't* be...