### PR TITLE
Enable link-time optimizations by default for most platforms.

### DIFF
--- a/arch/3ds/CONFIG.3DS
+++ b/arch/3ds/CONFIG.3DS
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-./config.sh --platform 3ds --enable-release --enable-meter --disable-utils \
-            --disable-sdl --enable-tremor --disable-screenshots \
+./config.sh --platform 3ds --enable-release --enable-lto --enable-meter \
+            --disable-sdl --enable-tremor --disable-screenshots --disable-utils \
             --enable-stdio-redirect "$@"
 

--- a/arch/android/CONFIG.ANDROID
+++ b/arch/android/CONFIG.ANDROID
@@ -4,5 +4,5 @@
 
 [ -z "$NDK_PATH" ] && { echo "Must define NDK_PATH!"; exit 1; }
 
-./config.sh --platform android --enable-release --disable-utils \
-  --disable-libpng --disable-gl-fixed "$@"
+./config.sh --platform android --enable-release --enable-lto \
+            --disable-utils --disable-libpng --disable-gl-fixed "$@"

--- a/arch/djgpp/CONFIG.DJGPP
+++ b/arch/djgpp/CONFIG.DJGPP
@@ -2,6 +2,6 @@
 
 [ -z "$DJGPP" ] && { echo "DJGPP not defined! Aborting."; exit 1; }
 
-./config.sh --platform djgpp --prefix "$DJGPP" --enable-release \
+./config.sh --platform djgpp --prefix "$DJGPP" --enable-release --enable-lto \
 	--enable-stb-vorbis --disable-libpng \
 	--enable-stdio-redirect --enable-meter --enable-extram "$@"

--- a/arch/dreamcast/CONFIG.DC
+++ b/arch/dreamcast/CONFIG.DC
@@ -2,7 +2,7 @@
 
 [ -z "$KOS_BASE" ] && { echo "\$KOS_BASE is unset. Aborting"; exit 1; }
 
-./config.sh --platform dreamcast --prefix "$KOS_BASE" --optimize-size \
+./config.sh --platform dreamcast --prefix "$KOS_BASE" --optimize-size --enable-lto \
             --disable-editor --disable-helpsys --disable-utils \
             --disable-screenshots --disable-stack-protector \
             --enable-meter --disable-libpng --enable-tremor --enable-release

--- a/arch/emscripten/CONFIG.HTML5
+++ b/arch/emscripten/CONFIG.HTML5
@@ -4,4 +4,5 @@
 # with software + canvas scaling. These should probably have their performace
 # compared at some point though.
 
-./config.sh --platform emscripten --enable-release --disable-softscale "$@"
+./config.sh --platform emscripten --enable-release --enable-lto \
+            --disable-softscale "$@"

--- a/arch/nds-blocksds/CONFIG.NDS
+++ b/arch/nds-blocksds/CONFIG.NDS
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-./config.sh --platform nds-blocksds --prefix $BLOCKSDS --optimize-size \
+./config.sh --platform nds-blocksds --prefix $BLOCKSDS --optimize-size --enable-lto \
             --disable-editor --disable-helpsys --disable-utils \
             --disable-libpng --enable-release --enable-meter \
             --enable-extram --disable-screenshots --enable-stdio-redirect "$@"

--- a/arch/nds/CONFIG.NDS
+++ b/arch/nds/CONFIG.NDS
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-./config.sh --platform nds --prefix $DEVKITARM --optimize-size \
+./config.sh --platform nds --prefix $DEVKITARM --optimize-size --enable-lto \
             --disable-editor --disable-helpsys --disable-utils \
             --disable-libpng --enable-release --enable-meter \
             --enable-extram --disable-screenshots --enable-stdio-redirect "$@"

--- a/arch/psvita/CONFIG.PSVITA
+++ b/arch/psvita/CONFIG.PSVITA
@@ -2,6 +2,6 @@
 
 [[ -z $VITASDK ]] && { echo "\$VITASDK is unset. Aborting"; exit 1; }
 
-./config.sh --platform psvita --prefix $VITASDK \
-            --disable-utils --enable-release --enable-stdio-redirect \
+./config.sh --platform psvita --prefix $VITASDK --enable-release --enable-lto \
+            --disable-utils --enable-stdio-redirect \
             --enable-meter --disable-gl "$@"

--- a/arch/switch/CONFIG.SWITCH
+++ b/arch/switch/CONFIG.SWITCH
@@ -4,6 +4,6 @@
 # by default. They don't perform as well as the softscale renderer on the
 # Switch anyway.
 
