### PR TITLE
Add load_image_from_[...] error codes and image_error_string.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -87,6 +87,8 @@ USERS
 + The SDL audio driver will now initialize the software mixer
   frequency with the value returned by SDL_OpenAudioDevice.
 + Fixed audible pops when setting MOD_FREQUENCY.
++ ccv and png2smzx now return slightly more useful error
+  messages when an image fails to load.
 
 DEVELOPERS
 

--- a/src/utils/ccv.c
+++ b/src/utils/ccv.c
@@ -504,6 +504,7 @@ static void LoadImage(struct image_file *dest, Config *cfg, const char *path)
 {
   struct image_raw_format format;
   struct image_raw_format *use_format = NULL;
+  enum image_error ret;
 
   if((cfg->w > 0) && (cfg->h > 0))
   {
@@ -513,8 +514,9 @@ static void LoadImage(struct image_file *dest, Config *cfg, const char *path)
     use_format = &format;
   }
 
-  if(!load_image_from_file(path, dest, use_format))
-    Error("Failed to load file '%s'", path);
+  ret = load_image_from_file(path, dest, use_format);
+  if(ret)
+    Error("Failed to load file '%s': %s", path, image_error_string(ret));
 }
 
 static void FreeImage(Image *img)

--- a/src/utils/image_file.h
+++ b/src/utils/image_file.h
@@ -38,6 +38,51 @@ enum image_bool_values
   IMAGE_TRUE
 };
 
+enum image_error
+{
+  IMAGE_OK = 0,
+  IMAGE_ERROR_UNKNOWN,
+  IMAGE_ERROR_IO,
+  IMAGE_ERROR_MEM,
+  IMAGE_ERROR_SIGNATURE,
+  IMAGE_ERROR_CONSTRAINT,
+  /* RAW errors. */
+  IMAGE_ERROR_RAW_UNSUPPORTED_BPP,
+  /* PNG errors. */
+  IMAGE_ERROR_PNG_INIT,
+  IMAGE_ERROR_PNG_FAILED,
+  /* GIF errors. */
+  IMAGE_ERROR_GIF_INVALID,
+  IMAGE_ERROR_GIF_SIGNATURE,
+  /* BMP errors. */
+  IMAGE_ERROR_BMP_UNSUPPORTED_DIB,
+  IMAGE_ERROR_BMP_UNSUPPORTED_PLANES,
+  IMAGE_ERROR_BMP_UNSUPPORTED_COMPRESSION,
+  IMAGE_ERROR_BMP_UNSUPPORTED_BPP,
+  IMAGE_ERROR_BMP_UNSUPPORTED_BPP_RLE8,
+  IMAGE_ERROR_BMP_UNSUPPORTED_BPP_RLE4,
+  IMAGE_ERROR_BMP_BAD_1BPP,
+  IMAGE_ERROR_BMP_BAD_2BPP,
+  IMAGE_ERROR_BMP_BAD_4BPP,
+  IMAGE_ERROR_BMP_BAD_8BPP,
+  IMAGE_ERROR_BMP_BAD_16BPP,
+  IMAGE_ERROR_BMP_BAD_24BPP,
+  IMAGE_ERROR_BMP_BAD_32BPP,
+  IMAGE_ERROR_BMP_BAD_RLE,
+  IMAGE_ERROR_BMP_BAD_SIZE,
+  IMAGE_ERROR_BMP_BAD_COLOR_TABLE,
+  /* NetPBM errors. */
+  IMAGE_ERROR_PBM_BAD_HEADER,
+  IMAGE_ERROR_PBM_BAD_MAXVAL,
+  IMAGE_ERROR_PAM_BAD_WIDTH,
+  IMAGE_ERROR_PAM_BAD_HEIGHT,
+  IMAGE_ERROR_PAM_BAD_DEPTH,
+  IMAGE_ERROR_PAM_BAD_MAXVAL,
+  IMAGE_ERROR_PAM_BAD_TUPLTYPE,
+  IMAGE_ERROR_PAM_MISSING_ENDHDR,
+  IMAGE_ERROR_PAM_DEPTH_TUPLTYPE_MISMATCH,
+};
+
 struct rgba_color
 {
   uint8_t r;
@@ -64,11 +109,19 @@ struct image_raw_format
   uint32_t bytes_per_pixel;
 };
 
-image_bool load_image_from_file(const char *filename, struct image_file *dest,
- const struct image_raw_format *raw_format);
-image_bool load_image_from_stream(void *handle, image_read_function readfn,
+enum image_error load_image_from_file(const char *filename,
+ struct image_file *dest, const struct image_raw_format *raw_format);
+enum image_error load_image_from_stream(void *handle, image_read_function readfn,
  struct image_file *dest, const struct image_raw_format *raw_format);
 void image_free(struct image_file *dest);
+
+/**
+ * Get the error string for a given error.
+ *
+ * @param   err   a `image_error` value.
+ * @returns       a statically allocated string corresponding to the error.
+ */
+const char *image_error_string(enum image_error err);
 
 #ifdef __cplusplus
 }

