### PR TITLE
p7zip is no longer a hard dependency for make archive.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -208,7 +208,7 @@ jobs:
 
   ARM-NDS:
     runs-on: ubuntu-latest
-    container: devkitpro/devkitarm
+    container: devkitpro/devkitarm:20241104
     steps:
       - run: echo "PATH=$DEVKITPRO/devkitARM/bin:$PATH" >> $GITHUB_ENV
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,6 @@ name: Regression tests
 env:
   MZXDEPS_DEBIAN_SDL2:  "zlib1g-dev libpng-dev libogg-dev libvorbis-dev libsdl2-dev"
   MZXDEPS_DEBIAN_MISC:  "libsdl1.2-dev libegl1-mesa-dev libmikmod-dev libopenmpt-dev"
-  MZXDEPS_DEBIAN_CROSS: "p7zip-full"
   MZXDEPS_MACOS:        "libpng libogg libvorbis sdl2"
   MZX_MAKE:             "make -j4"
 
@@ -143,7 +142,7 @@ jobs:
           msystem: MINGW64
           update: true
           install: >-
-            base-devel git p7zip
+            base-devel git
             mingw-w64-x86_64-gcc    mingw-w64-x86_64-zlib      mingw-w64-x86_64-libpng
             mingw-w64-x86_64-libogg mingw-w64-x86_64-libvorbis mingw-w64-x86_64-SDL2
       - uses: actions/checkout@v4
@@ -168,7 +167,7 @@ jobs:
           msystem: MINGW32
           update: true
           install: >-
-            base-devel git p7zip
+            base-devel git
             mingw-w64-i686-gcc      mingw-w64-i686-zlib        mingw-w64-i686-libpng
             mingw-w64-i686-libogg   mingw-w64-i686-libvorbis   mingw-w64-i686-SDL2
       - uses: actions/checkout@v4
@@ -185,8 +184,6 @@ jobs:
     runs-on: ubuntu-latest
     container: devkitpro/devkita64
     steps:
-      - name: Install dependencies
-        run: sudo apt update && sudo apt install -y --no-install-recommends $MZXDEPS_DEBIAN_CROSS
       - run: echo "PATH=$DEVKITPRO/devkitA64/bin:$PATH" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - name: Configure Switch
@@ -200,8 +197,6 @@ jobs:
     runs-on: ubuntu-latest
     container: devkitpro/devkitarm
     steps:
-      - name: Install dependencies
-        run: sudo apt update && sudo apt install -y --no-install-recommends $MZXDEPS_DEBIAN_CROSS
       - run: echo "PATH=$DEVKITPRO/devkitARM/bin:$PATH" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - name: Configure 3DS
@@ -215,8 +210,6 @@ jobs:
     runs-on: ubuntu-latest
     container: devkitpro/devkitarm
     steps:
-      - name: Install dependencies
-        run: sudo apt update && sudo apt install -y --no-install-recommends $MZXDEPS_DEBIAN_CROSS
       - run: echo "PATH=$DEVKITPRO/devkitARM/bin:$PATH" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - name: Configure NDS
@@ -230,8 +223,6 @@ jobs:
     runs-on: ubuntu-latest
     container: skylyrac/blocksds:slim-latest
     steps:
-      - name: Install dependencies
-        run: apt update && apt install -y --no-install-recommends $MZXDEPS_DEBIAN_CROSS
       - name: Install target dependencies
         run: wf-pacman -Syu --noconfirm && wf-pacman -S --noconfirm toolchain-gcc-arm-none-eabi-zlib
       - run: echo "BLOCKSDS=/opt/blocksds/core" >> $GITHUB_ENV
@@ -247,8 +238,6 @@ jobs:
     runs-on: ubuntu-latest
     container: devkitpro/devkitppc
     steps:
-      - name: Install dependencies
-        run: sudo apt update && sudo apt install -y --no-install-recommends $MZXDEPS_DEBIAN_CROSS
       - run: echo "PATH=$DEVKITPRO/devkitPPC/bin:$PATH" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - name: Configure Wii
@@ -262,8 +251,6 @@ jobs:
     runs-on: ubuntu-latest
     container: devkitpro/devkitppc
     steps:
-      - name: Install dependencies
-        run: sudo apt update && sudo apt install -y --no-install-recommends $MZXDEPS_DEBIAN_CROSS
       - run: echo "PATH=$DEVKITPRO/devkitPPC/bin:$PATH" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - name: Configure Wii U
@@ -276,8 +263,6 @@ jobs:
   Emscripten-HTML5:
     runs-on: ubuntu-latest
     steps:
-      - name: Install dependencies
-        run: sudo apt update && sudo apt install -y --no-install-recommends $MZXDEPS_DEBIAN_CROSS
       - name: Install Emscripten
         uses: mymindstorm/setup-emsdk@v14
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,7 +142,7 @@ jobs:
           msystem: MINGW64
           update: true
           install: >-
-            base-devel git
+            base-devel git zip
             mingw-w64-x86_64-gcc    mingw-w64-x86_64-zlib      mingw-w64-x86_64-libpng
             mingw-w64-x86_64-libogg mingw-w64-x86_64-libvorbis mingw-w64-x86_64-SDL2
       - uses: actions/checkout@v4
@@ -167,7 +167,7 @@ jobs:
           msystem: MINGW32
           update: true
           install: >-
-            base-devel git
+            base-devel git zip
             mingw-w64-i686-gcc      mingw-w64-i686-zlib        mingw-w64-i686-libpng
             mingw-w64-i686-libogg   mingw-w64-i686-libvorbis   mingw-w64-i686-SDL2
       - uses: actions/checkout@v4
@@ -223,6 +223,8 @@ jobs:
     runs-on: ubuntu-latest
     container: skylyrac/blocksds:slim-latest
     steps:
+      - name: Install dependencies
+        run: apt update && apt install -y --no-install-recommends zip
       - name: Install target dependencies
         run: wf-pacman -Syu --noconfirm && wf-pacman -S --noconfirm toolchain-gcc-arm-none-eabi-zlib
       - run: echo "BLOCKSDS=/opt/blocksds/core" >> $GITHUB_ENV

--- a/arch/zip.inc
+++ b/arch/zip.inc
@@ -6,4 +6,8 @@ archive: build
 	${RM} -r build/dist/${SUBPLATFORM}
 	${MKDIR} -p build/dist/${SUBPLATFORM}
 	@cd build/${SUBPLATFORM} && \
-	 7za a -tzip ../dist/${SUBPLATFORM}/${TARGET}-${SUBARCH}.zip *
+	if command -v 7za >/dev/null 2>/dev/null; then \
+		7za a -mx9 -tzip "../dist/${SUBPLATFORM}/${TARGET}-${SUBARCH}.zip" *; \
+	else \
+		zip -r9 "../dist/${SUBPLATFORM}/${TARGET}-${SUBARCH}.zip" *; \
+	fi


### PR DESCRIPTION
Removes the only extra dependency for platforms that rely on Debian-based containers for CI, which should hopefully resolve the recent failures.