### PR TITLE
Move SDL_LoadObject et al. to platform_sdl.c to fix warnings.

### DIFF
--- a/src/platform.h
+++ b/src/platform.h
@@ -78,6 +78,13 @@ union dso_fn_ptr_ptr
   dso_fn_ptr *value;
 };
 
+/* SDL1/2, dlopen return void * instead of a function pointer. */
+union dso_suppress_warning
+{
+  void *in;
+  dso_fn_ptr out;
+};
+
 struct dso_syms_map
 {
   const char *name;

--- a/src/platform.h
+++ b/src/platform.h
@@ -67,12 +67,36 @@ int real_main(int argc, char *argv[]);
 #include <stdint.h>
 #include <time.h>
 
+/* Use as (dso_fn_ptr *) to store a loaded void(*)(void) to a function pointer. */
+typedef void (*dso_fn_ptr)(void);
+struct dso_library;
+
+/* Initialize a (dso_fn_ptr *) via (void *) to avoid strict aliasing warnings. */
+union dso_fn_ptr_ptr
+{
+  void *in;
+  dso_fn_ptr *value;
+};
+
+struct dso_syms_map
+{
+  const char *name;
+  union dso_fn_ptr_ptr sym_ptr;
+};
+
+#define DSO_MAP_END { NULL, { NULL }}
+
 CORE_LIBSPEC void delay(uint32_t ms);
 CORE_LIBSPEC uint64_t get_ticks(void);
 CORE_LIBSPEC boolean platform_init(void);
 CORE_LIBSPEC void platform_quit(void);
 CORE_LIBSPEC boolean platform_system_time(struct tm *tm,
  int64_t *epoch, int32_t *nano);
+
+CORE_LIBSPEC struct dso_library *platform_load_library(const char *name);
+CORE_LIBSPEC void platform_unload_library(struct dso_library *library);
+CORE_LIBSPEC boolean platform_load_function(struct dso_library *library,
+ const struct dso_syms_map *syms_map);
 
 __M_END_DECLS
 

--- a/src/platform_time.c
+++ b/src/platform_time.c
@@ -57,20 +57,20 @@ static void convert_timestamp(int64_t *epoch, int32_t *nano,
  */
 static boolean system_time_win32(int64_t *epoch, int32_t *nano)
 {
+  static struct dso_library *dll;
   static void (WINAPI *_GetSystemTimePreciseAsFileTime)(LPFILETIME) = NULL;
+  static const struct dso_syms_map sym =
+   { "GetSystemTimePreciseAsFileTime", { &_GetSystemTimePreciseAsFileTime } };
   static boolean init = false;
   FILETIME ft;
 
   if(!init)
   {
-    void *dll = SDL_LoadObject("Kernel32.dll");
+    // Note: can't unload, or the function pointer will no longer be valid.
+    dll = platform_load_library("Kernel32.dll");
     if(dll)
-    {
-      union dso_fn_ptr_ptr tmp;
-      tmp.in = (dso_fn **)&_GetSystemTimePreciseAsFileTime;
-      *(tmp.value) = SDL_LoadFunction(dll, "GetSystemTimePreciseAsFileTime");
-      SDL_UnloadObject(dll);
-    }
+      platform_load_function(dll, &sym);
+
     init = true;
   }
 

--- a/src/render_egl.c
+++ b/src/render_egl.c
@@ -34,9 +34,11 @@ static enum gl_lib_type gl_type;
 
 #ifdef ANDROID
 
-dso_fn *GL_GetProcAddress(const char *proc)
+dso_fn_ptr GL_GetProcAddress(const char *proc)
 {
-  return (dso_fn *)dlsym(glso, proc);
+  union dso_suppress_warning value;
+  value.in = dlsym(glso, proc);
+  return value.out;
 }
 
 #endif /* ANDROID */

--- a/src/render_egl.h
+++ b/src/render_egl.h
@@ -40,15 +40,9 @@ boolean GL_LoadLibrary(enum gl_lib_type type);
 
 #ifndef ANDROID
 
-static inline dso_fn *GL_GetProcAddress(const char *proc)
+static inline dso_fn_ptr GL_GetProcAddress(const char *proc)
 {
-  union suppress_warning
-  {
-    void (*in)(void);
-    dso_fn *out;
-  } t;
-  t.in = eglGetProcAddress(proc);
-  return t.out;
+  return eglGetProcAddress(proc);
 }
 
 #else /* ANDROID */
@@ -56,7 +50,7 @@ static inline dso_fn *GL_GetProcAddress(const char *proc)
 /* Android's eglGetProcAddress is currently broken, so we
  * have to roll our own..
  */
-dso_fn *GL_GetProcAddress(const char *proc);
+dso_fn_ptr GL_GetProcAddress(const char *proc);
 
 #endif /* !ANDROID */
 

--- a/src/render_gl.c
+++ b/src/render_gl.c
@@ -19,6 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "platform.h"
 #include "render.h"
 #include "util.h"
 
@@ -82,13 +83,23 @@ void gl_error(const char *file, int line,
 
 #endif // DEBUG
 
+#ifdef CONFIG_SDL
+#if SDL_VERSION_ATLEAST(3,0,0)
+#define HAVE_SDL_FUNCTIONPOINTER
+#endif
+#endif
+
 boolean gl_load_syms(const struct dso_syms_map *map)
 {
   int i = 0;
 
   for(i = 0; map[i].name != NULL; i++)
   {
-    dso_fn **sym_ptr = map[i].sym_ptr.value;
+#ifdef HAVE_SDL_FUNCTIONPOINTER
+    SDL_FunctionPointer *sym_ptr = (SDL_FunctionPointer *)map[i].sym_ptr.value;
+#else
+    void **sym_ptr = (void **)map[i].sym_ptr.in;
+#endif
     *sym_ptr = GL_GetProcAddress(map[i].name);
     if(!*sym_ptr)
     {

--- a/src/render_gl.c
+++ b/src/render_gl.c
@@ -83,23 +83,14 @@ void gl_error(const char *file, int line,
 
 #endif // DEBUG
 
-#ifdef CONFIG_SDL
-#if SDL_VERSION_ATLEAST(3,0,0)
-#define HAVE_SDL_FUNCTIONPOINTER
-#endif
-#endif
-
 boolean gl_load_syms(const struct dso_syms_map *map)
 {
   int i = 0;
 
   for(i = 0; map[i].name != NULL; i++)
   {
-#ifdef HAVE_SDL_FUNCTIONPOINTER
-    SDL_FunctionPointer *sym_ptr = (SDL_FunctionPointer *)map[i].sym_ptr.value;
-#else
-    void **sym_ptr = (void **)map[i].sym_ptr.in;
-#endif
+    dso_fn_ptr *sym_ptr = map[i].sym_ptr.value;
+
     *sym_ptr = GL_GetProcAddress(map[i].name);
     if(!*sym_ptr)
     {

--- a/src/render_sdl.h
+++ b/src/render_sdl.h
@@ -126,9 +126,16 @@ static inline boolean GL_LoadLibrary(enum gl_lib_type type)
   return false;
 }
 
-static inline void *GL_GetProcAddress(const char *proc)
+static inline dso_fn_ptr GL_GetProcAddress(const char *proc)
 {
+#if SDL_VERSION_ATLEAST(3,0,0)
   return SDL_GL_GetProcAddress(proc);
+#else
+  /* SDL1/2 returns void * instead of a function pointer. */
+  union dso_suppress_warning value;
+  value.in = SDL_GL_GetProcAddress(proc);
+  return value.out;
+#endif
 }
 
 #endif // CONFIG_RENDER_GL_FIXED || CONFIG_RENDER_GL_PROGRAM

--- a/src/util.h
+++ b/src/util.h
@@ -123,24 +123,6 @@ static inline size_t round_to_power_of_two(size_t v)
   return v + 1;
 }
 
-/* Use as (dso_fn **) to store a loaded (void *) to a function pointer. */
-typedef void dso_fn;
-
-/* Initialize a (dso_fn **) via (void *) to avoid strict aliasing warnings. */
-union dso_fn_ptr_ptr
-{
-  void *in;
-  dso_fn **value;
-};
-
-struct dso_syms_map
-{
-  const char *name;
-  union dso_fn_ptr_ptr sym_ptr;
-};
-
-#define DSO_MAP_END { NULL, { NULL }}
-
 #include <sys/types.h>
 
 #if defined(__WIN32__) && defined(__STRICT_ANSI__)


### PR DESCRIPTION
SDL3 uses SDL_FunctionPointer instead of void * for function pointers, which introduces function/object aliasing warnings. Instead of using SDL_FUNCTION_POINTER_IS_VOID_POINTER to work around this (which introduces more warnings in unrelated places), it's easier to just combine all of the places these functions are used into platform_* functions. GL_GetProcAddress still requires a separate hack.