-./config.sh --platform switch --prefix $DEVKITPRO/devkitA64 --enable-release \
+./config.sh --platform switch --prefix $DEVKITPRO/devkitA64 --enable-release --enable-lto \
             --disable-utils --enable-meter --enable-stdio-redirect \
             --disable-gl $@

--- a/arch/wii/CONFIG.WII
+++ b/arch/wii/CONFIG.WII
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-./config.sh --platform wii --prefix $DEVKITPPC --disable-sdl --enable-release \
-            --disable-utils --enable-tremor --enable-meter \
+./config.sh --platform wii --prefix $DEVKITPPC --enable-release --enable-lto \
+            --disable-sdl --disable-utils --enable-tremor --enable-meter \
             --enable-stdio-redirect "$@"

--- a/arch/wiiu/CONFIG.WIIU
+++ b/arch/wiiu/CONFIG.WIIU
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-./config.sh --platform wiiu --prefix $DEVKITPPC --enable-release \
+./config.sh --platform wiiu --prefix $DEVKITPPC --enable-release --enable-lto \
             --disable-utils --enable-meter --enable-stdio-redirect \
             --disable-gl $@

--- a/debian/rules
+++ b/debian/rules
@@ -17,7 +17,7 @@ configure: configure-stamp
 configure-stamp:
 	dh_testdir
 	./config.sh --platform unix --as-needed-hack \
-	            --enable-release $(CONFIG_FLAGS)
+	            --enable-release --enable-lto $(CONFIG_FLAGS)
 	touch configure-stamp
 
 build: build-stamp

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -156,7 +156,8 @@ DEVELOPERS
 + Moved SDL renderer window creation to render_sdl.c so both of
   the SDL renderer-based renderers can benefit from it.
 + Removed floating point division usage in render_gl2.c.
-+ Added --enable-lto to enable link-time optimizations.
++ Added --enable-lto to enable link-time optimizations. This is
+  now enabled by default in most platforms' config scripts.
 + The sanitizer config.sh options can now be used with release
   builds e.g. --enable-release --enable-asan.
 + Simplified the configuration of system directories for ports

--- a/megazeux.spec
+++ b/megazeux.spec
@@ -1,5 +1,5 @@
 Name:		megazeux
-Version:	2.93
+Version:	2.93b
 Release:	1%{?dist}
 
 Summary:	A simple game creation system (GCS)
@@ -7,7 +7,7 @@ Summary:	A simple game creation system (GCS)
 Group:		Amusements/Games
 License:	GPLv2+
 URL:		https://www.digitalmzx.com/
-Source:		megazeux-2.93.tar.xz
+Source:		megazeux-2.93b.tar.xz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildRequires:	SDL2-devel
@@ -30,10 +30,10 @@ regardless of genre.
 See https://www.digitalmzx.com/ for more information.
 
 %prep
-%setup -q -n mzx293
+%setup -q -n mzx293b
 
 %build
-./config.sh --platform unix --enable-release --as-needed-hack \
+./config.sh --platform unix --enable-release --enable-lto --as-needed-hack \
             --libdir %{_libdir} \
             --gamesdir %{_bindir} \
             --sharedir %{_datadir} \
@@ -67,6 +67,9 @@ rm -rf "$RPM_BUILD_ROOT"
 %{_sysconfdir}/megazeux-config
 
 %changelog
+* Tue Sep 10 2024 Alice Rowan <petrifiedrowan@gmail.com> 2.93b-1
+- new upstream version, add --enable-lto
+
 * Sun Dec 31 2023 Alice Rowan <petrifiedrowan@gmail.com> 2.93-1
 - new upstream version, fix icon path
 

--- a/scripts/buildscripts/mzx-scripts/platforms/windows-x64.sh
+++ b/scripts/buildscripts/mzx-scripts/platforms/windows-x64.sh
@@ -54,7 +54,7 @@ platform_config_debug()
 
 platform_config_release()
 {
-	./config.sh --platform $MINGW64_PLATFORM $MINGW64_CONFIG --enable-release "$@"
+	./config.sh --platform $MINGW64_PLATFORM $MINGW64_CONFIG --enable-release --enable-lto "$@"
 }
 
 platform_check_build()

--- a/scripts/buildscripts/mzx-scripts/platforms/windows-x86.sh
+++ b/scripts/buildscripts/mzx-scripts/platforms/windows-x86.sh
@@ -54,7 +54,7 @@ platform_config_debug()
 
 platform_config_release()
 {
-	./config.sh --platform $MINGW32_PLATFORM $MINGW32_CONFIG --enable-release "$@"
+	./config.sh --platform $MINGW32_PLATFORM $MINGW32_CONFIG --enable-release --enable-lto "$@"
 }
 
 platform_check_build()


### PR DESCRIPTION
Also updates megazeux.spec for MZX 2.93b.