### PR TITLE
Fix board message clipping and color code behavior.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -54,7 +54,13 @@ USERS
   that line (same as the help file).
 + Fixed possible robot stack and scroll message memory leaks.
 + Fixed a 2.93 regression where color strings with escapes like
- "~x", where x is not a hex digit, would also print the ~ or @.
+  "~x", where x is not a hex digit, would also print the ~ or @.
++ Fixed clipping of the board message when it contains color
+  codes and when the message column is set to something besides
+  centered or 0. The next row will also use the correct color
+  code from the previous row (as if there had been no clipping)
+  instead of whatever the last color code displayed was. The old
+  behavior is version locked to <2.93.
 
 DEVELOPERS
 

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -326,9 +326,11 @@ void color_string_ext_special(const char *string, unsigned int x, unsigned int y
 void fill_line_ext(unsigned int length, unsigned int x, unsigned int y,
  uint8_t chr, uint8_t color, unsigned int chr_offset, unsigned int color_offset);
 
-size_t color_string_length(char *string, size_t max_size);
-size_t color_string_index_of(char *string, size_t max_size, size_t offset,
+size_t color_string_length(const char *string, size_t max_size);
+size_t color_string_index_of(const char *string, size_t max_size, size_t offset,
  int terminator);
+uint8_t color_string_get_final_color(const char *string, size_t max_size,
+ uint8_t initial_color);
 
 boolean change_video_output(struct config_info *conf, const char *output);
 int get_available_video_output_list(const char **buffer, int buffer_len);


### PR DESCRIPTION
* The board message now clips at the correct position when it overflows the right edge of the board. Previously, it would always be clipped at BYTE 80 instead of after the final byte that would display on screen. This caused wrapping bugs with non-centered message columns >0 and would clip messages containing color codes too early.
* When the board message clips the right side of the screen, the next line displayed will now use the correct color code from the previous line (as if no clipping had occurred) instead of whatever the last color that displayed on the screen was.
* Fixed some minor errors in `color_string_length` and `color_string_index_of`. They should now behave identically to the old `strlencolor` with regards to color codes and escapes. They also now take `const` string pointers.