### PR TITLE
Fix show thing regression caused by overlay_mode fixes.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -5,6 +5,15 @@ FIXES
 + TODO: 2.94 enables board message clipping bugfixes from 2.93b.
 
 
+GIT - MZX 2.93c
+
+USERS
+
++ Fixed the board editor show thing hotkeys (broken by 2.93b).
+
+DEVELOPERS
+
+
 September 10th, 2024 - MZX 2.93b
 
 This is mostly a big bugfix release, but there are a few new

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -1003,8 +1003,8 @@ static void draw_edit_window(struct editor_context *editor)
     {
       id_put(cur_board, x, y, a_x, a_y, a_x, a_y);
 
-      // Don't display flashing when the overlay is enabled.
-      if(flash_char && !cur_board->overlay_mode)
+      // Don't display flashing unless in board edit mode.
+      if(flash_char && editor->mode == EDIT_BOARD)
         flash_draw(editor, cur_board, x, y, a_x, a_y, flash_char);
     }
   }


### PR DESCRIPTION
Broken by #455, which missed one spot that still relied on the old hacky usage of `overlay_mode` in the editor display routine.

Fixes [issue 867](https://www.digitalmzx.com/forums/index.php?app=tracker&showissue=867).