### PR TITLE
Fix darwin-dist Gatekeeper errors caused by bad codesign handling.

### DIFF
--- a/arch/darwin/Makefile.in
+++ b/arch/darwin/Makefile.in
@@ -11,6 +11,9 @@ DSOSONAME  = -install_name ${LIBDIR}/
 DYLIBBUNDLER ?= @arch/darwin/bundle.sh
 LIPO         ?= @arch/darwin/lipo.sh
 
+CODESIGN_ID  ?= -
+CODESIGN     ?= codesign --force --deep --preserve-metadata=entitlements,requirements,flags,runtime --sign ${CODESIGN_ID}
+
 #
 # darwin specific recipes.
 # Enable 'make install' and 'make uninstall' for darwin builds.
@@ -98,6 +101,7 @@ CFLAGS   += -DSUBPLATFORM='"${REAL_ARCH}"'
 CXXFLAGS += -DSUBPLATFORM='"${REAL_ARCH}"'
 UTILS_ZLIB_LDFLAGS ?= ${PREFIX}/lib/libz.a
 UTILS_LIBPNG_LDFLAGS ?= ${PREFIX}/lib/libpng.a
+SDL_PREFIX := ${PREFIX}
 
 package: all
 	if [ -d "bundles/libs-${REAL_ARCH}" ]; then rm -rf "bundles/libs-${REAL_ARCH}"; fi
@@ -216,6 +220,13 @@ build:
 	${MV} ${build}/docs               ${mzx_app}/../Documentation
 ifeq (${BUILD_UTILS},1)
 	${MV} ${build}/utils/             ${mzx_app}/../Utilities
+	${CODESIGN}                       ${mzx_app}/../Utilities/ccv
+	${CODESIGN}                       ${mzx_app}/../Utilities/checkres
+	${CODESIGN}                       ${mzx_app}/../Utilities/downver
+	${CODESIGN}                       ${mzx_app}/../Utilities/png2smzx
+	${CODESIGN}                       ${mzx_app}/../Utilities/y4m2smzx
+	${CODESIGN}                       ${mzx_app}/../Utilities/hlp2txt
+	${CODESIGN}                       ${mzx_app}/../Utilities/txt2hlp
 endif
 	${MV} ${build}/${mzx}             ${mzx_app}/Contents/MacOS/MegaZeux
 ifneq (${BUILD_MZXRUN},)
@@ -225,7 +236,8 @@ ifneq (${BUILD_MODULAR},)
 	${MV} ${build}/${core_target}     ${mzx_app}/Contents/MacOS/
 	${MV} ${build}/${editor_target}   ${mzx_app}/Contents/MacOS/
 endif
-	${CP} -r ./bundles/libs-*         ${mzx_app}/Contents/
+	${MKDIR}                          ${mzx_app}/Contents/Frameworks
+	${CP} -r ./bundles/libs-*         ${mzx_app}/Contents/Frameworks
 ifneq (${BUILD_MZXRUN},)
 	${CP} -r ${mzx_app} ${mzxrun_app}
 	${RM} ${mzx_app}/Contents/MacOS/MZXRun
@@ -234,11 +246,14 @@ ifneq (${BUILD_MODULAR},)
 	${RM} ${mzxrun_app}/Contents/MacOS/${editor_target}
 endif
 	${CP} arch/darwin/MZXRun.plist    ${mzxrun_app}/Contents/Info.plist
+	${CODESIGN}                       ${mzxrun_app}/Contents/MacOS/MZXRun
 endif
 	${CP} arch/darwin/MegaZeux.plist  ${mzx_app}/Contents/Info.plist
+	${CODESIGN}                       ${mzx_app}/Contents/MacOS/MegaZeux
 
 archive: build
 	@arch/darwin/dmg.sh ${TARGET}
+	${CODESIGN} build/dist/darwin/${TARGET}.dmg
 
 clean: package_clean
 

--- a/arch/darwin/MegaZeux.plist
+++ b/arch/darwin/MegaZeux.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleIconFile</key>
 	<string>MegaZeux</string>
 	<key>CFBundleIdentifier</key>
-	<string>MegaZeux</string>
+	<string>com.digitalmzx.MegaZeux</string>
 	<key>CFBundleName</key>
 	<string>MegaZeux</string>
 </dict>

--- a/arch/darwin/bundle.sh
+++ b/arch/darwin/bundle.sh
@@ -10,10 +10,15 @@ if [ "$ARCH" = "ppc64" ]; then
 	export PATH="$(pwd)/arch/darwin/bin:$PATH"
 fi
 
+# Note: do not codesign here since there's no guarantee the MZX binaries
+# are being processed by dylibbundler in the "correct" order for codesign.
+# Signing should instead be performed during the .app bundling stage,
+# after the executables have been combined with lipo.
+#
 for exe in $@; do
 	if [ -f "$exe" ]; then
 		mkdir -p ./bundles
-		dylibbundler -cd -of -b -x $exe \
-		  -d "./bundles/libs-$ARCH/" -p "@executable_path/../libs-$ARCH/"
+		dylibbundler -ns -cd -of -b -x $exe \
+		  -d "./bundles/libs-$ARCH/" -p "@executable_path/../Frameworks/libs-$ARCH/"
 	fi
 done

--- a/arch/darwin/dmg.sh
+++ b/arch/darwin/dmg.sh
@@ -7,6 +7,7 @@ DMGNAME=${BASEDIR}/${TARGET}.dmg
 VOLNAME=MegaZeux
 
 mkdir -p ${BASEDIR}
+rm -f $DMGNAME
 hdiutil create $DMGNAME -size 100m -fs HFS+ \
                         -volname "$VOLNAME" -layout SPUD &&
 DEV_HANDLE=`hdid $DMGNAME | grep Apple_HFS | \

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -176,6 +176,11 @@ DEVELOPERS
 + Added dependency builder makefile system in scripts/deps to
   help with regenerating MinGW, DJGPP, darwin-dist, and Linux w/
   MemorySanitizer dependencies.
++ Overhauled the darwin-dist build system to allow for more
+  modern XcodeLegacy-based compilation, including code signing
+  and shared library support (via dylibbundler). The following
+  architectures are now supported: i386, x86_64, x86_64h, ppc,
+  ppc64, and arm64/arm64e (untested).
 
 
 December 31st, 2023 - MZX 2.93

--- a/scripts/deps/Makefile
+++ b/scripts/deps/Makefile
@@ -19,7 +19,7 @@ STB		= stb
 SDL12		= SDL-1.2.15
 SDL2_TIGER	= panther_sdl2
 SDL2_22		= SDL2-2.0.22
-SDL2_LATEST	= SDL2-2.30.5
+SDL2_LATEST	= SDL2-2.30.6
 #SDL3		= SDL3-3.2.0
 
 # Mac OS X/macOS compatibility builds rely on different versions of SDL2


### PR DESCRIPTION
Also adds a changelog entry for the darwin-dist overhaul and updates SDL2 latest to 2.30.6.