### PR TITLE
Add stb_vorbis support for DOS builds, fix DOS audio crashes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ SDL_LDFLAGS := $(LINK_DYNAMIC_IF_MIXED) $(SDL_LDFLAGS)
 endif # SDL
 
 #
-# libvorbis/tremor
+# libvorbis/tremor/stb_vorbis
 #
 
 VORBIS_CFLAGS  ?= -I${PREFIX}/include -DOV_EXCLUDE_STATIC_CALLBACKS
@@ -145,6 +145,9 @@ VORBIS_LDFLAGS ?= $(LINK_STATIC_IF_MIXED) -L${PREFIX}/lib -lvorbisidec -logg
 endif
 ifeq (${VORBIS},tremor-lowmem)
 VORBIS_LDFLAGS ?= $(LINK_STATIC_IF_MIXED) -L${PREFIX}/lib -lvorbisidec
+endif
+ifeq (${VORBIS},stb_vorbis)
+VORBIS_LDFLAGS ?= -L${PREFIX}/lib
 endif
 
 #

--- a/arch/djgpp/CONFIG.DJGPP
+++ b/arch/djgpp/CONFIG.DJGPP
@@ -3,5 +3,5 @@
 [ -z "$DJGPP" ] && { echo "DJGPP not defined! Aborting."; exit 1; }
 
 ./config.sh --platform djgpp --prefix "$DJGPP" --enable-release \
-	--enable-tremor-lowmem --disable-libpng --disable-screenshots \
+	--enable-stb-vorbis --disable-libpng --disable-screenshots \
 	--enable-stdio-redirect --enable-meter --enable-extram "$@"

--- a/arch/djgpp/Makefile.in
+++ b/arch/djgpp/Makefile.in
@@ -8,11 +8,12 @@ BINEXT = .exe
 EXTRA_LICENSES += ${LICENSE_DJGPP} ${LICENSE_LGPL2}
 
 # 387 emulation for FPU not have
-EXTRA_LIBS = -lemu
+#EXTRA_LIBS = -lemu
 
 # pc.h and sys/farptr.h have functions declared extern __inline__
 # Use -fgnu89-inline to avoid multiple-definition errors
 #-fgnu89-inline
+ARCH_CFLAGS   += -mfpmath=387
 ARCH_LDFLAGS  += ${EXTRA_LIBS}
 
 clean:

