### PR TITLE
Merge all SDL renderer update_colors functions.

### DIFF
--- a/src/render_sdl.h
+++ b/src/render_sdl.h
@@ -42,6 +42,8 @@ struct sdl_render_data
 #endif
   SDL_Surface *screen;
   SDL_Surface *shadow;
+  SDL_Color *palette_colors;
+  const SDL_PixelFormat *flat_format; // format used by sdl_update_colors.
 
   // SDL Renderer and overlay renderer texture format configuration.
   uint32_t (*rgb_to_yuv)(uint8_t r, uint8_t g, uint8_t b);
@@ -64,6 +66,8 @@ int sdl_flags(int depth, boolean fullscreen, boolean fullscreen_windowed,
  boolean resize);
 boolean sdl_get_fullscreen_resolution(int *width, int *height, boolean scaling);
 void sdl_destruct_window(struct graphics_data *graphics);
+void sdl_update_colors(struct graphics_data *graphics,
+ struct rgb_color *palette, unsigned int count);
 
 boolean sdl_set_video_mode(struct graphics_data *graphics, int width,
  int height, int depth, boolean fullscreen, boolean resize);
@@ -78,9 +82,6 @@ boolean sdl_check_video_mode(struct graphics_data *graphics, int width,
 boolean sdlrender_set_video_mode(struct graphics_data *graphics,
  int width, int height, int depth, boolean fullscreen, boolean resize,
  uint32_t sdl_rendererflags);
-
-void sdlrender_update_colors(struct graphics_data *graphics,
- struct rgb_color *palette, unsigned int count);
 #endif
 
 #if defined(CONFIG_RENDER_GL_FIXED) || defined(CONFIG_RENDER_GL_PROGRAM)

--- a/src/render_sdlaccel.c
+++ b/src/render_sdlaccel.c
@@ -370,7 +370,7 @@ static void sdlaccel_update_colors(struct graphics_data *graphics,
   struct sdlaccel_render_data *render_data = graphics->render_data;
   uint32_t i;
 
-  sdlrender_update_colors(graphics, palette, count);
+  sdl_update_colors(graphics, palette, count);
 
   for(i = 0; i < count; i++)
   {

--- a/src/render_soft.c
+++ b/src/render_soft.c
@@ -36,7 +36,6 @@ struct soft_render_data
 {
 #ifdef CONFIG_SDL
   struct sdl_render_data sdl;
-  SDL_Color sdlpal[SMZX_PAL_SIZE];
 #else
   unsigned pitch;
   unsigned bpp;
@@ -156,38 +155,7 @@ static void soft_update_colors(struct graphics_data *graphics,
  struct rgb_color *palette, unsigned int count)
 {
 #ifdef CONFIG_SDL
-  struct soft_render_data *render_data = graphics->render_data;
-  SDL_Surface *screen = soft_get_screen_surface(render_data);
-
-  unsigned int i;
-
-  if(graphics->bits_per_pixel != 8)
-  {
-    for(i = 0; i < count; i++)
-    {
-      graphics->flat_intensity_palette[i] =
-       SDL_MapRGBA(screen->format, palette[i].r, palette[i].g, palette[i].b,
-       255);
-    }
-  }
-  else
-  {
-    if(count > 256)
-      count = 256;
-
-    for(i = 0; i < count; i++)
-    {
-      render_data->sdlpal[i].r = palette[i].r;
-      render_data->sdlpal[i].g = palette[i].g;
-      render_data->sdlpal[i].b = palette[i].b;
-    }
-
-#if SDL_VERSION_ATLEAST(2,0,0)
-    SDL_SetPaletteColors(render_data->sdl.palette, render_data->sdlpal, 0, count);
-#else
-    SDL_SetColors(render_data->sdl.screen, render_data->sdlpal, 0, count);
-#endif
-  }
+  sdl_update_colors(graphics, palette, count);
 #endif /* CONFIG_SDL */
 }
 
@@ -307,9 +275,10 @@ static void soft_sync_screen(struct graphics_data *graphics)
 
   if(render_data->shadow)
   {
-    SDL_BlitSurface(render_data->shadow,
-     &render_data->shadow->clip_rect, render_data->screen,
-     &render_data->screen->clip_rect);
+    SDL_Rect src_rect = render_data->shadow->clip_rect;
+    SDL_Rect dest_rect = render_data->screen->clip_rect;
+    SDL_BlitSurface(render_data->shadow, &src_rect,
+     render_data->screen, &dest_rect);
   }
 
 #if SDL_VERSION_ATLEAST(2,0,0)

--- a/src/render_softscale.c
+++ b/src/render_softscale.c
@@ -293,7 +293,7 @@ void render_softscale_register(struct renderer *renderer)
   renderer->init_video = softscale_init_video;
   renderer->free_video = softscale_free_video;
   renderer->set_video_mode = softscale_set_video_mode;
-  renderer->update_colors = sdlrender_update_colors;
+  renderer->update_colors = sdl_update_colors;
   renderer->resize_screen = resize_screen_standard;
   renderer->get_screen_coords = get_screen_coords_scaled;
   renderer->set_screen_coords = set_screen_coords_scaled;

--- a/src/render_yuv.c
+++ b/src/render_yuv.c
@@ -151,19 +151,6 @@ static void yuv_free_video(struct graphics_data *graphics)
   graphics->render_data = NULL;
 }
 
-static void yuv_update_colors(struct graphics_data *graphics,
- struct rgb_color *palette, unsigned int count)
-{
-  struct yuv_render_data *render_data = graphics->render_data;
-  unsigned int i;
-
-  for(i = 0; i < count; i++)
-  {
-    graphics->flat_intensity_palette[i] =
-     render_data->sdl.rgb_to_yuv(palette[i].r, palette[i].g, palette[i].b);
-  }
-}
-
 static void yuv_lock_overlay(struct yuv_render_data *render_data,
  Uint32 **pixels, Uint32 *pitch)
 {
@@ -278,7 +265,7 @@ void render_yuv1_register(struct renderer *renderer)
   renderer->init_video = yuv_init_video;
   renderer->free_video = yuv_free_video;
   renderer->set_video_mode = yuv1_set_video_mode;
-  renderer->update_colors = yuv_update_colors;
+  renderer->update_colors = sdl_update_colors;
   renderer->resize_screen = resize_screen_standard;
   renderer->get_screen_coords = get_screen_coords_scaled;
   renderer->set_screen_coords = set_screen_coords_scaled;


### PR DESCRIPTION
SDL3 uses const equivalents to `SDL_PixelFormat` that have to be acquired in a different way from SDL1.2 and SDL2. This combines the remaining SDL-based update_colors renderer functions and adds an intermediary const `SDL_PixelFormat` to hopefully make the switch slightly easier.