### PR TITLE
Misc. cleanup and fix patches for scripts/deps.

### DIFF
--- a/arch/darwin/Makefile.in
+++ b/arch/darwin/Makefile.in
@@ -13,6 +13,7 @@ LIPO         ?= @arch/darwin/lipo.sh
 
 CODESIGN_ID  ?= -
 CODESIGN     ?= codesign --force --deep --preserve-metadata=entitlements,requirements,flags,runtime --sign ${CODESIGN_ID}
+CODESIGN_CHK ?= codesign --verify --deep --strict -vvvv
 
 #
 # darwin specific recipes.
@@ -247,13 +248,16 @@ ifneq (${BUILD_MODULAR},)
 endif
 	${CP} arch/darwin/MZXRun.plist    ${mzxrun_app}/Contents/Info.plist
 	${CODESIGN}                       ${mzxrun_app}/Contents/MacOS/MZXRun
+	${CODESIGN_CHK}                   ${mzxrun_app}
 endif
 	${CP} arch/darwin/MegaZeux.plist  ${mzx_app}/Contents/Info.plist
 	${CODESIGN}                       ${mzx_app}/Contents/MacOS/MegaZeux
+	${CODESIGN_CHK}                   ${mzx_app}
 
 archive: build
 	@arch/darwin/dmg.sh ${TARGET}
 	${CODESIGN} build/dist/darwin/${TARGET}.dmg
+	${CODESIGN_CHK} build/dist/darwin/${TARGET}.dmg
 
 clean: package_clean
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -187,6 +187,7 @@ DEVELOPERS
   architectures are now supported: i386, x86_64, x86_64h, ppc,
   ppc64, and arm64/arm64e (untested).
 + Updated libxmp to 4.6.0+6cb48a4a+sample rate patch.
++ Added more PowerPC64 GCC defines to platform_endian.h.
 
 
 December 31st, 2023 - MZX 2.93

--- a/scripts/deps/Makefile
+++ b/scripts/deps/Makefile
@@ -19,7 +19,7 @@ STB		= stb
 SDL12		= SDL-1.2.15
 SDL2_TIGER	= panther_sdl2
 SDL2_22		= SDL2-2.0.22
-SDL2_LATEST	= SDL2-2.30.6
+SDL2_LATEST	= SDL2-2.30.7
 #SDL3		= SDL3-3.2.0
 
 # Mac OS X/macOS compatibility builds rely on different versions of SDL2

--- a/scripts/deps/Makefile
+++ b/scripts/deps/Makefile
@@ -444,7 +444,7 @@ ${SDL12_TARGET}: | build/${SDL12} SDL12_clean
 	${ARCH_INIT}; \
 	./autogen.sh; \
 	ln -sf build-scripts/config.guess config.guess; \
-	${CONFIGURE}; \
+	${CONFIGURE} ${ARCH_CONFIGURE_SDL12_ARGS}; \
 	${MAKE}; \
 	${MAKE} install;
 

--- a/scripts/deps/Makefile
+++ b/scripts/deps/Makefile
@@ -101,7 +101,8 @@ SDL3_PACKAGE	= ${TARGET}/${LIB}/libSDL3.a \
 		  ${TARGET}/${INCLUDE}/SDL3
 
 .PHONY: all
-.PHONY: package package_dir package_clean zlib_package png_package
+.PHONY: package package_dir package_clean package_lazy
+.PHONY: zlib_package png_package
 .PHONY: vorbis_package tremor_package stb_package
 .PHONY: SDL12_package SDL2_package SDL3_package
 .PHONY: clean zlib_clean png_clean ogg_clean vorbis_clean tremor_clean
@@ -489,9 +490,22 @@ package_clean:
 	rm -rf ${TARGET}/${BIN}
 
 package_dir:
