### PR TITLE
Remove PPAL from the software layer renderers.

### DIFF
--- a/src/render_layer.cpp
+++ b/src/render_layer.cpp
@@ -190,7 +190,6 @@ void render_layer(void * RESTRICT pixels, int force_bpp, size_t pitch,
   size_t drawStart;
   int align = 8;
   int clip = 0;
-  int ppal = graphics->protected_pal_position;
 
   if(layer->x < 0 || layer->y < 0 ||
    (layer->x + layer->w * CHAR_W) > SCREEN_PIX_W ||
@@ -229,5 +228,5 @@ void render_layer(void * RESTRICT pixels, int force_bpp, size_t pitch,
   }
 
   render_layer_func(pixels, pitch, graphics, layer,
-   force_bpp, align, smzx, ppal, trans, clip);
+   force_bpp, align, smzx, trans, clip);
 }

--- a/src/render_layer_code.hpp
+++ b/src/render_layer_code.hpp
@@ -26,8 +26,11 @@
 // when working on this function it can be good to redirect make's stderr
 // stream to a file.
 
+#include "graphics.h"
 #include "platform_endian.h"
 #include "util.h"
+
+#include <stdlib.h>
 
 #ifdef IS_CXX_11
 #include <type_traits>
@@ -40,29 +43,24 @@
 template<typename PIXTYPE>
 static void render_layer_func(void * RESTRICT pixels, size_t pitch,
  const struct graphics_data *graphics, const struct video_layer *layer,
- int align, int smzx, int ppal, int trans, int clip);
+ int align, int smzx, int trans, int clip);
 
 template<typename PIXTYPE, typename ALIGNTYPE>
 static void render_layer_func(void * RESTRICT pixels, size_t pitch,
  const struct graphics_data *graphics, const struct video_layer *layer,
- int smzx, int ppal, int trans, int clip);
+ int smzx, int trans, int clip);
 
 template<typename PIXTYPE, typename ALIGNTYPE, int SMZX>
 static void render_layer_func(void * RESTRICT pixels, size_t pitch,
  const struct graphics_data *graphics, const struct video_layer *layer,
- int ppal, int trans, int clip);
-
-template<typename PIXTYPE, typename ALIGNTYPE, int SMZX, int PPAL>
-static void render_layer_func(void * RESTRICT pixels, size_t pitch,
- const struct graphics_data *graphics, const struct video_layer *layer,
  int trans, int clip);
 
-template<typename PIXTYPE, typename ALIGNTYPE, int SMZX, int PPAL, int TR>
+template<typename PIXTYPE, typename ALIGNTYPE, int SMZX, int TR>
 static void render_layer_func(void * RESTRICT pixels, size_t pitch,
  const struct graphics_data *graphics, const struct video_layer *layer,
  int clip);
 
-template<typename PIXTYPE, typename ALIGNTYPE, int SMZX, int PPAL, int TR, int CLIP>
+template<typename PIXTYPE, typename ALIGNTYPE, int SMZX, int TR, int CLIP>
 static void render_layer_func(void * RESTRICT pixels, size_t pitch,
  const struct graphics_data *graphics, const struct video_layer *layer);
 
@@ -73,30 +71,30 @@ static void render_layer_func(void * RESTRICT pixels, size_t pitch,
 template<>
 inline void render_layer_func<uint8_t>(void * RESTRICT pixels, size_t pitch,
  const struct graphics_data *graphics, const struct video_layer *layer,
- int align, int smzx, int ppal, int trans, int clip)
+ int align, int smzx, int trans, int clip)
 {
   switch(align)
   {
 #if ARCHITECTURE_BITS >= 64 && !defined(SKIP_64_ALIGN)
     case 64:
       render_layer_func<uint8_t, uint64_t>(pixels, pitch, graphics, layer,
-       smzx, ppal, trans, clip);
+       smzx, trans, clip);
       break;
 #endif /* ARCHITECTURE_BITS >= 64 */
 
     case 32:
       render_layer_func<uint8_t, uint32_t>(pixels, pitch, graphics, layer,
-       smzx, ppal, trans, clip);
+       smzx, trans, clip);
       break;
 
     case 16:
       render_layer_func<uint8_t, uint16_t>(pixels, pitch, graphics, layer,
-       smzx, ppal, trans, clip);
+       smzx, trans, clip);
       break;
 
     case 8:
       render_layer_func<uint8_t, uint8_t>(pixels, pitch, graphics, layer,
-       smzx, ppal, trans, clip);
+       smzx, trans, clip);
       break;
 
     default:
