### PR TITLE
Merge/cleanup renderer viewport calculation code.

### DIFF
--- a/arch/3ds/render.cpp
+++ b/arch/3ds/render.cpp
@@ -1201,12 +1201,11 @@ void render_ctr_register(struct renderer *renderer)
   renderer->init_video = ctr_init_video;
   renderer->free_video = ctr_free_video;
   renderer->create_window = ctr_create_window;
+  renderer->set_viewport = set_window_viewport_centered;
   renderer->update_colors = ctr_update_colors;
   renderer->remap_char_range = ctr_remap_char_range;
   renderer->remap_char = ctr_remap_char;
   renderer->remap_charbyte = ctr_remap_charbyte;
-  renderer->get_screen_coords = get_screen_coords_centered;
-  renderer->set_screen_coords = set_screen_coords_centered;
   renderer->render_layer = ctr_render_layer;
   renderer->render_cursor = ctr_render_cursor;
   renderer->render_mouse = ctr_render_mouse;

--- a/arch/3ds/render.cpp
+++ b/arch/3ds/render.cpp
@@ -1135,7 +1135,8 @@ static inline void ctr_draw_playfield(struct ctr_render_data *render_data,
   }
 }
 
-static void ctr_sync_screen(struct graphics_data *graphics)
+static void ctr_sync_screen(struct graphics_data *graphics,
+ struct video_window *window)
 {
   struct ctr_render_data *render_data = (struct ctr_render_data *) graphics->render_data;
 

--- a/arch/djgpp/render_ega.c
+++ b/arch/djgpp/render_ega.c
@@ -510,13 +510,12 @@ void render_ega_register(struct renderer *renderer)
   renderer->init_video = ega_init_video;
   renderer->free_video = ega_free_video;
   renderer->create_window = ega_create_window;
+  renderer->set_viewport = set_window_viewport_centered;
   renderer->set_screen_mode = ega_set_screen_mode;
   renderer->update_colors = ega_update_colors;
   renderer->remap_char_range = ega_remap_char_range;
   renderer->remap_char = ega_remap_char;
   renderer->remap_charbyte = ega_remap_charbyte;
-  renderer->get_screen_coords = get_screen_coords_centered;
-  renderer->set_screen_coords = set_screen_coords_centered;
   renderer->render_graph = ega_render_graph;
   renderer->hardware_cursor = ega_hardware_cursor;
   renderer->render_mouse = ega_render_mouse;

--- a/arch/djgpp/render_ega.c
+++ b/arch/djgpp/render_ega.c
@@ -482,7 +482,8 @@ static void ega_render_mouse(struct graphics_data *graphics,
   _farnspokeb(dest, _farnspeekb(dest) ^ 0xFF);
 }
 
-static void ega_sync_screen(struct graphics_data *graphics)
+static void ega_sync_screen(struct graphics_data *graphics,
+ struct video_window *window)
 {
   struct ega_render_data *render_data = graphics->render_data;
   uint8_t *src = graphics->charset;

--- a/arch/djgpp/render_svga.c
+++ b/arch/djgpp/render_svga.c
@@ -299,7 +299,8 @@ static void svga_render_mouse(struct graphics_data *graphics,
    graphics->bits_per_pixel, x, y, mask, 0, w, h);
 }
 
-static void svga_sync_screen(struct graphics_data *graphics)
+static void svga_sync_screen(struct graphics_data *graphics,
+ struct video_window *window)
 {
   struct svga_render_data *render_data = graphics->render_data;
   __dpmi_regs reg;

--- a/arch/djgpp/render_svga.c
+++ b/arch/djgpp/render_svga.c
@@ -343,9 +343,8 @@ void render_svga_register(struct renderer *renderer)
   renderer->init_video = svga_init_video;
   renderer->free_video = svga_free_video;
   renderer->create_window = svga_create_window;
+  renderer->set_viewport = set_window_viewport_centered;
   renderer->update_colors = svga_update_colors;
-  renderer->get_screen_coords = get_screen_coords_centered;
-  renderer->set_screen_coords = set_screen_coords_centered;
   renderer->render_graph = svga_render_graph;
   renderer->render_layer = svga_render_layer;
   renderer->render_cursor = svga_render_cursor;

--- a/arch/dreamcast/render.c
+++ b/arch/dreamcast/render.c
@@ -136,7 +136,8 @@ static void dc_render_mouse(struct graphics_data *graphics,
    0xFFFFFFFF, 0, w, h);
 }
 
-static void dc_sync_screen(struct graphics_data *graphics)
+static void dc_sync_screen(struct graphics_data *graphics,
+ struct video_window *window)
 {
   struct dc_render_data *render_data = graphics->render_data;
   pvr_vertex_t vtx;

--- a/arch/dreamcast/render.c
+++ b/arch/dreamcast/render.c
@@ -188,9 +188,8 @@ void render_dc_register(struct renderer *renderer)
   renderer->init_video = dc_init_video;
   renderer->free_video = dc_free_video;
   renderer->create_window = dc_create_window;
+  renderer->set_viewport = set_window_viewport_centered;
   renderer->update_colors = dc_update_colors;
-  renderer->get_screen_coords = get_screen_coords_centered;
-  renderer->set_screen_coords = set_screen_coords_centered;
   renderer->render_graph = dc_render_graph;
   renderer->render_layer = dc_render_layer;
   renderer->render_cursor = dc_render_cursor;

--- a/arch/dreamcast/render_fb.c
+++ b/arch/dreamcast/render_fb.c
@@ -127,9 +127,8 @@ void render_dc_fb_register(struct renderer *renderer)
   renderer->init_video = dc_fb_init_video;
   renderer->free_video = dc_fb_free_video;
   renderer->create_window = dc_fb_create_window;
+  renderer->set_viewport = set_window_viewport_centered;
   renderer->update_colors = dc_fb_update_colors;
-  renderer->get_screen_coords = get_screen_coords_centered;
-  renderer->set_screen_coords = set_screen_coords_centered;
   renderer->render_graph = dc_fb_render_graph;
   renderer->render_layer = dc_fb_render_layer;
   renderer->render_cursor = dc_fb_render_cursor;

--- a/arch/dreamcast/render_fb.c
+++ b/arch/dreamcast/render_fb.c
@@ -114,7 +114,8 @@ static void dc_fb_render_mouse(struct graphics_data *graphics,
    0xFFFFFFFF, 0, w, h);
 }
 
-static void dc_fb_sync_screen(struct graphics_data *graphics)
+static void dc_fb_sync_screen(struct graphics_data *graphics,
+ struct video_window *window)
 {
 //  struct dc_fb_render_data *render_data = graphics->render_data;
   vid_flip(-1);

--- a/arch/nds/render.c
+++ b/arch/nds/render.c
@@ -747,7 +747,8 @@ static void nds_render_mouse(struct graphics_data *graphics,
   // stub
 }
 
-static void nds_sync_screen(struct graphics_data *graphics)
+static void nds_sync_screen(struct graphics_data *graphics,
+ struct video_window *window)
 {
   // stub
 }

--- a/arch/nds/render.c
+++ b/arch/nds/render.c
@@ -850,11 +850,10 @@ void render_nds_register(struct renderer *renderer)
   renderer->init_video = nds_init_video;
   renderer->create_window = nds_create_window;
   renderer->update_colors = nds_update_colors;
+  renderer->set_viewport = set_window_viewport_centered;
   renderer->remap_char_range = nds_remap_char_range;
   renderer->remap_char = nds_remap_char;
   renderer->remap_charbyte = nds_remap_charbyte;
-  renderer->get_screen_coords = get_screen_coords_centered;
-  renderer->set_screen_coords = set_screen_coords_centered;
   renderer->render_graph = nds_render_graph;
   renderer->render_cursor = nds_render_cursor;
   renderer->render_mouse = nds_render_mouse;

--- a/arch/wii/render_gx.c
+++ b/arch/wii/render_gx.c
@@ -382,7 +382,7 @@ static boolean gx_create_window(struct graphics_data *graphics,
 {
   struct gx_render_data *render_data = graphics->render_data;
   float x, y, w, h, scale, xscale, yscale;
-  int fh, fs, sw, sh, dw, dh;
+  int fh;
 
   if(window->is_fullscreen)
     scale = 8.0 / 9.0;
@@ -393,20 +393,21 @@ static boolean gx_create_window(struct graphics_data *graphics,
     fh = 574;
   else
     fh = 480;
-  fs = fh * 720;
 
   if(CONF_GetAspectRatio() == CONF_ASPECT_16_9)
   {
-    sw = fs * 16;
-    sh = fs * 9;
-  }
-  else
-  {
-    sw = fs * 4;
-    sh = fs * 3;
+    // 4:3 stretched to 16:9; correct ratio for non-square pixels.
+    if(window->ratio == RATIO_CLASSIC_4_3)
+      window->ratio = RATIO_SQUARE_1_1;
+    else
+
+    if(window->ratio == RATIO_MODERN_64_35)
+      window->ratio = RATIO_CLASSIC_4_3;
   }
 
-  fix_viewport_ratio(sw, sh, &dw, &dh, graphics->ratio);
+  window->width_px = 720;
+  window->height_px = fh;
+  video_window_update_viewport(window);
 
   if(render_data->rmode->viWidth > render_data->rmode->fbWidth)
     xscale = (float)render_data->rmode->fbWidth / render_data->rmode->viWidth;
@@ -414,10 +415,10 @@ static boolean gx_create_window(struct graphics_data *graphics,
     xscale = 1.0;
   yscale = (float)render_data->rmode->efbHeight / render_data->rmode->viHeight;
 
-  w = (float)dw * 720 / sw * scale;
-  h = (float)dh * fh / sh * scale;
-  x = (720 - w) / 2 - render_data->rmode->viXOrigin;
-  y = (fh - h) / 2 - render_data->rmode->viYOrigin;
+  w = window->viewport_width * scale;
+  h = window->viewport_height * scale;
+  x = (window->width_px - w) / 2 - render_data->rmode->viXOrigin;
+  y = (window->height_px - h) / 2 - render_data->rmode->viYOrigin;
   w *= xscale; h *= yscale; x *= xscale; y *= yscale;
 
   render_data->sx0 = x;
@@ -960,12 +961,11 @@ void render_gx_register(struct renderer *renderer)
   renderer->free_video = gx_free_video;
   renderer->create_window = gx_create_window;
   renderer->resize_window = gx_create_window;
+  renderer->set_viewport = set_window_viewport_scaled;
   renderer->update_colors = gx_update_colors;
   renderer->remap_char_range = gx_remap_char_range;
   renderer->remap_char = gx_remap_char;
   renderer->remap_charbyte = gx_remap_charbyte;
-  renderer->get_screen_coords = get_screen_coords_centered;
-  renderer->set_screen_coords = set_screen_coords_centered;
   renderer->render_layer = gx_render_layer;
   renderer->render_cursor = gx_render_cursor;
   renderer->render_mouse = gx_render_mouse;

--- a/arch/wii/render_gx.c
+++ b/arch/wii/render_gx.c
@@ -397,6 +397,7 @@ static boolean gx_create_window(struct graphics_data *graphics,
   if(CONF_GetAspectRatio() == CONF_ASPECT_16_9)
   {
     // 4:3 stretched to 16:9; correct ratio for non-square pixels.
+    // TODO: real pixel aspect ratio correction instead of this hack.
     if(window->ratio == RATIO_CLASSIC_4_3)
       window->ratio = RATIO_SQUARE_1_1;
     else

--- a/arch/wii/render_gx.c
+++ b/arch/wii/render_gx.c
@@ -397,13 +397,8 @@ static boolean gx_create_window(struct graphics_data *graphics,
   if(CONF_GetAspectRatio() == CONF_ASPECT_16_9)
   {
     // 4:3 stretched to 16:9; correct ratio for non-square pixels.
-    // TODO: real pixel aspect ratio correction instead of this hack.
-    if(window->ratio == RATIO_CLASSIC_4_3)
-      window->ratio = RATIO_SQUARE_1_1;
-    else
-
-    if(window->ratio == RATIO_MODERN_64_35)
-      window->ratio = RATIO_CLASSIC_4_3;
+    window->ratio_numerator *= 3;
+    window->ratio_denominator *= 4;
   }
 
   window->width_px = 720;

--- a/arch/wii/render_gx.c
+++ b/arch/wii/render_gx.c
@@ -910,7 +910,8 @@ static void gx_render_mouse(struct graphics_data *graphics,
   GX_End();
 }
 
-static void gx_sync_screen(struct graphics_data *graphics)
+static void gx_sync_screen(struct graphics_data *graphics,
+ struct video_window *window)
 {
   struct gx_render_data *render_data = graphics->render_data;
   static u8 tex_ptn[12][2] = {

--- a/arch/wii/render_xfb.c
+++ b/arch/wii/render_xfb.c
@@ -338,7 +338,8 @@ static void xfb_copy_buffer(struct graphics_data *graphics)
   }
 }
 
-static void xfb_sync_screen(struct graphics_data *graphics)
+static void xfb_sync_screen(struct graphics_data *graphics,
+ struct video_window *window)
 {
   struct xfb_render_data *render_data = graphics->render_data;
 

--- a/arch/wii/render_xfb.c
+++ b/arch/wii/render_xfb.c
@@ -366,9 +366,8 @@ void render_xfb_register(struct renderer *renderer)
   renderer->init_video = xfb_init_video;
   renderer->free_video = xfb_free_video;
   renderer->create_window = xfb_create_window;
+  renderer->set_viewport = set_window_viewport_centered;
   renderer->update_colors = xfb_update_colors;
-  renderer->get_screen_coords = get_screen_coords_centered;
-  renderer->set_screen_coords = set_screen_coords_centered;
   renderer->render_graph = xfb_render_graph;
   renderer->render_layer = xfb_render_layer;
   renderer->render_cursor = xfb_render_cursor;

--- a/src/configure.h
+++ b/src/configure.h
@@ -44,6 +44,7 @@ enum ratio_type
   RATIO_CLASSIC_4_3,
   RATIO_MODERN_64_35,
   RATIO_STRETCH,
+  RATIO_SQUARE_1_1, // internal use only
   NUM_RATIO_TYPES
 };
 

--- a/src/configure.h
+++ b/src/configure.h
@@ -44,7 +44,6 @@ enum ratio_type
   RATIO_CLASSIC_4_3,
   RATIO_MODERN_64_35,
   RATIO_STRETCH,
-  RATIO_SQUARE_1_1, // internal use only
   NUM_RATIO_TYPES
 };
 

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1920,6 +1920,9 @@ unsigned video_window_by_platform_id(unsigned platform_id)
 /**
  * Update the scaled viewport coordinates within the window according to
  * the window's scaling ratio, for use in SDL update rectangles or glViewport.
+ * The viewport is also used to translate mouse coordinates between screen
+ * and window space.
+ *
  * This should be called by the renderer any time create_window forces the
  * window size (SDL window creation functions already handle this).
  * This is called automatically between resize_window and resize_callback.
@@ -1935,6 +1938,7 @@ void video_window_update_viewport(struct video_window *window)
   }
   else
   {
+    debug("Implement set_viewport!");
     window->viewport_x = 0;
     window->viewport_y = 0;
     window->viewport_width = window->width_px;

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1843,6 +1843,26 @@ boolean has_video_initialized(void)
   return graphics.is_initialized;
 }
 
+static void set_window_ratio(struct video_window *window, enum ratio_type ratio)
+{
+  switch(ratio)
+  {
+    case RATIO_MODERN_64_35:
+      window->ratio_numerator = 64;
+      window->ratio_denominator = 35;
+      break;
+    case RATIO_CLASSIC_4_3:
+      window->ratio_numerator = 4;
+      window->ratio_denominator = 3;
+      break;
+    default:
+    case RATIO_STRETCH:
+      window->ratio_numerator = 0;
+      window->ratio_denominator = 0;
+      break;
+  }
+}
+
 unsigned video_create_window(void)
 {
   struct video_window *window = &(graphics.window);
@@ -1855,7 +1875,7 @@ unsigned video_create_window(void)
   window->is_fullscreen_windowed = graphics.fullscreen_windowed;
   window->is_headless = false;
   window->allow_resize = graphics.allow_resize;
-  window->ratio = graphics.ratio;
+  set_window_ratio(window, graphics.ratio);
 
   if(graphics.fullscreen)
   {
@@ -1995,6 +2015,7 @@ static void resize_window(unsigned window_id, boolean fullscreen)
     }
     graphics.window.is_fullscreen = fullscreen;
     graphics.fullscreen = fullscreen;
+    set_window_ratio(&graphics.window, graphics.ratio);
 
     graphics.renderer.resize_window(&graphics, &graphics.window);
 

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1929,55 +1929,18 @@ unsigned video_window_by_platform_id(unsigned platform_id)
  */
 void video_window_update_viewport(struct video_window *window)
 {
-  /* TODO: this doesn't reduce size much, consider making it universal.
-   * The software renderers might be able to benefit from centering here. */
-#if defined(CONFIG_RENDER_GL_FIXED) || defined(CONFIG_RENDER_GL_PROGRAM) \
- || defined(CONFIG_RENDER_SOFTSCALE) || defined(CONFIG_RENDER_YUV) \
- || defined(CONFIG_RENDER_GX)
-
-  int width = MAX(window->width_px, 1);
-  int height = MAX(window->height_px, 1);
-  int numerator = 1;
-  int denominator = 1;
-
-  if(window->ratio == RATIO_CLASSIC_4_3)
+  if(graphics.renderer.set_viewport)
   {
-    numerator = 4;
-    denominator = 3;
+    graphics.renderer.set_viewport(&graphics, window);
   }
   else
-
-  if(window->ratio == RATIO_MODERN_64_35)
   {
-    numerator = 64;
-    denominator = 35;
+    window->viewport_x = 0;
+    window->viewport_y = 0;
+    window->viewport_width = window->width_px;
+    window->viewport_height = window->height_px;
+    window->is_integer_scaled = false;
   }
-
-  if(numerator > 1)
-  {
-    // (width / height) < (numerator / denominator)
-    // Multiply both sides by (height * denominator):
-    if(width * denominator < height * numerator)
-    {
-      height = (width * denominator) / numerator;
-      height = MAX(height, 1);
-    }
-    else
-    {
-      width = (height * numerator) / denominator;
-      width = MAX(width, 1);
-    }
-  }
-
-  window->viewport_x = (window->width_px - width) >> 1;
-  window->viewport_y = (window->height_px - height) >> 1;
-  window->viewport_width = width;
-  window->viewport_height = height;
-  window->is_integer_scaled = false;
-
-  if((width % SCREEN_PIX_W == 0) && (height % SCREEN_PIX_H == 0))
-    window->is_integer_scaled = true;
-#endif
 }
 
 /* Sync the current window size after it has ALREADY been changed by the
@@ -3174,13 +3137,34 @@ boolean get_char_visible_bitmask(uint16_t char_idx, uint8_t palette,
 void get_screen_coords(int screen_x, int screen_y, int *x, int *y,
  int *min_x, int *min_y, int *max_x, int *max_y)
 {
-  graphics.renderer.get_screen_coords(&graphics, screen_x, screen_y, x, y,
-   min_x, min_y, max_x, max_y);
+#if 0
+  if(graphics.renderer.get_screen_coords)
+  {
+    graphics.renderer.get_screen_coords(&graphics, &(graphics.window),
+     screen_x, screen_y, x, y, min_x, min_y, max_x, max_y);
+  }
+  else
+#endif
+  {
+    get_screen_coords_viewport(&graphics, &(graphics.window),
+     screen_x, screen_y, x, y, min_x, min_y, max_x, max_y);
+  }
 }
 
 void set_screen_coords(int x, int y, int *screen_x, int *screen_y)
 {
-  graphics.renderer.set_screen_coords(&graphics, x, y, screen_x, screen_y);
+#if 0
+  if(graphics.renderer.set_screen_coords)
+  {
+    graphics.renderer.set_screen_coords(&graphics, &(graphics.window),
+     x, y, screen_x, screen_y);
+  }
+  else
+#endif
+  {
+    set_screen_coords_viewport(&graphics, &(graphics.window),
+     x, y, screen_x, screen_y);
+  }
 }
 
 void focus_screen(int x, int y)

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -177,7 +177,8 @@ struct video_window
   int viewport_y;
   int viewport_width;
   int viewport_height;
-  enum ratio_type ratio;
+  int ratio_numerator;
+  int ratio_denominator;
 
   unsigned bits_per_pixel;
   boolean is_init;

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -143,7 +143,7 @@ struct renderer
                                 boolean enable);
   void    (*render_mouse)     (struct graphics_data *, unsigned x, unsigned y,
                                 unsigned w, unsigned h);
-  void    (*sync_screen)      (struct graphics_data *);
+  void    (*sync_screen)      (struct graphics_data *, struct video_window *);
   void    (*focus_pixel)      (struct graphics_data *, unsigned x, unsigned y);
 };
 
@@ -168,16 +168,18 @@ struct video_window
   // Real size of the window.
   unsigned width_px;
   unsigned height_px;
-  // Scaled viewport size within the window (fix_viewport_ratio).
-  //unsigned viewport_x;
-  //unsigned viewport_y;
-  //unsigned viewport_width;
-  //unsigned viewport_height;
+  // Scaled viewport size within the window (video_window_update_viewport).
+  // Not all renderers use these fields.
+  unsigned viewport_x;
+  unsigned viewport_y;
+  unsigned viewport_width;
+  unsigned viewport_height;
+  enum ratio_type ratio;
 
   unsigned bits_per_pixel;
   boolean is_init;
   boolean is_headless;
-  // These properties are refreshed by calling resize_window.
+  boolean is_integer_scaled;
   boolean is_fullscreen;
   boolean is_fullscreen_windowed;
   boolean allow_resize;
@@ -362,6 +364,7 @@ int get_current_video_output(void);
 unsigned video_create_window(void);
 CORE_LIBSPEC const struct video_window *video_get_window(unsigned window_id);
 unsigned video_window_by_platform_id(unsigned platform_id);
+void video_window_update_viewport(struct video_window *window);
 void video_sync_window_size(unsigned window_id,
  unsigned new_width_px, unsigned new_height_px);
 void video_resize_window(unsigned window_id,

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -173,10 +173,10 @@ struct video_window
   unsigned height_px;
   // Scaled viewport size within the window (video_window_update_viewport).
   // These variables are used to convert from screen space to real window space.
-  unsigned viewport_x;
-  unsigned viewport_y;
-  unsigned viewport_width;
-  unsigned viewport_height;
+  int viewport_x;
+  int viewport_y;
+  int viewport_width;
+  int viewport_height;
   enum ratio_type ratio;
 
   unsigned bits_per_pixel;

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -122,17 +122,20 @@ struct renderer
   boolean (*create_window)    (struct graphics_data *, struct video_window *);
   boolean (*resize_window)    (struct graphics_data *, struct video_window *);
   boolean (*resize_callback)  (struct graphics_data *, struct video_window *);
+  void    (*set_viewport)     (struct graphics_data *, struct video_window *);
+#if 0
+  void    (*get_screen_coords)(struct graphics_data *, struct video_window *,
+                                int screen_x, int screen_y, int *x, int *y,
+                                int *min_x, int *min_y, int *max_x, int *max_y);
+  void    (*set_screen_coords)(struct graphics_data *, struct video_window *,
+                                int x, int y, int *screen_x, int *screen_y);
+#endif
   boolean (*set_screen_mode)  (struct graphics_data *, unsigned mode);
   void    (*update_colors)    (struct graphics_data *, struct rgb_color *palette,
                                 unsigned int count);
   void    (*remap_char_range) (struct graphics_data *, uint16_t first, uint16_t count);
   void    (*remap_char)       (struct graphics_data *, uint16_t chr);
   void    (*remap_charbyte)   (struct graphics_data *, uint16_t chr, uint8_t byte);
-  void    (*get_screen_coords)(struct graphics_data *, int screen_x,
-                                int screen_y, int *x, int *y, int *min_x,
-                                int *min_y, int *max_x, int *max_y);
-  void    (*set_screen_coords)(struct graphics_data *, int x, int y,
-                                int *screen_x, int *screen_y);
   boolean (*switch_shader)    (struct graphics_data *, const char *name);
   void    (*render_graph)     (struct graphics_data *);
   void    (*render_layer)     (struct graphics_data *, struct video_layer *);
@@ -169,7 +172,7 @@ struct video_window
   unsigned width_px;
   unsigned height_px;
   // Scaled viewport size within the window (video_window_update_viewport).
-  // Not all renderers use these fields.
+  // These variables are used to convert from screen space to real window space.
   unsigned viewport_x;
   unsigned viewport_y;
   unsigned viewport_width;

--- a/src/render.c
+++ b/src/render.c
@@ -546,31 +546,12 @@ void set_window_viewport_centered(struct graphics_data *graphics,
 void set_window_viewport_scaled(struct graphics_data *graphics,
  struct video_window *window)
 {
-  int numerator = 0, denominator = 0;
+  int numerator = window->ratio_numerator;
+  int denominator = window->ratio_denominator;
   int width = MAX(window->width_px, 1);
   int height = MAX(window->height_px, 1);
 
-  if(window->ratio == RATIO_CLASSIC_4_3)
-  {
-    numerator = 4;
-    denominator = 3;
-  }
-  else
-
-  if(window->ratio == RATIO_MODERN_64_35)
-  {
-    numerator = 64;
-    denominator = 35;
-  }
-  else
-
-  if(window->ratio == RATIO_SQUARE_1_1)
-  {
-    numerator = 1;
-    denominator = 1;
-  }
-
-  if(numerator > 0)
+  if(numerator > 0 && denominator > 0)
   {
     // (width / height) < (numerator / denominator)
     // Multiply both sides by (height * denominator):

--- a/src/render.c
+++ b/src/render.c
@@ -608,12 +608,12 @@ void set_screen_coords_scaled(struct graphics_data *graphics, int x, int y,
 #endif /* CONFIG_RENDER_GL_FIXED || CONFIG_RENDER_GL_PROGRAM ||
  CONFIG_RENDER_YUV */
 
-// FIXME: Integerize
-
 #if defined(CONFIG_RENDER_GL_FIXED) || defined(CONFIG_RENDER_GL_PROGRAM) \
  || defined(CONFIG_RENDER_SOFTSCALE) || defined(CONFIG_RENDER_YUV) \
  || defined(CONFIG_RENDER_GX)
 
+// FIXME: finish replacement of this function with the window viewport fields.
+// The GX renderer and scaled screen coords functions still use it.
 void fix_viewport_ratio(int width, int height, int *v_width, int *v_height,
  enum ratio_type ratio)
 {
@@ -636,7 +636,8 @@ void fix_viewport_ratio(int width, int height, int *v_width, int *v_height,
     denominator = 35;
   }
 
-  if(((float)width / (float)height) < ((float)numerator / (float)denominator))
+  //if(((float)width / (float)height) < ((float)numerator / (float)denominator))
+  if(width * denominator < height * numerator)
   {
     height = (width * denominator) / numerator;
     *v_height = MAX(height, 1);

--- a/src/render.c
+++ b/src/render.c
@@ -502,151 +502,100 @@ void render_mouse(uint32_t *pixels, size_t pitch, uint8_t bpp, unsigned int x,
   }
 }
 
-void get_screen_coords_centered(struct graphics_data *graphics, int screen_x,
- int screen_y, int *x, int *y, int *min_x, int *min_y, int *max_x, int *max_y)
+void get_screen_coords_viewport(struct graphics_data *graphics,
+ struct video_window *window, int screen_x, int screen_y,
+ int *x, int *y, int *min_x, int *min_y, int *max_x, int *max_y)
 {
-  int w_offset, h_offset;
-  int target_width = graphics->window_width;
-  int target_height = graphics->window_height;
+  int rel_x = screen_x - window->viewport_x;
+  int rel_y = screen_y - window->viewport_y;
 
-  if(graphics->fullscreen)
-  {
-    target_width = graphics->resolution_width;
-    target_height = graphics->resolution_height;
-  }
+  if(window->viewport_width != SCREEN_PIX_W)
+    rel_x = rel_x * SCREEN_PIX_W / window->viewport_width;
 
-  w_offset = (target_width - 640) / 2;
-  h_offset = (target_height - 350) / 2;
+  if(window->viewport_height != SCREEN_PIX_H)
+    rel_y = rel_y * SCREEN_PIX_H / window->viewport_height;
 
-  *x = screen_x - w_offset;
-  *y = screen_y - h_offset;
-
-  *min_x = w_offset;
-  *min_y = h_offset;
-  *max_x = 639 + w_offset;
-  *max_y = 349 + h_offset;
+  *x = CLAMP(rel_x, 0, SCREEN_PIX_W - 1);
+  *y = CLAMP(rel_y, 0, SCREEN_PIX_H - 1);
+  *min_x = window->viewport_x;
+  *min_y = window->viewport_y;
+  *max_x = window->viewport_x + window->viewport_width - 1;
+  *max_y = window->viewport_y + window->viewport_height - 1;
 }
 
-void set_screen_coords_centered(struct graphics_data *graphics, int x, int y,
+void set_screen_coords_viewport(struct graphics_data *graphics,
+ struct video_window *window, int x, int y,
  int *screen_x, int *screen_y)
 {
-  int target_width = graphics->window_width;
-  int target_height = graphics->window_height;
-
-  if(graphics->fullscreen)
-  {
-    target_width = graphics->resolution_width;
-    target_height = graphics->resolution_height;
-  }
-
-  *screen_x = x + (target_width - 640) / 2;
-  *screen_y = y + (target_height - 350) / 2;
+  *screen_x = x * window->viewport_width / SCREEN_PIX_W + window->viewport_x;
+  *screen_y = y * window->viewport_height / SCREEN_PIX_H + window->viewport_y;
 }
 
-#if defined(CONFIG_RENDER_GL_FIXED) || defined(CONFIG_RENDER_GL_PROGRAM) \
- || defined(CONFIG_RENDER_SOFTSCALE) || defined(CONFIG_RENDER_YUV)
-
-void get_screen_coords_scaled(struct graphics_data *graphics, int screen_x,
- int screen_y, int *x, int *y, int *min_x, int *min_y, int *max_x, int *max_y)
+void set_window_viewport_centered(struct graphics_data *graphics,
+ struct video_window *window)
 {
-  int window_width = graphics->window_width;
-  int window_height = graphics->window_height;
-  int target_width;
-  int target_height;
-  int offset_x;
-  int offset_y;
-
-  if(graphics->fullscreen)
-  {
-    window_width = graphics->resolution_width;
-    window_height = graphics->resolution_height;
-  }
-
-  target_width = window_width;
-  target_height = window_height;
-
-  fix_viewport_ratio(window_width, window_height, &target_width, &target_height,
-   graphics->ratio);
-
-  offset_x = (window_width - target_width)/2;
-  offset_y = (window_height - target_height)/2;
-
-  *x = CLAMP( (screen_x - offset_x) * 640 / target_width, 0, 639 );
-  *y = CLAMP( (screen_y - offset_y) * 350 / target_height, 0, 349 );
-  *min_x = 0;
-  *min_y = 0;
-  *max_x = target_width - 1;
-  *max_y = target_height - 1;
+  window->viewport_x = (window->width_px - SCREEN_PIX_W) >> 1;
+  window->viewport_y = (window->height_px - SCREEN_PIX_H) >> 1;
+  window->viewport_width = SCREEN_PIX_W;
+  window->viewport_height = SCREEN_PIX_H;
+  window->is_integer_scaled = true;
 }
-
-void set_screen_coords_scaled(struct graphics_data *graphics, int x, int y,
- int *screen_x, int *screen_y)
-{
-  int window_width = graphics->window_width;
-  int window_height = graphics->window_height;
-  int target_width;
-  int target_height;
-  int offset_x;
-  int offset_y;
-
-  if(graphics->fullscreen)
-  {
-    window_width = graphics->resolution_width;
-    window_height = graphics->resolution_height;
-  }
-
-  fix_viewport_ratio(window_width, window_height, &target_width, &target_height,
-   graphics->ratio);
-
-  offset_x = (window_width - target_width)/2;
-  offset_y = (window_height - target_height)/2;
-
-  *screen_x = x * target_width / 640 + offset_x;
-  *screen_y = y * target_height / 350 + offset_y;
-}
-
-#endif /* CONFIG_RENDER_GL_FIXED || CONFIG_RENDER_GL_PROGRAM ||
- CONFIG_RENDER_YUV */
 
 #if defined(CONFIG_RENDER_GL_FIXED) || defined(CONFIG_RENDER_GL_PROGRAM) \
  || defined(CONFIG_RENDER_SOFTSCALE) || defined(CONFIG_RENDER_YUV) \
  || defined(CONFIG_RENDER_GX)
 
-// FIXME: finish replacement of this function with the window viewport fields.
-// The GX renderer and scaled screen coords functions still use it.
-void fix_viewport_ratio(int width, int height, int *v_width, int *v_height,
- enum ratio_type ratio)
+void set_window_viewport_scaled(struct graphics_data *graphics,
+ struct video_window *window)
 {
   int numerator = 0, denominator = 0;
+  int width = MAX(window->width_px, 1);
+  int height = MAX(window->height_px, 1);
 
-  *v_width = MAX(width, 1);
-  *v_height = MAX(height, 1);
-
-  if(ratio == RATIO_STRETCH)
-    return;
-
-  if(ratio == RATIO_CLASSIC_4_3)
+  if(window->ratio == RATIO_CLASSIC_4_3)
   {
     numerator = 4;
     denominator = 3;
   }
-  else if(ratio == RATIO_MODERN_64_35)
+  else
+
+  if(window->ratio == RATIO_MODERN_64_35)
   {
     numerator = 64;
     denominator = 35;
   }
-
-  //if(((float)width / (float)height) < ((float)numerator / (float)denominator))
-  if(width * denominator < height * numerator)
-  {
-    height = (width * denominator) / numerator;
-    *v_height = MAX(height, 1);
-  }
   else
+
+  if(window->ratio == RATIO_SQUARE_1_1)
   {
-    width = (height * numerator) / denominator;
-    *v_width = MAX(width, 1);
+    numerator = 1;
+    denominator = 1;
   }
+
+  if(numerator > 0)
+  {
+    // (width / height) < (numerator / denominator)
+    // Multiply both sides by (height * denominator):
+    if(width * denominator < height * numerator)
+    {
+      height = (width * denominator) / numerator;
+      height = MAX(height, 1);
+    }
+    else
+    {
+      width = (height * numerator) / denominator;
+      width = MAX(width, 1);
+    }
+  }
+
+  window->viewport_x = (window->width_px - width) >> 1;
+  window->viewport_y = (window->height_px - height) >> 1;
+  window->viewport_width = width;
+  window->viewport_height = height;
+  window->is_integer_scaled = false;
+
+  if((width % SCREEN_PIX_W == 0) && (height % SCREEN_PIX_H == 0))
+    window->is_integer_scaled = true;
 }
 
 #endif /* CONFIG_RENDER_GL_FIXED || CONFIG_RENDER_GL_PROGRAM ||

--- a/src/render.c
+++ b/src/render.c
@@ -534,16 +534,14 @@ void set_screen_coords_viewport(struct graphics_data *graphics,
 void set_window_viewport_centered(struct graphics_data *graphics,
  struct video_window *window)
 {
-  window->viewport_x = (window->width_px - SCREEN_PIX_W) >> 1;
-  window->viewport_y = (window->height_px - SCREEN_PIX_H) >> 1;
+  window->viewport_x = ((int)window->width_px - SCREEN_PIX_W) >> 1;
+  window->viewport_y = ((int)window->height_px - SCREEN_PIX_H) >> 1;
   window->viewport_width = SCREEN_PIX_W;
   window->viewport_height = SCREEN_PIX_H;
   window->is_integer_scaled = true;
 }
 
-#if defined(CONFIG_RENDER_GL_FIXED) || defined(CONFIG_RENDER_GL_PROGRAM) \
- || defined(CONFIG_RENDER_SOFTSCALE) || defined(CONFIG_RENDER_YUV) \
- || defined(CONFIG_RENDER_GX)
+#ifdef HAVE_SET_WINDOW_VIEWPORT_SCALED
 
 void set_window_viewport_scaled(struct graphics_data *graphics,
  struct video_window *window)
@@ -588,8 +586,8 @@ void set_window_viewport_scaled(struct graphics_data *graphics,
     }
   }
 
-  window->viewport_x = (window->width_px - width) >> 1;
-  window->viewport_y = (window->height_px - height) >> 1;
+  window->viewport_x = ((int)window->width_px - width) >> 1;
+  window->viewport_y = ((int)window->height_px - height) >> 1;
   window->viewport_width = width;
   window->viewport_height = height;
   window->is_integer_scaled = false;
@@ -598,5 +596,4 @@ void set_window_viewport_scaled(struct graphics_data *graphics,
     window->is_integer_scaled = true;
 }
 
-#endif /* CONFIG_RENDER_GL_FIXED || CONFIG_RENDER_GL_PROGRAM ||
- CONFIG_RENDER_YUV || CONFIG_RENDER_GX */
+#endif /* HAVE_SET_WINDOW_VIEWPORT_SCALED */

--- a/src/render.h
+++ b/src/render.h
@@ -64,14 +64,16 @@ void set_window_viewport_centered(struct graphics_data *graphics,
  struct video_window *window);
 
 #if defined(CONFIG_RENDER_GL_FIXED) || defined(CONFIG_RENDER_GL_PROGRAM) \
- || defined(CONFIG_RENDER_SOFTSCALE) || defined(CONFIG_RENDER_YUV) \
- || defined(CONFIG_RENDER_GX)
+ || defined(CONFIG_RENDER_SOFTSCALE) || defined(CONFIG_RENDER_SDLACCEL) \
+ || defined(CONFIG_RENDER_YUV) || defined(CONFIG_RENDER_GX) \
+ || defined(MZX_UNIT_TESTS)
+
+#define HAVE_SET_WINDOW_VIEWPORT_SCALED
 
 void set_window_viewport_scaled(struct graphics_data *graphics,
  struct video_window *window);
 
-#endif /* CONFIG_RENDER_GL_FIXED || CONFIG_RENDER_GL_PROGRAM ||
- CONFIG_RENDER_YUV || CONFIG_RENDER_GX */
+#endif /* CONFIG_RENDER_GL_FIXED || CONFIG_RENDER_GL_PROGRAM || ... */
 
 __M_END_DECLS
 

--- a/src/render.h
+++ b/src/render.h
@@ -54,28 +54,21 @@ void render_cursor(uint32_t *pixels, size_t pitch, uint8_t bpp, unsigned int x,
 void render_mouse(uint32_t *pixels, size_t pitch, uint8_t bpp, unsigned int x,
  unsigned int y, uint32_t mask, uint32_t amask, uint8_t w, uint8_t h);
 
-void get_screen_coords_centered(struct graphics_data *graphics, int screen_x,
- int screen_y, int *x, int *y, int *min_x, int *min_y, int *max_x, int *max_y);
-void set_screen_coords_centered(struct graphics_data *graphics, int x, int y,
+void get_screen_coords_viewport(struct graphics_data *graphics,
+ struct video_window *window, int screen_x, int screen_y,
+ int *x, int *y, int *min_x, int *min_y, int *max_x, int *max_y);
+void set_screen_coords_viewport(struct graphics_data *graphics,
+ struct video_window *window, int x, int y,
  int *screen_x, int *screen_y);
-
-#if defined(CONFIG_RENDER_GL_FIXED) || defined(CONFIG_RENDER_GL_PROGRAM) \
- || defined(CONFIG_RENDER_SOFTSCALE) || defined(CONFIG_RENDER_YUV)
-
-void get_screen_coords_scaled(struct graphics_data *graphics, int screen_x,
- int screen_y, int *x, int *y, int *min_x, int *min_y, int *max_x, int *max_y);
-void set_screen_coords_scaled(struct graphics_data *graphics, int x, int y,
- int *screen_x, int *screen_y);
-
-#endif /* CONFIG_RENDER_GL_FIXED || CONFIG_RENDER_GL_PROGRAM ||
- CONFIG_RENDER_YUV */
+void set_window_viewport_centered(struct graphics_data *graphics,
+ struct video_window *window);
 
 #if defined(CONFIG_RENDER_GL_FIXED) || defined(CONFIG_RENDER_GL_PROGRAM) \
  || defined(CONFIG_RENDER_SOFTSCALE) || defined(CONFIG_RENDER_YUV) \
  || defined(CONFIG_RENDER_GX)
 
-void fix_viewport_ratio(int width, int height, int *v_width, int *v_height,
- enum ratio_type ratio);
+void set_window_viewport_scaled(struct graphics_data *graphics,
+ struct video_window *window);
 
 #endif /* CONFIG_RENDER_GL_FIXED || CONFIG_RENDER_GL_PROGRAM ||
  CONFIG_RENDER_YUV || CONFIG_RENDER_GX */

--- a/src/render_gl.c
+++ b/src/render_gl.c
@@ -114,18 +114,3 @@ void gl_set_filter_method(enum gl_filter_type method,
   glTexParameterf_p(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameterf_p(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 }
-
-void get_context_width_height(struct graphics_data *graphics,
- int *width, int *height)
-{
-  if(!graphics->fullscreen)
-  {
-    *width = graphics->window_width;
-    *height = graphics->window_height;
-  }
-  else
-  {
-    *width = graphics->resolution_width;
-    *height = graphics->resolution_height;
-  }
-}

--- a/src/render_gl.h
+++ b/src/render_gl.h
@@ -71,8 +71,6 @@ boolean gl_load_syms(const struct dso_syms_map *map);
 void gl_set_filter_method(enum gl_filter_type method,
  void (GL_APIENTRY *glTexParameterf_p)(GLenum target, GLenum pname,
   GLfloat param));
-void get_context_width_height(struct graphics_data *graphics,
- int *width, int *height);
 
 // Used to request an OpenGL API version with gl_set_video_mode.
 // Currently this is only used to configure SDL on platforms that require

--- a/src/render_gl1.c
+++ b/src/render_gl1.c
@@ -151,15 +151,9 @@ static boolean gl1_resize_callback(struct graphics_data *graphics,
  struct video_window *window)
 {
   struct gl1_render_data *render_data = graphics->render_data;
-  int width = window->width_px;
-  int height = window->height_px;
-  int v_width, v_height;
 
-  get_context_width_height(graphics, &width, &height);
-  fix_viewport_ratio(width, height, &v_width, &v_height, graphics->ratio);
-
-  gl1.glViewport((width - v_width) >> 1, (height - v_height) >> 1,
-   v_width, v_height);
+  gl1.glViewport(window->viewport_x, window->viewport_y,
+   window->viewport_width, window->viewport_height);
   gl_check_error();
 
   gl1.glEnableClientState(GL_TEXTURE_COORD_ARRAY);
@@ -318,7 +312,8 @@ static void gl1_render_mouse(struct graphics_data *graphics,
    0x0, w, h);
 }
 
-static void gl1_sync_screen(struct graphics_data *graphics)
+static void gl1_sync_screen(struct graphics_data *graphics,
+ struct video_window *window)
 {
   struct gl1_render_data *render_data = graphics->render_data;
 

--- a/src/render_gl1.c
+++ b/src/render_gl1.c
@@ -354,9 +354,8 @@ void render_gl1_register(struct renderer *renderer)
   renderer->create_window = gl1_create_window;
   renderer->resize_window = gl_resize_window;
   renderer->resize_callback = gl1_resize_callback;
+  renderer->set_viewport = set_window_viewport_scaled;
   renderer->update_colors = gl1_update_colors;
-  renderer->get_screen_coords = get_screen_coords_scaled;
-  renderer->set_screen_coords = set_screen_coords_scaled;
   renderer->render_graph = gl1_render_graph;
   renderer->render_layer = gl1_render_layer;
   renderer->render_cursor = gl1_render_cursor;

--- a/src/render_gl2.c
+++ b/src/render_gl2.c
@@ -1001,12 +1001,11 @@ void render_gl2_register(struct renderer *renderer)
   renderer->create_window = gl2_create_window;
   renderer->resize_window = gl_resize_window;
   renderer->resize_callback = gl2_resize_callback;
+  renderer->set_viewport = set_window_viewport_scaled;
   renderer->update_colors = gl2_update_colors;
   renderer->remap_char_range = gl2_remap_char_range;
   renderer->remap_char = gl2_remap_char;
   renderer->remap_charbyte = gl2_remap_charbyte;
-  renderer->get_screen_coords = get_screen_coords_scaled;
-  renderer->set_screen_coords = set_screen_coords_scaled;
   renderer->render_layer = gl2_render_layer;
   renderer->render_cursor = gl2_render_cursor;
   renderer->render_mouse = gl2_render_mouse;

--- a/src/render_glsl.c
+++ b/src/render_glsl.c
@@ -1561,12 +1561,11 @@ void render_glsl_register(struct renderer *renderer)
   renderer->create_window = glsl_create_window;
   renderer->resize_window = gl_resize_window;
   renderer->resize_callback = glsl_resize_callback;
+  renderer->set_viewport = set_window_viewport_scaled;
   renderer->update_colors = glsl_update_colors;
   renderer->remap_char_range = glsl_remap_char_range;
   renderer->remap_char = glsl_remap_char;
   renderer->remap_charbyte = glsl_remap_charbyte;
-  renderer->get_screen_coords = get_screen_coords_scaled;
-  renderer->set_screen_coords = set_screen_coords_scaled;
   renderer->render_layer = glsl_render_layer;
   renderer->render_cursor = glsl_render_cursor;
   renderer->render_mouse = glsl_render_mouse;

--- a/src/render_glsl.c
+++ b/src/render_glsl.c
@@ -1130,7 +1130,9 @@ static void glsl_render_layer(struct graphics_data *graphics,
   }
 
   // Clamp draw area to size of screen texture.
-  get_context_width_height(graphics, &width, &height);
+  // TODO: do this elsewhere with proper access to the window struct.
+  width = graphics->window.width_px;
+  height = graphics->window.height_px;
   if(width < SCREEN_PIX_W || height < SCREEN_PIX_H)
   {
     if(width >= GL_POWER_2_WIDTH)
@@ -1381,15 +1383,15 @@ static void glsl_render_mouse(struct graphics_data *graphics,
   glsl.glDisable(GL_BLEND);
 }
 
-static void glsl_sync_screen(struct graphics_data *graphics)
+static void glsl_sync_screen(struct graphics_data *graphics,
+ struct video_window *window)
 {
   struct glsl_render_data *render_data = graphics->render_data;
-  int v_width, v_height, width, height;
+  int width = window->width_px;
+  int height = window->height_px;
 
-  get_context_width_height(graphics, &width, &height);
-  fix_viewport_ratio(width, height, &v_width, &v_height, graphics->ratio);
-  glsl.glViewport((width - v_width) >> 1, (height - v_height) >> 1,
-   v_width, v_height);
+  glsl.glViewport(window->viewport_x, window->viewport_y,
+   window->viewport_width, window->viewport_height);
 
   // Clamp draw area to size of screen texture.
   if(width < SCREEN_PIX_W || height < SCREEN_PIX_H)

--- a/src/render_gp2x.c
+++ b/src/render_gp2x.c
@@ -245,7 +245,8 @@ static void gp2x_render_mouse(struct graphics_data *graphics,
    0x0, w, h);
 }
 
-static void gp2x_sync_screen(struct graphics_data *graphics)
+static void gp2x_sync_screen(struct graphics_data *graphics,
+ struct video_window *window)
 {
   struct gp2x_render_data *render_data = graphics->render_data;
   SDL_Surface *screen = gp2x_get_screen_surface(render_data);

--- a/src/render_gp2x.c
+++ b/src/render_gp2x.c
@@ -201,23 +201,14 @@ static boolean gp2x_create_window(struct graphics_data *graphics,
   return true;
 }
 
-static void gp2x_get_screen_coords(struct graphics_data *graphics,
- int screen_x, int screen_y, int *x, int *y, int *min_x, int *min_y,
- int *max_x, int *max_y)
+static void gp2x_set_window_viewport(struct graphics_data *graphics,
+ struct video_window *window)
 {
-  *x = screen_x * 2;
-  *y = screen_y * 35 / 24;
-  *min_x = 0;
-  *min_y = 0;
-  *max_x = 319;
-  *max_y = 239;
-}
-
-static void gp2x_set_screen_coords(struct graphics_data *graphics,
- int x, int y, int *screen_x, int *screen_y)
-{
-  *screen_x = x / 2;
-  *screen_y = y * 24 / 35;
+  window->viewport_x = 0;
+  window->viewport_y = 0;
+  window->viewport_width = 320;
+  window->viewport_height = 240;
+  window->is_integer_scaled = false;
 }
 
 static void gp2x_render_graph(struct graphics_data *graphics)
@@ -303,9 +294,8 @@ void render_gp2x_register(struct renderer *renderer)
   renderer->free_video = gp2x_free_video;
   renderer->create_window = gp2x_create_window;
   renderer->resize_window = gp2x_create_window;
+  renderer->set_viewport = gp2x_set_window_viewport;
   renderer->update_colors = sdl_update_colors;
-  renderer->get_screen_coords = gp2x_get_screen_coords;
-  renderer->set_screen_coords = gp2x_set_screen_coords;
   renderer->render_graph = gp2x_render_graph;
   renderer->render_cursor = gp2x_render_cursor;
   renderer->render_mouse = gp2x_render_mouse;

--- a/src/render_gp2x.c
+++ b/src/render_gp2x.c
@@ -211,6 +211,27 @@ static void gp2x_set_window_viewport(struct graphics_data *graphics,
   window->is_integer_scaled = false;
 }
 
+#if 0
+static void gp2x_get_screen_coords(struct graphics_data *graphics,
+ int screen_x, int screen_y, int *x, int *y, int *min_x, int *min_y,
+ int *max_x, int *max_y)
+{
+  *x = screen_x * 2;
+  *y = screen_y * 35 / 24;
+  *min_x = 0;
+  *min_y = 0;
+  *max_x = 319;
+  *max_y = 239;
+}
+
+static void gp2x_set_screen_coords(struct graphics_data *graphics,
+ int x, int y, int *screen_x, int *screen_y)
+{
+  *screen_x = x / 2;
+  *screen_y = y * 24 / 35;
+}
+#endif
+
 static void gp2x_render_graph(struct graphics_data *graphics)
 {
   struct gp2x_render_data *render_data = graphics->render_data;

--- a/src/render_sdlaccel.c
+++ b/src/render_sdlaccel.c
@@ -776,12 +776,11 @@ void render_sdlaccel_register(struct renderer *renderer)
   renderer->create_window = sdlaccel_create_window;
   renderer->resize_window = sdl_resize_window;
   renderer->resize_callback = sdlaccel_resize_callback;
+  renderer->set_viewport = set_window_viewport_scaled;
   renderer->update_colors = sdlaccel_update_colors;
   renderer->remap_char_range = sdlaccel_remap_char_range;
   renderer->remap_char = sdlaccel_remap_char;
   renderer->remap_charbyte = sdlaccel_remap_charbyte;
-  renderer->get_screen_coords = get_screen_coords_scaled;
-  renderer->set_screen_coords = set_screen_coords_scaled;
   renderer->render_layer = sdlaccel_render_layer;
   renderer->render_cursor = sdlaccel_render_cursor;
   renderer->render_mouse = sdlaccel_render_mouse;

--- a/src/render_sdlaccel.c
+++ b/src/render_sdlaccel.c
@@ -746,19 +746,16 @@ static void sdlaccel_sync_screen(struct graphics_data *graphics,
   SDL_Texture *screen_tex = render_data->sdl.texture[TEX_SCREEN];
   SDL_Rect src;
   SDL_Rect dest;
-  int width = graphics->window.width_px;
-  int height = graphics->window.height_px;
-  int v_width, v_height;
 
   src.x = 0;
   src.y = 0;
   src.w = SCREEN_PIX_W;
   src.h = SCREEN_PIX_H;
 
-  dest_rect.x = window->viewport_x;
-  dest_rect.y = window->viewport_y;
-  dest_rect.w = window->viewport_width;
-  dest_rect.h = window->viewport_height;
+  dest.x = window->viewport_x;
+  dest.y = window->viewport_y;
+  dest.w = window->viewport_width;
+  dest.h = window->viewport_height;
 
   SDL_SetRenderTarget(renderer, NULL);
   SDL_RenderCopy(renderer, screen_tex, &src, &dest);

--- a/src/render_sdlaccel.c
+++ b/src/render_sdlaccel.c
@@ -738,7 +738,8 @@ static void sdlaccel_render_mouse(struct graphics_data *graphics, unsigned x,
   SDL_RenderFillRect(render_data->sdl.renderer, &dest);
 }
 
-static void sdlaccel_sync_screen(struct graphics_data *graphics)
+static void sdlaccel_sync_screen(struct graphics_data *graphics,
+ struct video_window *window)
 {
   struct sdlaccel_render_data *render_data = graphics->render_data;
   SDL_Renderer *renderer = render_data->sdl.renderer;
@@ -754,11 +755,10 @@ static void sdlaccel_sync_screen(struct graphics_data *graphics)
   src.w = SCREEN_PIX_W;
   src.h = SCREEN_PIX_H;
 
-  fix_viewport_ratio(width, height, &v_width, &v_height, graphics->ratio);
-  dest.x = (width - v_width) / 2;
-  dest.y = (height - v_height) / 2;
-  dest.w = v_width;
-  dest.h = v_height;
+  dest_rect.x = window->viewport_x;
+  dest_rect.y = window->viewport_y;
+  dest_rect.w = window->viewport_width;
+  dest_rect.h = window->viewport_height;
 
   SDL_SetRenderTarget(renderer, NULL);
   SDL_RenderCopy(renderer, screen_tex, &src, &dest);

--- a/src/render_soft.c
+++ b/src/render_soft.c
@@ -271,7 +271,8 @@ static void soft_render_mouse(struct graphics_data *graphics,
   soft_unlock_buffer(render_data);
 }
 
-static void soft_sync_screen(struct graphics_data *graphics)
+static void soft_sync_screen(struct graphics_data *graphics,
+ struct video_window *window)
 {
 #ifdef CONFIG_SDL
   struct sdl_render_data *render_data = graphics->render_data;

--- a/src/render_soft.c
+++ b/src/render_soft.c
@@ -300,9 +300,8 @@ void render_soft_register(struct renderer *renderer)
   renderer->free_video = soft_free_video;
   renderer->create_window = soft_create_window;
   renderer->resize_window = soft_create_window;
+  renderer->set_viewport = set_window_viewport_centered;
   renderer->update_colors = soft_update_colors;
-  renderer->get_screen_coords = get_screen_coords_centered;
-  renderer->set_screen_coords = set_screen_coords_centered;
   renderer->render_graph = soft_render_graph;
   renderer->render_layer = soft_render_layer;
   renderer->render_cursor = soft_render_cursor;

--- a/src/render_softscale.c
+++ b/src/render_softscale.c
@@ -290,9 +290,8 @@ void render_softscale_register(struct renderer *renderer)
   renderer->create_window = softscale_create_window;
   renderer->resize_window = sdl_resize_window;
   renderer->resize_callback = softscale_resize_callback;
+  renderer->set_viewport = set_window_viewport_scaled;
   renderer->update_colors = sdl_update_colors;
-  renderer->get_screen_coords = get_screen_coords_scaled;
-  renderer->set_screen_coords = set_screen_coords_scaled;
   renderer->render_graph = softscale_render_graph;
   renderer->render_layer = softscale_render_layer;
   renderer->render_cursor = softscale_render_cursor;

--- a/src/render_softscale.c
+++ b/src/render_softscale.c
@@ -259,23 +259,19 @@ static void softscale_render_mouse(struct graphics_data *graphics,
   render_mouse(pixels, pitch, bpp, x, y, 0xFFFFFFFF, amask, w, h);
 }
 
-static void softscale_sync_screen(struct graphics_data *graphics)
+static void softscale_sync_screen(struct graphics_data *graphics,
+ struct video_window *window)
 {
   struct softscale_render_data *render_data = graphics->render_data;
   SDL_Renderer *renderer = render_data->sdl.renderer;
   SDL_Texture *texture = render_data->sdl.texture[0];
   SDL_Rect *src_rect = &(render_data->texture_rect);
   SDL_Rect dest_rect;
-  int width = graphics->window.width_px;
-  int height = graphics->window.height_px;
-  int v_width, v_height;
 
-  fix_viewport_ratio(width, height, &v_width, &v_height, graphics->ratio);
-
-  dest_rect.x = (width - v_width) / 2;
-  dest_rect.y = (height - v_height) / 2;
-  dest_rect.w = v_width;
-  dest_rect.h = v_height;
+  dest_rect.x = window->viewport_x;
+  dest_rect.y = window->viewport_y;
+  dest_rect.w = window->viewport_width;
+  dest_rect.h = window->viewport_height;
 
   softscale_unlock_texture(render_data);
 

--- a/src/render_yuv.c
+++ b/src/render_yuv.c
@@ -257,9 +257,8 @@ void render_yuv1_register(struct renderer *renderer)
   renderer->free_video = yuv_free_video;
   renderer->create_window = yuv1_set_video_mode;
   renderer->resize_window = yuv1_set_video_mode;
+  renderer->set_viewport = set_window_viewport_scaled;
   renderer->update_colors = sdl_update_colors;
-  renderer->get_screen_coords = get_screen_coords_scaled;
-  renderer->set_screen_coords = set_screen_coords_scaled;
   renderer->render_graph = yuv_render_graph;
   renderer->render_layer = yuv1_render_layer;
   renderer->render_cursor = yuv_render_cursor;

--- a/src/render_yuv.c
+++ b/src/render_yuv.c
@@ -234,20 +234,18 @@ static void yuv_render_mouse(struct graphics_data *graphics,
   yuv_unlock_overlay(render_data);
 }
 
-static void yuv_sync_screen(struct graphics_data *graphics)
+static void yuv_sync_screen(struct graphics_data *graphics,
+ struct video_window *window)
 {
   struct yuv_render_data *render_data = graphics->render_data;
   int width = graphics->window.width_px, v_width;
   int height = graphics->window.height_px, v_height;
   SDL_Rect rect;
 
-  // FIXME: Putting this here is suboptimal
-  fix_viewport_ratio(width, height, &v_width, &v_height, graphics->ratio);
-
-  rect.x = (width - v_width) >> 1;
-  rect.y = (height - v_height) >> 1;
-  rect.w = v_width;
-  rect.h = v_height;
+  rect.x = window->viewport_x;
+  rect.y = window->viewport_y;
+  rect.w = window->viewport_width;
+  rect.h = window->viewport_height;
 
   SDL_DisplayYUVOverlay(render_data->sdl.overlay, &rect);
 }


### PR DESCRIPTION
This fixes numerous comments complaining about `fix_viewport_ratio` being used in render functions by instead calculating the viewport whenever the window is resized with a new, similar function in graphics.c. Doing this also allows the integer scaling state to be precalculated for all scaling renderers, which helps mainly `opengl2` right now (but could be extended to `opengl1` and `glsl`). The longstanding "FIXME" about the ratio being calculated using floats has also been resolved.

There are two places where this couldn't be fully fixed: `opengl2` and `glsl` using the viewport variables in `render_layer` to set the viewport every time a layer is rendered. Doing this correctly requires a new start of frame callback, which would be a good idea for other reasons (charset and palette update).

- [x] `get_screen_coords_scaled`/`set_screen_coords_scaled` also need to use the new render viewport variables.
- [x] The GX renderer viewport setup uses `fix_viewport_ratio` to generate the viewport in an unusal way and it needs to be converted.