### PR TITLE
Rewrite software mixer resampler prologue and epilogue handling.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -81,6 +81,7 @@ USERS
   environment variable TZ is not set.
 + The SDL audio driver will now initialize the software mixer
   frequency with the value returned by SDL_OpenAudioDevice.
++ Fixed audible pops when setting MOD_FREQUENCY.
 
 DEVELOPERS
 
@@ -122,6 +123,8 @@ DEVELOPERS
   signed, 8-bit signed, and 8-bit unsigned.
 + Audio streams with a null mix_data function are now supported.
   These streams will be ignored by the software mixer.
++ sampled_mix_data now properly handles output requests smaller
+  than the size of the audio buffer.
 
 
 December 31st, 2023 - MZX 2.93

--- a/src/audio/audio_mikmod.c
+++ b/src/audio/audio_mikmod.c
@@ -172,10 +172,10 @@ static boolean mm_mix_data(struct audio_stream *a_src, int32_t * RESTRICT buffer
  size_t frames, unsigned int channels)
 {
   struct mikmod_stream *mm_stream = (struct mikmod_stream *)a_src;
-  uint32_t read_wanted = mm_stream->s.allocated_data_length -
-   mm_stream->s.stream_offset;
-  uint8_t *read_buffer = (uint8_t *)mm_stream->s.output_data +
-   mm_stream->s.stream_offset;
+  void *read_buffer;
+  size_t read_wanted;
+
+  read_buffer = sampled_get_buffer(&mm_stream->s, &read_wanted);
 
   VC_WriteBytes((SBYTE *)read_buffer, read_wanted);
   sampled_mix_data((struct sampled_stream *)mm_stream, buffer, frames, channels);

--- a/src/audio/audio_modplug.cpp
+++ b/src/audio/audio_modplug.cpp
@@ -89,16 +89,15 @@ static void init_modplug_settings(void)
 static boolean mp_mix_data(struct audio_stream *a_src, int32_t * RESTRICT buffer,
  size_t frames, unsigned int channels)
 {
-  size_t read_len;
   struct modplug_stream *mp_stream = (struct modplug_stream *)a_src;
-  size_t read_wanted = mp_stream->s.allocated_data_length -
-   mp_stream->s.stream_offset;
-  uint8_t *read_buffer = (uint8_t *)mp_stream->s.output_data +
-   mp_stream->s.stream_offset;
+  void *read_buffer;
+  size_t read_wanted;
+  size_t read_len;
   boolean r_val = false;
 
-  read_len =
-   ModPlug_Read(mp_stream->module_data, read_buffer, read_wanted);
+  read_buffer = sampled_get_buffer(&mp_stream->s, &read_wanted);
+
+  read_len = ModPlug_Read(mp_stream->module_data, read_buffer, read_wanted);
 
   if(!a_src->volume)
   {
@@ -123,7 +122,7 @@ static boolean mp_mix_data(struct audio_stream *a_src, int32_t * RESTRICT buffer
     else
     {
       // FIXME: I think this memset should always be done?
-      memset(read_buffer + read_len, 0, read_wanted - read_len);
+      memset((uint8_t *)read_buffer + read_len, 0, read_wanted - read_len);
       r_val = true;
     }
 

--- a/src/audio/audio_openmpt.c
+++ b/src/audio/audio_openmpt.c
@@ -72,13 +72,15 @@ static boolean omp_mix_data(struct audio_stream *a_src, int32_t *buffer,
   struct openmpt_stream *omp_stream = (struct openmpt_stream *)a_src;
   struct sampled_stream *s = (struct sampled_stream *)a_src;
 
-  uint32_t read_wanted = s->allocated_data_length - s->stream_offset;
-  uint8_t *read_buffer = (uint8_t *)s->output_data + s->stream_offset;
+  int16_t *read_buffer;
+  size_t read_wanted;
   boolean r_val = false;
   uint32_t read_len;
 
+  read_buffer = (int16_t *)sampled_get_buffer(&omp_stream->s, &read_wanted);
+
   read_len = openmpt_module_read_interleaved_stereo(omp_stream->module_data,
-   s->frequency, read_wanted / 4, (int16_t *)read_buffer) * 4;
+   s->frequency, read_wanted / 4, read_buffer) * 4;
 
   if(read_len < read_wanted && !a_src->repeat)
   {

--- a/src/audio/audio_reality.cpp
+++ b/src/audio/audio_reality.cpp
@@ -83,12 +83,12 @@ static boolean rad_mix_data(struct audio_stream *a_src, int32_t * RESTRICT buffe
  size_t frames, unsigned int channels)
 {
   struct rad_stream *rad_stream = (struct rad_stream *)a_src;
-  uint32_t read_wanted = rad_stream->s.allocated_data_length -
-   rad_stream->s.stream_offset;
-  int16_t *read_buffer = rad_stream->s.output_data +
-   (rad_stream->s.stream_offset / 2);
+  int16_t *read_buffer;
+  size_t read_wanted;
   boolean rval = false;
   uint32_t i;
+
+  read_buffer = (int16_t *)sampled_get_buffer(&rad_stream->s, &read_wanted);
 
   for(i = 0; i < read_wanted; i += 4)
   {

--- a/src/audio/audio_vorbis.c
+++ b/src/audio/audio_vorbis.c
@@ -67,12 +67,12 @@ static boolean vorbis_mix_data(struct audio_stream *a_src,
 {
   uint32_t read_len = 0;
   struct vorbis_stream *v_stream = (struct vorbis_stream *)a_src;
-  uint32_t read_wanted = v_stream->s.allocated_data_length -
-   v_stream->s.stream_offset;
+  char *read_buffer;
+  size_t read_wanted;
   uint32_t pos = 0;
-  char *read_buffer = (char *)v_stream->s.output_data +
-   v_stream->s.stream_offset;
   int current_section;
+
+  read_buffer = (char *)sampled_get_buffer(&v_stream->s, &read_wanted);
 
   do
   {

--- a/src/audio/audio_wav.c
+++ b/src/audio/audio_wav.c
@@ -156,10 +156,10 @@ static boolean wav_mix_data(struct audio_stream *a_src, int32_t * RESTRICT buffe
 {
   uint32_t read_len = 0;
   struct wav_stream *w_stream = (struct wav_stream *)a_src;
-  uint32_t read_wanted = w_stream->s.allocated_data_length -
-   w_stream->s.stream_offset;
-  uint8_t *read_buffer = (uint8_t *)w_stream->s.output_data +
-   w_stream->s.stream_offset;
+  uint8_t *read_buffer;
+  size_t read_wanted;
+
+  read_buffer = (uint8_t *)sampled_get_buffer(&w_stream->s, &read_wanted);
 
   read_len = wav_read_data(w_stream, read_buffer, read_wanted, a_src->repeat);
 

--- a/src/audio/audio_xmp.c
+++ b/src/audio/audio_xmp.c
@@ -70,13 +70,14 @@ static boolean audio_xmp_mix_data(struct audio_stream *a_src,
  int32_t * RESTRICT buffer, size_t frames, unsigned int channels)
 {
   struct xmp_stream *stream = (struct xmp_stream *)a_src;
-  size_t read_wanted = stream->s.allocated_data_length -
-   stream->s.stream_offset;
-  uint8_t *read_buffer = (uint8_t *)stream->s.output_data +
-   stream->s.stream_offset;
+  void *read_buffer;
+  size_t read_wanted;
   boolean r_val = false;
+  int xmp_r_val;
 
-  int xmp_r_val =
+  read_buffer = sampled_get_buffer(&stream->s, &read_wanted);
+
+  xmp_r_val =
    xmp_play_buffer(stream->ctx, read_buffer, read_wanted, a_src->repeat ? 0 : 1);
 
   if(xmp_r_val == -XMP_END && !a_src->repeat)

--- a/src/audio/sampled_stream.cpp
+++ b/src/audio/sampled_stream.cpp
@@ -71,11 +71,9 @@ enum mixer_volume
   DYNAMIC     = 1
 };
 
-static void update_sample_index(struct sampled_stream *s_src, int64_t index)
-{
-  s_src->sample_index = index -
-   ((s_src->data_window_length / (s_src->channels * 2)) << FP_SHIFT);
-}
+/* Cubic resampling needs one prologue sample and three epilogue samples. */
+#define PROLOGUE_LENGTH (1 * STEREO * sizeof(int16_t))
+#define EPILOGUE_LENGTH (3 * STEREO * sizeof(int16_t))
 
 template<mixer_volume VOLUME>
 static int32_t volume_function(int32_t sample, int volume)
@@ -109,7 +107,7 @@ static void flat_mix_loop(struct sampled_stream *s_src,
       *(dest++) += smpl;
     }
   }
-  s_src->sample_index = 0;
+  s_src->sample_index = (write_len >> 1) << FP_SHIFT;
 }
 
 /**
@@ -185,7 +183,7 @@ static void resample_mix_loop(struct sampled_stream *s_src,
       *(dest++) += smpl;
     }
   }
-  update_sample_index(s_src, sample_index);
+  s_src->sample_index = sample_index;
 }
 
 template<mixer_channels CHANNELS, mixer_volume VOLUME>
@@ -249,24 +247,15 @@ static void mixer_function(struct sampled_stream *s_src,
   }
 }
 
-static void sampled_negative_threshold(struct sampled_stream *s_src)
+void *sampled_get_buffer(struct sampled_stream *s_src, size_t *needed)
 {
-  int32_t negative_threshold = ((s_src->frequency_delta + FP_AND) & ~FP_AND);
-
-  if(s_src->sample_index < -negative_threshold)
-  {
-    s_src->sample_index += negative_threshold;
-    s_src->negative_comp =
-     (size_t)(negative_threshold >> FP_SHIFT) * s_src->channels * 2;
-    s_src->stream_offset += s_src->negative_comp;
-  }
+  size_t total = s_src->data_window_length + PROLOGUE_LENGTH + EPILOGUE_LENGTH;
+  *needed = (total > s_src->stream_offset) ? total - s_src->stream_offset : 0;
+  return ((uint8_t *)s_src->output_data) + s_src->stream_offset;
 }
 
 void sampled_set_buffer(struct sampled_stream *s_src)
 {
-  size_t prologue_length = 4;
-  size_t epilogue_length = 12;
-  size_t bytes_per_sample = 2 * s_src->channels;
   size_t frequency = s_src->frequency;
   size_t data_window_length;
   size_t allocated_data_length;
@@ -277,44 +266,41 @@ void sampled_set_buffer(struct sampled_stream *s_src)
 
   frequency_delta = ((int64_t)frequency << FP_SHIFT) / audio.output_frequency;
 
-  s_src->frequency_delta = frequency_delta;
-  s_src->negative_comp = 0;
-
   data_window_length =
    (size_t)(ceil((double)audio.buffer_frames *
-   frequency / audio.output_frequency) * bytes_per_sample);
+   frequency / audio.output_frequency) * s_src->bytes_per_frame);
 
-  prologue_length += frequency_delta * bytes_per_sample;
-  //(size_t)ceil((double)frequency_delta) * bytes_per_sample;
+  allocated_data_length = data_window_length + PROLOGUE_LENGTH + EPILOGUE_LENGTH;
 
-  allocated_data_length = data_window_length + prologue_length +
-   epilogue_length;
+  if(allocated_data_length < s_src->bytes_per_frame)
+    allocated_data_length = s_src->bytes_per_frame;
 
-  if(allocated_data_length < bytes_per_sample)
-    allocated_data_length = bytes_per_sample;
+  /* If the buffer still contains data past the desired allocation, leave it.
+   * Otherwise, the audio will audibly skip. */
+  if(s_src->stream_offset > allocated_data_length)
+    allocated_data_length = s_src->stream_offset;
 
+  s_src->frequency_delta = frequency_delta;
   s_src->data_window_length = data_window_length;
   s_src->allocated_data_length = allocated_data_length;
-  s_src->prologue_length = prologue_length;
-  s_src->epilogue_length = epilogue_length;
-  s_src->stream_offset = prologue_length;
 
   s_src->output_data =
    (int16_t *)crealloc(s_src->output_data, allocated_data_length);
-
-  sampled_negative_threshold(s_src);
 }
 
 void sampled_mix_data(struct sampled_stream *s_src,
  int32_t * RESTRICT dest_buffer, size_t dest_frames, unsigned int dest_channels)
 {
   uint8_t *output_data = (uint8_t *)s_src->output_data;
-  int16_t *src_buffer = (int16_t *)(output_data + s_src->prologue_length);
+  int16_t *src_buffer = (int16_t *)(output_data + PROLOGUE_LENGTH);
   size_t write_len = dest_frames * dest_channels;
   int volume = ((struct audio_stream *)s_src)->volume;
   int resample_mode = audio.global_resample_mode + 1;
   enum mixer_volume   use_volume   = DYNAMIC;
   enum mixer_channels use_channels = STEREO;
+  size_t new_index;
+  size_t new_index_bytes;
+  size_t leftover_bytes = 0;
 
   // MZX currently only supports stereo output.
   assert(dest_channels == 2);
@@ -331,20 +317,23 @@ void sampled_mix_data(struct sampled_stream *s_src,
   mixer_function(s_src, dest_buffer, write_len, src_buffer, volume,
    resample_mode, use_channels, use_volume);
 
-  if(s_src->stream_offset == s_src->prologue_length)
-    s_src->stream_offset += s_src->epilogue_length;
+  /* Relocate the leftovers--plus the extra prologue and epilogue samples for
+   * the resamplers--back to the start of the buffer. */
+  new_index = s_src->sample_index >> FP_SHIFT;
+  new_index_bytes = new_index * s_src->bytes_per_frame;
+  if(new_index_bytes > s_src->data_window_length)
+    new_index_bytes = s_src->data_window_length;
 
-  if(s_src->negative_comp)
-  {
-    s_src->stream_offset -= s_src->negative_comp;
-    s_src->negative_comp = 0;
-  }
+  leftover_bytes = s_src->data_window_length - new_index_bytes;
 
-  sampled_negative_threshold(s_src);
+  /* Note new_index_bytes doesn't count the prologue, so both the source and
+   * the dest include it implicitly. */
+  memmove(output_data,
+   output_data + new_index_bytes,
+   leftover_bytes + PROLOGUE_LENGTH + EPILOGUE_LENGTH);
 
-  memmove(output_data, output_data +
-   s_src->allocated_data_length - s_src->stream_offset,
-   s_src->stream_offset);
+  s_src->stream_offset = leftover_bytes + PROLOGUE_LENGTH + EPILOGUE_LENGTH;
+  s_src->sample_index &= FP_AND;
 }
 
 void sampled_destruct(struct audio_stream *a_src)
@@ -363,9 +352,11 @@ void initialize_sampled_stream(struct sampled_stream *s_src,
   s_src->channels = channels;
   s_src->output_data = NULL;
   s_src->use_volume = use_volume;
+  s_src->bytes_per_frame = channels * sizeof(int16_t);
+  s_src->stream_offset = PROLOGUE_LENGTH;
   s_src->sample_index = 0;
 
   s_src->set_frequency(s_src, frequency);
 
-  memset(s_src->output_data, 0, s_src->prologue_length);
+  memset(s_src->output_data, 0, PROLOGUE_LENGTH);
 }

--- a/src/audio/sampled_stream.h
+++ b/src/audio/sampled_stream.h
@@ -35,11 +35,9 @@ struct sampled_stream
   int16_t *output_data;
   size_t data_window_length;
   size_t allocated_data_length;
-  size_t prologue_length;
-  size_t epilogue_length;
   size_t stream_offset;
-  size_t negative_comp;
   size_t channels;
+  unsigned bytes_per_frame;
   boolean use_volume;
   int64_t frequency_delta;
   int64_t sample_index;
@@ -53,6 +51,7 @@ struct sampled_stream_spec
   uint32_t  (* get_frequency)(struct sampled_stream *s_src);
 };
 
+void *sampled_get_buffer(struct sampled_stream *s_src, size_t *needed);
 void sampled_set_buffer(struct sampled_stream *s_src);
 void sampled_mix_data(struct sampled_stream *s_src,
  int32_t * RESTRICT dest_buffer, size_t dest_frames, unsigned int dest_channels);


### PR DESCRIPTION
Removes the old negative compensation code and replaces it with a much more straightforward way of handling resampling. This should fix the following bugs:

* sampled_mix_data no longer discards audio data if the requested number of frames is smaller than what the buffer is configured for. This was causing audio skips in the SDL3 port.
* sampled_mix_data no longer discards audio data when the input buffer is resized e.g. by changing the playback frequency. This fixes audible pops in games that set `MOD_FREQUENCY` a lot.
* Not a bug, but the old way of having each player calculate the current buffer position and remaining space in the buffer looked fragile. This is done in a sampled_stream function now out of necessity, so this should be less prone to breaking.