### PR TITLE
Add support for Sound Blaster Pro and Sound Blaster 16 8-bit modes.

### DIFF
--- a/arch/djgpp/audio.c
+++ b/arch/djgpp/audio.c
@@ -2,6 +2,7 @@
  *
  * Copyright (C) 2010 Alan Williams <mralert@gmail.com>
  * Copyright (C) 2019 Adrian Siekierka <kontakt@asie.pl>
+ * Copyright (C) 2024 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -30,19 +31,12 @@
 #include "../../src/audio/audio.h"
 #include "../../src/audio/audio_struct.h"
 #include "../../src/util.h"
+#include "driver_sb.h"
 #include "platform_djgpp.h"
 
 #ifdef CONFIG_AUDIO
 
 #define BUFFER_BLOCKS 2
-
-#define SB_PORT_DMA8_ACK          0xe
-#define SB_PORT_DMA16_ACK         0xf
-
-#define SB16_DSP_AUTOINIT_16_BIT  0xB6
-#define SB16_DSP_AUTOINIT_8_BIT   0xC6
-#define SB16_FORMAT_SIGNED        0x10
-#define SB16_FORMAT_STEREO        0x20
 
 struct sb_config
 {
@@ -61,9 +55,10 @@ struct sb_config
   unsigned buffer_size;
   unsigned active_dma;
   unsigned active_dma_ack;
+  unsigned active_dma_size;
   // driver-specific:
   // - to restore on deinit
-  uint8_t old_21h;
+  struct irq_state old_irq_state;
   _go32_dpmi_seginfo old_irq_handler;
   // - if nearptr enabled
   boolean nearptr_buffer_enabled;
@@ -108,7 +103,7 @@ static void audio_sb_interrupt(void)
 {
   audio_sb_next_block();
   inportb(sb_cfg.port + sb_cfg.active_dma_ack); // ack (sb)
-  outportb(0x20, 0x20); // ack (pic)
+  djgpp_irq_ack(sb_cfg.irq); // ack (pic)
 }
 
 static void audio_sb_parse_env(struct sb_config *conf, char *env)
@@ -123,16 +118,16 @@ static void audio_sb_parse_env(struct sb_config *conf, char *env)
         conf->port = strtol(token + 1, NULL, 16);
         break;
       case 'D':
-        conf->dma8 = strtol(token + 1, NULL, 16);
+        conf->dma8 = strtol(token + 1, NULL, 10);
         break;
       case 'H':
-        conf->dma16 = strtol(token + 1, NULL, 16);
+        conf->dma16 = strtol(token + 1, NULL, 10);
         break;
       case 'I':
-        conf->irq = strtol(token + 1, NULL, 16);
+        conf->irq = strtol(token + 1, NULL, 10);
         break;
       case 'T':
-        conf->type = strtol(token + 1, NULL, 16);
+        conf->type = strtol(token + 1, NULL, 10);
         break;
     }
   }
@@ -140,19 +135,25 @@ static void audio_sb_parse_env(struct sb_config *conf, char *env)
 
 static uint8_t audio_sb_dsp_read(void)
 {
-  while(!(inportb(sb_cfg.port + 0xE) & 0x80))
-    ;
+  int i;
+  for(i = 0; i < 8192; i++)
+    if(inportb(sb_cfg.port + 0xE) & 0x80)
+      break;
+
   return inportb(sb_cfg.port + 0xA);
 }
 
 static void audio_sb_dsp_write(uint8_t val)
 {
-  while(inportb(sb_cfg.port + 0xC) & 0x80)
-    ;
+  int i;
+  for(i = 0; i < 8192; i++)
+    if(!(inportb(sb_cfg.port + 0xC) & 0x80))
+      break;
+
   outportb(sb_cfg.port + 0xC, val);
 }
 
-static boolean audio_sb_dsp_detect(void)
+static boolean audio_sb_dsp_reset(void)
 {
   uint16_t i;
   outportb(sb_cfg.port + 0x6, 1);
@@ -169,40 +170,62 @@ static boolean audio_sb_dsp_detect(void)
   return i > 0;
 }
 