-	mkdir -p ${TARGET}/${LIB}
-	mkdir -p ${TARGET}/${INCLUDE}
-	mkdir -p ${TARGET}/${BIN}
+	if [ -d "${PLATFORM}/${ARCH}" ]; then \
+		mkdir -p ${TARGET}/${LIB}; \
+		mkdir -p ${TARGET}/${INCLUDE}; \
+		mkdir -p ${TARGET}/${BIN}; \
+	fi
+
+# macOS dylibbundler requires libraries with intact full names,
+# which the normal package targets can't handle. This copies the
+# entirety of bin, lib, and include instead, and then strips
+# out known bloat.
+package_lazy: | package_dir
+	cp -RP "${LIB}" "${TARGET}/${LIB}/../"
+	cp -RP "${INCLUDE}" "${TARGET}/${INCLUDE}/../"
+	cp -RP "${BIN}" "${TARGET}/${BIN}/../"
+	rm -rf "${TARGET}/${LIB}/png.framework"
+	rm -f "${TARGET}/${BIN}/png"*
 
 %.debug: % | package_dir
 	${HOST}-objcopy --only-keep-debug $< $@

--- a/scripts/deps/Makefile.macos.in
+++ b/scripts/deps/Makefile.macos.in
@@ -9,14 +9,9 @@ include ../../arch/darwin/Makefile.arch
 
 ifneq (${ARCH},)
 all: ${ZLIB_TARGET} ${PNG_TARGET} ${OGG_TARGET} ${VORBIS_TARGET} ${STB_TARGET}
-package: zlib_package png_package vorbis_package stb_package
-package: ${TARGET}/${LIB}/libz.dylib ${TARGET}/${LIB}/libpng16.dylib
-package: ${TARGET}/${LIB}/libogg.dylib ${TARGET}/${LIB}/libvorbis.dylib
-package: ${TARGET}/${LIB}/libvorbisfile.dylib
+package: package_lazy
 
 all: ${SDL2_TARGET}
-package: SDL2_package
-package: ${TARGET}/${LIB}/libSDL2.dylib
 
 CFLAGS = -O3
 CXXFLAGS = ${CFLAGS}

--- a/scripts/deps/Makefile.macos.in
+++ b/scripts/deps/Makefile.macos.in
@@ -13,6 +13,11 @@ package: package_lazy
 
 all: ${SDL2_TARGET}
 
+ifneq ($(filter ppc ppc64,${ARCH}),)
+all: ${SDL12_TARGET}
+HOST=powerpc-apple-darwin10
+endif
+
 CFLAGS = -O3
 CXXFLAGS = ${CFLAGS}
 USE_CMAKE := 1
@@ -30,6 +35,7 @@ ARCH_INIT = \
 	true
 
 ARCH_CONFIGURE_ARGS	=
+ARCH_CONFIGURE_SDL12_ARGS = --disable-video-x11
 ARCH_CONFIGURE_SDL2_ARGS = --without-x
 
 ARCH_CMAKE_ARGS = \

--- a/src/platform_endian.h
+++ b/src/platform_endian.h
@@ -69,7 +69,9 @@
   ((defined(__mips__) || defined(__mips) || defined(__MIPS__)) && \
     defined(_MIPS_SIM) && defined(_ABI64) && _MIPS_SIM == _ABI64) || \
   (defined(__GNUC__) && \
-    (defined(__x86_64__) || defined(__powerpc64__) || defined(__PPC64__) || \
+    (defined(__x86_64__) || \
+     defined(__powerpc64__) || defined(__PPC64__) || \
+     defined(__ppc64__) || defined(_ARCH_PPC64) || \
      defined(__aarch64__) || defined(__alpha__) || \
      defined(__s390x__) || defined(__zarch__)))
 #define ARCHITECTURE_BITS 64


### PR DESCRIPTION
- [x] Update SDL2 latest to 2.30.7.
- [x] Add `package_lazy` target that preserves symlinks to fix macOS packages for dylibbundler, which expects full library names and links.
- [x] macOS ppc and ppc64 now build SDL 1.2.15.
  - [x] G3 works
  - [ ] G4 works
  - [x] PowerPC64 works
- [x] ~~Attempt SDL 2.0.2 for ppc and ppc64?~~ Doesn't work, try the TigerPorts patches some other time.
- [x] Remove old frameworks and msvc.zip from repository, upload to megazeux-dependencies instead (+update docs). #474 