### PR TITLE
Support UNC paths, Linux/macOS colon paths, reject colons in fsafetest.

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -211,6 +211,7 @@ GAMECONTROLLERDB="true"
 FPSCOUNTER="false"
 LAYER_RENDERING="true"
 DOS_SVGA="true"
+DOS_ROOTS="false"
 VFS="true"
 
 #
@@ -885,6 +886,7 @@ if [ "$PLATFORM" = "nds" ] || [ "$PLATFORM" = "nds-blocksds" ]; then
 	echo "Enabling NDS-specific hacks."
 	echo "#define CONFIG_NDS" >> src/config.h
 	echo "BUILD_NDS=1" >> platform.inc
+	DOS_ROOTS="true"
 
 	echo "Force-disabling stack protector on NDS."
 	STACK_PROTECTOR="false"
@@ -923,6 +925,7 @@ if [ "$PLATFORM" = "3ds" ]; then
 	echo "Enabling 3DS-specific hacks."
 	echo "#define CONFIG_3DS" >> src/config.h
 	echo "BUILD_3DS=1" >> platform.inc
+	DOS_ROOTS="true"
 
 	#
 	# If the 3DS arch is enabled and SDL 1.2 is used, softscale is not
@@ -956,6 +959,7 @@ if [ "$PLATFORM" = "wii" ]; then
 	echo "Enabling Wii-specific hacks."
 	echo "#define CONFIG_WII" >> src/config.h
 	echo "BUILD_WII=1" >> platform.inc
+	DOS_ROOTS="true"
 
 	if [ "$SDL" = "false" ]; then
 		echo "Force-disabling software renderer on Wii."
@@ -978,6 +982,7 @@ if [ "$PLATFORM" = "wiiu" ]; then
 	echo "Enabling Wii U-specific hacks."
 	echo "#define CONFIG_WIIU" >> src/config.h
 	echo "BUILD_WIIU=1" >> platform.inc
+	DOS_ROOTS="true"
 
 	echo "Disabling utils on Wii U."
 	UTILS="false"
@@ -994,6 +999,7 @@ if [ "$PLATFORM" = "switch" ]; then
 	echo "Enabling Switch-specific hacks."
 	echo "#define CONFIG_SWITCH" >> src/config.h
 	echo "BUILD_SWITCH=1" >> platform.inc
+	DOS_ROOTS="true"
 
 	echo "Disabling utils on Switch."
 	UTILS="false"
@@ -1016,6 +1022,7 @@ if [ "$PLATFORM" = "psp" ]; then
 	echo "Enabling PSP-specific hacks."
 	echo "#define CONFIG_PSP" >> src/config.h
 	echo "BUILD_PSP=1" >> platform.inc
+	DOS_ROOTS="true"
 
 	echo "Force-disabling stack protector on PSP."
 	STACK_PROTECTOR="false"
@@ -1029,6 +1036,7 @@ if [ "$PLATFORM" = "psvita" ]; then
 	echo "Enabling PS Vita-specific hacks."
 	echo "#define CONFIG_PSVITA" >> src/config.h
 	echo "BUILD_PSVITA=1" >> platform.inc
+	DOS_ROOTS="true"
 
 	echo "Force-disabling utils on PS Vita."
 	UTILS="false"
@@ -1884,6 +1892,14 @@ if [ "$COUNTER_HASH" = "true" ]; then
 	echo "BUILD_COUNTER_HASH_TABLES=1" >> platform.inc
 else
 	echo "Hash table counter/string lookups disabled (using binary search)."
+fi
+
+#
+# DOS-style roots in POSIX-like environments, if enabled
+#
+if [ "$DOS_ROOTS" = "true" ]; then
+	echo "Enabling DOS-style roots."
+	echo "#define CONFIG_DOS_STYLE_ROOTS" >> src/config.h
 fi
 
 #

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -28,6 +28,9 @@ USERS
   bugs caused by stream management have also been fixed.
 + All "gamecontroller[...]" config.txt options have been renamed
   to "gamepad[...]". The old names are still supported.
++ Windows UNC paths are now supported in the file manager.
++ Paths with colons (:) are now explicitly supported in Linux
+  and macOS and always rejected in path strings used by worlds.
 + Fixed blank screen bugs that occur with the glslscale renderer
   in conjunction with Intel HD Graphics 2500 graphics drivers
   and possibly some other old drivers.