+static void audio_sb_mixer_set_stereo(boolean enable)
+{
+  int tmp;
+  if(sb_cfg.version_major != 3)
+    return;
+
+  tmp = inportb(sb_cfg.port + 0x5);
+  tmp = enable ? (tmp | SBPRO_MIXER_STEREO) : (tmp & ~SBPRO_MIXER_STEREO);
+
+  outportb(sb_cfg.port + 0x4, 0xe);
+  outportb(sb_cfg.port + 0x5, tmp);
+}
+
 void init_audio_platform(struct config_info *conf)
 {
   _go32_dpmi_seginfo new_irq_handler;
 
   // Try to find a Sound Blaster
+  // TODO: manual configuration
   char *sb_env = getenv("BLASTER");
   if(sb_env != NULL)
     audio_sb_parse_env(&sb_cfg, sb_env);
-  if(sb_cfg.port != 0)
-    if(!audio_sb_dsp_detect())
-      sb_cfg.port = 0;
-  if(sb_cfg.port != 0)
-  {
-    audio_sb_dsp_write(0xE1); // version
-    sb_cfg.version_major = audio_sb_dsp_read();
-    sb_cfg.version_minor = audio_sb_dsp_read();
 
-    if(sb_cfg.version_major < 4)
-      sb_cfg.port = 0;
-    else
+  if(sb_cfg.port == 0)
+    goto err;
 
-    if(sb_cfg.irq >= 8) // TODO: support IRQ8-15?
-      sb_cfg.port = 0;
-    else
+  if(!audio_sb_dsp_reset())
+    goto err;
 
-    if(sb_cfg.dma16 < 5 || sb_cfg.dma16 >= 8)
-      sb_cfg.port = 0;
-  }
+  audio_sb_dsp_write(SB_DSP_GET_VERSION);
+  sb_cfg.version_major = audio_sb_dsp_read();
+  sb_cfg.version_minor = audio_sb_dsp_read();
 
-  if(sb_cfg.port != 0)
+  info("Sound Blaster DSP %d.%02d - using A%03x I%d D%d H%d\n",
+   sb_cfg.version_major, sb_cfg.version_minor,
+   sb_cfg.port, sb_cfg.irq, sb_cfg.dma8, sb_cfg.dma16);
+
+  if(!SB_VERSION_ATLEAST(sb_cfg, SB_VERSION_SB1_REV))
+    goto err;
+
+  if(sb_cfg.irq >= 16)
+    goto err;
+
+  if(sb_cfg.dma8 >= 4) // TODO: support DMA >3?
+    goto err;
+
+  if(SB_VERSION_ATLEAST(sb_cfg, SB_VERSION_SB16) &&
+   (sb_cfg.dma16 < 5 || sb_cfg.dma16 >= 8))
+    goto err;
+
   {
     unsigned frames = conf->audio_buffer_samples;
     unsigned rate = conf->audio_sample_rate;
     unsigned sb16_format = 0;
+    unsigned time_constant = 0;
+    unsigned irq_vector;
     boolean is_16_bit = false;
 
     if(frames > 4096) // TODO: seems arbitrary
@@ -210,7 +233,7 @@ void init_audio_platform(struct config_info *conf)
 
     rate = CLAMP(rate, 5000, 44100);
 
-    if(sb_cfg.version_major >= 4) // SB16
+    if(SB_VERSION_ATLEAST(sb_cfg, SB_VERSION_SB16))
     {
       // TODO: configurable
       sb_cfg.buffer_format = SAMPLE_S16;
@@ -225,24 +248,27 @@ void init_audio_platform(struct config_info *conf)
     }
     else // pre-SB16
     {
-      uint8_t time_constant = 256 - (500000 / rate);
-      rate = 500000 / (256 - time_constant);
-      audio_sb_dsp_write(0x40); // set time constant
-      audio_sb_dsp_write(time_constant);
       sb_cfg.buffer_format = SAMPLE_U8;
       sb_cfg.buffer_channels = 1;
       // Sound Blaster Pro and up support stereo.
-      if(sb_cfg.version_major >= 3)
+      // TODO: configurable
+      if(SB_VERSION_ATLEAST(sb_cfg, SB_VERSION_SBPRO1))
         sb_cfg.buffer_channels = 2;
+
+      // Sound Blaster Pro stereo and all DSPs prior to 2.01 have a
+      // maximum rate of around 22050.
+      if(sb_cfg.buffer_channels == 2 || !SB_VERSION_ATLEAST(sb_cfg, SB_VERSION_SB2))
+        rate = CLAMP(rate, 5000, 22050);
+
+      time_constant = 256 - 1000000 / (sb_cfg.buffer_channels * rate);
+      rate = 1000000 / (sb_cfg.buffer_channels * (256 - time_constant));
     }
 
     sb_cfg.nearptr_buffer_enabled = djgpp_push_enable_nearptr();
 
     if(!audio_mixer_init(rate, frames, sb_cfg.buffer_channels))
-    {
-      sb_cfg.port = 0;
-      return;
-    }
+      goto err;
+
     sb_cfg.buffer_frames = audio.buffer_frames;
     sb_cfg.buffer_size = sb_cfg.buffer_frames * sb_cfg.buffer_channels *
      (is_16_bit ? sizeof(int16_t) : sizeof(uint8_t));
@@ -270,10 +296,7 @@ void init_audio_platform(struct config_info *conf)
     {
       sb_cfg.buffer = (uint8_t *)cmalloc(sb_cfg.buffer_size * BUFFER_BLOCKS);
       if(!sb_cfg.buffer)
-      {
-        sb_cfg.port = 0;
-        return;
-      }
+        goto err;
     }
 
     audio_sb_clear_buffer();
@@ -285,13 +308,13 @@ void init_audio_platform(struct config_info *conf)
     sb_cfg.buffer_block = 0;
 
     // configure irq
-    _go32_dpmi_get_protected_mode_interrupt_vector(8 + sb_cfg.irq, &sb_cfg.old_irq_handler);
+    irq_vector = djgpp_irq_vector(sb_cfg.irq);
+    _go32_dpmi_get_protected_mode_interrupt_vector(irq_vector, &sb_cfg.old_irq_handler);
     new_irq_handler.pm_offset = (int) audio_sb_interrupt;
     new_irq_handler.pm_selector = _go32_my_cs();
-    _go32_dpmi_chain_protected_mode_interrupt_vector(8 + sb_cfg.irq, &new_irq_handler);
+    _go32_dpmi_chain_protected_mode_interrupt_vector(irq_vector, &new_irq_handler);
 
-    sb_cfg.old_21h = inportb(0x21);
-    outportb(0x21, sb_cfg.old_21h & (~(1 << sb_cfg.irq)));
+    djgpp_irq_enable(sb_cfg.irq, &sb_cfg.old_irq_state);
 
     // configure dma
     if(is_16_bit)
@@ -304,26 +327,62 @@ void init_audio_platform(struct config_info *conf)
       sb_cfg.active_dma = sb_cfg.dma8;
       sb_cfg.active_dma_ack = SB_PORT_DMA8_ACK;
     }
+    sb_cfg.active_dma_size = (sb_cfg.buffer_frames << 1) - 1;
 
     djgpp_enable_dma(sb_cfg.active_dma, DMA_WRITE | DMA_AUTOINIT,
      sb_cfg.buffer_segment << 4, sb_cfg.buffer_size * BUFFER_BLOCKS);
 
-    // configure dsp
-    if(sb_cfg.version_major >= 4)
-    {
-      audio_sb_dsp_write(0xD1); // turn on speaker
+    audio_sb_dsp_write(SB_DSP_SPEAKER_ON);
 
-      audio_sb_dsp_write(0x41); // set sampling rate
+    // configure dsp
+    if(SB_VERSION_ATLEAST(sb_cfg, SB_VERSION_SB16))
+    {
+      audio_sb_dsp_write(SB_DSP_SET_SAMPLE_RATE);
       audio_sb_dsp_write(rate >> 8);
       audio_sb_dsp_write(rate & 0xFF);
 
       // configure transfer
       audio_sb_dsp_write(is_16_bit ? SB16_DSP_AUTOINIT_16_BIT : SB16_DSP_AUTOINIT_8_BIT);
       audio_sb_dsp_write(sb16_format); // mono/stereo, signed/unsigned
-      audio_sb_dsp_write(((sb_cfg.buffer_frames << 1) - 1) & 0xFF);
-      audio_sb_dsp_write(((sb_cfg.buffer_frames << 1) - 1) >> 8);
+      audio_sb_dsp_write(sb_cfg.active_dma_size);
+      audio_sb_dsp_write(sb_cfg.active_dma_size >> 8);
     }
+    else
+
+    if(SB_VERSION_ATLEAST(sb_cfg, SB_VERSION_SB1_REV))
+    {
+      audio_sb_mixer_set_stereo(sb_cfg.buffer_channels == 2);
+
+      audio_sb_dsp_write(SB_DSP_SET_TIME_CONSTANT);
+      audio_sb_dsp_write(time_constant);
+
+      audio_sb_dsp_write(SB_DSP_SET_DMA_BLOCK_SIZE);
+      audio_sb_dsp_write(sb_cfg.active_dma_size);
+      audio_sb_dsp_write(sb_cfg.active_dma_size >> 8);
+
+      // start transfer
+      if(SB_VERSION_ATLEAST(sb_cfg, SB_VERSION_SB2))
+        audio_sb_dsp_write(SB_DSP_AUTOINIT_8_BIT_HI);
+      else
+        audio_sb_dsp_write(SB_DSP_AUTOINIT_8_BIT);
+    }
+#if 0
+    else
+    {
+      audio_sb_dsp_write(SB_DSP_SET_TIME_CONSTANT);
+      audio_sb_dsp_write(time_constant);
+
+      audio_sb_dsp_write(SB_DSP_SINGLE_8_BIT); // single block transfer
+      audio_sb_dsp_write(sb_cfg.active_dma_size);
+      audio_sb_dsp_write(sb_cfg.active_dma_size >> 8);
+    }
+#endif
   }
+  return;
+
+err:
+  sb_cfg.port = 0;
+  return;
 }
 
 void quit_audio_platform(void)