--- a/src/utils/png2smzx.c
+++ b/src/utils/png2smzx.c
@@ -53,9 +53,10 @@ int main(int argc, char **argv)
   char output_base_name[MAX_PATH] = { '\0' };
   const char *ext;
 
-        int skip_char = -1;
+  int skip_char = -1;
 
   struct image_file img;
+  enum image_error ret;
   uint32_t i, t;
   mzx_tile *tile;
   mzx_glyph chr[256];
@@ -174,9 +175,10 @@ int main(int argc, char **argv)
 #endif
 
   // Do stuff
-  if(!load_image_from_file(input_file_name, &img, NULL))
+  ret = load_image_from_file(input_file_name, &img, NULL);
+  if(ret)
   {
-    fprintf(stderr, "Error reading image.\n");
+    fprintf(stderr, "Error reading image: %s\n", image_error_string(ret));
     return 1;
   }
 

--- a/unit/utils/image_file.cpp
+++ b/unit/utils/image_file.cpp
@@ -175,8 +175,8 @@ static void load_and_compare_image(const struct image_file_const &base,
 
   snprintf(path, sizeof(path), DATA_BASEDIR "%s", filename);
 
-  boolean ret = load_image_from_file(path, &img, NULL);
-  ASSERT(ret, "%s: load failed", filename);
+  enum image_error ret = load_image_from_file(path, &img, NULL);
+  ASSERT(ret == IMAGE_OK, "%s: load failed: %s", filename, image_error_string(ret));
   compare_image<COMPARE_FN>(base, img, filename);
   image_free(&img);
 }
@@ -300,14 +300,14 @@ UNITTEST(GIF)
   {
     struct image_file img{};
     char path[512];
-    boolean ret;
+    enum image_error ret;
 
     for(const auto &in : complex_inputs)
     {
       snprintf(path, sizeof(path), DATA_BASEDIR "%s", in.filename);
 
       ret = load_image_from_file(path, &img, NULL);
-      ASSERT(ret, "%s: load failed", in.filename);
+      ASSERT(ret == IMAGE_OK, "%s: load failed: %s", in.filename, image_error_string(ret));
       uint32_t chk = crc32(0ul, reinterpret_cast<uint8_t *>(img.data), img.width * img.height * 4);
       ASSERTEQ(chk, in.crc, "crc32 mismatch");
       image_free(&img);
@@ -474,7 +474,7 @@ UNITTEST(farbfeld)
 UNITTEST(raw)
 {
   struct image_file img{};
-  boolean ret;
+  enum image_error ret;
 
   static const struct image_raw_format gs_format = { base_gs_img.width, base_gs_img.height, 1 };
   static const struct image_raw_format gsa_format = { base_gs_img.width, base_gs_img.height, 2 };
@@ -484,7 +484,7 @@ UNITTEST(raw)
   SECTION(Greyscale)
   {
     ret = load_image_from_file(DATA_BASEDIR "raw_gs.raw", &img, &gs_format);
-    ASSERT(ret, "raw_gs.raw: load failed");
+    ASSERT(ret == IMAGE_OK, "raw_gs.raw: load failed: %s", image_error_string(ret));
     compare_image<compare_rgb>(base_gs_img, img, "raw_gs.raw");
     image_free(&img);
   }
@@ -492,7 +492,7 @@ UNITTEST(raw)
   SECTION(GreyscaleAlpha)
   {
     ret = load_image_from_file(DATA_BASEDIR "raw_gsa.raw", &img, &gsa_format);
-    ASSERT(ret, "raw_gsa.raw: load failed");
+    ASSERT(ret == IMAGE_OK, "raw_gsa.raw: load failed: %s", image_error_string(ret));
     compare_image<compare_rgba>(base_gs_img, img, "raw_gsa.raw");
     image_free(&img);
   }
@@ -500,7 +500,7 @@ UNITTEST(raw)
   SECTION(RGB)
   {
     ret = load_image_from_file(DATA_BASEDIR "raw_rgb.raw", &img, &rgb_format);
-    ASSERT(ret, "raw_rgb.raw: load failed");
+    ASSERT(ret == IMAGE_OK, "raw_rgb.raw: load failed: %s", image_error_string(ret));
     compare_image<compare_rgb>(base_rgba_img, img, "raw_rgb.raw");
     image_free(&img);
   }
@@ -508,7 +508,7 @@ UNITTEST(raw)
   SECTION(RGBA)
   {
     ret = load_image_from_file(DATA_BASEDIR "raw_rgba.raw", &img, &rgba_format);
-    ASSERT(ret, "raw_rgba.raw: load failed");
+    ASSERT(ret == IMAGE_OK, "raw_rgba.raw: load failed: %s", image_error_string(ret));
     compare_image<compare_rgba>(base_rgba_img, img, "raw_rgba.raw");
     image_free(&img);
   }


### PR DESCRIPTION
ccv and png2smzx now return slightly more useful error messages when an image fails to load.