### PR TITLE
Fix scroll colors for games that rely on protected palette scrolls.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -52,6 +52,11 @@ USERS
   characters past the first 64 will clip.
 + Clicking a line in the scroll display and editor now jumps to
   that line (same as the help file).
++ You can now toggle between editing scrolls with the protected
+  palette/charset and the game palette/charset with Alt+V.
++ Games for versions 2.80X through 2.90X now display scrolls
+  using the protected palette instead of the game palette (fixes
+  a scroll in Welkin).
 + Fixed possible robot stack and scroll message memory leaks.
 + Fixed a 2.93 regression where color strings with escapes like
   "~x", where x is not a hex digit, would also print the ~ or @.

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -238,6 +238,8 @@ CORE_LIBSPEC void color_line(unsigned int length, unsigned int x,
  unsigned int y, uint8_t color);
 CORE_LIBSPEC void fill_line(unsigned int length, unsigned int x, unsigned int y,
  uint8_t chr, uint8_t color);
+CORE_LIBSPEC void fill_line_ext(unsigned int length, unsigned int x, unsigned int y,
+ uint8_t chr, uint8_t color, unsigned int chr_offset, unsigned int color_offset);
 CORE_LIBSPEC void draw_char(uint8_t chr, uint8_t color, unsigned int x, unsigned int y);
 CORE_LIBSPEC void erase_char(unsigned int x, unsigned int y);
 CORE_LIBSPEC void erase_area(unsigned int x, unsigned int y,
@@ -323,8 +325,6 @@ void color_string_ext(const char *string, unsigned int x, unsigned int y,
  uint8_t color, boolean allow_newline, unsigned int chr_offset, unsigned int color_offset);
 void color_string_ext_special(const char *string, unsigned int x, unsigned int y,
  uint8_t *color, boolean allow_newline, unsigned int chr_offset, unsigned int color_offset);
-void fill_line_ext(unsigned int length, unsigned int x, unsigned int y,
- uint8_t chr, uint8_t color, unsigned int chr_offset, unsigned int color_offset);
 
 size_t color_string_length(const char *string, size_t max_size);
 size_t color_string_index_of(const char *string, size_t max_size, size_t offset,

--- a/src/intake.c
+++ b/src/intake.c
@@ -85,9 +85,11 @@ static inline void intake_old_place_char(char *string, int *currx,
 // Returns a delete if attempted at end of line. (exit_type==INTK_EXIT_ANY)
 
 int intake(struct world *mzx_world, char *string, int max_len, int display_len,
- int x, int y, char color, enum intake_exit_type exit_type, int *return_x_pos)
+ int x, int y, char color, enum intake_exit_type exit_type, boolean mask_colors,
+ int *return_x_pos)
 {
-  int use_mask = get_config()->mask_midchars;
+  int use_mask = get_config()->mask_midchars && mask_colors;
+  int c_offset = mask_colors ? 16 : 0;
   int currx, curr_len;
   int scrolledx, tmpx;
   int done = 0, place = 0;
@@ -121,11 +123,11 @@ int intake(struct world *mzx_world, char *string, int max_len, int display_len,
 
     cur_char = string[tmpx];
     string[tmpx] = '\0';
-    write_string_ext(string + scrolledx, x, y, color, flags, 0, 16);
+    write_string_ext(string + scrolledx, x, y, color, flags, 0, c_offset);
     string[tmpx] = cur_char;
 
     if(curr_len < display_len)
-      fill_line(display_len + 1 - curr_len, x + curr_len, y, 32, color);
+      fill_line_ext(display_len + 1 - curr_len, x + curr_len, y, 32, color, 0, c_offset);
 
     if(insert_on)
       cursor_underline(x + currx - scrolledx, y);
@@ -432,6 +434,20 @@ int intake(struct world *mzx_world, char *string, int max_len, int display_len,
       case IKEY_t:
       {
         // Hack for SFX editor dialog
+        if(get_alt_status(keycode_internal))
+        {
+          done = 1;
+        }
+        else
+        {
+          place = 1;
+        }
+        break;
+      }
+
+      case IKEY_v:
+      {
+        // Hack for scroll editor
         if(get_alt_status(keycode_internal))
         {
           done = 1;

--- a/src/intake.h
+++ b/src/intake.h
@@ -53,7 +53,8 @@ CORE_LIBSPEC boolean intake_get_insert(void);
 CORE_LIBSPEC void intake_set_insert(boolean new_insert_state);
 
 CORE_LIBSPEC int intake(struct world *mzx_world, char *string, int max_len, int display_len,
- int x, int y, char color, enum intake_exit_type exit_type, int *return_x_pos);
+ int x, int y, char color, enum intake_exit_type exit_type, boolean mask_colors,
+ int *return_x_pos);
 
 CORE_LIBSPEC subcontext *intake2(context *parent, char *dest, int max_length,
  int *pos_external, int *length_external);

--- a/src/window.c
+++ b/src/window.c
@@ -859,7 +859,7 @@ int input_window(struct world *mzx_world, const char *title,
     x += title_len + 1;
 
   ret = intake(mzx_world, buffer, max_len, max_len, x, y, 15,
-   INTK_EXIT_ENTER_ESC, NULL);
+   INTK_EXIT_ENTER_ESC, true, NULL);
 
   restore_screen();
 
@@ -2183,7 +2183,7 @@ static int click_input_box(struct world *mzx_world, struct dialog *di,
   if(start_x >= 0)
   {
     return intake(mzx_world, src->result, src->max_length, src->max_length,
-     x + (int)question_len + di->pad_space, y, DI_INPUT, INTK_EXIT_ANY,
+     x + (int)question_len + di->pad_space, y, DI_INPUT, INTK_EXIT_ANY, true,
      &start_x);
   }
   else
@@ -2449,7 +2449,7 @@ static int idle_input_box(struct world *mzx_world, struct dialog *di,
 
   return intake(mzx_world, src->result, src->max_length, src->max_length,
    x + (int)strlen(src->question) + di->pad_space, y, DI_INPUT, INTK_EXIT_ANY,
-   NULL);
+   true, NULL);
 }
 
 void construct_dialog(struct dialog *src, const char *title, int x, int y,


### PR DESCRIPTION
Games made for MegaZeux versions between 2.80h and 2.91f (inclusive) can rely on scrolls displaying their text using the protected palette. Adding support for this (locked to versions between 2.80X and 2.90X) fixes a scroll in Welkin.

Also added a toggle to the scroll editor to view a scroll using the game colors and charset and unbroke the protected palette frame display (broken a few commits ago while fixing color code display).