--- a/src/io/fsafeopen.c
+++ b/src/io/fsafeopen.c
@@ -572,12 +572,16 @@ static int fsafetest(const char *path, char *newpath, size_t buffer_len)
     return FSAFE_SUCCESS;
 
   // windows drive letters
+  if(strchr(newpath, ':') != NULL)
+    return -FSAFE_WINDOWS_DRIVE_LETTER_ERROR;
+  /*
   if(((newpath[0] >= 'A') && (newpath[0] <= 'Z')) ||
      ((newpath[0] >= 'a') && (newpath[0] <= 'z')))
   {
     if(newpath[1] == ':')
       return -FSAFE_WINDOWS_DRIVE_LETTER_ERROR;
   }
+  */
 
   // reject any pathname including /../
   for(i = 0; i < pathlen; i++)

--- a/src/io/path.c
+++ b/src/io/path.c
@@ -201,12 +201,47 @@ ssize_t path_is_absolute(const char *path)
   size_t len;
   size_t i;
 
+#ifdef PATH_UNC_ROOTS
+  // Windows unified DOS and UNC roots.
+  len = strlen(path);
+  if(len > 2 && isslash(path[0]) && isslash(path[1]) && !isslash(path[2]))
+  {
+    i = 3;
+    // UNC roots may be prefixed with \\.\UNC\, try to catch that.
+    if((path[2] == '.'|| path[2] == '?') && isslash(path[3])
+     && !strncasecmp(path + 4, "unc", 3) && isslash(path[7]))
+    {
+      i = 8;
+    }
+
+    // Host name or . or ?
+    for(; i < len; i++)
+      if(isslash(path[i]))
+        break;
+
+    if(i + 1 < len && !isslash(path[i + 1]))
+    {
+      // Share or root name.
+      for(i += 1; i < len; i++)
+        if(isslash(path[i]))
+          break;
+
+      if(isslash(path[i]))
+        return i + 1;
+
+      return i;
+    }
+  }
+#endif /* UNC roots */
+
   // Unix-style root.
   if(isslash(path[0]))
     return 1;
 
   // DOS-style root.
+#ifndef PATH_UNC_ROOTS
   len = strlen(path);