@@ -331,13 +390,28 @@ void quit_audio_platform(void)
   // Deinitialize audio
   if(sb_cfg.port != 0)
   {
-    audio_sb_dsp_write(0xD3); // turn off speaker
+    unsigned irq_vector = djgpp_irq_vector(sb_cfg.irq);
+
+    audio_sb_dsp_write(SB_DSP_SPEAKER_OFF);
+
+    if(SB_VERSION_ATLEAST(sb_cfg, SB_VERSION_SB1_REV))
+    {
+      // Stop autoinit DMA.
+      // This is usually done in the interrupt with a nonblocking write.
+      if(sb_cfg.active_dma == sb_cfg.dma16)
+        audio_sb_dsp_write(SB_DSP_EXIT_AUTO_16_BIT);
+      else
+        audio_sb_dsp_write(SB_DSP_EXIT_AUTO_8_BIT);
+
+      // Disable stereo (SBPro only).
+      audio_sb_mixer_set_stereo(false);
+    }
 
     // undo interrupt change
-    outportb(0x21, sb_cfg.old_21h);
+    djgpp_irq_restore(&sb_cfg.old_irq_state);
 
     // undo vector change
-    _go32_dpmi_set_protected_mode_interrupt_vector(8 + sb_cfg.irq, &sb_cfg.old_irq_handler);
+    _go32_dpmi_set_protected_mode_interrupt_vector(irq_vector, &sb_cfg.old_irq_handler);
 
     djgpp_disable_dma(sb_cfg.active_dma);
 

--- a/arch/djgpp/driver_sb.h
+++ b/arch/djgpp/driver_sb.h
@@ -1,0 +1,61 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2024 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef __AUDIO_DRIVER_SB_H
+#define __AUDIO_DRIVER_SB_H
+
+#define SB_VERSION_ATLEAST(cfg, ver) \
+ (((cfg.version_major << 8) | (cfg.version_minor)) >= (ver))
+
+#define SB_VERSION_SB1            0x100
+#define SB_VERSION_SB1_REV        0x200 /* SB 1.x with DSP 2.00 */
+#define SB_VERSION_SB2            0x201
+#define SB_VERSION_SBPRO1         0x300
+#define SB_VERSION_SBPRO2         0x302
+#define SB_VERSION_SB16           0x400
+
+#define SB_PORT_DMA8_ACK          0xe
+#define SB_PORT_DMA16_ACK         0xf
+
+#define SBPRO_MIXER_STEREO        0x02
+#define SBPRO_MIXER_FILTER        0x20
+
+#define SB_DSP_SET_TIME_CONSTANT  0x40
+#define SB_DSP_SET_SAMPLE_RATE    0x41
+#define SB_DSP_SET_DMA_BLOCK_SIZE 0x48
+#define SB_DSP_GET_VERSION        0xE1
+
+#define SB_DSP_SINGLE_8_BIT       0x14
+#define SB_DSP_AUTOINIT_8_BIT     0x1c
+#define SB_DSP_AUTOINIT_8_BIT_HI  0x90
+#define SB_DSP_PAUSE_8_BIT        0xD0
+#define SB_DSP_PAUSE_16_BIT       0xD5
+#define SB_DSP_CONTINUE_8_BIT     0xD4
+#define SB_DSP_CONTINUE_16_BIT    0xD6
+#define SB_DSP_EXIT_AUTO_8_BIT    0xDA
+#define SB_DSP_EXIT_AUTO_16_BIT   0xD9
+#define SB_DSP_SPEAKER_ON         0xD1
+#define SB_DSP_SPEAKER_OFF        0xD3
+
+#define SB16_DSP_AUTOINIT_16_BIT  0xB6
+#define SB16_DSP_AUTOINIT_8_BIT   0xC6
+#define SB16_FORMAT_SIGNED        0x10
+#define SB16_FORMAT_STEREO        0x20
+
+#endif /* __AUDIO_DRIVER_SB_H */

--- a/arch/djgpp/platform_djgpp.h
+++ b/arch/djgpp/platform_djgpp.h
@@ -88,6 +88,12 @@ struct vbe_mode_info
   uint16_t offscreen_size;
 } __attribute__((packed));
 