@@ -113,25 +111,25 @@ inline void render_layer_func<uint8_t>(void * RESTRICT pixels, size_t pitch,
 template<>
 inline void render_layer_func<uint16_t>(void * RESTRICT pixels, size_t pitch,
  const struct graphics_data *graphics, const struct video_layer *layer,
- int align, int smzx, int ppal, int trans, int clip)
+ int align, int smzx, int trans, int clip)
 {
   switch(align)
   {
 #if ARCHITECTURE_BITS >= 64 && !defined(SKIP_64_ALIGN)
     case 64:
       render_layer_func<uint16_t, uint64_t>(pixels, pitch, graphics, layer,
-       smzx, ppal, trans, clip);
+       smzx, trans, clip);
       break;
 #endif /* ARCHITECTURE_BITS >= 64 */
 
     case 32:
       render_layer_func<uint16_t, uint32_t>(pixels, pitch, graphics, layer,
-       smzx, ppal, trans, clip);
+       smzx, trans, clip);
       break;
 
     case 16:
       render_layer_func<uint16_t, uint16_t>(pixels, pitch, graphics, layer,
-       smzx, ppal, trans, clip);
+       smzx, trans, clip);
       break;
 
     default:
@@ -148,20 +146,20 @@ inline void render_layer_func<uint16_t>(void * RESTRICT pixels, size_t pitch,
 template<>
 inline void render_layer_func<uint32_t>(void * RESTRICT pixels, size_t pitch,
  const struct graphics_data *graphics, const struct video_layer *layer,
- int align, int smzx, int ppal, int trans, int clip)
+ int align, int smzx, int trans, int clip)
 {
   switch(align)
   {
 #if ARCHITECTURE_BITS >= 64 && !defined(SKIP_64_ALIGN)
     case 64:
       render_layer_func<uint32_t, uint64_t>(pixels, pitch, graphics, layer,
-       smzx, ppal, trans, clip);
+       smzx, trans, clip);
       break;
 #endif /* ARCHITECTURE_BITS >= 64 */
 
     case 32:
       render_layer_func<uint32_t, uint32_t>(pixels, pitch, graphics, layer,
-       smzx, ppal, trans, clip);
+       smzx, trans, clip);
       break;
 
     default:
@@ -179,26 +177,26 @@ inline void render_layer_func<uint32_t>(void * RESTRICT pixels, size_t pitch,
  */
 static inline void render_layer_func(void * RESTRICT pixels, size_t pitch,
  const struct graphics_data *graphics, const struct video_layer *layer,
- int bpp, int align, int smzx, int ppal, int trans, int clip)
+ int bpp, int align, int smzx, int trans, int clip)
 {
   switch(bpp)
   {
 #ifndef SKIP_8BPP
     case 8:
       render_layer_func<uint8_t>(pixels, pitch, graphics, layer,
-       align, smzx, ppal, trans, clip);
+       align, smzx, trans, clip);
       break;
 #endif
 #ifndef SKIP_16BPP
     case 16:
       render_layer_func<uint16_t>(pixels, pitch, graphics, layer,
-       align, smzx, ppal, trans, clip);
+       align, smzx, trans, clip);
       break;
 #endif
 #ifndef SKIP_32BPP
     case 32:
       render_layer_func<uint32_t>(pixels, pitch, graphics, layer,
-       align, smzx, ppal, trans, clip);
+       align, smzx, trans, clip);
       break;
 #endif
     default:
@@ -215,20 +213,20 @@ static inline void render_layer_func(void * RESTRICT pixels, size_t pitch,
 template<typename PIXTYPE, typename ALIGNTYPE>
 static inline void render_layer_func(void * RESTRICT pixels, size_t pitch,
  const struct graphics_data *graphics, const struct video_layer *layer,
- int smzx, int ppal, int trans, int clip)
+ int smzx, int trans, int clip)
 {
   switch(smzx)
   {
     case 0:
       render_layer_func<PIXTYPE, ALIGNTYPE, 0>(pixels, pitch, graphics, layer,
-       ppal, trans, clip);
+       trans, clip);
       break;
 
     case 1:
     case 2:
     case 3:
       render_layer_func<PIXTYPE, ALIGNTYPE, 1>(pixels, pitch, graphics, layer,
-       ppal, trans, clip);
+       trans, clip);
       break;
 
     default:
@@ -239,51 +237,9 @@ static inline void render_layer_func(void * RESTRICT pixels, size_t pitch,
 }
 
 /**
- * Protected palette offset is 16 or 256 (MZX).
- * 256 is valid for MZX mode, but 16 is invalid for SMZX.
- */
-template<typename PIXTYPE, typename ALIGNTYPE, int SMZX>
-static void render_layer_func(void * RESTRICT pixels, size_t pitch,
- const struct graphics_data *graphics, const struct video_layer *layer,
- int ppal, int trans, int clip)
-{
-  switch(ppal)
-  {
-
-    case 256:
-    {
-      // This protected palette position is valid for all SMZX modes.
-      render_layer_func<PIXTYPE, ALIGNTYPE, SMZX, 256>(pixels, pitch, graphics, layer,
-       trans, clip);
-      break;
-    }
-
-    case 16:
-    {
-      // NOTE: the protected palette should always be at 256 during SMZX mode,
-      // so reaching this point for an SMZX layer is nonsensical. This check
-      // also lets the compiler optimize these out, reducing binary size.
-      if(!SMZX)
-      {
-        render_layer_func<PIXTYPE, ALIGNTYPE, SMZX, 16>(pixels, pitch, graphics, layer,
-         trans, clip);
-        break;
-      }
-    }
-
-    /* fall-through */
-
-    default:
-      fprintf(mzxerr, "INVALID RENDERER ARG ppal=%d (smzx=%d)\n", ppal, SMZX);
-      exit(1);
-      break;
-  }
-}
-
-/**
  * Layer transparency enabled (1) or disabled (0).
  */
-template<typename PIXTYPE, typename ALIGNTYPE, int SMZX, int PPAL>
+template<typename PIXTYPE, typename ALIGNTYPE, int SMZX>
 static inline void render_layer_func(void * RESTRICT pixels, size_t pitch,
  const struct graphics_data *graphics, const struct video_layer *layer,
  int trans, int clip)