--- a/config.sh
+++ b/config.sh
@@ -115,6 +115,7 @@ usage() {
 	echo "  --disable-vorbis          Disable ogg/vorbis support."
 	echo "  --enable-tremor           Use libvorbisidec instead of libvorbis."
 	echo "  --enable-tremor-lowmem    Use libvorbisidec (lowmem) instead of libvorbis."
+	echo "  --enable-stb-vorbis       Use stb_vorbis instead of libvorbis."
 	echo
 	echo "Network options:"
 	echo "  --disable-network         Disable networking abilities."
@@ -403,6 +404,9 @@ while [ "$1" != "" ]; do
 
 	[ "$1" = "--disable-tremor-lowmem" ] && VORBIS="true"
 	[ "$1" = "--enable-tremor-lowmem" ]  && VORBIS="tremor-lowmem"
+
+	[ "$1" = "--disable-stb-vorbis" ] && VORBIS="true"
+	[ "$1" = "--enable-stb-vorbis" ]  && VORBIS="stb_vorbis"
 
 	[ "$1" = "--disable-pthread" ] && PTHREAD="false"
 	[ "$1" = "--enable-pthread" ]  && PTHREAD="true"
@@ -1037,6 +1041,11 @@ if [ "$PLATFORM" = "djgpp" ]; then
 
 	echo "Force-disabling stack protector (DOS)."
 	STACK_PROTECTOR="false"
+
+	if [ "$VORBIS" != "false" ] && [ "$VORBIS" != "stb_vorbis" ]; then
+		echo "Force-switching ogg/vorbis to stb_vorbis."
+		VORBIS="stb_vorbis"
+	fi
 
 	if [ "$DOS_SVGA" = "true" ]; then
 		echo "#define CONFIG_DOS_SVGA" >> src/config.h
@@ -1715,6 +1724,12 @@ elif [ "$VORBIS" = "tremor-lowmem" ]; then
 	echo "#define CONFIG_VORBIS" >> src/config.h
 	echo "#define CONFIG_TREMOR" >> src/config.h
 	echo "VORBIS=tremor-lowmem" >> platform.inc
+
+elif [ "$VORBIS" = "stb_vorbis" ]; then
+	echo "Using stb_vorbis in place of ogg/vorbis."
+	echo "#define CONFIG_VORBIS" >> src/config.h
+	echo "#define CONFIG_STB_VORBIS" >> src/config.h
+	echo "VORBIS=stb_vorbis" >> platform.inc
 else
 	echo "Ogg/vorbis disabled."
 fi

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -10,6 +10,9 @@ USERS
   DSP >=2.00 and the mono/8-bit modes of the Sound Blaster 16,
   but these are disabled for now (no software mixer support for
   mono output). IRQs higher than 7 are also supported now.
++ The DOS port now uses stb_vorbis for Ogg Vorbis playback,
+  which should fix most audio-related crash bugs. Related crash
+  bugs caused by stream management have also been fixed.
 + All "gamecontroller[...]" config.txt options have been renamed
   to "gamepad[...]". The old names are still supported.
 + Fixed blank screen bugs that occur with the glslscale renderer

--- a/docs/platform_matrix.html
+++ b/docs/platform_matrix.html
@@ -75,6 +75,7 @@ var rad = std("RAD");
 var libvorbis = std("libvorbis");
 var tremor = std("tremor");
 var tremor_lowmem = std("tremor<br>(lowmem)");
+var stb_vorbis = std("stb_vorbis");
 
 var render_ctr = std("render_ctr");
 var render_nds = std("render_nds");
@@ -254,7 +255,7 @@ var archs =
     layer_rendering:  yes,
     module_engine:    xmp,
     adlib_engine:     rad,
-    ogg_vorbis:       tremor_lowmem,
+    ogg_vorbis:       stb_vorbis,
     optimization:     speed,
     sdl:              no,
     editor:           yes,

--- a/src/about.c
+++ b/src/about.c
@@ -43,7 +43,7 @@
 #include <png.h>
 #endif
 #ifdef CONFIG_VORBIS
-#ifndef CONFIG_TREMOR
+#if !defined(CONFIG_TREMOR) && !defined(CONFIG_STB_VORBIS)
 #include <vorbis/codec.h>
 #endif
 #endif
@@ -192,10 +192,12 @@ static char **about_text(int *num_lines)
 #endif
 
 #ifdef CONFIG_VORBIS
-#ifndef CONFIG_TREMOR
-  lines[i++] = about_line("libvorbis: %s", vorbis_version_string());
-#else
+#if defined(CONFIG_STB_VORBIS)
+  lines[i++] = about_line("stb_vorbis");
+#elif defined(CONFIG_TREMOR)
   lines[i++] = about_line("libtremor");
+#else
+  lines[i++] = about_line("libvorbis: %s", vorbis_version_string());
 #endif
 #endif
 

--- a/src/audio/audio.c
+++ b/src/audio/audio.c
@@ -147,7 +147,7 @@ static void audio_stream_remove_from_lists(struct audio_stream *a_src)
   if(a_src == audio.stream_list_end)
     audio.stream_list_end = a_src->previous;
 
-#ifdef CONFIG_DJGPP
+#ifdef AUDIO_GARBAGE_COLLECTOR
   if(a_src == audio.garbage_list_base)
     audio.garbage_list_base = a_src->next;
 
@@ -164,7 +164,7 @@ static void audio_stream_remove_from_lists(struct audio_stream *a_src)
 
 static void audio_garbage_collect(void)
 {
-#ifdef CONFIG_DJGPP
+#ifdef AUDIO_GARBAGE_COLLECTOR
   struct audio_stream *a_src;
   struct audio_stream *next;
 
@@ -182,7 +182,7 @@ static void audio_garbage_collect(void)
 // the main thread creates a new stream or explicitly destroys other streams.
 static void audio_garbage_queue(struct audio_stream *a_src)
 {
-#ifdef CONFIG_DJGPP
+#ifdef AUDIO_GARBAGE_COLLECTOR
   audio_stream_remove_from_lists(a_src);
   audio_stream_insert_list(&audio.garbage_list_base,
    &audio.garbage_list_end, a_src);

--- a/src/audio/audio_struct.h
+++ b/src/audio/audio_struct.h
@@ -118,6 +118,10 @@ struct audio
   struct audio_stream *pcs_stream;
   struct audio_stream *stream_list_base;
   struct audio_stream *stream_list_end;
+#ifdef CONFIG_DJGPP
+  struct audio_stream *garbage_list_base;
+  struct audio_stream *garbage_list_end;
+#endif
 
   platform_mutex audio_mutex;
   platform_mutex audio_sfx_mutex;

--- a/src/audio/audio_struct.h
+++ b/src/audio/audio_struct.h
@@ -30,6 +30,10 @@ __M_BEGIN_DECLS
 #include "../configure.h"
 #include "../platform.h"
 
+#ifdef CONFIG_DJGPP
+#define AUDIO_GARBAGE_COLLECTOR
+#endif
+
 #if PLATFORM_BYTE_ORDER == PLATFORM_BIG_ENDIAN
 #define SAMPLE_S16 SAMPLE_S16MSB
 #else
@@ -118,7 +122,7 @@ struct audio
   struct audio_stream *pcs_stream;
   struct audio_stream *stream_list_base;
   struct audio_stream *stream_list_end;
-#ifdef CONFIG_DJGPP
+#ifdef AUDIO_GARBAGE_COLLECTOR
   struct audio_stream *garbage_list_base;
   struct audio_stream *garbage_list_end;
 #endif

--- a/src/audio/audio_vorbis.c
+++ b/src/audio/audio_vorbis.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2004 Gilead Kutnick <exophase@adelphia.net>
  * Copyright (C) 2004 madbrain
  * Copyright (C) 2007 Alistair John Strachan <alistair@devzero.co.uk>
- * Copyright (C) 2018 Alice Rowan <petrifiedrowan@gmail.com>
+ * Copyright (C) 2018, 2024 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -29,15 +29,116 @@
 #include "ext.h"
 #include "sampled_stream.h"
 
+#include "../io/memfile.h"
 #include "../io/vio.h"
 
-#ifdef CONFIG_TREMOR
+// Safety check: DJGPP absolutely can not use vorbis/tremor here because they
+// are not interrupt-safe. stb_vorbis can be used under the condition that
+// alloca is patched out (probably not interrupt-safe) and stdio is disabled
+// (not interrupt-safe). All allocations in the patched stb_vorbis are
+// performed during setup. Additionally, a patch is required to add sample-
+// accurate position tracking.
+//
+// alloca removal patch (not yet contributed upstream):
+// https://github.com/sezero/stb/commit/7dde771bc8181796d516b67b5e5391594674b041
+
+#if defined(CONFIG_DJGPP) && !defined(CONFIG_STB_VORBIS)
+#error Vorbis/Tremor are not interrupt-safe, please fix your config!
+#endif
+
+#if defined(CONFIG_STB_VORBIS)
+#define STB_VORBIS_NO_PUSHDATA_API
+#define STB_VORBIS_NO_STDIO
+#include <stb/stb_vorbis.c>
+#elif defined(CONFIG_TREMOR)
 #include <tremor/ivorbiscodec.h>
 #include <tremor/ivorbisfile.h>
 #else
 #include <vorbis/codec.h>
 #include <vorbis/vorbisfile.h>
 #endif
+
+typedef struct
+{
+  size_t stream_length;
+  int rate;
+  int channels;
+} audio_vorbis_info;
+
+#ifdef CONFIG_STB_VORBIS
+typedef stb_vorbis *audio_vorbis_handle;
+
+static boolean audio_vorbis_handle_init(audio_vorbis_handle *f, vfile *vf)
+{
+  struct memfile tmp;
+  int64_t len;
+  int err;
+
+  // stb_vorbis is mainly for the DOS port and file IO isn't
+  // interrupt safe, so force the entire file to RAM.
+  if(!vfile_force_to_memory(vf))
+    return false;
+
+  len = vfilelength(vf, true);
+  if(len < 0)
+    return false;
+
+  // TODO: stb_vorbis should really accept callbacks instead of this hack.
+  // This may potentially be disastrous with builds that use VFS caching.
+  if(!vfile_get_memfile_block(vf, len, &tmp))
+    return false;
+
+  *f = stb_vorbis_open_memory(tmp.start, len, &err, NULL);
+  return *f != NULL;
+}
+
+static void audio_vorbis_handle_close(audio_vorbis_handle *f)
+{
+  stb_vorbis_close(*f);
+  *f = NULL;
+}
+
+static boolean audio_vorbis_handle_info(audio_vorbis_info *dest,
+ audio_vorbis_handle *f)
+{
+  stb_vorbis_info info = stb_vorbis_get_info(*f);
+  dest->stream_length = stb_vorbis_stream_length_in_samples(*f);
+  dest->channels = info.channels;
+  dest->rate = info.sample_rate;
+  return true;
+}
+
+static char **audio_vorbis_handle_comments(int *num, audio_vorbis_handle *f)
+{
+  stb_vorbis_comment comment = stb_vorbis_get_comment(*f);
+  *num = comment.comment_list_length;
+  return comment.comment_list;
+}
+
+static int audio_vorbis_handle_rewind(audio_vorbis_handle *f)
+{
+  return stb_vorbis_seek_start(*f);
+}
+
+static int audio_vorbis_handle_seek(audio_vorbis_handle *f, int64_t position)
+{
+  return stb_vorbis_seek(*f, (uint32_t)position);
+}
+
+static int64_t audio_vorbis_handle_tell(audio_vorbis_handle *f)
+{
+  // Requires https://github.com/nothings/stb/pull/1295
+  return stb_vorbis_get_playback_sample_offset(*f);
+}
+
+static size_t audio_vorbis_handle_read(void * RESTRICT dest,
+ size_t bytes_to_read, unsigned channels, audio_vorbis_handle *f)
+{
+  return stb_vorbis_get_samples_short_interleaved(*f, channels, dest,
+   bytes_to_read >> 1) * channels * sizeof(int16_t);
+}
+
+#else /* libvorbis/tremor */
 
 // ov_read() documentation states the 'bigendianp' argument..
 //   "Specifies big or little endian byte packing.
@@ -52,160 +153,7 @@ static const int ENDIAN_PACKING = 0;
 #endif
 #endif // !CONFIG_TREMOR
 
-struct vorbis_stream
-{
-  struct sampled_stream s;
-  OggVorbis_File vorbis_file_handle;
-  vorbis_info *vorbis_file_info;
-  vfile *input_file;
-  uint32_t loop_start;
-  uint32_t loop_end;
-};
-
-static boolean vorbis_mix_data(struct audio_stream *a_src,
- int32_t * RESTRICT buffer, size_t frames, unsigned int channels)
-{
-  uint32_t read_len = 0;
-  struct vorbis_stream *v_stream = (struct vorbis_stream *)a_src;
-  char *read_buffer;
-  size_t read_wanted;
-  uint32_t pos = 0;
-  int current_section;
-
-  read_buffer = (char *)sampled_get_buffer(&v_stream->s, &read_wanted);
-
-  do
-  {
-    read_wanted -= read_len;
-
-    if(a_src->repeat && v_stream->loop_end)
-      pos = (uint32_t)ov_pcm_tell(&v_stream->vorbis_file_handle);
-
-#ifdef CONFIG_TREMOR
-    read_len =
-     ov_read(&(v_stream->vorbis_file_handle), read_buffer,
-     read_wanted, &current_section);
-#else
-    read_len =
-     ov_read(&(v_stream->vorbis_file_handle), read_buffer,
-     read_wanted, ENDIAN_PACKING, sizeof(int16_t), 1, &current_section);
-#endif
-
-    if(a_src->repeat && (pos < v_stream->loop_end) &&
-     (pos + read_len / v_stream->s.channels / sizeof(int16_t) >= v_stream->loop_end))
-    {
-      read_len = (v_stream->loop_end - pos) * v_stream->s.channels * sizeof(int16_t);
-      ov_pcm_seek(&(v_stream->vorbis_file_handle), v_stream->loop_start);
-    }
-
-    // If it hit the end go back to the beginning if repeat is on
-
-    if(read_len == 0)
-    {
-      if(a_src->repeat)
-      {
-        ov_raw_seek(&(v_stream->vorbis_file_handle), 0);
-
-        if(read_wanted)
-        {
-#ifdef CONFIG_TREMOR
-          read_len =
-           ov_read(&(v_stream->vorbis_file_handle), read_buffer,
-           read_wanted, &current_section);
-#else
-          read_len =
-           ov_read(&(v_stream->vorbis_file_handle), read_buffer,
-           read_wanted, ENDIAN_PACKING, sizeof(int16_t), 1, &current_section);
-#endif
-        }
-      }
-      else
-      {
-        memset(read_buffer, 0, read_wanted);
-      }
-    }
-
-    read_buffer += read_len;
-  } while((read_len < read_wanted) && read_len);
-
-  sampled_mix_data((struct sampled_stream *)v_stream, buffer, frames, channels);
-
-  if(read_len == 0)
-    return true;
-
-  return false;
-}
-
-static void vorbis_set_volume(struct audio_stream *a_src, unsigned int volume)
-{
-  a_src->volume = volume * 256 / 255;
-}
-
-static void vorbis_set_repeat(struct audio_stream *a_src, boolean repeat)
-{
-  a_src->repeat = repeat;
-}
-
-static void vorbis_set_position(struct audio_stream *a_src, uint32_t position)
-{
-  ov_pcm_seek(&(((struct vorbis_stream *)a_src)->vorbis_file_handle),
-   (ogg_int64_t)position);
-}
-
-static void vorbis_set_loop_start(struct audio_stream *a_src, uint32_t position)
-{
-  ((struct vorbis_stream *)a_src)->loop_start = position;
-}
-
-static void vorbis_set_loop_end(struct audio_stream *a_src, uint32_t position)
-{
-  ((struct vorbis_stream *)a_src)->loop_end = position;
-}
-
-static void vorbis_set_frequency(struct sampled_stream *s_src, uint32_t frequency)
-{
-  if(frequency == 0)
-    frequency = ((struct vorbis_stream *)s_src)->vorbis_file_info->rate;
-
-  s_src->frequency = frequency;
-
-  sampled_set_buffer(s_src);
-}
-
-static uint32_t vorbis_get_position(struct audio_stream *a_src)
-{
-  struct vorbis_stream *v = (struct vorbis_stream *)a_src;
-  return ov_pcm_tell(&v->vorbis_file_handle);
-}
-
-static uint32_t vorbis_get_length(struct audio_stream *a_src)
-{
-  struct vorbis_stream *v = (struct vorbis_stream *)a_src;
-  return ov_pcm_total(&v->vorbis_file_handle, -1);
-}
-
-static uint32_t vorbis_get_loop_start(struct audio_stream *a_src)
-{
-  return ((struct vorbis_stream *)a_src)->loop_start;
-}
-
-static uint32_t vorbis_get_loop_end(struct audio_stream *a_src)
-{
-  return ((struct vorbis_stream *)a_src)->loop_end;
-}
-
-static uint32_t vorbis_get_frequency(struct sampled_stream *s_src)
-{
-  return s_src->frequency;
-}
-
-static void vorbis_destruct(struct audio_stream *a_src)
-{
-  struct vorbis_stream *v_stream = (struct vorbis_stream *)a_src;
-  ov_clear(&(v_stream->vorbis_file_handle));
-  vfclose(v_stream->input_file);
-  sampled_destruct(a_src);
-}
+typedef OggVorbis_File audio_vorbis_handle;
 
 static size_t vorbis_read_fn(void *ptr, size_t size, size_t count, void *stream)
 {
@@ -239,31 +187,235 @@ static const ov_callbacks vorbis_callbacks =
   vorbis_tell_fn,
 };
 
-static void get_loopstart_loopend(struct vorbis_stream *v_stream,
- OggVorbis_File *open_file)
+static boolean audio_vorbis_handle_init(audio_vorbis_handle *f, vfile *vf)
 {
-  vorbis_comment *comment;
+  if(ov_open_callbacks(vf, f, NULL, 0, vorbis_callbacks) != 0)
+    return false;
+
+  return true;
+}
+
+static void audio_vorbis_handle_close(audio_vorbis_handle *f)
+{
+  ov_clear(f);
+}
+
+static boolean audio_vorbis_handle_info(audio_vorbis_info *dest,
+ audio_vorbis_handle *f)
+{
+  vorbis_info *vorbis_file_info = ov_info(f, -1);
+  if(!vorbis_file_info)
+    return false;
+
+  dest->stream_length = ov_pcm_total(f, -1);
+  dest->channels = vorbis_file_info->channels;
+  dest->rate = vorbis_file_info->rate;
+  return true;
+}
+
+static char **audio_vorbis_handle_comments(int *num, audio_vorbis_handle *f)
+{
+  vorbis_comment *comment = ov_comment(f, -1);
+  if(!comment)
+    return NULL;
+
+  *num = comment->comments;
+  return comment->user_comments;
+}
+
+static int audio_vorbis_handle_rewind(audio_vorbis_handle *f)
+{
+  return ov_raw_seek(f, 0);
+}
+
+static int audio_vorbis_handle_seek(audio_vorbis_handle *f, int64_t pos)
+{
+  return ov_pcm_seek(f, (ogg_int64_t)pos);
+}
+
+static int64_t audio_vorbis_handle_tell(audio_vorbis_handle *f)
+{
+  return ov_pcm_tell(f);
+}
+
+static size_t audio_vorbis_handle_read(void * RESTRICT dest,
+ size_t bytes_to_read, unsigned channels, audio_vorbis_handle *f)
+{
+  int current_bitstream;
+#ifdef CONFIG_TREMOR
+  return ov_read(f, dest, bytes_to_read, &current_bitstream);
+#else
+  return ov_read(f, dest, bytes_to_read,
+   ENDIAN_PACKING, sizeof(int16_t), 1, &current_bitstream);
+#endif
+}
+#endif /* libvorbis/tremor */
+
+struct vorbis_stream
+{
+  struct sampled_stream s;
+  audio_vorbis_handle handle;
+  audio_vorbis_info info;
+  vfile *input_file;
+  uint32_t loop_start;
+  uint32_t loop_end;
+};
+
+static boolean vorbis_mix_data(struct audio_stream *a_src,
+ int32_t * RESTRICT buffer, size_t frames, unsigned int channels)
+{
+  uint32_t read_len = 0;
+  struct vorbis_stream *v_stream = (struct vorbis_stream *)a_src;
+  char *read_buffer;
+  size_t read_wanted;
+  size_t read_channels = v_stream->s.channels;
+  uint32_t pos = 0;
+
+  read_buffer = (char *)sampled_get_buffer(&v_stream->s, &read_wanted);
+
+  do
+  {
+    read_wanted -= read_len;
+
+    if(a_src->repeat && v_stream->loop_end)
+      pos = (uint32_t)audio_vorbis_handle_tell(&v_stream->handle);
+
+    read_len = audio_vorbis_handle_read(read_buffer, read_wanted,
+     read_channels, &(v_stream->handle));
+
+    if(a_src->repeat && (pos < v_stream->loop_end) &&
+     (pos + read_len / read_channels / sizeof(int16_t) >= v_stream->loop_end))
+    {
+      read_len = (v_stream->loop_end - pos) * read_channels * sizeof(int16_t);
+      audio_vorbis_handle_seek(&(v_stream->handle), v_stream->loop_start);
+    }
+
+    // If it hit the end go back to the beginning if repeat is on
+
+    if(read_len == 0)
+    {
+      if(a_src->repeat)
+      {
+        audio_vorbis_handle_rewind(&(v_stream->handle));
+
+        if(read_wanted)
+        {
+          read_len = audio_vorbis_handle_read(read_buffer, read_wanted,
+           read_channels, &(v_stream->handle));
+        }
+      }
+      else
+      {
+        memset(read_buffer, 0, read_wanted);
+      }
+    }
+
+    read_buffer += read_len;
+  } while((read_len < read_wanted) && read_len);
+
+  sampled_mix_data((struct sampled_stream *)v_stream, buffer, frames, channels);
+
+  if(read_len == 0)
+    return true;
+
+  return false;
+}
+
+static void vorbis_set_volume(struct audio_stream *a_src, unsigned int volume)
+{
+  a_src->volume = volume * 256 / 255;
+}
+
+static void vorbis_set_repeat(struct audio_stream *a_src, boolean repeat)
+{
+  a_src->repeat = repeat;
+}
+
+static void vorbis_set_position(struct audio_stream *a_src, uint32_t position)
+{
+  struct vorbis_stream *v = (struct vorbis_stream *)a_src;
+  audio_vorbis_handle_seek(&v->handle, (int64_t)position);
+}
+
+static void vorbis_set_loop_start(struct audio_stream *a_src, uint32_t position)
+{
+  ((struct vorbis_stream *)a_src)->loop_start = position;
+}
+
+static void vorbis_set_loop_end(struct audio_stream *a_src, uint32_t position)
+{
+  ((struct vorbis_stream *)a_src)->loop_end = position;
+}
+
+static void vorbis_set_frequency(struct sampled_stream *s_src, uint32_t frequency)
+{
+  if(frequency == 0)
+    frequency = ((struct vorbis_stream *)s_src)->info.rate;
+
+  s_src->frequency = frequency;
+
+  sampled_set_buffer(s_src);
+}
+
+static uint32_t vorbis_get_position(struct audio_stream *a_src)
+{
+  struct vorbis_stream *v = (struct vorbis_stream *)a_src;
+  return (uint32_t)audio_vorbis_handle_tell(&v->handle);
+}
+
+static uint32_t vorbis_get_length(struct audio_stream *a_src)
+{
+  return ((struct vorbis_stream *)a_src)->info.stream_length;
+}
+
+static uint32_t vorbis_get_loop_start(struct audio_stream *a_src)
+{
+  return ((struct vorbis_stream *)a_src)->loop_start;
+}
+
+static uint32_t vorbis_get_loop_end(struct audio_stream *a_src)
+{
+  return ((struct vorbis_stream *)a_src)->loop_end;
+}
+
+static uint32_t vorbis_get_frequency(struct sampled_stream *s_src)
+{
+  return s_src->frequency;
+}
+
+static void vorbis_destruct(struct audio_stream *a_src)
+{
+  struct vorbis_stream *v_stream = (struct vorbis_stream *)a_src;
+  audio_vorbis_handle_close(&(v_stream->handle));
+  vfclose(v_stream->input_file);
+  sampled_destruct(a_src);
+}
+
+static void get_loopstart_loopend(struct vorbis_stream *v_stream)
+{
+  char **comments;
   int loopstart = -1;
   int looplength = -1;
   int loopend = -1;
+  int num;
   int i;
 
-  comment = ov_comment(open_file, -1);
-  if(!comment)
+  comments = audio_vorbis_handle_comments(&num, &(v_stream->handle));
+  if(!comments)
     return;
 
-  for(i = 0; i < comment->comments; i++)
+  for(i = 0; i < num; i++)
   {
-    if(!strncasecmp("loopstart=", comment->user_comments[i], 10))
-      loopstart = atoi(comment->user_comments[i] + 10);
+    if(!strncasecmp("loopstart=", comments[i], 10))
+      loopstart = atoi(comments[i] + 10);
     else
 
-    if(!strncasecmp("loopend=", comment->user_comments[i], 8))
-      loopend = atoi(comment->user_comments[i] + 8);
+    if(!strncasecmp("loopend=", comments[i], 8))
+      loopend = atoi(comments[i] + 8);
     else
 
-    if(!strncasecmp("looplength=", comment->user_comments[i], 11))
-      looplength = atoi(comment->user_comments[i] + 11);
+    if(!strncasecmp("looplength=", comments[i], 11))
+      looplength = atoi(comments[i] + 11);
   }
 
   if(loopstart >= 0 && (looplength > 0 || loopend > loopstart))
@@ -284,45 +436,34 @@ static struct audio_stream *construct_vorbis_stream(vfile *vf,
   struct vorbis_stream *v_stream;
   struct sampled_stream_spec s_spec;
   struct audio_stream_spec a_spec;
-  vorbis_info *vorbis_file_info;
 
-  OggVorbis_File open_file;
+  audio_vorbis_handle handle;
+  audio_vorbis_info info;
 
-#ifdef CONFIG_DJGPP
-  // DJGPP may have instability related to filesystem IO in the audio interrupt.
-  // TODO: this might have been entirely the tremor lowmem close function crash,
-  // so reenable this and use V_FORCE_CACHE in ext.c if problems continue.
-  /*
-  if(!vfile_force_to_memory(vf))
-    return NULL;
-  */
-#endif
-
-  if(ov_open_callbacks(vf, &open_file, NULL, 0, vorbis_callbacks) != 0)
+  if(!audio_vorbis_handle_init(&handle, vf))
     return NULL;
 
   // Surround OGGs not supported yet..
-  vorbis_file_info = ov_info(&open_file, -1);
-  if(!vorbis_file_info || vorbis_file_info->channels > 2)
+  if(!audio_vorbis_handle_info(&info, &handle) || info.channels > 2)
   {
-    ov_clear(&open_file);
+    audio_vorbis_handle_close(&handle);
     return NULL;
   }
 
-  v_stream = (struct vorbis_stream *)malloc(sizeof(struct vorbis_stream));
+  v_stream = (struct vorbis_stream *)cmalloc(sizeof(struct vorbis_stream));
   if(!v_stream)
   {
-    ov_clear(&open_file);
+    audio_vorbis_handle_close(&handle);
     return NULL;
   }
 
-  v_stream->vorbis_file_handle = open_file;
-  v_stream->vorbis_file_info = vorbis_file_info;
+  v_stream->handle = handle;
+  v_stream->info = info;
   v_stream->input_file = vf;
 
   v_stream->loop_start = 0;
   v_stream->loop_end = 0;
-  get_loopstart_loopend(v_stream, &open_file);
+  get_loopstart_loopend(v_stream);
 
   memset(&a_spec, 0, sizeof(struct audio_stream_spec));
   a_spec.mix_data       = vorbis_mix_data;
@@ -342,7 +483,7 @@ static struct audio_stream *construct_vorbis_stream(vfile *vf,
   s_spec.get_frequency = vorbis_get_frequency;
 
   initialize_sampled_stream((struct sampled_stream *)v_stream, &s_spec,
-   frequency, v_stream->vorbis_file_info->channels, true);
+   frequency, info.channels, true);
 
   initialize_audio_stream((struct audio_stream *)v_stream, &a_spec,
    volume, repeat);


### PR DESCRIPTION
* Added stb_vorbis support. DOS builds are now forced to build with stb_vorbis. This fixes crashes during Ogg Vorbis playback due to `malloc`/`free`/stdio usage in libvorbis/libtremor corrupting the heap during the audio interrupt.
* DOS builds now defer mix function audio stream destruction to a garbage list that is collected when the main thread creates or destroys audio streams. This fixes crashes during general audio playback due to `free`/other destructor function usage corrupting the heap during the audio interrupt.

- [x] ~~Investigate audio glitches that occur with stb_vorbis enabled in DOSBox but not in native Windows builds.~~ Leaving these for now.