### PR TITLE
Split set_video_mode into create_window and resize_window.

### DIFF
--- a/arch/3ds/render.cpp
+++ b/arch/3ds/render.cpp
@@ -496,8 +496,7 @@ static boolean ctr_init_video(struct graphics_data *graphics,
   graphics->window_height = 350;
 
   ctr_keyboard_init(&render_data);
-
-  return set_video_mode();
+  return true;
 }
 
 static void ctr_free_video(struct graphics_data *graphics)
@@ -520,8 +519,8 @@ static void ctr_free_video(struct graphics_data *graphics)
   C3D_Fini();
 }
 
-static boolean ctr_set_video_mode(struct graphics_data *graphics, int width,
- int height, int depth, boolean fullscreen, boolean resize)
+static boolean ctr_create_window(struct graphics_data *graphics,
+ struct video_window *window)
 {
   return true;
 }
@@ -1200,9 +1199,8 @@ void render_ctr_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = ctr_init_video;
   renderer->free_video = ctr_free_video;
-  renderer->set_video_mode = ctr_set_video_mode;
+  renderer->create_window = ctr_create_window;
   renderer->update_colors = ctr_update_colors;
-  renderer->resize_screen = resize_screen_standard;
   renderer->remap_char_range = ctr_remap_char_range;
   renderer->remap_char = ctr_remap_char;
   renderer->remap_charbyte = ctr_remap_charbyte;

--- a/arch/djgpp/event.c
+++ b/arch/djgpp/event.c
@@ -336,7 +336,7 @@ static boolean process_keypress(int key)
    get_alt_status(keycode_internal) &&
    get_ctrl_status(keycode_internal))
   {
-    toggle_fullscreen();
+    video_toggle_fullscreen();
     return true;
   }
 

--- a/arch/djgpp/render_ega.c
+++ b/arch/djgpp/render_ega.c
@@ -237,7 +237,8 @@ static boolean ega_is_ati_card(void)
 static boolean ega_init_video(struct graphics_data *graphics,
  struct config_info *conf)
 {
-  struct ega_render_data *render_data = cmalloc(sizeof(struct ega_render_data));
+  struct ega_render_data *render_data =
+   (struct ega_render_data *)cmalloc(sizeof(struct ega_render_data));
   int display, sel;
 
   if(!render_data)
@@ -276,7 +277,7 @@ static boolean ega_init_video(struct graphics_data *graphics,
   render_data->smzx_swap_nibbles = render_data->is_ati_card;
 
   graphics->render_data = render_data;
-  return set_video_mode();
+  return true;
 }
 
 static void ega_free_video(struct graphics_data *graphics)
@@ -333,8 +334,8 @@ static boolean ega_set_screen_mode(struct graphics_data *graphics, unsigned mode
   return true;
 }
 
-static boolean ega_set_video_mode(struct graphics_data *graphics,
- int width, int height, int depth, boolean fullscreen, boolean resize)
+static boolean ega_create_window(struct graphics_data *graphics,
+ struct video_window *window)
 {
   ega_set_screen_mode(graphics, graphics->screen_mode);
   return true;
@@ -507,10 +508,9 @@ void render_ega_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = ega_init_video;
   renderer->free_video = ega_free_video;
-  renderer->set_video_mode = ega_set_video_mode;
+  renderer->create_window = ega_create_window;
   renderer->set_screen_mode = ega_set_screen_mode;
   renderer->update_colors = ega_update_colors;
-  renderer->resize_screen = resize_screen_standard;
   renderer->remap_char_range = ega_remap_char_range;
   renderer->remap_char = ega_remap_char;
   renderer->remap_charbyte = ega_remap_charbyte;

--- a/arch/djgpp/render_svga.c
+++ b/arch/djgpp/render_svga.c
@@ -168,8 +168,7 @@ static boolean svga_init_video(struct graphics_data *graphics,
 
   memset((uint8_t *)(render_data.mapping.address + __djgpp_conventional_base), 0,
    vbe.pitch * vbe.height * (render_data.page_flip_ok ? 2 : 1));
-
-  return set_video_mode();
+  return true;
 }
 
 static void svga_free_video(struct graphics_data *graphics)
@@ -179,8 +178,8 @@ static void svga_free_video(struct graphics_data *graphics)
   djgpp_pop_enable_nearptr();
 }
 
-static boolean svga_set_video_mode(struct graphics_data *graphics, int width,
- int height, int depth, boolean fullscreen, boolean resize)
+static boolean svga_create_window(struct graphics_data *graphics,
+ struct video_window *window)
 {
   return true;
 }
@@ -342,9 +341,8 @@ void render_svga_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = svga_init_video;
   renderer->free_video = svga_free_video;
-  renderer->set_video_mode = svga_set_video_mode;
+  renderer->create_window = svga_create_window;
   renderer->update_colors = svga_update_colors;
-  renderer->resize_screen = resize_screen_standard;
   renderer->get_screen_coords = get_screen_coords_centered;
   renderer->set_screen_coords = set_screen_coords_centered;
   renderer->render_graph = svga_render_graph;

--- a/arch/dreamcast/render.c
+++ b/arch/dreamcast/render.c
@@ -74,8 +74,7 @@ static boolean dc_init_video(struct graphics_data *graphics,
   graphics->resolution_height = 350;
   graphics->window_width = 640;
   graphics->window_height = 350;
-
-  return set_video_mode();
+  return true;
 }
 
 static void dc_free_video(struct graphics_data *graphics)
@@ -84,8 +83,8 @@ static void dc_free_video(struct graphics_data *graphics)
   pvr_mem_free(render_data->texture);
 }
 
-static boolean dc_set_video_mode(struct graphics_data *graphics, int width,
- int height, int depth, boolean fullscreen, boolean resize)
+static boolean dc_create_window(struct graphics_data *graphics,
+ struct video_window *window)
 {
   return true;
 }
@@ -187,9 +186,8 @@ void render_dc_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = dc_init_video;
   renderer->free_video = dc_free_video;
-  renderer->set_video_mode = dc_set_video_mode;
+  renderer->create_window = dc_create_window;
   renderer->update_colors = dc_update_colors;
-  renderer->resize_screen = resize_screen_standard;
   renderer->get_screen_coords = get_screen_coords_centered;
   renderer->set_screen_coords = set_screen_coords_centered;
   renderer->render_graph = dc_render_graph;

--- a/arch/dreamcast/render_fb.c
+++ b/arch/dreamcast/render_fb.c
@@ -49,8 +49,7 @@ static boolean dc_fb_init_video(struct graphics_data *graphics,
   graphics->resolution_height = 350;
   graphics->window_width = 640;
   graphics->window_height = 350;
-
-  return set_video_mode();
+  return true;
 }
 
 static inline uint16_t *dc_fb_vram_ptr()
@@ -63,8 +62,8 @@ static void dc_fb_free_video(struct graphics_data *graphics)
 //  struct dc_fb_render_data *render_data = graphics->render_data;
 }
 
-static boolean dc_fb_set_video_mode(struct graphics_data *graphics, int width,
- int height, int depth, boolean fullscreen, boolean resize)
+static boolean dc_fb_create_window(struct graphics_data *graphics,
+ struct video_window *window)
 {
   return true;
 }
@@ -126,9 +125,8 @@ void render_dc_fb_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = dc_fb_init_video;
   renderer->free_video = dc_fb_free_video;
-  renderer->set_video_mode = dc_fb_set_video_mode;
+  renderer->create_window = dc_fb_create_window;
   renderer->update_colors = dc_fb_update_colors;
-  renderer->resize_screen = resize_screen_standard;
   renderer->get_screen_coords = get_screen_coords_centered;
   renderer->set_screen_coords = set_screen_coords_centered;
   renderer->render_graph = dc_fb_render_graph;

--- a/arch/install.inc
+++ b/arch/install.inc
@@ -171,6 +171,7 @@ ifeq (${BUILD_RENDER_GL_PROGRAM},1)
 		assets/glsl/scalers/hqscale.frag \
 		assets/glsl/scalers/hqscale.vert \
 		assets/glsl/scalers/nearest.frag \
+		assets/glsl/scalers/sai.frag \
 		assets/glsl/scalers/semisoft.frag \
 		assets/glsl/scalers/sepia.frag \
 		assets/glsl/scalers/simple.frag \

--- a/arch/nds/render.c
+++ b/arch/nds/render.c
@@ -452,8 +452,8 @@ static boolean nds_init_video(struct graphics_data *graphics,
   return true;
 }
 
-static boolean nds_set_video_mode(struct graphics_data *graphics,
- int width, int height, int depth, boolean fullscreen, boolean resize)
+static boolean nds_create_window(struct graphics_data *graphics,
+ struct video_window *window)
 {
   return true;	// stub
 }
@@ -735,11 +735,6 @@ static void nds_update_colors(struct graphics_data *graphics,
     nds_update_palette_entry(palette, i);
 }
 
-static void nds_resize_screen(struct graphics_data *graphics, int w, int h)
-{
-  // stub
-}
-
 static void nds_render_cursor(struct graphics_data *graphics, unsigned int x,
  unsigned int y, uint16_t color, unsigned int lines, unsigned int offset)
 {
@@ -852,9 +847,8 @@ void render_nds_register(struct renderer *renderer)
 {
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = nds_init_video;
-  renderer->set_video_mode = nds_set_video_mode;
+  renderer->create_window = nds_create_window;
   renderer->update_colors = nds_update_colors;
-  renderer->resize_screen = nds_resize_screen;
   renderer->remap_char_range = nds_remap_char_range;
   renderer->remap_char = nds_remap_char;
   renderer->remap_charbyte = nds_remap_charbyte;

--- a/arch/wii/event.c
+++ b/arch/wii/event.c
@@ -927,7 +927,7 @@ static boolean process_event(union event *ev)
        get_alt_status(keycode_internal) &&
        get_ctrl_status(keycode_internal))
       {
-        toggle_fullscreen();
+        video_toggle_fullscreen();
         return true;
       }
 

--- a/arch/wii/render_gx.c
+++ b/arch/wii/render_gx.c
@@ -368,8 +368,7 @@ static boolean gx_init_video(struct graphics_data *graphics,
 
   guOrtho(projmtx, -1, sh - 1, 0, sw, -1.0, 1.0);
   GX_LoadProjectionMtx(projmtx, GX_ORTHOGRAPHIC);
-
-  return set_video_mode();
+  return true;
 }
 
 static void gx_free_video(struct graphics_data *graphics)
@@ -378,14 +377,14 @@ static void gx_free_video(struct graphics_data *graphics)
   graphics->render_data = NULL;
 }
 
-static boolean gx_set_video_mode(struct graphics_data *graphics,
- int width, int height, int depth, boolean fullscreen, boolean resize)
+static boolean gx_create_window(struct graphics_data *graphics,
+ struct video_window *window)
 {
   struct gx_render_data *render_data = graphics->render_data;
   float x, y, w, h, scale, xscale, yscale;
   int fh, fs, sw, sh, dw, dh;
 
-  if(fullscreen)
+  if(window->is_fullscreen)
     scale = 8.0 / 9.0;
   else
     scale = 8.0 / 10.0;
@@ -958,9 +957,9 @@ void render_gx_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = gx_init_video;
   renderer->free_video = gx_free_video;
-  renderer->set_video_mode = gx_set_video_mode;
+  renderer->create_window = gx_create_window;
+  renderer->resize_window = gx_create_window;
   renderer->update_colors = gx_update_colors;
-  renderer->resize_screen = resize_screen_standard;
   renderer->remap_char_range = gx_remap_char_range;
   renderer->remap_char = gx_remap_char;
   renderer->remap_charbyte = gx_remap_charbyte;

--- a/arch/wii/render_xfb.c
+++ b/arch/wii/render_xfb.c
@@ -118,7 +118,7 @@ static boolean xfb_init_video(struct graphics_data *graphics,
   if(rmode->viTVMode & VI_NON_INTERLACE)
     VIDEO_WaitVSync();
 
-  return set_video_mode();
+  return true;
 }
 
 static void xfb_free_video(struct graphics_data *graphics)
@@ -127,8 +127,8 @@ static void xfb_free_video(struct graphics_data *graphics)
   graphics->render_data = NULL;
 }
 
-static boolean xfb_set_video_mode(struct graphics_data *graphics,
- int width, int height, int depth, boolean fullscreen, boolean resize)
+static boolean xfb_create_window(struct graphics_data *graphics,
+ struct video_window *window)
 {
   return true;
 }
@@ -364,9 +364,8 @@ void render_xfb_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = xfb_init_video;
   renderer->free_video = xfb_free_video;
-  renderer->set_video_mode = xfb_set_video_mode;
+  renderer->create_window = xfb_create_window;
   renderer->update_colors = xfb_update_colors;
-  renderer->resize_screen = resize_screen_standard;
   renderer->get_screen_coords = get_screen_coords_centered;
   renderer->set_screen_coords = set_screen_coords_centered;
   renderer->render_graph = xfb_render_graph;