@@ -291,12 +247,12 @@ static inline void render_layer_func(void * RESTRICT pixels, size_t pitch,
   switch(trans)
   {
     case 0:
-      render_layer_func<PIXTYPE, ALIGNTYPE, SMZX, PPAL, 0>(pixels, pitch, graphics, layer,
+      render_layer_func<PIXTYPE, ALIGNTYPE, SMZX, 0>(pixels, pitch, graphics, layer,
        clip);
       break;
 
     case 1:
-      render_layer_func<PIXTYPE, ALIGNTYPE, SMZX, PPAL, 1>(pixels, pitch, graphics, layer,
+      render_layer_func<PIXTYPE, ALIGNTYPE, SMZX, 1>(pixels, pitch, graphics, layer,
        clip);
       break;
 
@@ -310,7 +266,7 @@ static inline void render_layer_func(void * RESTRICT pixels, size_t pitch,
 /**
  * Renderer should clip the layer at the screen boundaries (1) or not (0).
  */
-template<typename PIXTYPE, typename ALIGNTYPE, int SMZX, int PPAL, int TR>
+template<typename PIXTYPE, typename ALIGNTYPE, int SMZX, int TR>
 static inline void render_layer_func(void * RESTRICT pixels, size_t pitch,
  const struct graphics_data *graphics, const struct video_layer *layer,
  int clip)
@@ -318,11 +274,11 @@ static inline void render_layer_func(void * RESTRICT pixels, size_t pitch,
   switch(clip)
   {
     case 0:
-      render_layer_func<PIXTYPE, ALIGNTYPE, SMZX, PPAL, TR, 0>(pixels, pitch, graphics, layer);
+      render_layer_func<PIXTYPE, ALIGNTYPE, SMZX, TR, 0>(pixels, pitch, graphics, layer);
       break;
 
     case 1:
-      render_layer_func<PIXTYPE, ALIGNTYPE, SMZX, PPAL, TR, 1>(pixels, pitch, graphics, layer);
+      render_layer_func<PIXTYPE, ALIGNTYPE, SMZX, TR, 1>(pixels, pitch, graphics, layer);
       break;
 
     default:
@@ -336,25 +292,15 @@ static inline void render_layer_func(void * RESTRICT pixels, size_t pitch,
  * Mode 0 and UI layer color selection function.
  * This needs to be done for both colors.
  */
-template<int BPP, int TR, int PPAL>
-static inline int select_color_16(uint8_t color, int tcol)
+static inline int select_color_16(uint8_t color, int ppal)
 {
   // Palette values >= 16, prior to offsetting, are from the protected palette.
-  if((BPP > 8 || PPAL < 240) && color >= 16)
+  if(color >= 16)
   {
-    return (color - 16) % 16 + PPAL;
+    return (color - 16) % 16 + ppal;
   }
   else
-
-  // Check for protected palette tcols in 8bpp SMZX mode and allow this
-  // special case through (as it will not be displayed).
-  if(TR && BPP == 8 && PPAL >= 240 && color >= 16 &&
-   ((color - 16) % 16 + PPAL) == tcol)
-  {
-    return tcol;
-  }
-  else
-    return color & 0x0F;
+    return color;
 }
 
 // Macros to perform these shifts while ignoring spurious compiler warnings
@@ -495,7 +441,7 @@ static inline ALIGNTYPE get_colors_mzx(ALIGNTYPE (&set_colors)[16],
  * Finally, render the layer.
  * The optimizer will optimize out the unnecessary parts for relevant renderers.
  */
-template<typename PIXTYPE, typename ALIGNTYPE, int SMZX, int PPAL, int TR, int CLIP>
+template<typename PIXTYPE, typename ALIGNTYPE, int SMZX, int TR, int CLIP>
 static inline void render_layer_func(void * RESTRICT pixels, size_t pitch,
  const struct graphics_data *graphics, const struct video_layer *layer)
 {
@@ -561,6 +507,7 @@ static inline void render_layer_func(void * RESTRICT pixels, size_t pitch,
   // ALIGNTYPE instead helps avoid some warnings.
   ALIGNTYPE char_colors[4];
   int char_idx[4];
+  int ppal = graphics->protected_pal_position;
   int write_pos;
 
   int pixel_x;
@@ -643,15 +590,15 @@ static inline void render_layer_func(void * RESTRICT pixels, size_t pitch,
           }
           else
           {
-            char_idx[0] = select_color_16<BPP, TR, PPAL>(src->bg_color, tcol);
-            char_idx[1] = select_color_16<BPP, TR, PPAL>(src->fg_color, tcol);
+            char_idx[0] = select_color_16(src->bg_color, ppal);
+            char_idx[1] = select_color_16(src->fg_color, ppal);
 
             for(i = 0; i < 2; i++)
             {
               if(BPP > 8)
                 char_colors[i] = graphics->flat_intensity_palette[char_idx[i]];
               else
-                char_colors[i] = char_idx[i];
+                char_colors[i] = (uint8_t)char_idx[i];
             }
 
             if(TR)


### PR DESCRIPTION
Removing the static `PPAL` variable from the software layer renderers reduces the total number of renderers by 1/3 and opens up the possibility of 8-bit ppal=240 rendering in the future without needing extra renderers. This seems to overall have no impact whatsoever on performance, with maybe a very slight performance benefit on average (still testing).

64-bit: 108 → 72
32-bit: 72 → 48
HTML5, Wii, Vita: 12 → 8
Android: 24/12 → 16/8