### PR TITLE
android: Support 16K page sizes.

### DIFF
--- a/arch/android/Makefile.deps
+++ b/arch/android/Makefile.deps
@@ -23,6 +23,7 @@ LIBOGG_VERSION    ?= 1.3.5
 LIBVORBIS_VERSION ?= 1.3.7
 WGET              ?= wget
 TAR               ?= tar
+PATCH             ?= patch
 
 DEPS              := arch/android/deps
 DEPS_BUILD        := arch/android/deps/.build
@@ -52,6 +53,7 @@ ${DEPS}/SDL2-${SDL_VERSION}: | ${DEPS}
 	${RM} -f $@.tar.gz
 	${WGET} https://www.libsdl.org/release/SDL2-${SDL_VERSION}.tar.gz -O$@.tar.gz
 	${TAR} -xzf $@.tar.gz -C ${DEPS}/
+	${PATCH} -i ../../SDL2-page-sizes.patch -p1 -d ${DEPS}/SDL2-${SDL_VERSION}
 
 ${DEPS}/libogg-${LIBOGG_VERSION}: | ${DEPS}
 	$(if ${V},,@echo "  WGET    " $@)

--- a/arch/android/Makefile.in
+++ b/arch/android/Makefile.in
@@ -94,6 +94,8 @@ CLANG_PRE    := ${ANDROID_LIBS}
 BINUTILS_PRE := ${ANDROID_LIBS}
 ABI          := arm64-v8a
 SDK          := 21
+# https://developer.android.com/guide/practices/page-sizes
+ARCH_LDFLAGS   += -Wl,-z,max-page-size=16384
 else
 
 ifeq (${ANDROID_TARGET},i686)
@@ -110,6 +112,8 @@ CLANG_PRE    := ${ANDROID_LIBS}
 BINUTILS_PRE := ${ANDROID_LIBS}
 ABI          := x86_64
 SDK          := 21
+# https://developer.android.com/guide/practices/page-sizes
+ARCH_LDFLAGS   += -Wl,-z,max-page-size=16384
 else
 
 ANDROID_LIBS := none

--- a/arch/android/SDL2-page-sizes.patch
+++ b/arch/android/SDL2-page-sizes.patch
@@ -1,0 +1,23 @@
+diff -Nrup SDL2-2.30.9.orig/Android.mk SDL2-2.30.9/Android.mk
+--- SDL2-2.30.9.orig/Android.mk	2023-06-04 08:55:56.000000000 +0200
++++ SDL2-2.30.9/Android.mk	2024-12-01 10:07:36.795771235 +0100
+@@ -83,6 +83,9 @@ LOCAL_LDLIBS := -ldl -lGLESv1_CM -lGLESv
+ 
+ LOCAL_LDFLAGS := -Wl,--no-undefined
+ 
++# https://developer.android.com/guide/practices/page-sizes
++LOCAL_LDFLAGS += "-Wl,-z,max-page-size=16384"
++
+ ifeq ($(NDK_DEBUG),1)
+     cmd-strip :=
+ endif
+@@ -104,7 +107,8 @@ LOCAL_MODULE_FILENAME := libSDL2
+ 
+ LOCAL_LDLIBS :=
+ 
+-LOCAL_LDFLAGS :=
++# https://developer.android.com/guide/practices/page-sizes
++LOCAL_LDFLAGS := "-Wl,-z,max-page-size=16384"
+ 
+ LOCAL_EXPORT_LDLIBS := -ldl -lGLESv1_CM -lGLESv2 -llog -landroid
+ 

--- a/arch/android/libogg-Android.mk
+++ b/arch/android/libogg-Android.mk
@@ -6,6 +6,9 @@ LOCAL_MODULE := libogg
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_C_INCLUDES)
 
+# https://developer.android.com/guide/practices/page-sizes
+LOCAL_LDFLAGS += "-Wl,-z,max-page-size=16384"
+
 LOCAL_SRC_FILES := src/bitwise.c src/framing.c
 
 include $(BUILD_SHARED_LIBRARY)

--- a/arch/android/libvorbis-Android.mk
+++ b/arch/android/libvorbis-Android.mk
@@ -7,6 +7,9 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/include $(LOCAL_PATH)/lib
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/include
 LOCAL_SHARED_LIBRARIES := libogg
 
+# https://developer.android.com/guide/practices/page-sizes
+LOCAL_LDFLAGS += "-Wl,-z,max-page-size=16384"
+
 LOCAL_SRC_FILES := lib/mdct.c lib/smallft.c lib/block.c lib/envelope.c lib/window.c lib/lsp.c \
 			lib/lpc.c lib/analysis.c lib/synthesis.c lib/psy.c lib/info.c \
 			lib/floor1.c lib/floor0.c \
@@ -20,6 +23,9 @@ LOCAL_MODULE := libvorbisfile
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/include $(LOCAL_PATH)/lib
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/include
 LOCAL_SHARED_LIBRARIES := libogg libvorbis
+
+# https://developer.android.com/guide/practices/page-sizes
+LOCAL_LDFLAGS += "-Wl,-z,max-page-size=16384"
 
 LOCAL_SRC_FILES := lib/vorbisfile.c
 


### PR DESCRIPTION
As of Android 15, devices will be able to ship with 16 KB page sizes instead of the previous default of 4 KB. This requires updating the NDK (which we are not doing as to keep compatibility with API level 16 for 2.93c) or adjusting the build process of all shared libraries (which is done by this commit).