### PR TITLE
Use opacity masks when software rendering transparent layers.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -19,6 +19,8 @@ USERS
 + HTML5: fixed the poor performance of FREADn and other features
   that rely on calculating the length of an open file.
 + Clear world (Alt+R) now resets the world version.
++ Software layer rendering performance for transparent sprites
+  has been improved, significantly in some cases.
 + Fixed a software layer renderer bug where a buffer with a
   pixel alignment that varies between lines would cause the
   frame to render incorrectly.

--- a/src/render_layer_code.hpp
+++ b/src/render_layer_code.hpp
@@ -1,7 +1,7 @@
 /* MegaZeux
  *
  * Copyright (C) 2017 Dr Lancer-X <drlancer@megazeux.org>
- * Copyright (C) 2020 Alice Rowan <petrifiedrowan@gmail.com>
+ * Copyright (C) 2020, 2024 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -346,16 +346,10 @@ static inline int select_color_16(uint8_t color, int ppal)
  * Since this requires 1<<PPW values to be computed, 8 PPW renderers would
  * need 256 combinations, which would probably hurt performance more than help
  * it. Instead, 8 PPW just uses a special case of the 4 PPW code (see below).
- *
- * Note: this optimization is not worth implementing for SMZX as doubling is
- * much faster to precompute in SMZX mode.
  */
 template<int BPP, int PPW, typename ALIGNTYPE>
