### PR TITLE
Fix bug where intake would sometimes skip handling input text.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -38,6 +38,8 @@ USERS
 + Fixed the board editor show thing hotkeys (broken by 2.93b).
 + Fixed a crash that would occur in builds using extra memory
   hacks (DOS) when copying blocks between boards in the editor.
++ Fixed text input bugs caused by a 2.93b change accidentally
+  reenabling old deadcode for exiting intake().
 
 DEVELOPERS
 

--- a/src/editor/sfx_edit.c
+++ b/src/editor/sfx_edit.c
@@ -241,10 +241,10 @@ void sfx_edit(struct world *mzx_world)
         num_elements = counts[page];
         num_sfx = num_elements;
 
+        memset(buffers, 0, sizeof(buffers));
         for(i = 0, pos = offsets[page]; i < num_sfx; i++, pos++)
         {
           const struct custom_sfx *sfx = sfx_get(custom_sfx, pos);
-          buffers[i][0] = '\0';
 
           update_label(sfx, pos, i);
           if(sfx)

--- a/src/intake.c
+++ b/src/intake.c
@@ -94,7 +94,7 @@ int intake(struct world *mzx_world, char *string, int max_len, int display_len,
   int currx, curr_len;
   int scrolledx, tmpx;
   int done = 0, place = 0;
-  char cur_char = 0;
+  char tmp_char;
   boolean select_char = false;
   int mouse_press;
   int action;
@@ -122,10 +122,10 @@ int intake(struct world *mzx_world, char *string, int max_len, int display_len,
       tmpx = display_len;
     }
 
-    cur_char = string[tmpx];
+    tmp_char = string[tmpx];
     string[tmpx] = '\0';
     write_string_ext(string + scrolledx, x, y, color, flags, 0, c_offset);
-    string[tmpx] = cur_char;
+    string[tmpx] = tmp_char;
 
     if(curr_len < display_len)
     {
@@ -487,13 +487,6 @@ int intake(struct world *mzx_world, char *string, int max_len, int display_len,
     if(place)
     {
       int num_placed = 0;
-
-      if((cur_char != 0) && (cur_char < 32) && (exit_type == INTK_EXIT_ANY))
-      {
-        done = 1;
-        key = cur_char;
-      }
-      else
 
       while((curr_len < max_len) && (!done) && num_placed < KEY_UNICODE_MAX)
       {


### PR DESCRIPTION
Commit 25d638bd repurposed the original `cur_char`, which originally held the input internal keycode. It was changed to instead do nothing in 0d725815 when SDL_TEXTINPUT handling was implemented, however, the original exit check prior to text input wasn't removed. Repurposing this variable reactivated that check and caused some text input fields to stop accepting input altogether (dependent on data stored in old board names, or particularly in the SFX editor, uninitialized memory).

Since the check has been dead for a while with fundamentally no problems, it has been removed entirely. The variable has been renamed to avoid being shadowed by the new handler, which also uses `cur_char`. Finally, the SFX string buffers in the SFX editor are cleared now (to avoid potential MSan whining if the UI ever gets unit tests).