--- a/config.txt
+++ b/config.txt
@@ -153,11 +153,12 @@
 
 # If this setting is enabled, instead of regular fullscreen MZX will create
 # a borderless window with the current desktop resolution when fullscreen
-# is enabled. This overrides fullscreen_resolution. Disabled by default.
+# is enabled. This overrides fullscreen_resolution. Disabled by default
+# except on macOS, where it is enabled by default.
 
 # fullscreen_windowed = 0
 
-# The resolution MZX uses in a window. If you renderer supports
+# The resolution MZX uses in a window. If your renderer supports
 # it, MZX will be scaled to fit this specification. Otherwise
 # the setting is ignored.
 

--- a/config.txt
+++ b/config.txt
@@ -715,10 +715,11 @@
 
 # mask_midchars = 1
 
-# Set to 1 if you would rather MZX's mouse pointer used the
-# system mouse cursor.
+# Set to 1/"on" to display the system mouse; set to "only" to display ONLY
+# the system mouse (i.e. hide the software mouse cursor). MegaZeux versions
+# prior to 2.93c treated a setting of 1 like "only".
 
-# system_mouse = 0
+# system_mouse = off
 
 # Set to 1 to let MZX grab the mouse pointer while active.
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -22,6 +22,8 @@ USERS
 + Fixed window resize bugs in Linux (particularly Wayland)
   caused by MZX recreating the window every time a window resize
   event was received.
++ Fixed junk display in the letterbox area after resizing using
+  the software, gp2x, or SDL 1.2 overlay renderers.
 + Fixed sai.frag not being installed by "make install" or
   distributed with Unix-style packages for Linux/BSD/Darwin.
 + Fixed the board editor show thing hotkeys (broken by 2.93b).

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -26,9 +26,11 @@ USERS
   restored by setting it to "only". The new behavior of "1" is
   more useful, especially in Wayland (due to forced mouse grab
   when the system cursor is hidden).
-+ Fixed window resize bugs in Linux (particularly Wayland)
-  caused by MZX recreating the window every time a window resize
-  event was received.
++ macOS now enables fullscreen_windowed by default to work
+  around macOS bugs involving real fullscreen and maximizing.
++ Fixed window resize bugs in Windows, macOS, Linux/BSD (both
+  X11 and Wayland), and probably other operating systems caused
+  by MZX recreating the window after every window resize event.
 + Fixed junk display in the letterbox area after resizing using
   the software, gp2x, or SDL 1.2 overlay renderers.
 + Fixed sai.frag not being installed by "make install" or

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -14,10 +14,37 @@ USERS
   Original Sound Blaster with the old DSP is still unsupported.
 + The DOS port and SDL ports now support mono audio. Mono can be
   selected with the new config option "audio_output_channels".
++ Setting the config option "system_mouse" to "1" or "on" will
+  no longer disable the software cursor. The old behavior can be
+  restored by setting it to "only". The new behavior of "1" is
+  more useful, especially in Wayland (due to forced mouse grab
+  when the system cursor is hidden).
++ Fixed window resize bugs in Linux (particularly Wayland)
+  caused by MZX recreating the window every time a window resize
+  event was received.
++ Fixed sai.frag not being installed by "make install" or
+  distributed with Unix-style packages for Linux/BSD/Darwin.
 + Fixed the board editor show thing hotkeys (broken by 2.93b).
 
 DEVELOPERS
 
++ Split the renderer function "set_video_mode" into two renderer
+  functions "create_window" and "resize_window" to more closely
+  reflect the reality of SDL2/3. The former is used during
+  renderer init and is mandatory; the latter is used to resize
+  and update other window settings like mouse grab/visibility
+  e.g. when switching to/from fullscreen, and is optional. If
+  it is not provided, switching to/from fullscreen will do
+  nothing. "resize_window" is also invoked in SDL 1.2 when a
+  window resize event is received. Some renderers (software,
+  gp2x) still use the same implementation for both functions.
++ Renamed the renderer function "resize_screen" to
+  "resize_callback" to more accurately reflect its purpose. It
+  is called in response to SDL2/3 window resize events and after
+  "resize_window" (by the video functions that call it, see
+  above). This function is now responsible for post-resize
+  maintenance such as glViewport and selecting the filter mode,
+  and is no longer required to call update_screen.
 + Added detection for LoongArch64. 64-bit architectures that
   platform_endian.h fails to identify as such should no longer
   abort in the software layer renderer.

--- a/src/SDLmzx.h
+++ b/src/SDLmzx.h
@@ -99,13 +99,6 @@ static inline void SDL_SetWindowIcon(SDL_Window *window, SDL_Surface *icon)
    SDL_WM_SetIcon(icon, NULL);
 }
 