-static inline void set_colors_mzx(ALIGNTYPE (&dest)[16], ALIGNTYPE (&cols)[4])
+static inline void set_colors_mzx(ALIGNTYPE (&dest)[16], ALIGNTYPE bg, ALIGNTYPE fg)
 {
-  ALIGNTYPE bg = cols[0];
-  ALIGNTYPE fg = cols[1];
-
 #if PLATFORM_BYTE_ORDER == PLATFORM_LIL_ENDIAN
   switch(PPW)
   {
@@ -425,17 +419,74 @@ static inline void set_colors_mzx(ALIGNTYPE (&dest)[16], ALIGNTYPE (&cols)[4])
 #endif
 }
 
+/* Colors should be pre-doubled here. */
+template<int BPP, int PPW, typename ALIGNTYPE>
+static inline void set_colors_smzx(ALIGNTYPE (&dest)[16], ALIGNTYPE (&cols)[4])
+{
+  ALIGNTYPE c0 = cols[0];
+  ALIGNTYPE c1 = cols[1];
+  ALIGNTYPE c2 = cols[2];
+  ALIGNTYPE c3 = cols[3];
+  switch(PPW)
+  {
+    case 1:
+    case 2:
+      break;
+
+    case 4:
+    case 8:
+#if PLATFORM_BYTE_ORDER == PLATFORM_LIL_ENDIAN
+      dest[0]  = BPPx2(c0) | c0;
+      dest[1]  = BPPx2(c1) | c0;
+      dest[2]  = BPPx2(c2) | c0;
+      dest[3]  = BPPx2(c3) | c0;
+      dest[4]  = BPPx2(c0) | c1;
+      dest[5]  = BPPx2(c1) | c1;
+      dest[6]  = BPPx2(c2) | c1;
+      dest[7]  = BPPx2(c3) | c1;
+      dest[8]  = BPPx2(c0) | c2;
+      dest[9]  = BPPx2(c1) | c2;
+      dest[10] = BPPx2(c2) | c2;
+      dest[11] = BPPx2(c3) | c2;
+      dest[12] = BPPx2(c0) | c3;
+      dest[13] = BPPx2(c1) | c3;
+      dest[14] = BPPx2(c2) | c3;
+      dest[15] = BPPx2(c3) | c3;
+#else
+      dest[0]  = BPPx2(c0) | c0;
+      dest[1]  = BPPx2(c0) | c1;
+      dest[2]  = BPPx2(c0) | c2;
+      dest[3]  = BPPx2(c0) | c3;
+      dest[4]  = BPPx2(c1) | c0;
+      dest[5]  = BPPx2(c1) | c1;
+      dest[6]  = BPPx2(c1) | c2;
+      dest[7]  = BPPx2(c1) | c3;
+      dest[8]  = BPPx2(c2) | c0;
+      dest[9]  = BPPx2(c2) | c1;
+      dest[10] = BPPx2(c2) | c2;
+      dest[11] = BPPx2(c2) | c3;
+      dest[12] = BPPx2(c3) | c0;
+      dest[13] = BPPx2(c3) | c1;
+      dest[14] = BPPx2(c3) | c2;
+      dest[15] = BPPx2(c3) | c3;
+#endif
+      break;
+  }
+}
+
+template<int PPW>
+static inline unsigned get_colors_index(unsigned char_byte, int write_pos)
+{
+  return ((char_byte << (write_pos * PPW)) & 0xff) >> (8 - PPW);
+}
+
 /**
  * Use the set_colors array to compute multiple pixel values simultaneously.
  * This optimization is only useful for PPW >= 2 renderers.
  */
 template<int PPW, typename ALIGNTYPE>
-static inline ALIGNTYPE get_colors_mzx(ALIGNTYPE (&set_colors)[16],
- uint8_t char_byte, int write_pos)
+static inline ALIGNTYPE get_colors(ALIGNTYPE (&set_colors)[16], unsigned idx)
 {
-  unsigned int mask = ((0xFF) << (8 - PPW)) & 0xFF;
-  unsigned int idx = (char_byte & (mask >> (write_pos * PPW))) << (write_pos * PPW) >> (8 - PPW);
-
   switch(PPW)
   {
     // Should be unreachable, but some compilers complain...
@@ -517,12 +568,13 @@ static inline void render_layer_func(
 
   // Transparency vars...
   int tcol = layer->transparent_col;
-  ALIGNTYPE bgdata;
   ALIGNTYPE mask = (PIXTYPE)(~0);
+  ALIGNTYPE smask = BPPx1(mask) | mask;
 
   const uint8_t *char_ptr;
   unsigned int current_char_byte;
   unsigned int pcol;
+  unsigned idx;
 
   ALIGNTYPE *drawPtr;
   ALIGNTYPE pix;
@@ -545,6 +597,7 @@ static inline void render_layer_func(
   int pixel_y;
 
   ALIGNTYPE set_colors[16];
+  ALIGNTYPE set_opaque[16];
   uint16_t last_fg = 0xFFFF;
   uint16_t last_bg = 0xFFFF;
   boolean has_tcol = false;
@@ -589,12 +642,13 @@ static inline void render_layer_func(
         {
           if(SMZX)
           {
+            unsigned int pal = ((src->bg_color & 0xF) << 4) | (src->fg_color & 0xF);
+            ALIGNTYPE masks[4];
             all_tcol = true;
             has_tcol = false;
             byte_tcol = 0xFFFF;
             for(i = 0; i < 4; i++)
             {
-              unsigned int pal = ((src->bg_color & 0xF) << 4) | (src->fg_color & 0xF);
               char_idx[i] = graphics->smzx_indices[pal * 4 + i];
 
               if(BPP > 8)
@@ -611,12 +665,20 @@ static inline void render_layer_func(
                 }
                 has_tcol |= char_idx[i] == tcol;
                 all_tcol &= char_idx[i] == tcol;
+                if(PPW > 2)
+                  masks[i] = char_idx[i] == tcol ? 0 : smask;
               }
 
               // If writing more than 2 pixels at once, preemptively double
               // them. This saves having to perform this operation later...
               if(PPW > 1)
                 char_colors[i] |= BPPx1(char_colors[i]);
+            }
+            if(PPW > 2)
+            {
+              set_colors_smzx<BPP, PPW>(set_colors, char_colors);
+              if(TR && has_tcol)
+                set_colors_smzx<BPP, PPW>(set_opaque, masks);
             }
           }
           else
@@ -639,8 +701,16 @@ static inline void render_layer_func(
               byte_tcol = (char_idx[1] == tcol) ? 0xFF : 0x00;
             }
 
-            if(PPW > 1 && (!TR || !has_tcol))
-              set_colors_mzx<BPP,PPW>(set_colors, char_colors);
+            if(PPW > 1)
+            {
+              set_colors_mzx<BPP, PPW>(set_colors, char_colors[0], char_colors[1]);
+              if(TR && has_tcol)
+              {
+                ALIGNTYPE m0 = !byte_tcol ? 0 : mask;
+                ALIGNTYPE m1 = byte_tcol ? 0 : mask;
+                set_colors_mzx<BPP, PPW>(set_opaque, m0, m1);
+              }
+            }
           }
         }
 
@@ -670,90 +740,53 @@ static inline void render_layer_func(
                ((pixel_x + write_pos * PPW >= PIXEL_X_MINIMUM) &&
                 (pixel_x + write_pos * PPW < width_px)))
               {
-                if(!SMZX)
+                if(!SMZX && PPW == 1)
                 {
-                  if(PPW > 1 && (!TR || !has_tcol))
+                  pcol = !!(current_char_byte & (0x80 >> write_pos));
+                  if(!TR || !has_tcol || tcol != char_idx[pcol])
+                    drawPtr[write_pos] = char_colors[pcol];
+                }
+                else
+
+                if(SMZX && PPW == 1)
+                {
+                  pcol = (current_char_byte & (0xC0 >> write_pos)) << write_pos >> 6;
+                  if(TR && has_tcol && tcol == char_idx[pcol])
                   {
-                    drawPtr[write_pos] = get_colors_mzx<PPW>(set_colors,
-                     current_char_byte, write_pos);
+                    write_pos++;
                     continue;
                   }
 
-                  if(TR)
-                    bgdata = drawPtr[write_pos];
+                  pix = char_colors[pcol];
+                  if(!CLIP || (pixel_x + write_pos * PPW >= 0))
+                    drawPtr[write_pos] = pix;
 
-                  pix = 0;
-                  for(i = 0; i < PPW; i++)
-                  {
-                    //ALIGNTYPE shift = write_pos * PPW + (PPW - 1 - i);
-                    //pcol = (current_char_byte & (0x80 >> shift)) >> (7 - shift);
+                  write_pos++;
 
-                    // This seems to perform a little better than the old method (above).
-                    pcol = !!(current_char_byte & (0x80 >> (write_pos * PPW + (PPW - 1 - i))));
+                  if(!CLIP || (pixel_x + write_pos * PPW < width_px))
+                    drawPtr[write_pos] = pix;
+                }
+                else
 
-                    if(TR && char_idx[pcol] == tcol)
-                      pix |= bgdata & (mask << PIXEL_POS(i));
-                    else
-                      pix |= char_colors[pcol] << PIXEL_POS(i);
-                  }
+                if(SMZX && PPW == 2)
+                {
+                  ALIGNTYPE shift = write_pos * PPW;
+                  pcol = (current_char_byte & (0xC0 >> shift)) << shift >> 6;
 
-                  drawPtr[write_pos] = pix;
+                  if(!TR || !has_tcol || tcol != char_idx[pcol])
+                    drawPtr[write_pos] = char_colors[pcol];
                 }
                 else
                 {
-                  if(PPW == 1)
+                  idx = get_colors_index<PPW>(current_char_byte, write_pos);
+                  pix = get_colors<PPW>(set_colors, idx);
+
+                  if(TR && has_tcol)
                   {
-                    pcol = (current_char_byte & (0xC0 >> write_pos)) << write_pos >> 6;
-
-                    pix = char_colors[pcol];
-                    if(!CLIP || (pixel_x + write_pos * PPW >= 0))
-                    {
-                      if(!TR || tcol != char_idx[pcol])
-                        drawPtr[write_pos] = pix;
-                    }
-                    write_pos++;
-
-                    if(!CLIP || (pixel_x + write_pos * PPW < width_px))
-                    {
-                      if(!TR || tcol != char_idx[pcol])
-                        drawPtr[write_pos] = pix;
-                    }
+                    ALIGNTYPE opaque = get_colors<PPW>(set_opaque, idx);
+                    pix = (pix & opaque) | (drawPtr[write_pos] & ~opaque);
                   }
-                  else
-                  {
-                    // NOTE: SMZX colors were already doubled above, so they
-                    // need to be shift+ORed once only.
-                    pix = 0;
-                    if(TR && has_tcol)
-                    {
-                      bgdata = drawPtr[write_pos];
-
-                      for(i = 0; i < PPW; i += 2)
-                      {
-                        ALIGNTYPE shift = write_pos * PPW + (PPW - 2 - i);
-                        pcol = (current_char_byte & (0xC0 >> shift)) << shift >> 6;
-
-                        if(char_idx[pcol] == tcol)
-                        {
-                          pix |= bgdata &
-                           ((mask << PIXEL_POS(i)) |
-                            (mask << PIXEL_POS(i + 1)));
-                        }
-                        else
-                          pix |= char_colors[pcol] << PIXEL_POS_PAIR(i);
-                      }
-                    }
-                    else
-                    {
-                      for(i = 0; i < PPW; i += 2)
-                      {
-                        ALIGNTYPE shift = write_pos * PPW + (PPW - 2 - i);
-                        pcol = (current_char_byte & (0xC0 >> shift)) << shift >> 6;
-                        pix |= char_colors[pcol] << PIXEL_POS_PAIR(i);
-                      }
-                    }
-                    drawPtr[write_pos] = pix;
-                  }
+                  drawPtr[write_pos] = pix;
                 }
               }
               else


### PR DESCRIPTION
* Minor changes/improvements for MZX 1PPW, SMZX 1PPW, SMZX 2PPW transparent rendering.
* SMZX 4PPW+ renderers now use `set_colors_smzx` to generate color lookup tables.
* MZX 2PPW+ and SMZX 4PPW+ transparent renderers now use opacity masks generated with `set_colors_*`, resulting in large performance improvements in many cases and simplifying the renderer code.