### PR TITLE
Move software mixer configuration out of audio driver code.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -77,6 +77,8 @@ USERS
   the player is pushed onto them.
 + The DJGPP port now locks all of its memory. This prevents
   paging crashes related to audio, but increases memory usage.
++ The SDL audio driver will now initialize the software mixer
+  frequency with the value returned by SDL_OpenAudioDevice.
 
 DEVELOPERS
 
@@ -109,6 +111,15 @@ DEVELOPERS
 + Fixed testworlds process running check edge cases.
 + Fixed config.sh and platform_endian.h detection for IBM Z and
   System/390 architecture.
++ Software mixer configuration (rate, buffer, channels) is now
+  done using the function audio_mixer_init instead of each
+  driver handling it manually.
++ The software mixer render function now takes the number of
+  frames and channels to render and the output format instead
+  of the number of bytes. Supported output formats are 16-bit
+  signed, 8-bit signed, and 8-bit unsigned.
++ Audio streams with a null mix_data function are now supported.
+  These streams will be ignored by the software mixer.
 
 
 December 31st, 2023 - MZX 2.93

--- a/src/audio/audio.c
+++ b/src/audio/audio.c
@@ -120,6 +120,9 @@ static unsigned int volume_function(int input, int volume_setting)
 
 void destruct_audio_stream(struct audio_stream *a_src)
 {
+  if(a_src == audio.primary_stream)
+    audio.primary_stream = NULL;
+
   if(a_src == audio.stream_list_base)
     audio.stream_list_base = a_src->next;
 
@@ -180,12 +183,48 @@ void initialize_audio_stream(struct audio_stream *a_src,
   UNLOCK();
 }
 
-static void clip_buffer(int16_t *dest, int32_t *src, size_t len)
+static void clip_buffer_u8(uint8_t *dest, int32_t *src, size_t samples)
 {
   int32_t cur_sample;
   size_t i;
 
-  for(i = 0; i < len; i++)
+  for(i = 0; i < samples; i++)
+  {
+    cur_sample = src[i];
+    if(cur_sample > 32767)
+      cur_sample = 32767;
+
+    if(cur_sample < -32768)
+      cur_sample = -32768;
+
+    dest[i] = (uint8_t)(cur_sample >> 8) + 128;
+  }
+}
+
+static void clip_buffer_s8(int8_t *dest, int32_t *src, size_t samples)
+{
+  int32_t cur_sample;
+  size_t i;
+
+  for(i = 0; i < samples; i++)
+  {
+    cur_sample = src[i];
+    if(cur_sample > 32767)
+      cur_sample = 32767;
+
+    if(cur_sample < -32768)
+      cur_sample = -32768;
+
+    dest[i] = cur_sample >> 8;
+  }
+}
+
+static void clip_buffer_s16(int16_t *dest, int32_t *src, size_t samples)
+{
+  int32_t cur_sample;
+  size_t i;
+
+  for(i = 0; i < samples; i++)
   {
     cur_sample = src[i];
     if(cur_sample > 32767)
@@ -199,48 +238,164 @@ static void clip_buffer(int16_t *dest, int32_t *src, size_t len)
 }
 
 /**
- * Audio callback for threaded software mixing. The output buffer must be
- * 16-bit stereo and the length value must be the size of the buffer in bytes
- * (i.e. the frame count times 4).
+ * Render `frames` number of audio frames with the software mixer. The
+ * output buffer must be able to hold a number of bytes equal to the
+ * requested frames times the requested channels times the size in bytes
+ * of the requested sample type. Destroys any audio streams that end
+ * while rendering the output.
+ * TODO: the mixer requires exactly 2 output channels currently.
+ *
+ * Returns the number of frames successfully renderered.
  */
-void audio_callback(int16_t *stream, size_t len)
+size_t audio_mixer_render_frames(void *stream, unsigned frames,
+ unsigned channels, unsigned format)
 {
-  boolean destroy_flag;
   struct audio_stream *current_astream;
+  size_t frames_chn;
+  boolean destroy_flag;
 
   LOCK();
 
   current_astream = audio.stream_list_base;
 
-  if(current_astream)
+  if(current_astream && audio.mix_buffer && frames && channels)
   {
-    size_t frames = len / (2 * sizeof(int16_t));
-    memset(audio.mix_buffer, 0, frames * 2 * sizeof(int32_t));
+    // Due to how resampling is implemented, the requested frames
+    // should never exceed the buffer's number of frames. If it does,
+    // this call can't complete the entire request.
+    if(frames > audio.buffer_frames)
+      frames = audio.buffer_frames;
+
+    // Additionally, if the output channels exceed the configured
+    // number of channels, the frames may need to be limited further.
+    frames_chn = frames * channels;
+    if(frames_chn * sizeof(int32_t) > audio.buffer_bytes)
+    {
+      frames = audio.buffer_bytes / (channels * sizeof(int32_t));
+      frames_chn = frames * channels;
+    }
+
+    memset(audio.mix_buffer, 0, frames_chn * sizeof(int32_t));
 
     while(current_astream != NULL)
     {
       struct audio_stream *next_astream = current_astream->next;
 
-      destroy_flag = current_astream->mix_data(current_astream,
-       audio.mix_buffer, frames, 2);
-
-      if(destroy_flag)
+      if(current_astream->mix_data)
       {
-        current_astream->destruct(current_astream);
+        destroy_flag = current_astream->mix_data(current_astream,
+         audio.mix_buffer, frames, channels);
 
-        // if the destroyed stream was our music, we shouldn't
-        // let end_mod try to destroy it again.
-        if(current_astream == audio.primary_stream)
-          audio.primary_stream = NULL;
+        if(destroy_flag)
+          current_astream->destruct(current_astream);
       }
 
       current_astream = next_astream;
     }
 
-    clip_buffer(stream, audio.mix_buffer, frames * 2);
+    switch(format)
+    {
+      case SAMPLE_U8:
+        clip_buffer_u8((uint8_t *)stream, audio.mix_buffer, frames_chn);
+        break;
+
+      case SAMPLE_S8:
+        clip_buffer_s8((int8_t *)stream, audio.mix_buffer, frames_chn);
+        break;
+
+      case SAMPLE_S16:
+        clip_buffer_s16((int16_t *)stream, audio.mix_buffer, frames_chn);
+        break;
+
+      default:
+        warn("clip_buffer unimplemented for sample format %d!\n", format);
+    }
   }
 
   UNLOCK();
+
+  return frames;
+}
+
+/**
+ * This function initializes audio.output_frequency, audio.mix_buffer,
+ * and audio.buffer_frames for software mixing. This function may reconfigure
+ * the provided values of any of these fields.
+ *
+ * This should be called when initializing a sound driver but before unpausing
+ * audio, and any time the sample rate, number of buffer frames, or the number
+ * of output channels changes (also while audio is paused). Sample format
+ * changes are handled in the audio callback directly.
+ */
+boolean audio_mixer_init(unsigned rate, unsigned frames, unsigned channels)
+{
+  boolean ret = false;
+  size_t sz;
+
+  debug("--MIXER-- attempting init with rate=%u, frames=%u, channels=%u\n",
+   rate, frames, channels);
+
+  if(rate == 0)
+    rate = 44100;
+  if(rate < 256 || rate > 384000)
+    goto err;
+
+  if(frames == 0)
+    frames = 1024;
+  frames = CLAMP(frames, 8, 65536);
+  frames = round_to_power_of_two(frames);
+
+  if(channels == 0)
+    channels = 2;
+  if(channels > 2)
+    goto err;
+
+  sz = sizeof(int32_t) * frames * channels;
+
+  LOCK();
+
+  if(!audio.mix_buffer || audio.buffer_bytes != sz)
+  {
+    int32_t *buffer = (int32_t *)crealloc(audio.mix_buffer, sz);
+    if(!buffer)
+    {
+      debug("--MIXER-- failed buffer alloc of size %zu\n", sz);
+      goto err_unlock;
+    }
+
+    audio.mix_buffer = buffer;
+    audio.buffer_bytes = sz;
+  }
+
+  audio.output_frequency = rate;
+  audio.buffer_frames = frames;
+  audio.buffer_channels = channels;
+  ret = true;
+
+  // TODO: if there are any open audio streams, they should sampled_set_buffer
+  // since they rely on output_frequency and buffer_frames.
+
+err_unlock:
+  UNLOCK();
+
+err:
+  debug("--MIXER-- init %s with rate=%u, frames=%u, channels=%u\n",
+   ret ? "OK" : "FAILURE", rate, frames, channels);
+  return ret;
+}
+
+/**
+ * Free the software mixer buffer. This does not need to be called
+ * in driver exit functions; quit_audio will call it for them.
+ */
+void audio_mixer_free(void)
+{
+  free(audio.mix_buffer);
+  audio.mix_buffer = NULL;
+  audio.buffer_bytes = 0;
+  audio.buffer_frames = 0;
+  audio.buffer_channels = 0;
+  audio.output_frequency = 44100;
 }
 
 void init_audio(struct config_info *conf)
@@ -251,7 +406,7 @@ void init_audio(struct config_info *conf)
   platform_mutex_init(&audio.audio_debug_mutex);
 #endif
 
-  audio.output_frequency = conf->output_frequency;
+  audio.output_frequency = 44100; // Dummy value.
   audio.global_resample_mode = conf->resample_mode;
 
   audio.max_simultaneous_samples = -1;
@@ -304,8 +459,10 @@ void quit_audio(void)
 
   LOCK();
 
+  audio_mixer_free();
   audio_ext_free_registry();
   free(audio.pcs_stream);
+  audio.pcs_stream = NULL;
 
   UNLOCK();
 

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -81,8 +81,12 @@ void destruct_audio_stream(struct audio_stream *a_src);
 void initialize_audio_stream(struct audio_stream *a_src,
  struct audio_stream_spec *a_spec, unsigned int volume, boolean repeat);
 
+size_t audio_mixer_render_frames(void *stream, unsigned frames,
+ unsigned channels, unsigned format);
+boolean audio_mixer_init(unsigned rate, unsigned frames, unsigned channels);
+void audio_mixer_free(void);
+
 // Platform-related functions.
-void audio_callback(int16_t *stream, size_t len);
 void init_audio_platform(struct config_info *conf);
 void quit_audio_platform(void);
 

--- a/src/audio/audio_struct.h
+++ b/src/audio/audio_struct.h
@@ -31,9 +31,9 @@ __M_BEGIN_DECLS
 #include "../platform.h"
 
 #if PLATFORM_BYTE_ORDER == PLATFORM_BIG_ENDIAN
-#define SAMPLE_S16SYS SAMPLE_S16MSB
+#define SAMPLE_S16 SAMPLE_S16MSB
 #else
-#define SAMPLE_S16SYS SAMPLE_S16LSB
+#define SAMPLE_S16 SAMPLE_S16LSB
 #endif
 
 enum wav_format
@@ -105,7 +105,9 @@ struct audio_stream_spec
 struct audio
 {
   int32_t *mix_buffer;
-  size_t buffer_samples;
+  size_t buffer_bytes;
+  unsigned buffer_frames;
+  unsigned buffer_channels;
 
   size_t output_frequency;
   unsigned int global_resample_mode;

--- a/src/audio/audio_wav.c
+++ b/src/audio/audio_wav.c
@@ -129,7 +129,7 @@ static uint32_t wav_read_data(struct wav_stream *w_stream,
         new_offset = w_stream->loop_start;
       }
 
-      if(w_stream->format != SAMPLE_S16SYS)
+      if(w_stream->format != SAMPLE_S16)
       {
         // Swap bytes to match the current platform endianness...
         for(i = 0; i < read_len; i += 2)

--- a/src/audio/audio_xmp.c
+++ b/src/audio/audio_xmp.c
@@ -221,7 +221,7 @@ static boolean audio_xmp_get_sample(struct audio_stream *a_src, unsigned int whi
       // MZX supports all of these, so just copy the sample directly.
       if(sam->flg & XMP_SAMPLE_16BIT)
       {
-        dest->format = SAMPLE_S16SYS;
+        dest->format = SAMPLE_S16;
         dest->data_length *= 2;
       }
       else

--- a/src/audio/sampled_stream.cpp
+++ b/src/audio/sampled_stream.cpp
@@ -281,7 +281,7 @@ void sampled_set_buffer(struct sampled_stream *s_src)
   s_src->negative_comp = 0;
 
   data_window_length =
-   (size_t)(ceil((double)audio.buffer_samples *
+   (size_t)(ceil((double)audio.buffer_frames *
    frequency / audio.output_frequency) * bytes_per_sample);
 
   prologue_length += frequency_delta * bytes_per_sample;

--- a/src/configure.c
+++ b/src/configure.c
@@ -57,6 +57,8 @@
 
 #ifdef CONFIG_DREAMCAST
 #define VIDEO_OUTPUT_DEFAULT "dreamcast"
+#define AUDIO_BUFFER_SAMPLES 2048 // the value KOS seems to like best
+#define AUDIO_SAMPLE_RATE 44100
 #define SAVE_SLOTS_DEFAULT true
 #endif
 
@@ -277,7 +279,7 @@ static const struct config_info user_conf_default =
   true,                         // allow screenshots
 
   // Audio options
-  AUDIO_SAMPLE_RATE,            // output_frequency
+  AUDIO_SAMPLE_RATE,            // audio_sample_rate
   AUDIO_BUFFER_SAMPLES,         // audio_buffer_samples
   0,                            // oversampling_on
   RESAMPLE_MODE_DEFAULT,        // resample_mode
@@ -1047,7 +1049,7 @@ static void config_set_audio_freq(struct config_info *conf, char *name,
 {
   int result;
   if(config_int(&result, value, 1, INT_MAX))
-    conf->output_frequency = result;
+    conf->audio_sample_rate = result;
 }
 
 static void config_force_bpp(struct config_info *conf, char *name,

--- a/src/configure.h
+++ b/src/configure.h
@@ -128,7 +128,7 @@ struct config_info
   boolean allow_screenshots;
 
   // Audio options
-  int output_frequency;
+  int audio_sample_rate;
   int audio_buffer_samples;
   boolean oversampling_on;
   enum resample_mode resample_mode;

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -545,7 +545,7 @@ UNITTEST(Settings)
 
   SECTION(audio_sample_rate)
   {
-    TEST_INT("audio_sample_rate", conf->output_frequency, 1, INT_MAX);
+    TEST_INT("audio_sample_rate", conf->audio_sample_rate, 1, INT_MAX);
   }
 
   SECTION(audio_buffer_samples)


### PR DESCRIPTION
* Software mixer configuration is now performed by audio_mixer_init, which does basic sample rate checking and bounding on the buffer size and number of channels.
* The software mixer render function now takes a number of frames, channels, and the sample format instead of a number of bytes. It is up to the audio driver to calculate the number of frames needed if its API requests a number of bytes instead. The supported sample formats are SAMPLE_S16, SAMPLE_S8, and SAMPLE_U8.
* The software mixer now ignores audio streams with a NULL mix_data function instead of crashing. Nothing currently relies on this.
* The SDL audio driver will select whichever sample rate is returned by SDL_OpenAudioStream now instead of using the input value.