### PR TITLE
Misc. fullscreen tweaks/fixes.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -39,6 +39,8 @@ USERS
   by MZX recreating the window after every window resize event.
 + Fixed junk display in the letterbox area after resizing using
   the software, gp2x, or SDL 1.2 overlay renderers.
++ The software and gp2x renderers now enable blitting when the
+  created window is smaller than expected instead of crashing.
 + Fixed sai.frag not being installed by "make install" or
   distributed with Unix-style packages for Linux/BSD/Darwin.
 + Fixed the board editor show thing hotkeys (broken by 2.93b).

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1768,8 +1768,8 @@ boolean init_video(struct config_info *conf, const char *caption)
   {
     // The driver should attempt to pick the best resolution automatically.
     // Not all create_window implementations support this.
-    graphics.resolution_width = -1;
-    graphics.resolution_height = -1;
+    graphics.resolution_width = 0;
+    graphics.resolution_height = 0;
   }
 
   if(conf->window_width <= 0 || conf->window_height <= 0)

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1881,18 +1881,6 @@ unsigned video_create_window(void)
   {
     window->width_px = graphics.resolution_width;
     window->height_px = graphics.resolution_height;
-
-#ifdef CONFIG_SDL
-    // If fullscreen_windowed is enabled, the driver should automatically pick
-    // the size of the window in all situations.
-    // TODO: too many console renderers are forcing resolution in init_video,
-    // so only do this for SDL.
-    if(graphics.fullscreen_windowed)
-    {
-      window->width_px = -1;
-      window->height_px = -1;
-    }
-#endif
   }
   else
   {

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -146,21 +146,21 @@ static boolean sdl_get_closest_usable_display_mode(SDL_DisplayMode *display_mode
 #endif /* SDL_VERSION_ATLEAST(2,0,0) */
 
 static boolean sdl_get_fullscreen_resolution(int *width, int *height,
- boolean renderer_supports_scaling)
+ boolean match_current_desktop)
 {
 #if SDL_VERSION_ATLEAST(2,0,0)
 
   SDL_DisplayMode display_mode;
   boolean have_mode = false;
 
-  if(renderer_supports_scaling)
+  if(match_current_desktop)
   {
     // Use the current desktop resolution.
     have_mode = sdl_get_desktop_display_mode(&display_mode);
   }
   else
   {
-    have_mode = sdl_get_closest_usable_display_mode(&display_mode, 320, 240);
+    have_mode = sdl_get_closest_usable_display_mode(&display_mode, 640, 350);
   }
 
   if(have_mode)
@@ -190,9 +190,11 @@ static void auto_fullscreen_size(struct graphics_data *graphics,
   int width = graphics->resolution_width;
   int height = graphics->resolution_height;
 
-  if(width < 0 || height < 0)
+  // Fullscreen windowed should always autodetect the size regardless of config.
+  if(width <= 0 || height <= 0 || window->is_fullscreen_windowed)
   {
-    if(!sdl_get_fullscreen_resolution(&width, &height, renderer_supports_scaling))
+    if(!sdl_get_fullscreen_resolution(&width, &height,
+     renderer_supports_scaling || window->is_fullscreen_windowed))
     {
       width = 640;
       height = 480;

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -588,6 +588,15 @@ boolean sdl_create_window_soft(struct graphics_data *graphics,
   if(depth == BPP_AUTO)
     graphics->bits_per_pixel = window->bits_per_pixel = SDL_BYTESPERPIXEL(fmt) * 8;
 
+  if((unsigned)render_data->screen->w < window->width_px ||
+   (unsigned)render_data->screen->h < window->height_px)
+  {
+    matched = false;
+    warn("Window surface (%dx%d) is smaller than expected (%ux%u).\n",
+     render_data->screen->w, render_data->screen->h,
+     window->width_px, window->height_px);
+  }
+
   if(!matched)
   {
     Uint32 Rmask, Gmask, Bmask, Amask;


### PR DESCRIPTION
* `graphics.resolution_width/height` are unsigned, so the auto value should be 0.
  This only kind of worked before by mistake and it was getting past the filter
  in the `software` renderer's `init_video` function.
* `fullscreen_windowed` is now handled entirely by the renderer.
* Bumped the minimum automatic fullscreen size back up to 640x350. The `gp2x`
  renderer overrides it anyway and 320x240 is quite bad for `software`.
* The `software` and `gp2x` renderers now enable blitting when the window
  surface is too small instead of crashing. SDL3 in Wayland reports several sizes
  smaller than 640x480, which made it possible to encounter this bug finally.