-static inline void SDL_SetWindowGrab(SDL_Window *window, SDL_bool grabbed)
-{
-  // Not a perfect equivalent; the SDL 1.2 version will grab even if unfocused
-  SDL_GrabMode mode = (grabbed == SDL_TRUE) ? SDL_GRAB_ON : SDL_GRAB_OFF;
-  SDL_WM_GrabInput(mode);
-}
-
 static inline char *SDL_GetCurrentVideoDriver(void)
 {
   static char namebuf[16];

--- a/src/SDLmzx.h
+++ b/src/SDLmzx.h
@@ -71,7 +71,7 @@ typedef Uint32 SDL_threadID;
 
 #define SDL_SetEventFilter(filter, userdata) SDL_SetEventFilter(filter)
 
-#ifdef CONFIG_X11
+#if defined(_WIN32) || defined(CONFIG_X11)
 static inline SDL_bool SDL_GetWindowWMInfo(SDL_Window *window,
                                            SDL_SysWMinfo *info)
 {

--- a/src/compat.h
+++ b/src/compat.h
@@ -65,7 +65,8 @@
 #define __M_BEGIN_DECLS
 #define __M_END_DECLS
 
-#if !defined(CONFIG_WII) && !defined(CONFIG_NDS) && !defined(CONFIG_3DS)
+#if !defined(CONFIG_WII) && !defined(CONFIG_NDS) && !defined(CONFIG_3DS) && \
+ !defined(CONFIG_DREAMCAST)
 
 #undef false
 #undef true

--- a/src/configure.c
+++ b/src/configure.c
@@ -49,6 +49,13 @@
 #define UPDATE_AUTO_CHECK_DEFAULT UPDATE_AUTO_CHECK_SILENT
 #endif
 
+#ifdef __APPLE__
+// Regular fullscreen behaves badly in conjunction with the maximized
+// fullscreen behavior in Mac OS X Lion and later, and can lock the
+// computer on a black screen in Monterey.
+#define FULLSCREEN_WINDOWED_DEFAULT true
+#endif
+
 #ifdef CONFIG_NDS
 #define VIDEO_OUTPUT_DEFAULT "nds"
 #define VIDEO_RATIO_DEFAULT RATIO_CLASSIC_4_3
@@ -199,6 +206,10 @@
 #define FULLSCREEN_DEFAULT 0
 #endif
 
+#ifndef FULLSCREEN_WINDOWED_DEFAULT
+#define FULLSCREEN_WINDOWED_DEFAULT false
+#endif
+
 #ifndef VIDEO_RATIO_DEFAULT
 #define VIDEO_RATIO_DEFAULT RATIO_MODERN_64_35
 #endif
@@ -267,7 +278,7 @@ static const struct config_info user_conf_default =
 {
   // Video options
   FULLSCREEN_DEFAULT,           // fullscreen
-  false,                        // fullscreen_windowed
+  FULLSCREEN_WINDOWED_DEFAULT,  // fullscreen_windowed
   FULLSCREEN_WIDTH_DEFAULT,     // resolution_width
   FULLSCREEN_HEIGHT_DEFAULT,    // resolution_height
   640,                          // window_width

--- a/src/configure.c
+++ b/src/configure.c
@@ -319,7 +319,7 @@ static const struct config_info user_conf_default =
   false,                        // startup_editor
   false,                        // standalone_mode
   false,                        // no_titlescreen
-  false,                        // system_mouse
+  SYSTEM_MOUSE_OFF,             // system_mouse
   false,                        // grab_mouse
   SAVE_SLOTS_DEFAULT,           // save_slots
   "%w.",                        // save_slots_name
@@ -422,8 +422,11 @@ static const struct config_enum cursor_hint_type_values[] =
 
 static const struct config_enum system_mouse_values[] =
 {
-  { "0", 0 },
-  { "1", 1 }
+  { "0", SYSTEM_MOUSE_OFF },
+  { "1", SYSTEM_MOUSE_ON },
+  { "off", SYSTEM_MOUSE_OFF },
+  { "on", SYSTEM_MOUSE_ON },
+  { "only", SYSTEM_MOUSE_HIDE_SOFTWARE_MOUSE },
 };
 
 static const struct config_enum screensaver_disable_values[] =

--- a/src/configure.h
+++ b/src/configure.h
@@ -63,6 +63,14 @@ enum gl_filter_type
   NUM_GL_FILTER_TYPES
 };
 
+enum system_mouse_type
+{
+  SYSTEM_MOUSE_OFF,
+  SYSTEM_MOUSE_ON,
+  SYSTEM_MOUSE_HIDE_SOFTWARE_MOUSE,
+  NUM_SYSTEM_MOUSE_TYPES
+};
+
 enum cursor_mode_types
 {
   CURSOR_MODE_UNDERLINE,  // Underline for text entry (insert).
@@ -162,7 +170,7 @@ struct config_info
   boolean startup_editor;
   boolean standalone_mode;
   boolean no_titlescreen;
-  boolean system_mouse;
+  enum system_mouse_type system_mouse;
   boolean grab_mouse;
   boolean save_slots;
   char save_slots_name[256];

--- a/src/core.c
+++ b/src/core.c
@@ -741,7 +741,7 @@ static boolean core_draw(core_context *root)
   }
 
 #ifdef CONFIG_FPS
-  if(is_fullscreen() && ctx_data->context_type != CTX_EDITOR)
+  if(video_is_fullscreen() && ctx_data->context_type != CTX_EDITOR)
   {
     // If we're in fullscreen mode, draw an onscreen FPS display.
     char fpsbuf[32];

--- a/src/editor/clipboard_x11.c
+++ b/src/editor/clipboard_x11.c
@@ -26,7 +26,7 @@
 
 #if defined(CONFIG_SDL)
 #include "../SDLmzx.h"
-#include "../graphics.h"
+#include "../render_sdl.h"
 #endif
 
 static char **copy_buffer;
@@ -88,9 +88,8 @@ static inline int event_callback(const SDL_Event *event)
 
 static inline void set_X11_event_callback(void)
 {
-  const struct video_window *_window = video_get_window(1);
   SDL_EventState(SDL_SYSWMEVENT, SDL_ENABLE);
-  SDL_SetEventFilter(event_callback, SDL_GetWindowFromID(_window->platform_id));
+  SDL_SetEventFilter(event_callback, sdl_get_current_window());
 }
 
 #endif /* SDL_VERSION_ATLEAST(1,2,0) */

--- a/src/editor/clipboard_x11.c
+++ b/src/editor/clipboard_x11.c
@@ -26,7 +26,7 @@
 
 #if defined(CONFIG_SDL)
 #include "../SDLmzx.h"
-#include "../render_sdl.h"
+#include "../graphics.h"
 #endif
 
 static char **copy_buffer;
@@ -46,7 +46,10 @@ static inline boolean get_X11_display_and_window(SDL_Window *window,
   SDL_VERSION(&info.version);
 
   if(!window)
-    window = SDL_GetWindowFromID(sdl_window_id);
+  {
+    const struct video_window *_window = video_get_window(1);
+    window = SDL_GetWindowFromID(_window->platform_id);
+  }
   if(!window || !SDL_GetWindowWMInfo(window, &info) || info.subsystem != SDL_SYSWM_X11)
     return false;
 
@@ -87,8 +90,9 @@ static inline int event_callback(const SDL_Event *event)
 
 static inline void set_X11_event_callback(void)
 {
+  const struct video_window *_window = video_get_window(1);
   SDL_EventState(SDL_SYSWMEVENT, SDL_ENABLE);
-  SDL_SetEventFilter(event_callback, SDL_GetWindowFromID(sdl_window_id));
+  SDL_SetEventFilter(event_callback, SDL_GetWindowFromID(_window->platform_id));
 }
 
 #endif /* SDL_VERSION_ATLEAST(1,2,0) */

--- a/src/editor/clipboard_x11.c
+++ b/src/editor/clipboard_x11.c
@@ -46,10 +46,8 @@ static inline boolean get_X11_display_and_window(SDL_Window *window,
   SDL_VERSION(&info.version);
 
   if(!window)
-  {
-    const struct video_window *_window = video_get_window(1);
-    window = SDL_GetWindowFromID(_window->platform_id);
-  }
+    window = sdl_get_current_window();
+
   if(!window || !SDL_GetWindowWMInfo(window, &info) || info.subsystem != SDL_SYSWM_X11)
     return false;
 

--- a/src/event_sdl.c
+++ b/src/event_sdl.c
@@ -1079,8 +1079,7 @@ static boolean process_event(SDL_Event *event)
 
     case SDL_MOUSEMOTION:
     {
-      const struct video_window *_window = video_get_window(1);
-      SDL_Window *window = SDL_GetWindowFromID(_window->platform_id);
+      SDL_Window *window = sdl_get_current_window();
       int mx_real = event->motion.x;
       int my_real = event->motion.y;
       int mx, my, min_x, min_y, max_x, max_y;
@@ -1648,8 +1647,7 @@ void __wait_event(void)
 
 void __warp_mouse(int x, int y)
 {
-  const struct video_window *_window = video_get_window(1);
-  SDL_Window *window = SDL_GetWindowFromID(_window->platform_id);
+  SDL_Window *window = sdl_get_current_window();
 
   if((x < 0) || (y < 0))
   {

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1861,13 +1861,17 @@ unsigned video_create_window(void)
     window->width_px = graphics.resolution_width;
     window->height_px = graphics.resolution_height;
 
+#ifdef CONFIG_SDL
     // If fullscreen_windowed is enabled, the driver should automatically pick
     // the size of the window in all situations.
+    // TODO: too many console renderers are forcing resolution in init_video,
+    // so only do this for SDL.
     if(graphics.fullscreen_windowed)
     {
       window->width_px = -1;
       window->height_px = -1;
     }
+#endif
   }
   else
   {

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1885,13 +1885,6 @@ unsigned video_create_window(void)
     set_window_caption(graphics.default_caption);
     set_window_icon();
 
-    // Store the final fullscreen size--it was likely modified.
-    if(graphics.fullscreen)
-    {
-      graphics.resolution_width = window->width_px;
-      graphics.resolution_height = window->height_px;
-    }
-
     // Make sure a BPP was selected by the renderer (if applicable).
     if(window->bits_per_pixel == BPP_AUTO)
       warn("renderer.create_window must auto-select BPP! Report this!\n");

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1263,7 +1263,8 @@ void update_screen(void)
     }
   }
 
-  if(graphics.mouse_status)
+  if(graphics.mouse_status &&
+   graphics.system_mouse != SYSTEM_MOUSE_HIDE_SOFTWARE_MOUSE)
   {
     int mouse_x, mouse_y;
     get_mouse_pixel_position(&mouse_x, &mouse_y);
@@ -1472,7 +1473,7 @@ static boolean set_graphics_output(struct config_info *conf)
 
   renderer->reg(&graphics.renderer);
   graphics.renderer_num = i;
-  graphics.renderer_is_headless = false;
+  graphics.window.is_init = false;
 
   debug("Video: using '%s' renderer.\n", renderer->name);
   return true;
@@ -1522,18 +1523,10 @@ static SDL_Surface *png_read_icon(const char *name)
 
 #endif // CONFIG_PNG && CONFIG_SDL && CONFIG_ICON && !__WIN32__
 
-static void set_window_grab(boolean grabbed)
-{
-#ifdef CONFIG_SDL
-  SDL_Window *window = SDL_GetWindowFromID(sdl_window_id);
-  SDL_SetWindowGrab(window, grabbed ? SDL_TRUE : SDL_FALSE);
-#endif
-}
-
 void set_window_caption(const char *caption)
 {
 #ifdef CONFIG_SDL
-  SDL_Window *window = SDL_GetWindowFromID(sdl_window_id);
+  SDL_Window *window = SDL_GetWindowFromID(graphics.window.platform_id);
   SDL_SetWindowTitle(window, caption);
 #endif
 }
@@ -1557,7 +1550,7 @@ static void set_window_icon(void)
     HICON icon = LoadIcon(GetModuleHandle(NULL), MAKEINTRESOURCE(1));
     if(icon)
     {
-      SDL_Window *window = SDL_GetWindowFromID(sdl_window_id);
+      SDL_Window *window = SDL_GetWindowFromID(graphics.window.platform_id);
       SendMessage(SDL_GetWindowProperty_HWND(window),
        WM_SETICON, ICON_BIG, (LPARAM)icon);
     }
@@ -1568,7 +1561,7 @@ static void set_window_icon(void)
     SDL_Surface *icon = png_read_icon(ICONFILE);
     if(icon)
     {
-      SDL_Window *window = SDL_GetWindowFromID(sdl_window_id);
+      SDL_Window *window = SDL_GetWindowFromID(graphics.window.platform_id);
       SDL_SetWindowIcon(window, icon);
       SDL_FreeSurface(icon);
     }
@@ -1731,6 +1724,19 @@ void destruct_layers(void)
   graphics.layer_count = 0;
 }
 
+static boolean try_init_video(struct config_info *conf)
+{
+  if(graphics.renderer.init_video(&graphics, conf))
+  {
+    if(video_create_window())
+      return true;
+
+    if(graphics.renderer.free_video)
+      graphics.renderer.free_video(&graphics);
+  }
+  return false;
+}
+
 boolean init_video(struct config_info *conf, const char *caption)
 {
   graphics.screen_mode = 0;
@@ -1760,27 +1766,10 @@ boolean init_video(struct config_info *conf, const char *caption)
 
   if(conf->resolution_width <= 0 || conf->resolution_height <= 0)
   {
-#ifdef CONFIG_SDL
-    // TODO maybe be able to communicate with the renderer instead of this hack
-    boolean is_scaling = true;
-    int width;
-    int height;
-
-    if(!strcmp(conf->video_output, "software"))
-      is_scaling = false;
-
-    if(sdl_get_fullscreen_resolution(&width, &height, is_scaling))
-    {
-      graphics.resolution_width = width;
-      graphics.resolution_height = height;
-    }
-    else
-#endif
-    {
-      // "Safe" resolution
-      graphics.resolution_width = 640;
-      graphics.resolution_height = 480;
-    }
+    // The driver should attempt to pick the best resolution automatically.
+    // Not all create_window implementations support this.
+    graphics.resolution_width = -1;
+    graphics.resolution_height = -1;
   }
 
   if(conf->window_width <= 0 || conf->window_height <= 0)
@@ -1791,7 +1780,7 @@ boolean init_video(struct config_info *conf, const char *caption)
 
   snprintf(graphics.default_caption, 32, "%s", caption);
 
-  if(!graphics.renderer.init_video(&graphics, conf))
+  if(!try_init_video(conf))
   {
     // Try falling back to the first registered renderer
     debug("Failed to initialize '%s', attempting fallback.\n", conf->video_output);
@@ -1799,7 +1788,7 @@ boolean init_video(struct config_info *conf, const char *caption)
     if(!set_graphics_output(conf))
       return false;
 
-    if(!graphics.renderer.init_video(&graphics, conf))
+    if(!try_init_video(conf))
     {
       // One last attempt with the "safest" settings.
       // NOTE: this was originally done in set_video_mode.
@@ -1810,18 +1799,13 @@ boolean init_video(struct config_info *conf, const char *caption)
       graphics.allow_resize = false;
       conf->force_bpp = BPP_AUTO;
 
-      if(!graphics.renderer.init_video(&graphics, conf))
+      if(!try_init_video(conf))
       {
         warn("Failed to initialize video.\n");
         return false;
       }
     }
   }
-
-#ifdef CONFIG_SDL
-  if(!graphics.system_mouse)
-    SDL_ShowCursor(SDL_DISABLE);
-#endif
 
   ec_load_set_secondary(mzx_res_get_by_id(MZX_DEFAULT_CHR),
    graphics.default_charset);
@@ -1841,6 +1825,7 @@ void quit_video(void)
     graphics.renderer.free_video(&graphics);
 
   destruct_layers();
+  graphics.window.is_init = false;
 }
 
 boolean has_video_initialized(void)
@@ -1852,58 +1837,191 @@ boolean has_video_initialized(void)
 #endif /* CONFIG_SDL */
 
   // Renderers can also report as headless.
-  if(graphics.renderer_is_headless)
+  if(graphics.window.is_init && graphics.window.is_headless)
     return false;
 
   return graphics.is_initialized;
 }
 
-boolean set_video_mode(void)
+unsigned video_create_window(void)
 {
-  int target_width, target_height;
-  int target_depth = graphics.bits_per_pixel;
-  boolean fullscreen = graphics.fullscreen;
-  boolean resize = graphics.allow_resize;
-  boolean ret;
+  struct video_window *window = &(graphics.window);
 
-#ifdef CONFIG_SDL
-  if(fullscreen && graphics.fullscreen_windowed)
+  if(window->is_init)
+    return false;
+
+  window->bits_per_pixel = graphics.bits_per_pixel;
+  window->is_fullscreen = graphics.fullscreen;
+  window->is_fullscreen_windowed = graphics.fullscreen_windowed;
+  window->is_headless = false;
+  window->allow_resize = graphics.allow_resize;
+
+  if(graphics.fullscreen)
   {
-    // TODO maybe be able to communicate with the renderer instead of this hack
-    if(sdl_get_fullscreen_resolution(&target_width, &target_height, true))
+    window->width_px = graphics.resolution_width;
+    window->height_px = graphics.resolution_height;
+
+    // If fullscreen_windowed is enabled, the driver should automatically pick
+    // the size of the window in all situations.
+    if(graphics.fullscreen_windowed)
     {
-      graphics.resolution_width = target_width;
-      graphics.resolution_height = target_height;
+      window->width_px = -1;
+      window->height_px = -1;
     }
-  }
-#endif
-
-  if(fullscreen)
-  {
-    target_width = graphics.resolution_width;
-    target_height = graphics.resolution_height;
   }
   else
   {
-    target_width = graphics.window_width;
-    target_height = graphics.window_height;
+    window->width_px = graphics.window_width;
+    window->height_px = graphics.window_height;
   }
 
-  ret = graphics.renderer.set_video_mode(&graphics,
-   target_width, target_height, target_depth, fullscreen, resize);
-
-  if(ret)
+  if(graphics.renderer.create_window(&graphics, window))
   {
+    window->is_init = true;
     set_window_caption(graphics.default_caption);
-    set_window_grab(graphics.grab_mouse);
     set_window_icon();
 
-    // Make sure a BPP was selected by the renderer (if applicable).
-    if(graphics.bits_per_pixel == BPP_AUTO)
-      warn("renderer.set_video_mode must auto-select BPP! Report this!\n");
-  }
+    // Store the final fullscreen size--it was likely modified.
+    if(graphics.fullscreen)
+    {
+      graphics.resolution_width = window->width_px;
+      graphics.resolution_height = window->height_px;
+    }
 
-  return ret;
+    // Make sure a BPP was selected by the renderer (if applicable).
+    if(window->bits_per_pixel == BPP_AUTO)
+      warn("renderer.create_window must auto-select BPP! Report this!\n");
+
+    return 1;
+  }
+  return 0;
+}
+
+static boolean valid_window_id(unsigned window_id)
+{
+  return window_id == 1;
+}
+
+const struct video_window *video_get_window(unsigned window_id)
+{
+  if(valid_window_id(window_id))
+    return &graphics.window;
+
+  return NULL;
+}
+
+unsigned video_window_by_platform_id(unsigned platform_id)
+{
+  if(graphics.window.platform_id == platform_id)
+    return 1;
+
+  return 0;
+}
+
+/* Sync the current window size after it has ALREADY been changed by the
+ * platform or by a call to a graphics.c window resize function.
+ * SDL2/3 reports a window resize event after it is resized;
+ * this is the only situation in which this should be called anywhere else. */
+void video_sync_window_size(unsigned window_id,
+ unsigned new_width_px, unsigned new_height_px)
+{
+  if(valid_window_id(window_id))
+  {
+    graphics.window.width_px = new_width_px;
+    graphics.window.height_px = new_height_px;
+
+    if(graphics.window.is_fullscreen)
+    {
+      graphics.resolution_width = new_width_px;
+      graphics.resolution_height = new_height_px;
+    }
+    else
+    {
+      graphics.window_width = new_width_px;
+      graphics.window_height = new_height_px;
+    }
+    // TODO: call fix_viewport_ratio and update the viewport position here
+    // instead of in 50 million other places.
+
+    if(graphics.renderer.resize_callback)
+      graphics.renderer.resize_callback(&graphics, &graphics.window);
+
+    graphics.palette_dirty = true;
+    update_screen();
+  }
+}
+
+static void resize_window(unsigned window_id, boolean fullscreen)
+{
+  if(graphics.renderer.resize_window)
+  {
+    if(fullscreen)
+    {
+      graphics.window.width_px = graphics.resolution_width;
+      graphics.window.height_px = graphics.resolution_height;
+    }
+    else
+    {
+      graphics.window.width_px = graphics.window_width;
+      graphics.window.height_px = graphics.window_height;
+    }
+    graphics.window.is_fullscreen = fullscreen;
+    graphics.fullscreen = fullscreen;
+
+    graphics.renderer.resize_window(&graphics, &graphics.window);
+
+    // Renderer resize_window may have modified the requested dimensions.
+    video_sync_window_size(window_id,
+     graphics.window.width_px, graphics.window.height_px);
+  }
+}
+
+/* Change the current window size. This should NOT be called in response to
+ * SDL2/3 window resize events, but when something in MegaZeux explicitly
+ * wants the window size to change. If currently in fullscreen, this switches
+ * to windowed mode. */
+void video_resize_window(unsigned window_id,
+ unsigned new_width_px, unsigned new_height_px)
+{
+  if(graphics.renderer.resize_window && valid_window_id(window_id))
+  {
+    graphics.window_width = new_width_px;
+    graphics.window_height = new_height_px;
+    resize_window(window_id, false);
+  }
+}
+
+/* Set the current fullscreen size and switch to fullscreen mode. */
+void video_resize_fullscreen(unsigned window_id,
+ unsigned new_width_px, unsigned new_height_px)
+{
+  if(graphics.renderer.resize_window && valid_window_id(window_id))
+  {
+    graphics.resolution_width = new_width_px;
+    graphics.resolution_height = new_height_px;
+    resize_window(window_id, true);
+  }
+}
+
+void video_toggle_fullscreen(void)
+{
+  unsigned current_fullscreen = video_get_fullscreen_window();
+  if(current_fullscreen)
+    resize_window(current_fullscreen, false);
+  else
+    resize_window(1, true);
+}
+
+unsigned video_get_fullscreen_window(void)
+{
+  if(graphics.window.is_fullscreen)
+    return 1;
+  return 0;
+}
+
+boolean video_is_fullscreen(void)
+{
+  return video_get_fullscreen_window() > 0;
 }
 
 boolean change_video_output(struct config_info *conf, const char *output)
@@ -1924,7 +2042,7 @@ boolean change_video_output(struct config_info *conf, const char *output)
 
   set_graphics_output(conf);
 
-  if(!graphics.renderer.init_video(&graphics, conf))
+  if(!try_init_video(conf))
   {
     retval = false;
 
@@ -1936,7 +2054,7 @@ boolean change_video_output(struct config_info *conf, const char *output)
     }
     else
 
-    if(!graphics.renderer.init_video(&graphics, conf))
+    if(!try_init_video(conf))
     {
       warn("Failed to roll back video mode!\n");
       fallback = true;
@@ -1959,7 +2077,7 @@ boolean change_video_output(struct config_info *conf, const char *output)
       exit(1);
     }
 
-    if(!graphics.renderer.init_video(&graphics, conf))
+    if(!try_init_video(conf))
     {
       warn("Failed to set fallback video mode, aborting!\n");
       exit(1);
@@ -1988,38 +2106,6 @@ int get_available_video_output_list(const char **buffer, int buffer_len)
 int get_current_video_output(void)
 {
   return graphics.renderer_num;
-}
-
-boolean is_fullscreen(void)
-{
-  return graphics.fullscreen;
-}
-
-void toggle_fullscreen(void)
-{
-  graphics.fullscreen = !graphics.fullscreen;
-  graphics.palette_dirty = true;
-  if(!set_video_mode())
-  {
-    warn("Failed to set video mode toggling fullscreen. Aborting\n");
-    exit(1);
-  }
-  update_screen();
-}
-
-void resize_screen(unsigned int w, unsigned int h)
-{
-  if(!graphics.fullscreen && graphics.allow_resize)
-  {
-    graphics.window_width = w;
-    graphics.window_height = h;
-    if(!set_video_mode())
-    {
-      warn("Failed to set video mode resizing window. Aborting\n");
-      exit(1);
-    }
-    graphics.renderer.resize_screen(&graphics, w, h);
-  }
 }
 
 static void dirty_ui(void)
@@ -2586,14 +2672,12 @@ void cursor_off(void)
 
 void m_hide(void)
 {
-  if(!graphics.system_mouse)
-    graphics.mouse_status = false;
+  graphics.mouse_status = false;
 }
 
 void m_show(void)
 {
-  if(!graphics.system_mouse)
-    graphics.mouse_status = true;
+  graphics.mouse_status = true;
 }
 
 void mouse_size(unsigned int width, unsigned int height)

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -113,17 +113,18 @@ enum write_string_flags
 
 struct graphics_data;
 struct video_layer;
+struct video_window;
 
 struct renderer
 {
   boolean (*init_video)       (struct graphics_data *, struct config_info *);
   void    (*free_video)       (struct graphics_data *);
-  boolean (*set_video_mode)   (struct graphics_data *, int width, int height,
-                                int depth, boolean fullscreen, boolean resize);
+  boolean (*create_window)    (struct graphics_data *, struct video_window *);
+  boolean (*resize_window)    (struct graphics_data *, struct video_window *);
+  boolean (*resize_callback)  (struct graphics_data *, struct video_window *);
   boolean (*set_screen_mode)  (struct graphics_data *, unsigned mode);
   void    (*update_colors)    (struct graphics_data *, struct rgb_color *palette,
                                 unsigned int count);
-  void    (*resize_screen)    (struct graphics_data *, int width, int height);
   void    (*remap_char_range) (struct graphics_data *, uint16_t first, uint16_t count);
   void    (*remap_char)       (struct graphics_data *, uint16_t chr);
   void    (*remap_charbyte)   (struct graphics_data *, uint16_t chr, uint8_t byte);
@@ -161,8 +162,31 @@ struct video_layer
   boolean empty;
 };
 
+struct video_window
+{
+  unsigned platform_id;
+  // Real size of the window.
+  unsigned width_px;
+  unsigned height_px;
+  // Scaled viewport size within the window (fix_viewport_ratio).
+  //unsigned viewport_x;
+  //unsigned viewport_y;
+  //unsigned viewport_width;
+  //unsigned viewport_height;
+
+  unsigned bits_per_pixel;
+  boolean is_init;
+  boolean is_headless;
+  // These properties are refreshed by calling resize_window.
+  boolean is_fullscreen;
+  boolean is_fullscreen_windowed;
+  boolean allow_resize;
+  boolean grab_mouse;
+};
+
 struct graphics_data
 {
+  struct video_window window;
   unsigned int screen_mode;
   char default_caption[32];
   struct char_element text_video[SCREEN_W * SCREEN_H];
@@ -176,7 +200,6 @@ struct graphics_data
   uint32_t saved_intensity[SMZX_PAL_SIZE];
   uint32_t backup_intensity[SMZX_PAL_SIZE];
   boolean is_initialized;
-  boolean renderer_is_headless;
   boolean default_smzx_loaded;
   boolean palette_dirty;
   boolean smzx_dirty;
@@ -201,8 +224,8 @@ struct graphics_data
   uint32_t cursor_timestamp;
   unsigned int mouse_width;
   unsigned int mouse_height;
+  enum system_mouse_type system_mouse;
   boolean mouse_status;
-  boolean system_mouse;
   boolean grab_mouse;
   boolean fullscreen;
   boolean fullscreen_windowed;
@@ -336,10 +359,19 @@ boolean change_video_output(struct config_info *conf, const char *output);
 int get_available_video_output_list(const char **buffer, int buffer_len);
 int get_current_video_output(void);
 
-boolean set_video_mode(void);
-boolean is_fullscreen(void);
-void toggle_fullscreen(void);
-void resize_screen(unsigned int w, unsigned int h);
+unsigned video_create_window(void);
+CORE_LIBSPEC const struct video_window *video_get_window(unsigned window_id);
+unsigned video_window_by_platform_id(unsigned platform_id);
+void video_sync_window_size(unsigned window_id,
+ unsigned new_width_px, unsigned new_height_px);
+void video_resize_window(unsigned window_id,
+ unsigned new_width_px, unsigned new_height_px);
+void video_resize_fullscreen(unsigned window_id,
+ unsigned new_width_px, unsigned new_height_px);
+void video_toggle_fullscreen(void);
+unsigned video_get_fullscreen_window(void);
+boolean video_is_fullscreen(void);
+
 void set_screen(struct char_element *src);
 void get_screen(struct char_element *dest);
 

--- a/src/render.c
+++ b/src/render.c
@@ -650,9 +650,3 @@ void fix_viewport_ratio(int width, int height, int *v_width, int *v_height,
 
 #endif /* CONFIG_RENDER_GL_FIXED || CONFIG_RENDER_GL_PROGRAM ||
  CONFIG_RENDER_YUV || CONFIG_RENDER_GX */
-
-void resize_screen_standard(struct graphics_data *graphics, int w, int h)
-{
-  graphics->palette_dirty = true;
-  update_screen();
-}

--- a/src/render.h
+++ b/src/render.h
@@ -80,8 +80,6 @@ void fix_viewport_ratio(int width, int height, int *v_width, int *v_height,
 #endif /* CONFIG_RENDER_GL_FIXED || CONFIG_RENDER_GL_PROGRAM ||
  CONFIG_RENDER_YUV || CONFIG_RENDER_GX */
 
-void resize_screen_standard(struct graphics_data *graphics, int w, int h);
-
 __M_END_DECLS
 
 #endif // __RENDER_H

--- a/src/render_egl.c
+++ b/src/render_egl.c
@@ -234,7 +234,7 @@ err_cleanup:
 boolean gl_resize_window(struct graphics_data *graphics,
  struct video_window *window)
 {
-  struct gl_version dummy = {}; // TODO: fix this
+  struct gl_version dummy = { 0, 0 }; // TODO: fix this
   gl_cleanup(graphics);
   return gl_create_window(graphics, window, dummy);
 }

--- a/src/render_egl.h
+++ b/src/render_egl.h
@@ -28,8 +28,10 @@ __M_BEGIN_DECLS
 
 #include <EGL/egl.h>
 
-boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
- int depth, boolean fullscreen, boolean resize, struct gl_version req_ver);
+boolean gl_create_window(struct graphics_data *graphics,
+ struct video_window *window, struct gl_version req_ver);
+boolean gl_resize_window(struct graphics_data *graphics,
+ struct video_window *window);
 void gl_set_attributes(struct graphics_data *graphics);
 boolean gl_swap_buffers(struct graphics_data *graphics);
 void gl_cleanup(struct graphics_data *graphics);

--- a/src/render_gl1.c
+++ b/src/render_gl1.c
@@ -279,6 +279,18 @@ static void gl1_update_colors(struct graphics_data *graphics,
   }
 }
 
+static void gl1_render_graph(struct graphics_data *graphics)
+{
+  struct gl1_render_data *render_data = graphics->render_data;
+  unsigned int mode = graphics->screen_mode;
+  unsigned pitch = SCREEN_PIX_W * sizeof(uint32_t);
+
+  if(!mode)
+    render_graph32(render_data->pixels, pitch, graphics);
+  else
+    render_graph32s(render_data->pixels, pitch, graphics);
+}
+
 static void gl1_render_layer(struct graphics_data *graphics,
  struct video_layer *layer)
 {
@@ -350,6 +362,7 @@ void render_gl1_register(struct renderer *renderer)
   renderer->update_colors = gl1_update_colors;
   renderer->get_screen_coords = get_screen_coords_scaled;
   renderer->set_screen_coords = set_screen_coords_scaled;
+  renderer->render_graph = gl1_render_graph;
   renderer->render_layer = gl1_render_layer;
   renderer->render_cursor = gl1_render_cursor;
   renderer->render_mouse = gl1_render_mouse;

--- a/src/render_gl1.c
+++ b/src/render_gl1.c
@@ -109,15 +109,14 @@ struct gl1_render_data
   struct sdl_render_data sdl;
 #endif
   uint32_t *pixels;
-  unsigned int w;
-  unsigned int h;
   GLuint texture_number;
 };
 
 static boolean gl1_init_video(struct graphics_data *graphics,
  struct config_info *conf)
 {
-  struct gl1_render_data *render_data = cmalloc(sizeof(struct gl1_render_data));
+  struct gl1_render_data *render_data =
+   (struct gl1_render_data *)cmalloc(sizeof(struct gl1_render_data));
 
   if(!render_data)
     goto err_out;
@@ -139,9 +138,6 @@ static boolean gl1_init_video(struct graphics_data *graphics,
   if(conf->force_bpp == 16 || conf->force_bpp == 32)
     graphics->bits_per_pixel = conf->force_bpp;
 
-  if(!set_video_mode())
-    goto err_free_render_data;
-
   return true;
 
 err_free_render_data:
@@ -151,10 +147,12 @@ err_out:
   return false;
 }
 
-static void gl1_resize_screen(struct graphics_data *graphics,
- int width, int height)
+static boolean gl1_resize_callback(struct graphics_data *graphics,
+ struct video_window *window)
 {
   struct gl1_render_data *render_data = graphics->render_data;
+  int width = window->width_px;
+  int height = window->height_px;
   int v_width, v_height;
 
   get_context_width_height(graphics, &width, &height);
@@ -183,17 +181,17 @@ static void gl1_resize_screen(struct graphics_data *graphics,
    GL_POWER_2_HEIGHT, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   gl_set_filter_method(graphics->gl_filter_method, gl1.glTexParameterf);
+  return true;
 }
 
-static boolean gl1_set_video_mode(struct graphics_data *graphics,
- int width, int height, int depth, boolean fullscreen, boolean resize)
+static boolean gl1_create_window(struct graphics_data *graphics,
+ struct video_window *window)
 {
   struct gl1_render_data *render_data = graphics->render_data;
 
   gl_set_attributes(graphics);
 
-  if(!gl_set_video_mode(graphics, width, height, depth, fullscreen, resize,
-   gl_required_version))
+  if(!gl_create_window(graphics, window, gl_required_version))
     return false;
 
   gl_set_attributes(graphics);
@@ -237,18 +235,14 @@ static boolean gl1_set_video_mode(struct graphics_data *graphics,
   }
 #endif
 
-  render_data->pixels = cmalloc(sizeof(uint32_t) * SCREEN_PIX_W * SCREEN_PIX_H);
+  render_data->pixels = (uint32_t *)cmalloc(sizeof(uint32_t) * SCREEN_PIX_W * SCREEN_PIX_H);
   if(!render_data->pixels)
   {
     gl_cleanup(graphics);
     return false;
   }
 
-  render_data->w = SCREEN_PIX_W;
-  render_data->h = SCREEN_PIX_H;
-
-  gl1_resize_screen(graphics, width, height);
-  return true;
+  return gl1_resize_callback(graphics, window);
 }
 
 static void gl1_free_video(struct graphics_data *graphics)
@@ -282,24 +276,13 @@ static void gl1_update_colors(struct graphics_data *graphics,
   }
 }
 
-static void gl1_render_graph(struct graphics_data *graphics)
-{
-  struct gl1_render_data *render_data = graphics->render_data;
-  unsigned int mode = graphics->screen_mode;
-
-  if(!mode)
-    render_graph32(render_data->pixels, render_data->w * 4, graphics);
-  else
-    render_graph32s(render_data->pixels, render_data->w * 4, graphics);
-}
-
 static void gl1_render_layer(struct graphics_data *graphics,
  struct video_layer *layer)
 {
   struct gl1_render_data *render_data = graphics->render_data;
 
-  render_layer(render_data->pixels, render_data->w, render_data->h,
-   render_data->w * 4, 32, graphics, layer);
+  render_layer(render_data->pixels, SCREEN_PIX_W, SCREEN_PIX_H,
+   SCREEN_PIX_W * sizeof(uint32_t), 32, graphics, layer);
 }
 
 static void gl1_render_cursor(struct graphics_data *graphics, unsigned int x,
@@ -307,7 +290,7 @@ static void gl1_render_cursor(struct graphics_data *graphics, unsigned int x,
 {
   struct gl1_render_data *render_data = graphics->render_data;
 
-  render_cursor(render_data->pixels, render_data->w * 4, 32, x, y,
+  render_cursor(render_data->pixels, SCREEN_PIX_W * sizeof(uint32_t), 32, x, y,
    graphics->flat_intensity_palette[color], lines, offset);
 }
 
@@ -316,7 +299,7 @@ static void gl1_render_mouse(struct graphics_data *graphics,
 {
   struct gl1_render_data *render_data = graphics->render_data;
 
-  render_mouse(render_data->pixels, render_data->w * 4, 32, x, y, 0xFFFFFFFF,
+  render_mouse(render_data->pixels, SCREEN_PIX_W * sizeof(uint32_t), 32, x, y, 0xFFFFFFFF,
    0x0, w, h);
 }
 
@@ -334,7 +317,7 @@ static void gl1_sync_screen(struct graphics_data *graphics)
     texture_width, texture_height
   };
 
-  gl1.glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, render_data->w, render_data->h,
+  gl1.glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, SCREEN_PIX_W, SCREEN_PIX_H,
    GL_RGBA, GL_UNSIGNED_BYTE, render_data->pixels);
   gl_check_error();
 
@@ -358,12 +341,12 @@ void render_gl1_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = gl1_init_video;
   renderer->free_video = gl1_free_video;
-  renderer->set_video_mode = gl1_set_video_mode;
+  renderer->create_window = gl1_create_window;
+  renderer->resize_window = gl_resize_window;
+  renderer->resize_callback = gl1_resize_callback;
   renderer->update_colors = gl1_update_colors;
-  renderer->resize_screen = gl1_resize_screen;
   renderer->get_screen_coords = get_screen_coords_scaled;
   renderer->set_screen_coords = set_screen_coords_scaled;
-  renderer->render_graph = gl1_render_graph;
   renderer->render_layer = gl1_render_layer;
   renderer->render_cursor = gl1_render_cursor;
   renderer->render_mouse = gl1_render_mouse;

--- a/src/render_gl1.c
+++ b/src/render_gl1.c
@@ -251,8 +251,11 @@ static void gl1_free_video(struct graphics_data *graphics)
 
   if(render_data)
   {
-    gl1.glDeleteTextures(1, &render_data->texture_number);
-    gl_check_error();
+    if(gl1.glDeleteTextures)
+    {
+      gl1.glDeleteTextures(1, &render_data->texture_number);
+      gl_check_error();
+    }
 
     gl_cleanup(graphics);
     free(render_data);

--- a/src/render_gl2.c
+++ b/src/render_gl2.c
@@ -210,14 +210,20 @@ err_free_render_data:
 static void gl2_free_video(struct graphics_data *graphics)
 {
   struct gl2_render_data *render_data = graphics->render_data;
-  gl2.glDeleteTextures(NUM_TEXTURES, render_data->textures);
-  gl_check_error();
 
-  gl_cleanup(graphics);
+  if(render_data)
+  {
+    if(gl2.glDeleteTextures)
+    {
+      gl2.glDeleteTextures(NUM_TEXTURES, render_data->textures);
+      gl_check_error();
+    }
 
-  free(render_data->pixels);
-  free(render_data);
-  graphics->render_data = NULL;
+    gl_cleanup(graphics);
+    free(render_data->pixels);
+    free(render_data);
+    graphics->render_data = NULL;
+  }
 }
 
 static void gl2_remap_char_range(struct graphics_data *graphics, uint16_t first,

--- a/src/render_gl2.c
+++ b/src/render_gl2.c
@@ -170,10 +170,11 @@ static const GLubyte color_array_white[4 * 4] =
 static boolean gl2_init_video(struct graphics_data *graphics,
  struct config_info *conf)
 {
-  struct gl2_render_data *render_data = cmalloc(sizeof(struct gl2_render_data));
+  struct gl2_render_data *render_data =
+   (struct gl2_render_data *)cmalloc(sizeof(struct gl2_render_data));
 
   if(!render_data)
-    goto err_out;
+    return false;
 
   if(!GL_LoadLibrary(GL_LIB_FIXED))
     goto err_free_render_data;
@@ -192,23 +193,17 @@ static boolean gl2_init_video(struct graphics_data *graphics,
     graphics->bits_per_pixel = conf->force_bpp;
 
   // We want to deal internally with 32bit surfaces
-  render_data->pixels = cmalloc(sizeof(uint32_t) * GL_POWER_2_WIDTH *
+  render_data->pixels = (uint32_t *)cmalloc(sizeof(uint32_t) * GL_POWER_2_WIDTH *
    GL_POWER_2_HEIGHT);
 
   if(!render_data->pixels)
     goto err_free_render_data;
 
-  if(!set_video_mode())
-    goto err_free_pixels;
-
   return true;
 
-err_free_pixels:
-  free(render_data->pixels);
 err_free_render_data:
   free(render_data);
   graphics->render_data = NULL;
-err_out:
   return false;
 }
 
@@ -253,10 +248,12 @@ static void gl2_remap_charbyte(struct graphics_data *graphics,
   gl2_remap_char(graphics, chr);
 }
 
-static void gl2_resize_screen(struct graphics_data *graphics,
- int width, int height)
+static boolean gl2_resize_callback(struct graphics_data *graphics,
+ struct video_window *window)
 {
   struct gl2_render_data *render_data = graphics->render_data;
+  int width = window->width_px;
+  int height = window->height_px;
   int v_width, v_height;
   int charset_width, charset_height;
 
@@ -339,15 +336,15 @@ static void gl2_resize_screen(struct graphics_data *graphics,
   gl2.glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, TEX_BG_WIDTH, TEX_BG_HEIGHT,
    0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
   gl_check_error();
+  return true;
 }
 
-static boolean gl2_set_video_mode(struct graphics_data *graphics,
- int width, int height, int depth, boolean fullscreen, boolean resize)
+static boolean gl2_create_window(struct graphics_data *graphics,
+ struct video_window *window)
 {
   gl_set_attributes(graphics);
 
-  if(!gl_set_video_mode(graphics, width, height, depth, fullscreen, resize,
-   gl_required_version))
+  if(!gl_create_window(graphics, window, gl_required_version))
     return false;
 
   gl_set_attributes(graphics);
@@ -391,8 +388,7 @@ static boolean gl2_set_video_mode(struct graphics_data *graphics,
   }
 #endif
 
-  gl2_resize_screen(graphics, width, height);
-  return true;
+  return gl2_resize_callback(graphics, window);
 }
 
 static void gl2_update_colors(struct graphics_data *graphics,
@@ -1014,9 +1010,10 @@ void render_gl2_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = gl2_init_video;
   renderer->free_video = gl2_free_video;
-  renderer->set_video_mode = gl2_set_video_mode;
+  renderer->create_window = gl2_create_window;
+  renderer->resize_window = gl_resize_window;
+  renderer->resize_callback = gl2_resize_callback;
   renderer->update_colors = gl2_update_colors;
-  renderer->resize_screen = resize_screen_standard;
   renderer->remap_char_range = gl2_remap_char_range;
   renderer->remap_char = gl2_remap_char;
   renderer->remap_charbyte = gl2_remap_charbyte;

--- a/src/render_glsl.c
+++ b/src/render_glsl.c
@@ -716,7 +716,6 @@ err_free:
   return false;
 }
 
-// FIXME free more
 static void glsl_free_video(struct graphics_data *graphics)
 {
   struct glsl_render_data *render_data = graphics->render_data;
@@ -739,11 +738,14 @@ static void glsl_free_video(struct graphics_data *graphics)
       gl_check_error();
     }
 
-    glsl.glDeleteTextures(NUM_TEXTURES, render_data->textures);
-    gl_check_error();
+    if(glsl.glDeleteTextures)
+    {
+      glsl.glDeleteTextures(NUM_TEXTURES, render_data->textures);
+      gl_check_error();
 
-    glsl.glUseProgram(0);
-    gl_check_error();
+      glsl.glUseProgram(0);
+      gl_check_error();
+    }
 
     gl_cleanup(graphics);
     free(render_data->pixels);

--- a/src/render_gp2x.c
+++ b/src/render_gp2x.c
@@ -155,7 +155,7 @@ static boolean gp2x_init_video(struct graphics_data *graphics,
  struct config_info *conf)
 {
   struct gp2x_render_data *render_data =
-   cmalloc(sizeof(struct gp2x_render_data));
+   (struct gp2x_render_data *)cmalloc(sizeof(struct gp2x_render_data));
 
   if(!render_data)
     return false;
@@ -171,8 +171,7 @@ static boolean gp2x_init_video(struct graphics_data *graphics,
   graphics->resolution_height = 240;
   graphics->window_width = 320;
   graphics->window_height = 240;
-
-  return set_video_mode();
+  return true;
 }
 
 static void gp2x_free_video(struct graphics_data *graphics)
@@ -183,14 +182,14 @@ static void gp2x_free_video(struct graphics_data *graphics)
   graphics->render_data = NULL;
 }
 
-static boolean gp2x_set_video_mode(struct graphics_data *graphics,
- int width, int height, int depth, boolean fullscreen, boolean resize)
+static boolean gp2x_create_window(struct graphics_data *graphics,
+ struct video_window *window)
 {
   struct gp2x_render_data *render_data = graphics->render_data;
   const SDL_PixelFormat *format;
   uint32_t halfmask;
 
-  if(!sdl_set_video_mode(graphics, width, height, depth, fullscreen, resize))
+  if(!sdl_create_window_soft(graphics, window))
     return false;
 
   format = render_data->sdl.flat_format;
@@ -301,9 +300,9 @@ void render_gp2x_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = gp2x_init_video;
   renderer->free_video = gp2x_free_video;
-  renderer->set_video_mode = gp2x_set_video_mode;
+  renderer->create_window = gp2x_create_window;
+  renderer->resize_window = gp2x_create_window;
   renderer->update_colors = sdl_update_colors;
-  renderer->resize_screen = resize_screen_standard;
   renderer->get_screen_coords = gp2x_get_screen_coords;
   renderer->set_screen_coords = gp2x_set_screen_coords;
   renderer->render_graph = gp2x_render_graph;

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -1143,7 +1143,7 @@ boolean gl_resize_window(struct graphics_data *graphics,
 void gl_set_attributes(struct graphics_data *graphics)
 {
   // Note that this function is called twice- both before and after
-  // gl_set_video_mode
+  // gl_create_window
   SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 
   if(graphics->gl_vsync == 0)

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -994,7 +994,8 @@ void sdl_set_texture_scale_mode(struct graphics_data *graphics,
   if(render_data->texture[texture_id])
   {
     SDL_ScaleMode mode;
-    if(is_integer_scale(graphics, window->width_px, window->height_px))
+    if(!allow_non_integer ||
+     is_integer_scale(graphics, window->width_px, window->height_px))
       mode = SDL_ScaleModeNearest;
     else
       mode = SDL_ScaleModeLinear;

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -648,6 +648,9 @@ boolean sdl_create_window_soft(struct graphics_data *graphics,
 
 #endif // !SDL_VERSION_ATLEAST(2,0,0)
 
+  // Wipe the letterbox area, if any.
+  SDL_FillRect(render_data->screen, NULL, 0);
+
   SDL_SetWindowGrab(render_data->window, window->grab_mouse);
   sdl_set_system_cursor(graphics);
   return true;

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -26,7 +26,18 @@
 
 #include <limits.h>
 
-CORE_LIBSPEC Uint32 sdl_window_id;
+static void sdl_set_system_cursor(struct graphics_data *graphics)
+{
+#if SDL_VERSION_ATLEAST(3,0,0)
+  if(graphics->system_mouse == SYSTEM_MOUSE_OFF)
+    SDL_HideCursor();
+  else
+    SDL_ShowCursor();
+#else
+  int value = (graphics->system_mouse == SYSTEM_MOUSE_OFF) ? SDL_DISABLE : SDL_ENABLE;
+  SDL_ShowCursor(value);
+#endif
+}
 
 #if SDL_VERSION_ATLEAST(2,0,0)
 static void sdl_set_screensaver_enabled(boolean enable)
@@ -39,89 +50,110 @@ static void sdl_set_screensaver_enabled(boolean enable)
 }
 #endif
 
-int sdl_flags(int depth, boolean fullscreen, boolean fullscreen_windowed,
- boolean resize)
+int sdl_flags(const struct video_window *window)
 {
   int flags = 0;
 
-  if(fullscreen)
+  if(window->is_fullscreen)
   {
 #if SDL_VERSION_ATLEAST(2,0,0)
-    if(fullscreen_windowed)
-    {
-      // FIXME There's no built-in flag to achieve fake fullscreen. Disabling
-      // the border, ignoring the fullscreen flags, and using native resolution
-      // seems to be the best way to approximate it.
-      flags |= SDL_WINDOW_BORDERLESS;
-    }
+    if(window->is_fullscreen_windowed)
+      flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
     else
 #endif
       flags |= SDL_WINDOW_FULLSCREEN;
 
 #if !SDL_VERSION_ATLEAST(2,0,0)
-    if(depth == 8)
+    if(window->bits_per_pixel == 8)
       flags |= SDL_HWPALETTE;
 #endif
   }
   else
-    if(resize)
+    if(window->allow_resize)
       flags |= SDL_WINDOW_RESIZABLE;
 
   return flags;
 }
 
-boolean sdl_get_fullscreen_resolution(int *width, int *height, boolean scaling)
+#if SDL_VERSION_ATLEAST(2,0,0)
+// Get the current desktop resolution, if possible.
+static boolean sdl_get_desktop_display_mode(SDL_DisplayMode *display_mode)
+{
+  if(SDL_GetDesktopDisplayMode(0, display_mode) == 0)
+  {
+    debug("Queried desktop mode: %d x %d, %dHz, %s\n",
+     display_mode->w, display_mode->h, display_mode->refresh_rate,
+     SDL_GetPixelFormatName(display_mode->format));
+    return true;
+  }
+
+  warn("Failed to query desktop display mode: %s\n", SDL_GetError());
+
+  if(SDL_GetNumDisplayModes(0))
+    if(SDL_GetDisplayMode(0, 0, display_mode) == 0)
+      return true;
+
+  return false;
+}
+
+// Get the smallest possible resolution bigger than both 640x350 and requested.
+// Smaller means the software renderer will occupy more screen space.
+static boolean sdl_get_closest_usable_display_mode(SDL_DisplayMode *display_mode,
+ int width, int height)
+{
+  SDL_DisplayMode mode;
+  int min_size = INT_MAX;
+  int count;
+  int i;
+
+  count = SDL_GetNumDisplayModes(0);
+
+  debug("Display modes:\n");
+
+  for(i = 0; i < count; i++)
+  {
+    if(SDL_GetDisplayMode(0, i, &mode) != 0)
+      continue;
+
+    debug("%d: %d x %d, %dHz, %s\n", i, mode.w, mode.h, mode.refresh_rate,
+     SDL_GetPixelFormatName(mode.format));
+
+    if((mode.w * mode.h < min_size) && (mode.w >= width) && (mode.h >= height))
+    {
+      min_size = mode.w * mode.h;
+      *display_mode = mode;
+    }
+  }
+  if(min_size < INT_MAX)
+    return true;
+
+  return false;
+}
+#endif /* SDL_VERSION_ATLEAST(2,0,0) */
+
+static boolean sdl_get_fullscreen_resolution(int *width, int *height,
+ boolean renderer_supports_scaling)
 {
 #if SDL_VERSION_ATLEAST(2,0,0)
+
   SDL_DisplayMode display_mode;
   boolean have_mode = false;
-  int count;
-  int ret;
 
-  if(scaling)
+  if(renderer_supports_scaling)
   {
     // Use the current desktop resolution.
-    ret = SDL_GetDesktopDisplayMode(0, &display_mode);
-
-    if(ret)
-    {
-      count = SDL_GetNumDisplayModes(0);
-      if(count)
-        ret = SDL_GetDisplayMode(0, 0, &display_mode);
-    }
-    if(!ret)
-      have_mode = true;
+    have_mode = sdl_get_desktop_display_mode(&display_mode);
   }
   else
   {
-    // Get the smallest possible resolution bigger than 640x350.
-    // Smaller means the software renderer will occupy more screen space.
-    SDL_DisplayMode mode;
-    int min_size = INT_MAX;
-    int i;
-
-    count = SDL_GetNumDisplayModes(0);
-
-    debug("Display modes:\n");
-
-    for(i = 0; i < count; i++)
-    {
-      ret = SDL_GetDisplayMode(0, i, &mode);
-      debug("%d: %d x %d, %dHz, %s\n", i, mode.w, mode.h, mode.refresh_rate,
-       SDL_GetPixelFormatName(mode.format));
-
-      if(!ret && (mode.w * mode.h < min_size) &&
-       (mode.w >= SCREEN_PIX_W) && (mode.h >= SCREEN_PIX_H))
-      {
-        min_size = mode.w * mode.h;
-        display_mode = mode;
-        have_mode = true;
-      }
-    }
+    have_mode = sdl_get_closest_usable_display_mode(&display_mode, 320, 240);
   }
 
   if(have_mode)
   {
+    debug("\n");
+    debug("selected: %d x %d, %.02fHz, %s\n", display_mode.w, display_mode.h,
+     (float)display_mode.refresh_rate, SDL_GetPixelFormatName(display_mode.format));
     *width = display_mode.w;
     *height = display_mode.h;
     return true;
@@ -131,6 +163,35 @@ boolean sdl_get_fullscreen_resolution(int *width, int *height, boolean scaling)
 #endif
 
   return false;
+}
+
+/**
+ * Automatically detect and correct the fullscreen size if required.
+ * This should be done even if the window isn't initially fullscreen.
+ * If the window is fullscreen, the window size will also be updated.
+ */
+static void auto_fullscreen_size(struct graphics_data *graphics,
+ struct video_window *window, boolean renderer_supports_scaling)
+{
+  int width = graphics->resolution_width;
+  int height = graphics->resolution_height;
+
+  if(width < 0 || height < 0)
+  {
+    if(!sdl_get_fullscreen_resolution(&width, &height, renderer_supports_scaling))
+    {
+      width = 640;
+      height = 480;
+    }
+
+    graphics->resolution_width = width;
+    graphics->resolution_height = height;
+    if(window->is_fullscreen)
+    {
+      window->width_px = graphics->resolution_width;
+      window->height_px = graphics->resolution_height;
+    }
+  }
 }
 
 /**
@@ -238,13 +299,19 @@ static uint32_t sdl_pixel_format_priority(uint32_t pixel_format,
  * being picked by SDL (which needs to be checked for MZX support), MZX
  * instead needs to test its preferred pixel format by querying SDL.
  */
-boolean sdl_check_video_mode(struct graphics_data *graphics, int width,
- int height, int *depth, int flags)
+boolean sdl_check_video_mode(struct graphics_data *graphics,
+ struct video_window *window, boolean renderer_supports_scaling, int flags)
 {
   static int system_bpp = 0;
   static boolean has_system_bpp = false;
-  int in_depth = *depth;
+  int width;
+  int height;
+  int in_depth = window->bits_per_pixel;
   int out_depth;
+
+  auto_fullscreen_size(window, renderer_supports_scaling);
+  width = window->width_px;
+  height = window->height_px;
 
   if(!has_system_bpp)
   {
@@ -270,13 +337,13 @@ boolean sdl_check_video_mode(struct graphics_data *graphics, int width,
     return false;
   }
 
-  if(*depth == BPP_AUTO)
+  if(window->bits_per_pixel == BPP_AUTO)
   {
     if(out_depth == 8 || out_depth == 16 || out_depth == 32)
     {
       debug("SDL_VideoModeOK recommends BPP=%d\n", out_depth);
       graphics->bits_per_pixel = out_depth;
-      *depth = out_depth;
+      window->bits_per_pixel = out_depth;
     }
     else
 
@@ -284,7 +351,7 @@ boolean sdl_check_video_mode(struct graphics_data *graphics, int width,
     {
       debug("SDL_VideoModeOK recommends unsupported BPP=%d; using 32bpp\n", out_depth);
       graphics->bits_per_pixel = 32;
-      *depth = 32;
+      window->bits_per_pixel = 32;
     }
   }
   return true;
@@ -435,18 +502,20 @@ void sdl_update_colors(struct graphics_data *graphics,
 // software
 // gp2x
 
-boolean sdl_set_video_mode(struct graphics_data *graphics, int width,
- int height, int depth, boolean fullscreen, boolean resize)
+boolean sdl_create_window_soft(struct graphics_data *graphics,
+ struct video_window *window)
 {
   struct sdl_render_data *render_data = graphics->render_data;
 
 #if SDL_VERSION_ATLEAST(2,0,0)
   SDL_PixelFormat *format;
-  boolean fullscreen_windowed = graphics->fullscreen_windowed;
+  int depth = window->bits_per_pixel;
   boolean matched = false;
   Uint32 fmt;
 
   sdl_destruct_window(graphics);
+
+  auto_fullscreen_size(graphics, window, false);
 
 #if defined(__EMSCRIPTEN__) && SDL_VERSION_ATLEAST(2,0,10)
   // Also, a hint needs to be set to make SDL_UpdateWindowSurface not crash.
@@ -454,8 +523,8 @@ boolean sdl_set_video_mode(struct graphics_data *graphics, int width,
 #endif
 
   render_data->window = SDL_CreateWindow("MegaZeux",
-   SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height,
-   sdl_flags(depth, fullscreen, fullscreen_windowed, resize));
+   SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+   window->width_px, window->height_px, sdl_flags(window));
 
   if(!render_data->window)
   {
@@ -502,7 +571,7 @@ boolean sdl_set_video_mode(struct graphics_data *graphics, int width,
   debug("Using pixel format: %s\n", SDL_GetPixelFormatName(fmt));
 
   if(depth == BPP_AUTO)
-    graphics->bits_per_pixel = SDL_BYTESPERPIXEL(fmt) * 8;
+    graphics->bits_per_pixel = window->bits_per_pixel = SDL_BYTESPERPIXEL(fmt) * 8;
 
   if(!matched)
   {
@@ -511,8 +580,8 @@ boolean sdl_set_video_mode(struct graphics_data *graphics, int width,
 
     SDL_PixelFormatEnumToMasks(fmt, &bpp, &Rmask, &Gmask, &Bmask, &Amask);
 
-    render_data->shadow = SDL_CreateRGBSurface(0, width, height, bpp,
-     Rmask, Gmask, Bmask, Amask);
+    render_data->shadow = SDL_CreateRGBSurface(0,
+     window->width_px, window->height_px, bpp, Rmask, Gmask, Bmask, Amask);
 
     debug("Blitting enabled. Rendering performance will be reduced.\n");
   }
@@ -552,17 +621,16 @@ boolean sdl_set_video_mode(struct graphics_data *graphics, int width,
     render_data->palette = NULL;
   }
 
-  sdl_window_id = SDL_GetWindowID(render_data->window);
+  window->platform_id = SDL_GetWindowID(render_data->window);
   sdl_set_screensaver_enabled(graphics->disable_screensaver == SCREENSAVER_ENABLE);
 
 #else // !SDL_VERSION_ATLEAST(2,0,0)
 
-  if(!sdl_check_video_mode(graphics, width, height, &depth,
-   sdl_flags(depth, fullscreen, false, resize)))
+  if(!sdl_check_video_mode(graphics, window, false, sdl_flags(window)))
     return false;
 
-  render_data->screen = SDL_SetVideoMode(width, height, depth,
-   sdl_flags(depth, fullscreen, false, resize));
+  render_data->screen = SDL_SetVideoMode(window->width_px, window->height_px,
+   window->bits_per_pixel, sdl_flags(window));
 
   if(!render_data->screen)
     return false;
@@ -580,6 +648,8 @@ boolean sdl_set_video_mode(struct graphics_data *graphics, int width,
 
 #endif // !SDL_VERSION_ATLEAST(2,0,0)
 
+  SDL_SetWindowGrab(render_data->window, window->grab_mouse);
+  sdl_set_system_cursor(graphics);
   return true;
 
 #if SDL_VERSION_ATLEAST(2,0,0)
@@ -587,6 +657,79 @@ err_free:
   sdl_destruct_window(graphics);
   return false;
 #endif // SDL_VERSION_ATLEAST(2,0,0)
+}
+
+boolean sdl_resize_window(struct graphics_data *graphics,
+ struct video_window *window)
+{
+#if SDL_VERSION_ATLEAST(2,0,0)
+  struct sdl_render_data *render_data = graphics->render_data;
+
+  if(window->is_fullscreen)
+  {
+    // Unlike window creation, SDL can't be nicely provided with a target
+    // resolution for real fullscreen, so MZX has to manually find one.
+    SDL_DisplayMode mode;
+    boolean real_fullscreen = false;
+
+    if(!window->is_fullscreen_windowed &&
+     sdl_get_closest_usable_display_mode(&mode, window->width_px, window->height_px))
+    {
+      debug("\n");
+      debug("selected: %d x %d, %.02fHz, %s\n", mode.w, mode.h,
+       (float)mode.refresh_rate, SDL_GetPixelFormatName(mode.format));
+
+#if SDL_VERSION_ATLEAST(3,0,0)
+      if(SDL_SetWindowFullscreenMode(render_data->window, &mode) &&
+         SDL_SetWindowFullscreen(render_data->window, true))
+#else
+      if(SDL_SetWindowDisplayMode(render_data->window, &mode) == 0 &&
+         SDL_SetWindowFullscreen(render_data->window, SDL_WINDOW_FULLSCREEN) == 0)
+#endif
+      {
+        graphics->resolution_width = mode.w;
+        graphics->resolution_height = mode.h;
+        window->width_px = mode.w;
+        window->height_px = mode.h;
+        real_fullscreen = true;
+      }
+      else
+      {
+        debug("failed to set selected fullscreen mode: %s\n", SDL_GetError());
+        debug("falling back to fullscreen windowed\n");
+      }
+    }
+
+    if(!real_fullscreen)
+    {
+#if SDL_VERSION_ATLEAST(3,0,0)
+      // Select borderless desktop fullscreen.
+      SDL_SetWindowFullscreenMode(render_data->window, NULL);
+      SDL_SetWindowFullscreen(render_data->window, true);
+#else
+      SDL_SetWindowFullscreen(render_data->window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+#endif
+    }
+  }
+  else
+  {
+    SDL_SetWindowFullscreen(render_data->window, 0);
+    SDL_SetWindowBordered(render_data->window, 1);
+    SDL_SetWindowResizable(render_data->window, window->allow_resize);
+    // TODO: doesn't seem to reliably work??
+    SDL_SetWindowSize(render_data->window, window->width_px, window->height_px);
+    SDL_SetWindowPosition(render_data->window,
+     SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+  }
+
+  SDL_SetWindowGrab(render_data->window, window->grab_mouse);
+  sdl_set_system_cursor(graphics);
+  return true;
+
+#else
+  // SDL_SetVideoMode
+  return sdl_create_window_soft(graphics, window);
+#endif
 }
 
 
@@ -750,20 +893,22 @@ static void find_texture_format(struct graphics_data *graphics,
  * This function will also pick nearest or linear scaling automatically based
  * on the scaling ratio and window size.
  */
-boolean sdlrender_set_video_mode(struct graphics_data *graphics,
- int width, int height, int depth, boolean fullscreen, boolean resize,
- uint32_t sdl_rendererflags)
+boolean sdl_create_window_renderer(struct graphics_data *graphics,
+ struct video_window *window, uint32_t sdl_rendererflags)
 {
   struct sdl_render_data *render_data = graphics->render_data;
-  boolean fullscreen_windowed = graphics->fullscreen_windowed;
 
   sdl_destruct_window(graphics);
 
+  auto_fullscreen_size(graphics, window, true);
+
+#if !SDL_VERSION_ATLEAST(2,0,12)
   // Use linear filtering unless the display is being integer scaled.
   if(is_integer_scale(graphics, width, height))
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "0");
   else
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "1");
+#endif
 
 #if defined(__EMSCRIPTEN__) && SDL_VERSION_ATLEAST(2,0,10)
   // Not clear if this hint is required to make this renderer not crash, but
@@ -778,8 +923,8 @@ boolean sdlrender_set_video_mode(struct graphics_data *graphics,
   }
 
   render_data->window = SDL_CreateWindow("MegaZeux",
-   SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height,
-   sdl_flags(depth, fullscreen, fullscreen_windowed, resize));
+   SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+   window->width_px, window->height_px, sdl_flags(window));
 
   if(!render_data->window)
   {
@@ -807,6 +952,7 @@ boolean sdlrender_set_video_mode(struct graphics_data *graphics,
   }
 
   find_texture_format(graphics, sdl_rendererflags);
+  window->bits_per_pixel = graphics->bits_per_pixel;
 
   if(!render_data->rgb_to_yuv)
   {
@@ -823,13 +969,42 @@ boolean sdlrender_set_video_mode(struct graphics_data *graphics,
   SDL_SetRenderDrawColor(render_data->renderer, 0, 0, 0, SDL_ALPHA_OPAQUE);
   SDL_RenderClear(render_data->renderer);
 
-  sdl_window_id = SDL_GetWindowID(render_data->window);
+  window->platform_id = SDL_GetWindowID(render_data->window);
   sdl_set_screensaver_enabled(graphics->disable_screensaver == SCREENSAVER_ENABLE);
+  SDL_SetWindowGrab(render_data->window, window->grab_mouse);
+  sdl_set_system_cursor(graphics);
   return true;
 
 err_free:
   sdl_destruct_window(graphics);
   return false;
+}
+
+/* Set the texture scaling mode for a given texture.
+ * If allow_non_integer is true, the best is selected given whether or not
+ * the screen is an integer multiple of 640x350. If false, nearest is used.
+ * This only works for SDL 2.0.12 and up; prior should rely on hints. */
+void sdl_set_texture_scale_mode(struct graphics_data *graphics,
+ struct video_window *window, int texture_id, boolean allow_non_integer)
+{
+#if SDL_VERSION_ATLEAST(2,0,12)
+  struct sdl_render_data *render_data =
+   (struct sdl_render_data *)graphics->render_data;
+
+  if(render_data->texture[texture_id])
+  {
+    SDL_ScaleMode mode;
+    if(is_integer_scale(graphics, window->width_px, window->height_px))
+      mode = SDL_ScaleModeNearest;
+    else
+      mode = SDL_ScaleModeLinear;
+
+    if(SDL_SetTextureScaleMode(render_data->texture[texture_id], mode))
+      warn("Failed to set texture %d scale mode: %s\n", texture_id, SDL_GetError());
+  }
+  else
+    warn("Texture %d is null!\n", texture_id);
+#endif
 }
 
 #endif /* CONFIG_RENDER_SOFTSCALE || CONFIG_RENDER_SDLACCEL */
@@ -842,15 +1017,15 @@ err_free:
 
 #if defined(CONFIG_RENDER_GL_FIXED) || defined(CONFIG_RENDER_GL_PROGRAM)
 
-boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
- int depth, boolean fullscreen, boolean resize, struct gl_version req_ver)
+boolean gl_create_window(struct graphics_data *graphics,
+ struct video_window *window, struct gl_version req_ver)
 {
   struct sdl_render_data *render_data = graphics->render_data;
 
 #if SDL_VERSION_ATLEAST(2,0,0)
-  boolean fullscreen_windowed = graphics->fullscreen_windowed;
-
   sdl_destruct_window(graphics);
+
+  auto_fullscreen_size(graphics, window, true);
 
 #ifdef CONFIG_GLES
   // Hints to make SDL use OpenGL ES drivers (e.g. ANGLE) on Windows/Linux.
@@ -884,8 +1059,8 @@ boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
 #endif
 
   render_data->window = SDL_CreateWindow("MegaZeux",
-   SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height,
-   GL_STRIP_FLAGS(sdl_flags(depth, fullscreen, fullscreen_windowed, resize)));
+   SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+   window->width_px, window->height_px, GL_STRIP_FLAGS(sdl_flags(window)));
 
   if(!render_data->window)
   {
@@ -907,17 +1082,16 @@ boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
     goto err_free;
   }
 
-  sdl_window_id = SDL_GetWindowID(render_data->window);
+  window->platform_id = SDL_GetWindowID(render_data->window);
   sdl_set_screensaver_enabled(graphics->disable_screensaver == SCREENSAVER_ENABLE);
 
 #else // !SDL_VERSION_ATLEAST(2,0,0)
 
-  if(!sdl_check_video_mode(graphics, width, height, &depth,
-       GL_STRIP_FLAGS(sdl_flags(depth, fullscreen, false, resize))))
+  if(!sdl_check_video_mode(graphics, window, true, GL_STRIP_FLAGS(sdl_flags(window))))
     return false;
 
-  if(!SDL_SetVideoMode(width, height, depth,
-       GL_STRIP_FLAGS(sdl_flags(depth, fullscreen, false, resize))))
+  if(!SDL_SetVideoMode(window->width_px, window->height_px, window->bits_per_pixel,
+       GL_STRIP_FLAGS(sdl_flags(window))))
     return false;
 
 #endif // !SDL_VERSION_ATLEAST(2,0,0)
@@ -925,6 +1099,8 @@ boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
   render_data->screen = NULL;
   render_data->shadow = NULL;
 
+  SDL_SetWindowGrab(render_data->window, window->grab_mouse);
+  sdl_set_system_cursor(graphics);
   return true;
 
 #if SDL_VERSION_ATLEAST(2,0,0)
@@ -932,6 +1108,18 @@ err_free:
   sdl_destruct_window(graphics);
   return false;
 #endif // SDL_VERSION_ATLEAST(2,0,0)
+}
+
+boolean gl_resize_window(struct graphics_data *graphics,
+ struct video_window *window)
+{
+#if SDL_VERSION_ATLEAST(2,0,0)
+  return sdl_resize_window(graphics, window);
+#else
+  // SDL_SetVideoMode
+  struct gl_version dummy = {};
+  return gl_create_window(graphics, window, dummy);
+#endif
 }
 
 void gl_set_attributes(struct graphics_data *graphics)

--- a/src/render_sdl.h
+++ b/src/render_sdl.h
@@ -60,28 +60,27 @@ struct sdl_render_data
 #define YUV_PRIORITY 422
 #define YUV_DISABLE 0
 
-extern CORE_LIBSPEC Uint32 sdl_window_id;
-
-int sdl_flags(int depth, boolean fullscreen, boolean fullscreen_windowed,
- boolean resize);
-boolean sdl_get_fullscreen_resolution(int *width, int *height, boolean scaling);
+int sdl_flags(const struct video_window *window);
 void sdl_destruct_window(struct graphics_data *graphics);
 void sdl_update_colors(struct graphics_data *graphics,
  struct rgb_color *palette, unsigned int count);
 
-boolean sdl_set_video_mode(struct graphics_data *graphics, int width,
- int height, int depth, boolean fullscreen, boolean resize);
+boolean sdl_create_window_soft(struct graphics_data *graphics,
+ struct video_window *window);
+boolean sdl_resize_window(struct graphics_data *graphics,
+ struct video_window *window);
 
 #if !SDL_VERSION_ATLEAST(2,0,0)
 // Used internally only.
-boolean sdl_check_video_mode(struct graphics_data *graphics, int width,
- int height, int *depth, int flags);
+boolean sdl_check_video_mode(struct graphics_data *graphics,
+ struct video_window *window, boolean renderer_supports_scaling, int flags);
 #endif
 
 #if SDL_VERSION_ATLEAST(2,0,0)
-boolean sdlrender_set_video_mode(struct graphics_data *graphics,
- int width, int height, int depth, boolean fullscreen, boolean resize,
- uint32_t sdl_rendererflags);
+boolean sdl_create_window_renderer(struct graphics_data *graphics,
+ struct video_window *window, uint32_t sdl_rendererflags);
+void sdl_set_texture_scale_mode(struct graphics_data *graphics,
+ struct video_window *window, int texture_id, boolean allow_non_integer);
 #endif
 
 #if defined(CONFIG_RENDER_GL_FIXED) || defined(CONFIG_RENDER_GL_PROGRAM)
@@ -98,8 +97,10 @@ boolean sdlrender_set_video_mode(struct graphics_data *graphics,
 
 #define GL_STRIP_FLAGS(A) ((A & GL_ALLOW_FLAGS) | SDL_WINDOW_OPENGL)
 
-boolean gl_set_video_mode(struct graphics_data *graphics, int width, int height,
- int depth, boolean fullscreen, boolean resize, struct gl_version req_ver);
+boolean gl_create_window(struct graphics_data *graphics,
+ struct video_window *window, struct gl_version req_ver);
+boolean gl_resize_window(struct graphics_data *graphics,
+ struct video_window *window);
 void gl_set_attributes(struct graphics_data *graphics);
 boolean gl_swap_buffers(struct graphics_data *graphics);
 

--- a/src/render_sdl.h
+++ b/src/render_sdl.h
@@ -60,6 +60,12 @@ struct sdl_render_data
 #define YUV_PRIORITY 422
 #define YUV_DISABLE 0
 
+static inline SDL_Window *sdl_get_current_window(void)
+{
+  const struct video_window *window = video_get_window(1);
+  return SDL_GetWindowFromID(window ? window->platform_id : 0);
+}
+
 int sdl_flags(const struct video_window *window);
 void sdl_destruct_window(struct graphics_data *graphics);
 void sdl_update_colors(struct graphics_data *graphics,

--- a/src/render_soft.c
+++ b/src/render_soft.c
@@ -99,8 +99,10 @@ static boolean soft_init_video(struct graphics_data *graphics,
 {
   struct soft_render_data *render_data =
    (struct soft_render_data *)ccalloc(1, sizeof(struct soft_render_data));
-  graphics->render_data = render_data;
+  if(!render_data)
+    return false;
 
+  graphics->render_data = render_data;
   graphics->allow_resize = 0;
   graphics->bits_per_pixel = 32;
 
@@ -119,7 +121,7 @@ static boolean soft_init_video(struct graphics_data *graphics,
    conf->force_bpp == 16 || conf->force_bpp == 32)
     graphics->bits_per_pixel = conf->force_bpp;
 
-  return set_video_mode();
+  return true;
 }
 
 static void soft_free_video(struct graphics_data *graphics)
@@ -132,20 +134,21 @@ static void soft_free_video(struct graphics_data *graphics)
   graphics->render_data = NULL;
 }
 
-static boolean soft_set_video_mode(struct graphics_data *graphics,
- int width, int height, int depth, boolean fullscreen, boolean resize)
+static boolean soft_create_window(struct graphics_data *graphics,
+ struct video_window *window)
 {
 #ifdef CONFIG_SDL
-  return sdl_set_video_mode(graphics, width, height, depth, fullscreen, resize);
+  return sdl_create_window_soft(graphics, window);
 #else
 
-  struct soft_render_data *render_data = graphics->render_data;
+  struct soft_render_data *render_data =
+   (struct soft_render_data *)graphics->render_data;
 
-  graphics->bits_per_pixel = 8;
-  render_data->pitch = (graphics->bits_per_pixel / 8) * SCREEN_PIX_W;
-  render_data->bpp = graphics->bits_per_pixel;
+  window->bits_per_pixel = 8;
+  render_data->pitch = (window->bits_per_pixel / 8) * SCREEN_PIX_W;
+  render_data->bpp = window->bits_per_pixel;
 
-  graphics->renderer_is_headless = true;
+  window->is_headless = true;
   return true;
 
 #endif /* !CONFIG_SDL */
@@ -294,9 +297,9 @@ void render_soft_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = soft_init_video;
   renderer->free_video = soft_free_video;
-  renderer->set_video_mode = soft_set_video_mode;
+  renderer->create_window = soft_create_window;
+  renderer->resize_window = soft_create_window;
   renderer->update_colors = soft_update_colors;
-  renderer->resize_screen = resize_screen_standard;
   renderer->get_screen_coords = get_screen_coords_centered;
   renderer->set_screen_coords = set_screen_coords_centered;
   renderer->render_graph = soft_render_graph;

--- a/src/render_yuv.c
+++ b/src/render_yuv.c
@@ -88,6 +88,10 @@ static boolean yuv_set_video_mode_size(struct graphics_data *graphics,
   if(!render_data->sdl.overlay)
     goto err_free;
 
+  // Wipe the letterbox area, if any.
+  // This must be performed on the window surface, not the overlay.
+  SDL_FillRect(render_data->sdl.screen, NULL, 0);
+  SDL_Flip(render_data->sdl.screen);
   return true;
 
 err_free:

--- a/src/render_yuv.c
+++ b/src/render_yuv.c
@@ -41,23 +41,21 @@ struct yuv_render_data
 {
   struct sdl_render_data sdl;
   Uint32 bpp;
-  Uint32 w;
-  Uint32 h;
 };
 
 static boolean yuv_set_video_mode_size(struct graphics_data *graphics,
- int width, int height, int depth, boolean fullscreen, boolean resize,
- int yuv_width, int yuv_height)
+ struct video_window *window, int yuv_width, int yuv_height)
 {
   struct yuv_render_data *render_data = graphics->render_data;
 
-  if(!sdl_check_video_mode(graphics, width, height, &depth,
-   sdl_flags(depth, fullscreen, false, resize) | SDL_ANYFORMAT))
+  window->bits_per_pixel = 32;
+  if(!sdl_check_video_mode(graphics, window, true, sdl_flags(window) | SDL_ANYFORMAT))
     return false;
 
   // the YUV renderer _requires_ 32bit colour
-  render_data->sdl.screen = SDL_SetVideoMode(width, height, 32,
-   sdl_flags(depth, fullscreen, false, resize) | SDL_ANYFORMAT);
+  render_data->sdl.screen =
+   SDL_SetVideoMode(window->width_px, window->height_px, 32,
+    sdl_flags(window) | SDL_ANYFORMAT);
 
   if(!render_data->sdl.screen)
     goto err_free;
@@ -90,8 +88,6 @@ static boolean yuv_set_video_mode_size(struct graphics_data *graphics,
   if(!render_data->sdl.overlay)
     goto err_free;
 
-  render_data->w = width;
-  render_data->h = height;
   return true;
 
 err_free:
@@ -100,29 +96,30 @@ err_free:
 }
 
 static boolean yuv1_set_video_mode(struct graphics_data *graphics,
- int width, int height, int depth, boolean fullscreen, boolean resize)
+ struct video_window *window)
 {
   struct yuv_render_data *render_data = graphics->render_data;
   render_data->bpp = 32;
 
-  return yuv_set_video_mode_size(graphics, width, height, depth, fullscreen,
-   resize, YUV1_OVERLAY_WIDTH, YUV1_OVERLAY_HEIGHT);
+  return yuv_set_video_mode_size(graphics, window,
+   YUV1_OVERLAY_WIDTH, YUV1_OVERLAY_HEIGHT);
 }
 
 static boolean yuv2_set_video_mode(struct graphics_data *graphics,
- int width, int height, int depth, boolean fullscreen, boolean resize)
+ struct video_window *window)
 {
   struct yuv_render_data *render_data = graphics->render_data;
   render_data->bpp = 16;
 
-  return yuv_set_video_mode_size(graphics, width, height, depth, fullscreen,
-   resize, YUV2_OVERLAY_WIDTH, YUV2_OVERLAY_HEIGHT);
+  return yuv_set_video_mode_size(graphics, window,
+   YUV2_OVERLAY_WIDTH, YUV2_OVERLAY_HEIGHT);
 }
 
 static boolean yuv_init_video(struct graphics_data *graphics,
  struct config_info *conf)
 {
-  struct yuv_render_data *render_data = cmalloc(sizeof(struct yuv_render_data));
+  struct yuv_render_data *render_data =
+   (struct yuv_render_data *)cmalloc(sizeof(struct yuv_render_data));
   if(!render_data)
     return false;
 
@@ -132,14 +129,6 @@ static boolean yuv_init_video(struct graphics_data *graphics,
   graphics->render_data = render_data;
   graphics->allow_resize = conf->allow_resize;
   graphics->ratio = conf->video_ratio;
-
-  if(!set_video_mode())
-  {
-    free(render_data);
-    graphics->render_data = NULL;
-    return false;
-  }
-
   return true;
 }
 
@@ -244,8 +233,8 @@ static void yuv_render_mouse(struct graphics_data *graphics,
 static void yuv_sync_screen(struct graphics_data *graphics)
 {
   struct yuv_render_data *render_data = graphics->render_data;
-  int width = render_data->w, v_width;
-  int height = render_data->h, v_height;
+  int width = graphics->window.width_px, v_width;
+  int height = graphics->window.height_px, v_height;
   SDL_Rect rect;
 
   // FIXME: Putting this here is suboptimal
@@ -264,9 +253,9 @@ void render_yuv1_register(struct renderer *renderer)
   memset(renderer, 0, sizeof(struct renderer));
   renderer->init_video = yuv_init_video;
   renderer->free_video = yuv_free_video;
-  renderer->set_video_mode = yuv1_set_video_mode;
+  renderer->create_window = yuv1_set_video_mode;
+  renderer->resize_window = yuv1_set_video_mode;
   renderer->update_colors = sdl_update_colors;
-  renderer->resize_screen = resize_screen_standard;
   renderer->get_screen_coords = get_screen_coords_scaled;
   renderer->set_screen_coords = set_screen_coords_scaled;
   renderer->render_graph = yuv_render_graph;
@@ -279,6 +268,7 @@ void render_yuv1_register(struct renderer *renderer)
 void render_yuv2_register(struct renderer *renderer)
 {
   render_yuv1_register(renderer);
-  renderer->set_video_mode = yuv2_set_video_mode;
+  renderer->create_window = yuv2_set_video_mode;
+  renderer->resize_window = yuv2_set_video_mode;
   renderer->render_layer = NULL;
 }

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -107,6 +107,12 @@ constexpr gl_filter_type INVALID<gl_filter_type>()
 }
 
 template<>
+constexpr system_mouse_type INVALID<system_mouse_type>()
+{
+  return NUM_SYSTEM_MOUSE_TYPES;
+}
+
+template<>
 constexpr cursor_mode_types INVALID<cursor_mode_types>()
 {
   return NUM_CURSOR_MODE_TYPES;
@@ -726,7 +732,20 @@ UNITTEST(Settings)
 
   SECTION(system_mouse)
   {
-    TEST_ENUM("system_mouse", conf->system_mouse, boolean_data);
+    constexpr system_mouse_type DEFAULT = INVALID<system_mouse_type>();
+    static const config_test_single data[] =
+    {
+      { "0", SYSTEM_MOUSE_OFF },
+      { "1", SYSTEM_MOUSE_ON },
+      { "off", SYSTEM_MOUSE_OFF },
+      { "on", SYSTEM_MOUSE_ON },
+      { "only", SYSTEM_MOUSE_HIDE_SOFTWARE_MOUSE },
+      { "mzxrun", DEFAULT },
+      { "ksdjfksdf", DEFAULT },
+      { "2", DEFAULT },
+      { "", DEFAULT },
+    };
+    TEST_ENUM("system_mouse", conf->system_mouse, data);
   }
 
   SECTION(grab_mouse)


### PR DESCRIPTION
* Renderer set_video_mode has been split into create_window (called
  during renderer init) and resize_window (called whenever the window
  enters/exits fullscreen, potentially at other times in the future).
  This allows SDL2/3 to use a resize_window implementation which
  does NOT completely recreate the window, which should behave more
  nicely for some platforms.
* Renderer resize_screen has been replaced with resize_callback,
  which no longer calls update_screen. Instead, this function is
  used during window creation and after a resize occurs so renderers
  can update things like glViewport.
* The SDL2/3 window resize events no longer attempt to resize the
  window, and instead calls a function that invokes resize_callback.
  This fixes broken window resizing in Wayland.
* The SDL software, gp2x, and SDL 1.2 overlay renderers now wipe the
  area outside of their scaling viewport after resize.
* When system_mouse is 1, both the software and system mouse cursor
  will display. To get the old system_mouse=1 behavior, use
  system_mouse=only instead.
* macOS now enables fullscreen_windowed by default.
* sai.frag is now properly installed by make install.

- [x] macOS
- [x] X11
- [x] Dreamcast (build only)
- [x] pspdev (dkP r16)
- [x] clipboard_x11 and event_sdl usage is not nullsafe
- [x] EGL testing
- [x] finish review