+struct irq_state
+{
+  int port_21h;
+  int port_A1h;
+};
+
 int djgpp_display_adapter_detect(void);
 const char *djgpp_display_adapter_name(int adapter);
 int djgpp_malloc_boundary(int len_bytes, int boundary_bytes, int *selector);
@@ -95,6 +101,11 @@ boolean djgpp_push_enable_nearptr(void);
 boolean djgpp_pop_enable_nearptr(void);
 void djgpp_enable_dma(uint8_t port, uint8_t mode, int offset, int bytes);
 void djgpp_disable_dma(uint8_t port);
+
+void djgpp_irq_enable(int irq, struct irq_state *old_state);
+void djgpp_irq_restore(struct irq_state *old_state);
+void djgpp_irq_ack(int irq);
+int djgpp_irq_vector(int irq);
 
 __M_END_DECLS
 

--- a/arch/djgpp/platform_djgpp.h
+++ b/arch/djgpp/platform_djgpp.h
@@ -21,6 +21,14 @@
 #ifndef __PLATFORM_DJGPP_H
 #define __PLATFORM_DJGPP_H
 
+#include "../../src/compat.h"
+
+__M_BEGIN_DECLS
+
+#define DMA_AUTOINIT  0x10
+#define DMA_READ      0x44
+#define DMA_WRITE     0x48
+
 enum
 {
   DISPLAY_ADAPTER_UNSUPPORTED,
@@ -87,5 +95,7 @@ boolean djgpp_push_enable_nearptr(void);
 boolean djgpp_pop_enable_nearptr(void);
 void djgpp_enable_dma(uint8_t port, uint8_t mode, int offset, int bytes);
 void djgpp_disable_dma(uint8_t port);
+
+__M_END_DECLS
 
 #endif // __PLATFORM_DJGPP_H

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -5,6 +5,11 @@ FREAD/FREADn bugfixes, as the old behavior was unusably buggy.
 
 USERS
 
++ The DOS port now supports Sound Blaster Pro in stereo mode.
+  The driver should also support all other Sound Blasters with
+  DSP >=2.00 and the mono/8-bit modes of the Sound Blaster 16,
+  but these are disabled for now (no software mixer support for
+  mono output). IRQs higher than 7 are also supported now.
 + All "gamecontroller[...]" config.txt options have been renamed
   to "gamepad[...]". The old names are still supported.
 + Fixed blank screen bugs that occur with the glslscale renderer


### PR DESCRIPTION
- [x] Hardware testing.
  - [x] Fix crash when exiting MegaZeux on real hardware.
  - [x] ~~Fix stuttering bug in Windows 98 SE? Do xmp, MikMod do this?~~ ignoring for now :(
  - [x] ~~Doesn't work with the CS4237B.~~ driver wasn't installed.
- [x] Test SB16 8-bit modes.
- [x] Test SB16 mono modes.
- [x] Test SBPro stereo mode.
- [x] Test SBPro mono mode.
- [x] Test SB2.