+#endif
   for(i = 0; i < len; i++)
   {
     if(isslash(path[i]))
@@ -218,13 +253,20 @@ ssize_t path_is_absolute(const char *path)
         break;
 
       i++;
+#ifdef PATH_DOS_STYLE_ROOTS
+      // True DOS-style roots do not require a trailing slash.
       if(!path[i])
         return i;
+#endif
 
       if(isslash(path[i]))
       {
         while(isslash(path[i]))
           i++;
+#ifndef PATH_DOS_STYLE_ROOTS
+        // Allow DOS-style roots in Linux only with >=2 slashes.
+        if(i >= 2 && isslash(path[i - 2]))
+#endif
         return i;
       }
       break;
@@ -485,8 +527,29 @@ ssize_t path_get_parent(char *dest, size_t dest_len, const char *path)
 size_t path_clean_slashes(char *path, size_t path_len)
 {
   boolean need_copy = false;
+  size_t root_len;
   size_t i = 0;
   size_t j = 0;
+
+  root_len = path_is_absolute(path);
+#ifdef PATH_UNC_ROOTS
+  // UNC roots should retain two slashes at the start.
+  if(root_len >= 2 && isslash(path[0]) && isslash(path[1]))
+  {
+    path[0] = path[1] = DIR_SEPARATOR_CHAR;
+    i = j = 1; // Merge >2 slashes into the second one.
+  }
+#endif
+#ifndef PATH_DOS_STYLE_ROOTS
+  // Non-native DOS-style double slash roots should retain two slashes.
+  if(root_len >= 4 && !isslash(path[0]))
+  {
+    while(root_len >= 3 && path[root_len - 3] != ':')
+      root_len--;
+    path[root_len - 2] = path[root_len - 1] = DIR_SEPARATOR_CHAR;
+    i = j = root_len - 1; // Merge >2 slashes into the second slash.
+  }
+#endif
 
   while((i < path_len) && path[i])
   {
@@ -511,7 +574,8 @@ size_t path_clean_slashes(char *path, size_t path_len)
   }
   path[j] = '\0';
 
-  if((j >= 2) && (path[j - 1] == DIR_SEPARATOR_CHAR) && (path[j - 2] != ':'))
+  // Trim trailing slashes unless they are a component of the root.
+  if(j >= 2 && j > root_len && path[j - 1] == DIR_SEPARATOR_CHAR)
     path[--j] = '\0';
 
   return j;
@@ -530,8 +594,34 @@ size_t path_clean_slashes(char *path, size_t path_len)
 size_t path_clean_slashes_copy(char *dest, size_t dest_len, const char *path)
 {
   size_t path_len = strlen(path);
+  size_t root_len;
   size_t i = 0;
   size_t j = 0;
+
+  root_len = path_is_absolute(path);
+#ifdef PATH_UNC_ROOTS
+  // UNC roots should retain two slashes at the start.
+  if(root_len >= 2 && isslash(path[0]) && isslash(path[1]))
+  {
+    if(dest_len >= 2)
+      dest[j++] = DIR_SEPARATOR_CHAR;
+    i = 1; // Merge >2 slashes into the second one.
+  }
+#endif
+#ifndef PATH_DOS_STYLE_ROOTS
+  // Non-native DOS-style double slash roots should retain two slashes.
+  if(root_len >= 4 && !isslash(path[0]))
+  {
+    while(j < dest_len - 1 && i < root_len && !isslash(path[i]))
+      dest[j++] = path[i++];
+
+    i++;
+    if(j < dest_len - 1)
+      dest[j++] = DIR_SEPARATOR_CHAR;
+    // Merge >2 slashes into the second slash.
+    root_len = j + 1;
+  }
+#endif
 
   while((i < path_len) && (j < dest_len - 1))
   {
@@ -547,7 +637,8 @@ size_t path_clean_slashes_copy(char *dest, size_t dest_len, const char *path)
   }
   dest[j] = '\0';
 
-  if((j >= 2) && (dest[j - 1] == DIR_SEPARATOR_CHAR) && (dest[j - 2] != ':'))
+  // Trim trailing slashes unless they are a component of the root.
+  if(j >= 2 && j > root_len && dest[j - 1] == DIR_SEPARATOR_CHAR)
     dest[--j] = '\0';
 
   return j;
@@ -694,6 +785,7 @@ static ssize_t path_navigate_internal(char *path, size_t path_len, const char *t
   const char *next;
   const char *end;
   char current_char;
+  size_t root_len;
   size_t len;
 
   if(!path || !target || !target[0])
@@ -702,43 +794,35 @@ static ssize_t path_navigate_internal(char *path, size_t path_len, const char *t
   current = target;
   end = target + strlen(target);
 
-  next = strchr(target, ':');
-  if(next)
+  len = path_is_absolute(target);
+  if(len)
   {
     /**
-     * Destination starts with a Windows-style root directory.
+     * Destination starts with any type of root, including:
+     *
+     * 1) a Unix-style root directory e.g. / or \.
+     * Aside from Unix-likes, these are also supported by console platforms.
+     * Even Windows (back through XP at least) doesn't seem to mind them.
+     *
+     * 2) a DOS-style root directory e.g. C: or sdcard:/.
      * Aside from Windows, these are often used by console SDKs (albeit with /
      * instead of \) to distinguish SD cards and the like.
+     * Linux and macOS also allow them for VFS roots (with double slashes).
+     *
+     * 3) a Windows-style UNC root (Windows only) e.g. \\localhost\share\
+     * These are used for network folders and long paths.
      */
-    // Make sure this is actually a well-formed absolute path.
-    if(!path_is_absolute(target))
-      return -1;
-
-    snprintf(buffer, MAX_PATH, "%.*s" DIR_SEPARATOR, (int)(next - target + 1),
-     target);
-    buffer[MAX_PATH - 1] = '\0';
+    next = target + len;
+    snprintf(buffer, MAX_PATH, "%.*s" DIR_SEPARATOR, (int)len, target);
+    path_clean_slashes(buffer, MAX_PATH);
 
     if(allow_checks && vstat(buffer, &stat_info) < 0)
       return -1;
 
-    current = next + 1;
-    if(isslash(current[0]))
+    current = next;
+    while(isslash(current[0]))
       current++;
   }
-  else
-
-  if(isslash(target[0]))
-  {
-    /**
-     * Destination starts with a Unix-style root directory.
-     * Aside from Unix-likes, these are also supported by console platforms.
-     * Even Windows (back through XP at least) doesn't seem to mind them.
-     */
-    snprintf(buffer, MAX_PATH, DIR_SEPARATOR);
-    buffer[MAX_PATH - 1] = '\0';
-    current = target + 1;
-  }
-
   else
   {
     /**
@@ -756,8 +840,15 @@ static ssize_t path_navigate_internal(char *path, size_t path_len, const char *t
     }
   }
 
+#ifdef PATH_DOS_STYLE_ROOTS
+  // Any attempted DOS-style root after the start is a broken path.
+  if(strchr(current, ':'))
+    return -1;
+#endif
+
   current_char = current[0];
   len = strlen(buffer);
+  root_len = path_is_absolute(buffer);
 
   // Apply directory fragments to the path.
   while(current_char != '\0')
@@ -779,17 +870,21 @@ static ssize_t path_navigate_internal(char *path, size_t path_len, const char *t
     {
       // Skip the rightmost separator (current level) and look for the
       // previous separator. If found, truncate the path to it.
-      char *pos = buffer + len - 1;
-      do
+      // Do not attempt to consume portions of the root.
+      if(len > root_len)
       {
-        pos--;
-      }
-      while(pos >= buffer && !isslash(*pos));
+        char *pos = buffer + len - 1;
+        do
+        {
+          pos--;
+        }
+        while(pos >= buffer && !isslash(*pos));
 
-      if(pos >= buffer)
-      {
-        pos[1] = '\0';
-        len = strlen(buffer);
+        if(pos >= buffer)
+        {
+          pos[1] = '\0';
+          len = strlen(buffer);
+        }
       }
     }
     else

--- a/src/io/path.h
+++ b/src/io/path.h
@@ -28,6 +28,17 @@ __M_BEGIN_DECLS
 
 #include <stddef.h>
 
+#if defined(_WIN32) || defined(CONFIG_DJGPP) || defined(__amigaos__) || \
+ defined(CONFIG_DOS_STYLE_ROOTS)
+// DOS-style roots with one slash (all platforms allow two).
+#define PATH_DOS_STYLE_ROOTS
+#endif
+
+#if defined(_WIN32)
+// Windows-style UNC roots.
+#define PATH_UNC_ROOTS
+#endif
+
 #ifndef DIR_SEPARATOR
 #if defined(__WIN32__) || defined(CONFIG_DJGPP)
 #define DIR_SEPARATOR "\\"

--- a/src/io/vio.c
+++ b/src/io/vio.c
@@ -118,22 +118,45 @@ static boolean vio_cache_directory_recursively(vfilesystem *vfs, const char *pat
   path_clean_slashes_copy(tmp, MAX_PATH, path);
   next = tmp;
   len = path_is_absolute(tmp);
-  if(tmp[0] != '/' && len)
+  if(len > 1)
   {
+#ifdef PATH_DOS_STYLE_ROOTS
+    int skip = 0;
     // Last character of the root should be /, next to last :.
     if(len < 3 || tmp[len - 2] != ':')
       return false;
 
+#ifdef PATH_UNC_ROOTS
+    // Reject UNC host/share paths as network files should be assumed volatile.
+    // Allow local file UNC prefixes.
+    if(isslash(tmp[0]))
+    {
+      if(len > 4 && (!memcmp(tmp, "\\\\.\\", 4) || !memcmp(tmp, "\\\\?\\", 4)) &&
+       strncasecmp(tmp + 4, "unc\\", 4))
+      {
+        next += 4;
+        skip = 4;
+      }
+      else
+        return false;
+    }
+#endif
+
     path_tokenize(&next);
     tmp[len - 2] = '\0';
 
-    ret = vfs_make_root(vfs, tmp);
+    ret = vfs_make_root(vfs, tmp + skip);
     if(ret != 0 && ret != -EEXIST)
       return false;
 
     // Repair current fragment.
     tmp[len - 2] = ':';
     tmp[len - 1] = DIR_SEPARATOR_CHAR;
+#else
+    // DOS-style roots are only supported as VFS roots and should never
+    // make it here!
+    return false;
+#endif
   }
   else
 


### PR DESCRIPTION
* Added support for Windows UNC paths. Host/share and \\?\unc\ format paths are not supported by the VFS and will never be cached.
* Linux and macOS now allow colons in path names. VFS roots for these platforms require a double slash after the colon to be recognized.
* fsafetest now rejects colons ANYWHERE in a path string instead of as the second character. This fixes potential usage of fat:/ et al.

- [x] Finish VFS UNC path test cases.