### PR TITLE
Update libxmp to 4.6.1+sample rate patch.

### DIFF
--- a/contrib/libxmp/Makefile.megazeux
+++ b/contrib/libxmp/Makefile.megazeux
@@ -38,6 +38,7 @@ SRC_OBJS = \
   far_extras.o    \
   filetype.o      \
   filter.o        \
+  flow.o          \
   format.o        \
   hio.o           \
   hmn_extras.o    \

--- a/contrib/libxmp/Makefile.megazeux-gen
+++ b/contrib/libxmp/Makefile.megazeux-gen
@@ -52,6 +52,7 @@ install := \
 	${dest_src}/far_extras.h \
 	${dest_src}/filetype.c \
 	${dest_src}/filter.c \
+	${dest_src}/flow.c \
 	${dest_src}/format.c \
 	${dest_src}/format.h \
 	${dest_src}/hio.c \

--- a/contrib/libxmp/docs/Changelog
+++ b/contrib/libxmp/docs/Changelog
@@ -1,28 +1,93 @@
 Stable versions
 ---------------
 
-4.6.1 (?):
+4.6.1 (20250101):
 	Changes by Claudio Matsuoka:
 	- The full library is now under MIT license
 	Changes by Alice Rowan:
+	- Add stereo sample loading support for IT, S3M, XM, MED, LIQ, and
+	  Digital Tracker (partial).
+	- Add sample preamplification to filter mixers for high sample rates.
+	- Add support for Ultra Tracker tempo commands.
+	- Load Ultra Tracker comments instead of skipping them.
+	- Implement support for Protracker instrument swapping.
+	- Implement retrigger effects for MED, OctaMED, and Liquid Tracker
+	  where only one retrigger occurs. Liquid Tracker (new format) and
+	  Digital Symphony now allow retrigger values larger than 15.
 	- Fix XM envelope sustain points that exist on a zero-length loop.
+	- Fix XM extra fine portamento effect memory.
+	- Fix XM portamento up and portamento down memory (only for modules
+	  where FT2 bug compatibility is enabled, for now).
 	- Fix loading edge case STMs with an EOF byte of 2.
 	- Fix loading Imago Orpheus modules with null instrument magic
 	  strings, bidirectional samples, and disabled default panning.
 	- Faster IT loading by buffering pattern, sample, and comment reads.
 	- Fix loop detection edge cases broken by S3M/IT marker scan bugs.
+	- Add fix for IT break to module scan (was missed in libxmp 4.5.0.)
+	- Fix restart position for >64k sample and Digital Tracker MODs.
+	- Reset Invert Loop position when a new instrument is encountered.
+	- MOD: make presence of invert loop override tracker ID guesses.
+	  M.K. modules within Amiga limits which use EFx invert loop are
+	  now IDed as Protracker.
+	- Multiple Digital Tracker bug fixes:
+	  * Support for loading Digital Tracker 2.03 DTMs (MOD patterns).
+	  * Support for loading Digital Tracker 1.9 DTMs (VERS/SV19).
+	  * Better Digital Tracker version fingerprinting.
+	  * Fix Digital Tracker 2.03 global sample rate and bit depth fields.
+	  * Fix Digital Tracker 2.04 pattern note loading (was off-by-one).
+	  * Fix Digital Tracker instrument loops (loop end was off-by-one).
+	  * Allow patterns up to 396 rows in Digital Home Studio DTMs.
+	  * Support for Digital Tracker 1.9 "MIDI note" transpose.
+	  * Simulate Digital Tracker effects bugs where possible.
+	  * Fix loading of Digital Tracker module names (not always 32 bytes).
+	- Liquid Tracker bug fixes:
+	  * [Old] Fix loading of module and instrument names (fixes the old
+	    format version of WASTETIM.LIQ).
+	  * [Old] Fix loading of instrument lengths/loops (32-bit, not 16-bit).
+	  * [Old] Fix loading of pattern notes and volumes (off-by-one).
+	  * [Old] Fix initial panning.
+	  * [Old] Most effects are now supported. H70/H6A is not yet supported.
+	    Fxx, if it was ever implemented, is not yet supported.
+	  * [New] Fixed Pan Control, Retrigger, Global Volume effects, and
+	    vibrato/tremolo waveform 3. P70/P6A is not yet supported.
+	  * [New] Fix incorrect bounding of notes that caused several LIQs
+	    to fail to load.
+	  * [New] Fix loading of pattern volumes (off-by-one).
+	  * [New] 16-bit samples with loops no longer cause a failed load.
+	  * [New] Fix loading of instrument global volumes.
+	  * [New] Add support for ping pong loops.
+	  * [New] Fix initial channel volume/pan tables for 0.00 LIQs.
+	  * [New] Support channel volume and instrument global volume gain
+	    functionality by doubling the mix volume once for each (4x total).
+	  * [Both] Stopped incorrectly applying QUIRK_S3MLOOP, QUIRK_VOLPDN,
+	    QUIRK_S3MRTG, and QUIRK_MARKER.
+	- Fix loading of Poly Tracker (PTM) empty sample names.
+	- Fix Real Tracker loader on targets where char is unsigned by default.
 	- Fix out-of-bounds reads in His Master's Noise Mupp instruments.
 	- Fix slow ProWizard testing.
+	- Fix Paula mixer state leak after changing XMP_PLAYER_MODE.
 	- Replace rand() with a built-in reentrant alternative.
 	- xmp_set_tempo_factor now returns -XMP_ERROR_STATE when called prior
 	  to xmp_start_player (instead of causing crashes).
 	- Fix mixer crashes caused by previously valid tempo factors after
 	  sample rate or BPM changes.
+	- Passing NULL to xmp_set_instrument_path() now unsets the instrument
+	  path instead of crashing.
+	- Merge song file instrument path detection routines.
+	- Fix module scan pattern delay counting.
+	- Add compatibility for non-standard Pattern Loop implementations:
+	  Scream Tracker 3.01b; Scream Tracker 3.03b+; Impulse Tracker 1.00;
+	  Impulse Tracker 1.04 to 2.09; Modplug Tracker 1.16; Digital Tracker
+	  <=2.04; Digital Tracker 1.9; Octalyser; Imago Orpheus; Liquid Tracker;
+	  Poly Tracker. (MOD, FT2, and IT 2.10+ were already supported.)
+	- Fixed numerous defects found by fuzzing.
 	Changes by Thomas Neumann:
 	- Fix XM envelope handling
 	- Bug fixes to DSMI loader
 	- Fix 16-bit sample check in MultiTracker loader
 	- Fix finetune in MultiTracker loader
+	- Fix XM restart position, so that it is possible to play
+	 "10 Days Of Abstinence.xm"
 	Changes by Saga Musix:
 	- S3M: Detect PlayerPRO, Velvet Studio and old MPT versions
 	Changes by ds-sloth:
@@ -1990,5 +2055,3 @@ Development (unreleased) versions
 
 0.05 and before:
 	- Lots of changes.
-
-

--- a/contrib/libxmp/include/xmp.h
+++ b/contrib/libxmp/include/xmp.h
@@ -29,11 +29,11 @@
 extern "C" {
 #endif
 
-#define XMP_VERSION "4.6.0"
-#define XMP_VERCODE 0x040600
+#define XMP_VERSION "4.6.1"
+#define XMP_VERCODE 0x040601
 #define XMP_VER_MAJOR 4
 #define XMP_VER_MINOR 6
-#define XMP_VER_RELEASE 0
+#define XMP_VER_RELEASE 1
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
 # if defined(LIBXMP_STATIC)

--- a/contrib/libxmp/src/control.c
+++ b/contrib/libxmp/src/control.c
@@ -559,8 +559,13 @@ int xmp_set_instrument_path(xmp_context opaque, const char *path)
 	struct context_data *ctx = (struct context_data *)opaque;
 	struct module_data *m = &ctx->m;
 
-	if (m->instrument_path != NULL)
+	if (m->instrument_path != NULL) {
 		free(m->instrument_path);
+		m->instrument_path = NULL;
+	}
+	if (path == NULL) {
+		return 0;
+	}
 
 	m->instrument_path = libxmp_strdup(path);
 	if (m->instrument_path == NULL) {

--- a/contrib/libxmp/src/effects.c
+++ b/contrib/libxmp/src/effects.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2022 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -173,23 +173,24 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 				goto fx_f_porta_up;
 			case 0xe:
 				fxp &= 0x0f;
-				fxp |= 0x10;
-				goto fx_xf_porta;
+				goto fx_xf_porta_up;
 			}
 		}
 
-		SET(PITCHBEND);
-
 		if (fxp != 0) {
+			SET(PITCHBEND);
 			xc->freq.slide = -fxp;
 			if (HAS_QUIRK(QUIRK_UNISLD))
 				xc->porta.memory = fxp;
-		} else if (xc->freq.slide > 0) {
-			xc->freq.slide *= -1;
 		}
 		break;
 	case FX_PORTA_DN:	/* Portamento down */
-		EFFECT_MEMORY(fxp, xc->freq.memory);
+		/* FT2 has separate up and down memory. */
+		if (HAS_QUIRK(QUIRK_FT2BUGS)) {
+			EFFECT_MEMORY(fxp, xc->freq.down_memory);
+		} else {
+			EFFECT_MEMORY(fxp, xc->freq.memory);
+		}
 
 		if (HAS_QUIRK(QUIRK_FINEFX)
 		    && (fnum == 0 || !HAS_QUIRK(QUIRK_ITVPOR))) {
@@ -199,19 +200,15 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 				goto fx_f_porta_dn;
 			case 0xe:
 				fxp &= 0x0f;
-				fxp |= 0x20;
-				goto fx_xf_porta;
+				goto fx_xf_porta_dn;
 			}
 		}
 
-		SET(PITCHBEND);
-
 		if (fxp != 0) {
+			SET(PITCHBEND);
 			xc->freq.slide = fxp;
 			if (HAS_QUIRK(QUIRK_UNISLD))
 				xc->porta.memory = fxp;
-		} else if (xc->freq.slide < 0) {
-			xc->freq.slide *= -1;
 		}
 		break;
 	case FX_TONEPORTA:	/* Tone portamento */
@@ -416,27 +413,7 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 			}
 			break;
 		case EX_PATTERN_LOOP:	/* Loop pattern */
-			if (fxp == 0) {
-				/* mark start of loop */
-				f->loop[chn].start = p->row;
-				if (HAS_QUIRK(QUIRK_FT2BUGS))
-				  p->flow.jumpline = p->row;
-			} else {
-				/* end of loop */
-				if (f->loop[chn].count) {
-					if (--f->loop[chn].count) {
-						/* **** H:FIXME **** */
-						f->loop_chn = ++chn;
-					} else {
-						if (HAS_QUIRK(QUIRK_S3MLOOP))
-							f->loop[chn].start =
-							    p->row + 1;
-					}
-				} else {
-					f->loop[chn].count = fxp;
-					f->loop_chn = ++chn;
-				}
-			}
+			libxmp_process_pattern_loop(ctx, f, chn, p->row, fxp);
 			break;
 		case EX_TREMOLO_WF:	/* Set tremolo waveform */
 			libxmp_lfo_set_waveform(&xc->tremolo.lfo, fxp & 3);
@@ -445,11 +422,14 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 			fxp <<= 4;
 			goto fx_setpan;
 		case EX_RETRIG:		/* Retrig note */
+#ifndef LIBXMP_CORE_PLAYER
+		    fx_retrig:
+#endif
 			SET(RETRIG);
 			xc->retrig.val = fxp;
-			xc->retrig.count = LSN(xc->retrig.val) + 1;
+			xc->retrig.count = fxp + 1;
 			xc->retrig.type = 0;
-			xc->retrig.limit = 0;
+			xc->retrig.limit = HAS_QUIRK(QUIRK_RTONCE) ? 1 : 0;
 			break;
 		case EX_F_VSLIDE_UP:	/* Fine volume slide up */
 			EFFECT_MEMORY(fxp, xc->fine_vol.up_memory);
@@ -594,8 +574,9 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 		xc->vol.fslide2 = -fxp;
 		break;
 	case FX_IT_BREAK:	/* Pattern break with hex parameter */
-		if (!f->loop_chn)
-		{
+		/* IT break is not applied if a lower channel looped (2.00+).
+		 * (Labyrinth of Zeux ZX_11.it "Raceway"). */
+		if (f->loop_dest < 0) {
 			p->flow.pbreak = 1;
 			p->flow.jumpline = fxp;
 		}
@@ -694,11 +675,11 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 	case FX_MULTI_RETRIG:	/* Multi retrig */
 		EFFECT_MEMORY_S3M(fxp);
 		if (fxp) {
-			xc->retrig.val = fxp;
-			xc->retrig.type = MSN(xc->retrig.val);
+			xc->retrig.val = LSN(fxp);
+			xc->retrig.type = MSN(fxp);
 		}
 		if (note) {
-			xc->retrig.count = LSN(xc->retrig.val) + 1;
+			xc->retrig.count = xc->retrig.val + 1;
 		}
 		xc->retrig.limit = 0;
 		SET(RETRIG);
@@ -720,14 +701,20 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 		SET(TREMOR);
 		break;
 	case FX_XF_PORTA:	/* Extra fine portamento */
-	      fx_xf_porta:
-		SET(FINE_BEND);
-		switch (MSN(fxp)) {
-		case 1:
-			xc->freq.fslide = -0.25 * LSN(fxp);
+		h = MSN(fxp);
+		fxp &= 0x0f;
+		switch (h) {
+		case XX_XF_PORTA_UP:	/* Extra fine portamento up */
+			EFFECT_MEMORY(fxp, xc->fine_porta.xf_up_memory);
+		      fx_xf_porta_up:
+			SET(FINE_BEND);
+			xc->freq.fslide = -0.25 * fxp;
 			break;
-		case 2:
-			xc->freq.fslide = 0.25 * LSN(fxp);
+		case XX_XF_PORTA_DN:	/* Extra fine portamento down */
+			EFFECT_MEMORY(fxp, xc->fine_porta.xf_down_memory);
+		      fx_xf_porta_dn:
+			SET(FINE_BEND);
+			xc->freq.fslide = 0.25 * fxp;
 			break;
 		}
 		break;
@@ -1090,6 +1077,22 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 
 	/* ULT effects */
 
+	case FX_ULT_TEMPO:	/* ULT tempo */
+		/* Has unusual semantics and is hard to split into multiple
+		 * effects, due to ULT's two effects lanes per channel:
+		 *
+		 * 00:    reset both speed and BPM to the default 6/125.
+		 * 01-2f: set speed
+		 * 30-ff: set BPM (CIA compatible)
+		 */
+		if (fxp == 0) {
+			p->speed = 6;
+			p->st26_speed = 0;
+			fxp = 125;
+		} else if (fxp < 0x30) {
+			goto fx_s3m_speed;
+		}
+		goto fx_s3m_bpm;
 	case FX_ULT_TPORTA:	/* ULT tone portamento */
 		/* Like normal persistent tone portamento, except:
 		 *
@@ -1122,6 +1125,8 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 		p->flow.jumpline = fxp;
 		p->flow.jump_in_pat = p->ord;
 		break;
+	case FX_RETRIG:		/* Retrigger with extended range */
+		goto fx_retrig;
 #endif
 
 	default:

--- a/contrib/libxmp/src/effects.h
+++ b/contrib/libxmp/src/effects.h
@@ -49,6 +49,10 @@
 #define EX_PATT_DELAY	0x0e
 #define EX_INVLOOP	0x0f
 
+/* XM extended effects 2 */
+#define XX_XF_PORTA_UP	0x01
+#define XX_XF_PORTA_DN	0x02
+
 #ifndef LIBXMP_CORE_PLAYER
 /* Oktalyzer effects */
 #define FX_OKT_ARP3	0x70
@@ -88,7 +92,8 @@
 #define FX_FAR_RETRIG	0x6d	/* FAR retrigger */
 #define FX_FAR_DELAY	0x6e	/* FAR note offset */
 
-/* Other frequency based effects (ULT, etc) */
+/* ULT effects */
+#define FX_ULT_TEMPO	0x5f
 #define FX_ULT_TPORTA   0x6f
 #endif
 
@@ -138,6 +143,7 @@
 #define FX_PITCH_ADD	0xb8	/* SFX add steps to current note */
 #define FX_PITCH_SUB	0xb9	/* SFX add steps to current note */
 #define FX_LINE_JUMP	0xba	/* Archimedes jump to line in current order */
+#define FX_RETRIG	0xbb	/* Retrigger with extended range (LIQ, DSym) */
 #endif
 
 #define FX_SURROUND	0x8d	/* S3M/IT */

--- a/contrib/libxmp/src/flow.c
+++ b/contrib/libxmp/src/flow.c
@@ -1,0 +1,111 @@
+/* Extended Module Player
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "common.h"
+
+/* Process a pattern loop effect with the parameter fxp. A parameter of 0
+ * will set the loop target, and a parameter of 1-15 (most formats) or
+ * 1-255 (OctaMED) will perform a loop.
+ *
+ * The compatibility logic for Pattern Loop is complex, so a flow_control
+ * argument is taken such that the scan can use this function directly.
+ *
+ * If the development tests ever start building against effects.c, this
+ * can be moved back to effects.c.
+ */
+void libxmp_process_pattern_loop(struct context_data *ctx,
+		struct flow_control *f, int chn, int row, int fxp)
+{
+	struct module_data *m = &ctx->m;
+	struct xmp_module *mod = &m->mod;
+	int *start = &f->loop[chn].start;
+	int *count = &f->loop[chn].count;
+	int i;
+
+	/* Digital Tracker: only the first E60 or E6x is handled per row. */
+	if (HAS_FLOW_MODE(FLOW_LOOP_FIRST_EFFECT) && f->loop_param >= 0) {
+		return;
+	}
+	f->loop_param = fxp;
+
+	/* Scream Tracker 3, Digital Tracker, Octalyser, and probably others
+	 * use global loop targets and counts. Later versions of Digital
+	 * Tracker use a global target but per-track counts. */
+	if (HAS_FLOW_MODE(FLOW_LOOP_GLOBAL_TARGET)) {
+		start = &f->loop_start;
+	}
+	if (HAS_FLOW_MODE(FLOW_LOOP_GLOBAL_COUNT)) {
+		count = &f->loop_count;
+	}
+
+	if (fxp == 0) {
+		/* mark start of loop */
+		/* Liquid Tracker: M60 is ignored for channels with count >= 1 */
+		if (HAS_FLOW_MODE(FLOW_LOOP_IGNORE_TARGET) && *count >= 1) {
+			return;
+		}
+		*start = row;
+		if (HAS_QUIRK(QUIRK_FT2BUGS))
+			f->jumpline = row;
+	} else {
+		/* end of loop */
+		if (*start < 0) {
+			/* Scream Tracker 3.01b: if SB0 wasn't used, the first
+			 * SBx used will set the loop target to its row. */
+			if (HAS_FLOW_MODE(FLOW_LOOP_INIT_SAMEROW)) {
+				*start = row;
+			} else {
+				*start = 0;
+			}
+		}
+
+		if (*count) {
+			if (--(*count)) {
+				f->loop_dest = *start;
+			} else {
+				/* S3M and IT: loop termination advances the
+				 * loop target past SBx. */
+				if (HAS_FLOW_MODE(FLOW_LOOP_END_ADVANCES)) {
+					*start = row + 1;
+				}
+				/* Liquid Tracker cancels any other loop jumps
+				 * this row started on loop termination. */
+				if (HAS_FLOW_MODE(FLOW_LOOP_END_CANCELS)) {
+					f->loop_dest = -1;
+				}
+				f->loop_active_num--;
+			}
+		} else {
+			/* Modplug Tracker: only begin a loop if no
+			 * other channel is currently looping. */
+			if (HAS_FLOW_MODE(FLOW_LOOP_ONE_AT_A_TIME)) {
+				for (i = 0; i < mod->chn; i++) {
+					if (i != chn && f->loop[i].count != 0)
+						return;
+				}
+			}
+			*count = fxp;
+			f->loop_dest = *start;
+			f->loop_active_num++;
+		}
+	}
+}

--- a/contrib/libxmp/src/lfo.c
+++ b/contrib/libxmp/src/lfo.c
@@ -140,7 +140,7 @@ int libxmp_lfo_get(struct context_data *ctx, struct lfo *lfo, int is_vibrato)
 void libxmp_lfo_update(struct lfo *lfo)
 {
 	lfo->phase += lfo->rate;
-	lfo->phase %= WAVEFORM_SIZE;
+	lfo->phase &= WAVEFORM_SIZE - 1; /* Rate may be negative, don't %= */
 }
 
 void libxmp_lfo_set_phase(struct lfo *lfo, int phase)

--- a/contrib/libxmp/src/load.c
+++ b/contrib/libxmp/src/load.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2022 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/contrib/libxmp/src/load_helpers.c
+++ b/contrib/libxmp/src/load_helpers.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2023 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -304,6 +304,7 @@ void libxmp_load_prologue(struct context_data *ctx)
 	m->gvol = m->gvolbase = 0x40;
 	m->vol_table = NULL;
 	m->quirk = 0;
+	m->flow_mode = FLOW_MODE_GENERIC;
 	m->read_event_type = READ_EVENT_MOD;
 	m->period_type = PERIOD_AMIGA;
 	m->compare_vblank = 0;
@@ -493,18 +494,21 @@ int libxmp_set_player_mode(struct context_data *ctx)
 	case XMP_MODE_MOD:
 		m->c4rate = C4_PAL_RATE;
 		m->quirk = 0;
+		m->flow_mode = FLOW_MODE_GENERIC;
 		m->read_event_type = READ_EVENT_MOD;
 		m->period_type = PERIOD_AMIGA;
 		break;
 	case XMP_MODE_NOISETRACKER:
 		m->c4rate = C4_PAL_RATE;
 		m->quirk = QUIRK_NOBPM;
+		m->flow_mode = FLOW_MODE_GENERIC;
 		m->read_event_type = READ_EVENT_MOD;
 		m->period_type = PERIOD_MODRNG;
 		break;
 	case XMP_MODE_PROTRACKER:
 		m->c4rate = C4_PAL_RATE;
 		m->quirk = QUIRK_PROTRACK;
+		m->flow_mode = FLOW_MODE_GENERIC;
 		m->read_event_type = READ_EVENT_MOD;
 		m->period_type = PERIOD_MODRNG;
 		break;
@@ -512,12 +516,14 @@ int libxmp_set_player_mode(struct context_data *ctx)
 		q = m->quirk & (QUIRK_VSALL | QUIRK_ARPMEM);
 		m->c4rate = C4_NTSC_RATE;
 		m->quirk = QUIRKS_ST3 | q;
+		m->flow_mode = FLOW_MODE_ST3_321;
 		m->read_event_type = READ_EVENT_ST3;
 		break;
 	case XMP_MODE_ST3:
 		q = m->quirk & (QUIRK_VSALL | QUIRK_ARPMEM);
 		m->c4rate = C4_NTSC_RATE;
 		m->quirk = QUIRKS_ST3 | QUIRK_ST3BUGS | q;
+		m->flow_mode = FLOW_MODE_ST3_321;
 		m->read_event_type = READ_EVENT_ST3;
 		break;
 	case XMP_MODE_ST3GUS:
@@ -525,27 +531,32 @@ int libxmp_set_player_mode(struct context_data *ctx)
 		m->c4rate = C4_NTSC_RATE;
 		m->quirk = QUIRKS_ST3 | QUIRK_ST3BUGS | q;
 		m->quirk &= ~QUIRK_RSTCHN;
+		m->flow_mode = FLOW_MODE_ST3_321;
 		m->read_event_type = READ_EVENT_ST3;
 		break;
 	case XMP_MODE_XM:
 		m->c4rate = C4_NTSC_RATE;
 		m->quirk = QUIRKS_FT2;
+		m->flow_mode = FLOW_MODE_GENERIC;
 		m->read_event_type = READ_EVENT_FT2;
 		break;
 	case XMP_MODE_FT2:
 		m->c4rate = C4_NTSC_RATE;
 		m->quirk = QUIRKS_FT2 | QUIRK_FT2BUGS;
+		m->flow_mode = FLOW_MODE_GENERIC;
 		m->read_event_type = READ_EVENT_FT2;
 		break;
 	case XMP_MODE_IT:
 		m->c4rate = C4_NTSC_RATE;
 		m->quirk = QUIRKS_IT | QUIRK_VIBHALF | QUIRK_VIBINV;
+		m->flow_mode = FLOW_MODE_IT_210;
 		m->read_event_type = READ_EVENT_IT;
 		break;
 	case XMP_MODE_ITSMP:
 		m->c4rate = C4_NTSC_RATE;
 		m->quirk = QUIRKS_IT | QUIRK_VIBHALF | QUIRK_VIBINV;
 		m->quirk &= ~(QUIRK_VIRTUAL | QUIRK_RSTCHN);
+		m->flow_mode = FLOW_MODE_IT_210;
 		m->read_event_type = READ_EVENT_IT;
 		break;
 	default:

--- a/contrib/libxmp/src/loaders/common.c
+++ b/contrib/libxmp/src/loaders/common.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2023 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -299,7 +299,7 @@ int libxmp_copy_name_for_fopen(char *dest, const char *name, int n)
 	 * malicious when given to fopen. This should only be used on song files.
 	 */
 	if (!strcmp(name, ".") || strstr(name, "..") ||
-	    name[0] == '\\' || name[0] == '/' || name[0] == ':')
+	    name[0] == '\\' || name[0] == '/' || name[0] == ':' || name[0] == '\0')
 		return -1;
 
 	for (i = 0; i < n - 1; i++) {
@@ -432,16 +432,18 @@ void libxmp_disable_continue_fx(struct xmp_event *event)
 int libxmp_check_filename_case(const char *dir, const char *name, char *new_name, int size)
 {
 	char path[XMP_MAXPATH];
+	int ret;
 	snprintf(path, sizeof(path), "%s/%s", dir, name);
 	if (! (libxmp_get_filetype(path) & XMP_FILETYPE_FILE))
 		return 0;
-	strncpy(new_name, name, size);
-	return 1;
+	ret = snprintf(new_name, size, "%s", name);
+	return (ret < size);
 }
 #else /* target has dirent */
 int libxmp_check_filename_case(const char *dir, const char *name, char *new_name, int size)
 {
 	int found = 0;
+	int ret = size;
 	DIR *dirp;
 	struct dirent *d;
 
@@ -452,26 +454,53 @@ int libxmp_check_filename_case(const char *dir, const char *name, char *new_name
 	while ((d = readdir(dirp)) != NULL) {
 		if (!strcasecmp(d->d_name, name)) {
 			found = 1;
-			strncpy(new_name, d->d_name, size);
+			ret = snprintf(new_name, size, "%s", d->d_name);
 			break;
 		}
 	}
 
 	closedir(dirp);
 
-	return found;
+	return found ? (ret < size) : 0;
 }
 #endif
 
-void libxmp_get_instrument_path(struct module_data *m, char *path, int size)
+static const char *libxmp_get_instrument_path(struct module_data *m)
 {
+	const char *env;
 	if (m->instrument_path) {
-		strncpy(path, m->instrument_path, size);
-	} else if (getenv("XMP_INSTRUMENT_PATH")) {
-		strncpy(path, getenv("XMP_INSTRUMENT_PATH"), size);
-	} else {
-		strncpy(path, ".", size);
+		return m->instrument_path;
 	}
+	env = getenv("XMP_INSTRUMENT_PATH");
+	if (env) {
+		return env;
+	}
+	return NULL;
+}
+
+int libxmp_find_instrument_file(struct module_data *m, char *path_dest,
+				int path_dest_len, const char *ins_name)
+{
+	const char *ins_path;
+	char name[256];
+	int ret;
+
+	ins_path = libxmp_get_instrument_path(m);
+	if (ins_path != NULL &&
+	    libxmp_check_filename_case(ins_path, ins_name, name, sizeof(name))) {
+		ret = snprintf(path_dest, path_dest_len, "%s/%s", ins_path, name);
+		path_dest[path_dest_len - 1] = '\0';
+		return (ret < path_dest_len);
+	}
+
+	/* Try the module dir if the instrument path didn't work. */
+	if (m->dirname != NULL &&
+	    libxmp_check_filename_case(m->dirname, ins_name, name, sizeof(name))) {
+		ret = snprintf(path_dest, path_dest_len, "%s%s", m->dirname, name);
+		path_dest[path_dest_len - 1] = '\0';
+		return (ret < path_dest_len);
+	}
+	return 0;
 }
 #endif /* LIBXMP_CORE_PLAYER */
 
@@ -585,8 +614,13 @@ void libxmp_apply_mpt_preamp(struct module_data *m)
 
 char *libxmp_strdup(const char *src)
 {
-	size_t len = strlen(src) + 1;
-	char *buf = (char *) malloc(len);
+	size_t len;
+	char *buf;
+	if (src == NULL) {
+		return NULL;
+	}
+	len = strlen(src) + 1;
+	buf = (char *) malloc(len);
 	if (buf) {
 		memcpy(buf, src, len);
 	}

--- a/contrib/libxmp/src/loaders/gdm_load.c
+++ b/contrib/libxmp/src/loaders/gdm_load.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2021 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -444,6 +444,11 @@ static int gdm_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	}
 
 	m->quirk |= QUIRK_ARPMEM | QUIRK_FINEFX;
+
+	/* BWSB actually gets several aspects of this wrong, but this
+	 * seems to be the intent. No original GDMs exist so it's not
+	 * likely there's a reason to simulate its mistakes here. */
+	m->flow_mode = FLOW_MODE_ST3_321;
 
 	return 0;
 }

--- a/contrib/libxmp/src/loaders/itsex.c
+++ b/contrib/libxmp/src/loaders/itsex.c
@@ -95,6 +95,8 @@ int itsex_decompress8(HIO_HANDLE *src, uint8 *dst, int len,
 	uint8 left = 0, temp = 0, temp2 = 0;
 	uint32 d, pos;
 
+	memset(&in, 0, sizeof(in)); /* bogus GCC 12 -Wmaybe-uninitialized */
+
 	while (len) {
 		if (!block_count) {
 			block_count = 0x8000;
@@ -189,6 +191,8 @@ int itsex_decompress16(HIO_HANDLE *src, int16 *dst, int len,
 	uint8 left = 0;
 	int16 temp = 0, temp2 = 0;
 	uint32 d, pos;
+
+	memset(&in, 0, sizeof(in)); /* bogus GCC 12 -Wmaybe-uninitialized */
 
 	while (len) {
 		if (!block_count) {

--- a/contrib/libxmp/src/loaders/loader.h
+++ b/contrib/libxmp/src/loaders/loader.h
@@ -48,7 +48,7 @@ void	libxmp_decode_protracker_event	(struct xmp_event *, const uint8 *);
 void	libxmp_decode_noisetracker_event(struct xmp_event *, const uint8 *);
 void	libxmp_disable_continue_fx	(struct xmp_event *);
 int	libxmp_check_filename_case	(const char *, const char *, char *, int);
-void	libxmp_get_instrument_path	(struct module_data *, char *, int);
+int	libxmp_find_instrument_file	(struct module_data *, char *, int, const char *);
 void	libxmp_set_type			(struct module_data *, const char *, ...);
 int	libxmp_load_sample		(struct module_data *, HIO_HANDLE *, int,
 					 struct xmp_sample *, const void *);

--- a/contrib/libxmp/src/loaders/med2_load.c
+++ b/contrib/libxmp/src/loaders/med2_load.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2021 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -185,58 +185,38 @@ static int med2_load(struct module_data *m, HIO_HANDLE *f, const int start)
 
 	for (i = 0; i < 31; i++) {
 		char path[XMP_MAXPATH];
-		char ins_path[256];
 		char ins_name[32];
-		char name[256];
 		HIO_HANDLE *s = NULL;
-		int found = 0;
 
 		if (libxmp_copy_name_for_fopen(ins_name, mod->xxi[i].name, 32) != 0)
 			continue;
 
-		libxmp_get_instrument_path(m, ins_path, 256);
-		if (libxmp_check_filename_case(ins_path, ins_name, name, 256)) {
-			snprintf(path, XMP_MAXPATH, "%s/%s", ins_path, name);
-			found = 1;
-		}
-
-		/* Try the module dir if the instrument path didn't work. */
-		if (!found && m->dirname != NULL &&
-		    libxmp_check_filename_case(m->dirname, ins_name, name, 256)) {
-			snprintf(path, XMP_MAXPATH, "%s%s", m->dirname, name);
-			found = 1;
-		}
-
-		if (found) {
-			if ((s = hio_open(path,"rb")) != NULL) {
-				mod->xxs[i].len = hio_size(s);
-			}
-		}
-
-		if (mod->xxs[i].len > 0) {
-			mod->xxi[i].nsm = 1;
-		}
-
-		if (!strlen(mod->xxi[i].name) && !mod->xxs[i].len) {
-			if (s != NULL) {
-				hio_close(s);
-			}
-			continue;
-		}
-
-		D_(D_INFO "[%2X] %-32.32s %04x %04x %04x %c V%02x",
-			i, mod->xxi[i].name, mod->xxs[i].len, mod->xxs[i].lps,
-			mod->xxs[i].lpe,
+		D_(D_INFO "[%2X] %-32.32s ---- %04x %04x %c V%02x",
+			i, mod->xxi[i].name, mod->xxs[i].lps, mod->xxs[i].lpe,
 			mod->xxs[i].flg & XMP_SAMPLE_LOOP ? 'L' : ' ',
 			mod->xxi[i].sub[0].vol);
 
-		if (s != NULL) {
-			int ret = libxmp_load_sample(m, s, 0, &mod->xxs[i], NULL);
-			hio_close(s);
-			if (ret < 0) {
-				return -1;
-			}
+		if (!libxmp_find_instrument_file(m, path, sizeof(path), ins_name))
+			continue;
+
+		if ((s = hio_open(path, "rb")) == NULL) {
+			continue;
 		}
+
+		mod->xxs[i].len = hio_size(s);
+		if (mod->xxs[i].len == 0) {
+			hio_close(s);
+			continue;
+		}
+		mod->xxi[i].nsm = 1;
+
+		D_(D_INFO "     %-32s %04x", "(OK)", mod->xxs[i].len);
+
+		if (libxmp_load_sample(m, s, 0, &mod->xxs[i], NULL) < 0) {
+			hio_close(s);
+			return -1;
+		}
+		hio_close(s);
 	}
 
 	return 0;

--- a/contrib/libxmp/src/loaders/med3_load.c
+++ b/contrib/libxmp/src/loaders/med3_load.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2021 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -208,14 +208,17 @@ static int unpack_block(struct module_data *m, uint16 bnum, uint8 *from, uint16 
 				} else if (event->fxp == 0xfe) {
 					event->fxp = event->fxt = 0;
 				} else if (event->fxp == 0xf1) {
+					/* Retrigger once on tick 3 */
 					event->fxt = FX_EXTENDED;
 					event->fxp = (EX_RETRIG << 4) | 3;
 				} else if (event->fxp == 0xf2) {
-					event->fxt = FX_EXTENDED;
-					event->fxp = (EX_CUT << 4) | 3;
-				} else if (event->fxp == 0xf3) {
+					/* Delay until tick 3 */
 					event->fxt = FX_EXTENDED;
 					event->fxp = (EX_DELAY << 4) | 3;
+				} else if (event->fxp == 0xf3) {
+					/* Retrigger once on tick 2 */
+					event->fxt = FX_EXTENDED;
+					event->fxp = (EX_RETRIG << 4) | 2;
 				} else if (event->fxp > 10) {
 					event->fxt = FX_S3M_BPM;
 					event->fxp = 125 * event->fxp / 33;
@@ -335,6 +338,7 @@ static int med3_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	D_(D_INFO "Sliding: %d", sliding);
 	D_(D_INFO "Play transpose: %d", transp);
 
+	m->quirk |= QUIRK_RTONCE;
 	if (sliding == 6)
 		m->quirk |= QUIRK_VSALL | QUIRK_PBALL;
 

--- a/contrib/libxmp/src/loaders/med4_load.c
+++ b/contrib/libxmp/src/loaders/med4_load.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2022 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -76,14 +76,17 @@ static void fix_effect(struct xmp_event *event, int hexvol)
 			event->fxp = event->fxt = 0;
 			event->vol = 1;
 		} else if (event->fxp == 0xf1) {
+			/* Retrigger once on tick 3 */
 			event->fxt = FX_EXTENDED;
 			event->fxp = (EX_RETRIG << 4) | 3;
 		} else if (event->fxp == 0xf2) {
-			event->fxt = FX_EXTENDED;
-			event->fxp = (EX_CUT << 4) | 3;
-		} else if (event->fxp == 0xf3) {
+			/* Delay until tick 3 */
 			event->fxt = FX_EXTENDED;
 			event->fxp = (EX_DELAY << 4) | 3;
+		} else if (event->fxp == 0xf3) {
+			/* Retriger once on tick 2 */
+			event->fxt = FX_EXTENDED;
+			event->fxp = (EX_RETRIG << 4) | 2;
 		} else if (event->fxp > 0xf0) {
 			event->fxp = event->fxt = 0;
 		} else if (event->fxp > 10) {
@@ -172,7 +175,7 @@ static int med4_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	uint8 m0;
 	uint64 mask;
 	int transp, masksz;
-	int32 pos;
+	long pos;
 	int vermaj, vermin;
 	uint8 trkvol[16], buf[1024];
 	struct xmp_event *event;
@@ -309,6 +312,7 @@ static int med4_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	flags = hio_read8s(f);
 	mod->spd = hio_read16b(f);
 
+	m->quirk |= QUIRK_RTONCE;
 	if (~flags & 0x20)	/* sliding */
 		m->quirk |= QUIRK_VSALL | QUIRK_PBALL;
 
@@ -546,7 +550,7 @@ static int med4_load(struct module_data *m, HIO_HANDLE *f, const int start)
 				_len -= 22;
 			}
 
-			if (_len < 0) {
+			if (_len < 0 || _len > hio_size(f)) {
 				D_(D_CRIT "invalid sample %d length", i);
 				return -1;
 			}
@@ -565,7 +569,7 @@ static int med4_load(struct module_data *m, HIO_HANDLE *f, const int start)
 
 	smp_idx = 0;
 	for (i = 0; mask != 0 && i < num_ins; i++, mask <<= 1) {
-		int length, type;
+		int length, length2, type;
 		struct SynthInstr synth;
 		struct xmp_instrument *xxi;
 		struct xmp_subinstrument *sub;
@@ -620,9 +624,14 @@ static int med4_load(struct module_data *m, HIO_HANDLE *f, const int start)
 			if (hio_error(f))
 				return -1;
 
+			/* FIXME: load waveforms too
+			 * how much of this can be merged with MMD? */
 			hio_seek(f, pos + hio_read32b(f), SEEK_SET);
-			length = hio_read32b(f);
-			type = hio_read16b(f);
+			length2 = hio_read32b(f);
+			if (hio_read16b(f) != 0) {
+				D_(D_CRIT "hybrid %d has non-sample at pos 0", i);
+				return -1;
+			}
 
 			if (libxmp_med_new_instrument_extras(xxi) != 0)
 				return -1;
@@ -647,7 +656,7 @@ static int med4_load(struct module_data *m, HIO_HANDLE *f, const int start)
 
 			xxs = &mod->xxs[smp_idx];
 
-			xxs->len = length;
+			xxs->len = length2;
 			xxs->lps = temp_inst[i].loop_start;
 			xxs->lpe = temp_inst[i].loop_end;
 			xxs->flg = temp_inst[i].loop_end > 2 ?
@@ -665,6 +674,7 @@ static int med4_load(struct module_data *m, HIO_HANDLE *f, const int start)
 			if (mmd_alloc_tables(m, i, &synth) != 0)
 				return -1;
 
+			hio_seek(f, pos + length, SEEK_SET);
 			continue;
 		}
 

--- a/contrib/libxmp/src/loaders/mmd1_load.c
+++ b/contrib/libxmp/src/loaders/mmd1_load.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2023 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -175,6 +175,7 @@ static int mmd1_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	 * convert header
 	 */
 	m->c4rate = C4_NTSC_RATE;
+	m->quirk |= QUIRK_RTONCE;
 	m->quirk |= song.flags & FLAG_STSLIDE ? 0 : QUIRK_VSALL | QUIRK_PBALL;
 	hexvol = song.flags & FLAG_VOLHEX;
 	med_8ch = song.flags & FLAG_8CHANNEL;

--- a/contrib/libxmp/src/loaders/mmd3_load.c
+++ b/contrib/libxmp/src/loaders/mmd3_load.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2022 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -194,6 +194,7 @@ static int mmd3_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	 * convert header
 	 */
 	m->c4rate = C4_NTSC_RATE;
+	m->quirk |= QUIRK_RTONCE;
 	m->quirk |= song.flags & FLAG_STSLIDE ? 0 : QUIRK_VSALL | QUIRK_PBALL;
 	hexvol = song.flags & FLAG_VOLHEX;
 	med_8ch = song.flags & FLAG_8CHANNEL;

--- a/contrib/libxmp/src/loaders/mmd_common.c
+++ b/contrib/libxmp/src/loaders/mmd_common.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2023 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -224,6 +224,9 @@ void mmd_xlat_fx(struct xmp_event *event, int bpm_on, int bpmlen, int med_8ch,
 			event->fxp = (EX_DELAY << 4) | 3;
 			break;
 		case 0xf3:	/* Play note three times */
+			/* Actually just retriggers once on tick 2, except
+			 * for a bug in OctaMED <=4.00 where it will retrigger
+			 * every tick from tick 2 onward. */
 			event->fxt = FX_EXTENDED;
 			event->fxp = (EX_RETRIG << 4) | 2;
 			break;

--- a/contrib/libxmp/src/loaders/mod_load.c
+++ b/contrib/libxmp/src/loaders/mod_load.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2023 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -297,6 +297,8 @@ static int get_tracker_id(struct module_data *m, struct mod_header *mh, int id)
 	int has_vol_in_empty_ins = 0;
 	int i;
 
+	D_(D_INFO "attempting initial tracker ID via header details");
+
 	/* Check if has instruments with loop size 0 */
 	for (i = 0; i < 31; i++) {
 		if (mh->ins[i].loop_size == 0) {
@@ -318,8 +320,10 @@ static int get_tracker_id(struct module_data *m, struct mod_header *mh, int id)
 	 */
 	if (mh->restart == mod->pat) {
 		if (mod->chn == 4) {
+			D_(D_INFO "restart=#pat and 4ch -> Soundtracker");
 			id = TRACKER_SOUNDTRACKER;
 		} else {
+			D_(D_INFO "restart=#pat and !4ch -> unknown");
 			id = TRACKER_UNKNOWN;
 		}
 	} else if (mh->restart == 0x78) {
@@ -327,36 +331,46 @@ static int get_tracker_id(struct module_data *m, struct mod_header *mh, int id)
 			/* Can't trust this for Noisetracker, MOD.Data City Remix
 			 * has Protracker effects and Noisetracker restart byte
 			 */
+			D_(D_INFO "restart=78 and 4ch -> maybe Noisetracker");
 			id = TRACKER_PROBABLY_NOISETRACKER;
 		} else {
+			D_(D_INFO "restart=78 and !4ch -> unknown");
 			id = TRACKER_UNKNOWN;
 		}
 		return id;
 	} else if (mh->restart < 0x7f) {
 		if (mod->chn == 4 && !has_vol_in_empty_ins) {
+			D_(D_INFO "restart<7f and 4ch and empty ins are "
+			   "volume 0 -> Noisetracker");
 			id = TRACKER_NOISETRACKER;
 		} else {
+			D_(D_INFO "restart<7f and not Noisetracker -> unknown");
 			id = TRACKER_UNKNOWN; /* ? */
 		}
 		mod->rst = mh->restart;
 	} else if (mh->restart == 0x7f) {
 		if (mod->chn == 4) {
 			if (has_loop_0) {
+				D_(D_INFO "restart=7f and 4ch and 0-size loop -> clone");
 				id = TRACKER_CLONE;
 			}
 		} else {
+			D_(D_INFO "restart=7f and !4ch -> Scream Tracker");
 			id = TRACKER_SCREAMTRACKER3;
 		}
 		return id;
 	} else if (mh->restart > 0x7f) {
+		D_(D_INFO "restart>7f -> unknown");
 		id = TRACKER_UNKNOWN; /* ? */
 		return id;
 	}
 
 	if (!has_loop_0) { /* All loops are size 2 or greater */
+		D_(D_INFO "no instrument 0-length loops...");
 
 		for (i = 0; i < 31; i++) {
 			if (mh->ins[i].size == 1 && mh->ins[i].volume == 0) {
+				D_(D_INFO "...and length 2 with 0 volume -> converted");
 				return TRACKER_CONVERTED;
 			}
 		}
@@ -366,6 +380,7 @@ static int get_tracker_id(struct module_data *m, struct mod_header *mh, int id)
 				break;
 		}
 		if (i == 31) {	/* No st- instruments */
+			D_(D_INFO "...and no ST- instruments...");
 			for (i = 0; i < 31; i++) {
 				if (mh->ins[i].size != 0
 				    || mh->ins[i].loop_size != 1) {
@@ -375,14 +390,17 @@ static int get_tracker_id(struct module_data *m, struct mod_header *mh, int id)
 				switch (mod->chn) {
 				case 4:
 					if (has_vol_in_empty_ins) {
+						D_(D_INFO "...and 4ch, vol in empty -> OpenMPT");
 						id = TRACKER_OPENMPT;
 					} else {
+						D_(D_INFO "...and 4ch -> Noisetracker");
 						id = TRACKER_NOISETRACKER;
 						/* or Octalyser */
 					}
 					break;
 				case 6:
 				case 8:
+					D_(D_INFO "..and 6ch or 8ch -> Octalyser");
 					id = TRACKER_OCTALYSER;
 					break;
 				default:
@@ -391,22 +409,28 @@ static int get_tracker_id(struct module_data *m, struct mod_header *mh, int id)
 				return id;
 			}
 
+			D_(D_INFO "...and no empty...");
 			if (mod->chn == 4) {
+				D_(D_INFO "...and 4ch -> Protracker");
 				id = TRACKER_PROTRACKER;
 			} else if (mod->chn == 6 || mod->chn == 8) {
 				/* FastTracker 1.01? */
+				D_(D_INFO "...and 6ch or 8ch -> Fast Tracker");
 				id = TRACKER_FASTTRACKER;
 			} else {
+				D_(D_INFO "...and %dch -> unknown", mod->chn);
 				id = TRACKER_UNKNOWN;
 			}
 		}
 	} else { /* Has loops with size 0 */
+		D_(D_INFO "instrument with 0-length loop...");
 		for (i = 15; i < 31; i++) {
 			/* Is the name or size set? */
 			if (mh->ins[i].name[0] || mh->ins[i].size > 0)
 				break;
 		}
 		if (i == 31 && is_st_ins((char *)mh->ins[14].name)) {
+			D_(D_INFO "...and <=15 instruments and ST-* -> converted ST");
 			return TRACKER_CONVERTEDST;
 		}
 
@@ -416,13 +440,16 @@ static int get_tracker_id(struct module_data *m, struct mod_header *mh, int id)
 				break;
 		}
 		if (i < 31) {
+			D_(D_INFO "...and >15 instruments and ST-* -> converted");
 			return TRACKER_UNKNOWN_CONV;
 		}
 
 		if (mod->chn == 4 || mod->chn == 6 || mod->chn == 8) {
+			D_(D_INFO "...and >15 instruments and 4ch/6ch/8ch -> Fast Tracker");
 			return TRACKER_FASTTRACKER;
 		}
 
+		D_(D_INFO "...and >15 instruments and %dch -> unknown", mod->chn);
 		id = TRACKER_UNKNOWN;	/* ?! */
 	}
 
@@ -449,6 +476,7 @@ static int mod_load(struct module_data *m, HIO_HANDLE *f, const int start)
     int needs_timing_detection = 0;
     int samerow_fxx = 0;		/* speed + BPM set on same row */
     int high_fxx = 0;			/* high Fxx is used anywhere */
+    int invert_loop = 0;		/* EFx found anywhere in module */
 #endif
     int ptkloop = 0;			/* Protracker loop */
 
@@ -504,6 +532,7 @@ static int mod_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	    mod->chn = mod_magic[i].ch;
 	    tracker_id = mod_magic[i].id;
 	    detected = mod_magic[i].flag;
+	    D_(D_INFO "magic match %4.4s -> %d", magic, tracker_id);
 	    break;
 	}
     }
@@ -533,20 +562,23 @@ static int mod_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	} else {
 	    return -1;
 	}
-	#ifndef LIBXMP_CORE_PLAYER
+#ifndef LIBXMP_CORE_PLAYER
+	D_(D_INFO "#CHN or ##CH signature -> FastTracker or TakeTracker");
 	tracker_id = mod->chn & 1 ? TRACKER_TAKETRACKER : TRACKER_FASTTRACKER2;
 	detected = 1;
-	#endif
+#endif
     }
 
     strncpy(mod->name, (char *) mh.name, 20);
 
     mod->len = mh.len;
-    /* mod->rst = mh.restart; */
-
-    if (mod->rst >= mod->len)
-	mod->rst = 0;
     memcpy(mod->xxo, mh.order, 128);
+
+    if (mh.restart < 0x7f && mh.restart != 0x78 && (int)mh.restart < mod->len) {
+	/* TODO: an older version of this code was commented out 23+ years ago
+	 * and adding this may have rebroke something. */
+	mod->rst = mh.restart;
+    }
 
     for (i = 0; i < 128; i++) {
 	/* This fixes dragnet.mod (garbage in the order list) */
@@ -570,6 +602,7 @@ static int mod_load(struct module_data *m, HIO_HANDLE *f, const int start)
 
 #ifndef LIBXMP_CORE_PLAYER
 	if (mh.ins[i].size >= 0x8000) {
+	    D_(D_INFO "sample %d >64k length -> OpenMPT", i);
 	    tracker_id = TRACKER_OPENMPT;
 	    needs_timing_detection = 0;
 	    detected = 1;
@@ -627,8 +660,10 @@ static int mod_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	hio_seek(f, start + pos, SEEK_SET);
 
 	if (num_read == 4 && !memcmp(idbuffer, "FLEX", 4)) {
+	    D_(D_INFO "FlexTrax FLEX data detected -> FlexTrax");
 	    tracker_id = TRACKER_FLEXTRAX;
 	    needs_timing_detection = 0;
+	    detected = 1;
 	    goto skip_test;
 	}
     }
@@ -652,15 +687,19 @@ static int mod_load(struct module_data *m, HIO_HANDLE *f, const int start)
 
     if (!strncmp(magic, "M.K.", 4) && maybe_wow &&
 		(0x43c + mod->pat * 32 * 0x40 + smp_size) == (m->size & ~1)) {
+	D_(D_INFO "file is M.K. with Mod's Grave characteristics -> Mod's Grave");
 	mod->chn = 8;
 	tracker_id = TRACKER_MODSGRAVE;
 	needs_timing_detection = 0;
+	detected = 1;
     } else {
 	/* Test for Protracker song files */
 	ptsong = !strncmp((char *)magic, "M.K.", 4) &&
 		 (0x43c + mod->pat * 0x400 == m->size);
 	if (ptsong) {
+		D_(D_INFO "file is Protracker song length M.K. -> Protracker");
 		tracker_id = TRACKER_PROTRACKER;
+		detected = 1;
 		goto skip_test;
 	} else {
 	/* something else */
@@ -669,6 +708,7 @@ static int mod_load(struct module_data *m, HIO_HANDLE *f, const int start)
     }
 
 skip_test:
+    D_(D_INFO "initial tracker ID: %d%s", tracker_id, detected ? " (locked in)" : "");
 #endif
 
     if (mod->chn >= XMP_MAX_CHANNELS) {
@@ -734,6 +774,7 @@ skip_test:
 		    unsigned char fxp = LSN(mod_event[3]);
 
 		    if ((fxt > 0x06 && fxt < 0x0a) || (fxt == 0x0e && fxp > 1)) {
+			D_(D_INFO "non-Noisetracker effect -> unknown");
 			tracker_id = TRACKER_UNKNOWN;
 		    }
 		}
@@ -748,6 +789,10 @@ skip_test:
 			speed_row = 1;
 		    }
 		}
+		/* Usage of effect EFx is typically Protracker invert loop. */
+		if (LSN(mod_event[2]) == 0xe && MSN(mod_event[3]) == 0xf) {
+		    invert_loop = 1;
+		}
 		mod_event += 4;
 	    }
 	    if (bpm_row && speed_row) {
@@ -757,6 +802,8 @@ skip_test:
 
 	if (out_of_range) {
 	    if (tracker_id == TRACKER_UNKNOWN && mh.restart == 0x7f) {
+		D_(D_INFO "unknown tracker w/ restart 0x7f and out-of-range "
+		   "notes are present -> Scream Tracker");
 		tracker_id = TRACKER_SCREAMTRACKER3;
 	    }
 
@@ -766,8 +813,16 @@ skip_test:
 		tracker_id == TRACKER_PROBABLY_NOISETRACKER ||
 		tracker_id == TRACKER_SOUNDTRACKER) {   /* note > B-3 */
 
+		D_(D_INFO "maybe-Amiga with out-of-range note -> unknown");
 		tracker_id = TRACKER_UNKNOWN;
 	    }
+	} else if (invert_loop && !detected &&
+	    (tracker_id == TRACKER_NOISETRACKER ||
+	     tracker_id == TRACKER_PROBABLY_NOISETRACKER)) {
+	    /* Switch Noisetracker to Protracker to disable event filtering. */
+	    D_(D_INFO "effect EFx is present in suspected Noisetracker -> "
+	       "more likely Protracker");
+	    tracker_id = TRACKER_PROTRACKER;
 	}
 #endif
 
@@ -817,6 +872,8 @@ skip_test:
 	    tracker_id == TRACKER_PROBABLY_NOISETRACKER ||
 	    tracker_id == TRACKER_SOUNDTRACKER) {
 
+	    D_(D_INFO "low Fxx and high Fxx on the same line, but tracker ID "
+	       "selected a VBlank-only tracker -> unknown");
 	    tracker_id = TRACKER_UNKNOWN;
 	}
 	m->compare_vblank = 0;
@@ -853,6 +910,16 @@ skip_test:
 	}
     }
 
+    if (invert_loop && !detected && !out_of_range) {
+	/* If EFx was detected and NO notes were out-of-range,
+	 * that's a strong indicator of a Protracker origin. */
+	D_(D_INFO "effect EFx and no out-of-range notes -> Protracker or OpenMPT");
+	if (tracker_id != TRACKER_OPENMPT) {
+	    tracker_id = TRACKER_PROTRACKER;
+	}
+	detected = 1;
+    }
+
     switch (tracker_id) {
     case TRACKER_PROTRACKER:
 	tracker = "Protracker";
@@ -876,9 +943,13 @@ skip_test:
 	break;
     case TRACKER_OCTALYSER:
 	tracker = "Octalyser";
+	if (detected) {
+		m->flow_mode = FLOW_MODE_OCTALYSER;
+	}
 	break;
     case TRACKER_DIGITALTRACKER:
 	tracker = "Digital Tracker";
+	m->flow_mode = FLOW_MODE_DTM_203;
 	break;
     case TRACKER_FLEXTRAX:
 	tracker = "Flextrax";
@@ -919,6 +990,8 @@ skip_test:
     } else {
 	snprintf(mod->type, XMP_NAME_SIZE, "%s %s", tracker, magic);
     }
+
+    D_(D_INFO "final tracker ID: %d", tracker_id);
 #else
     libxmp_set_type(m, (mod->chn == 4) ? "Protracker" : "Fasttracker");
 #endif
@@ -937,31 +1010,30 @@ skip_test:
 
 	flags = (ptkloop && mod->xxs[i].lps == 0) ? SAMPLE_FLAG_FULLREP : 0;
 
-	#ifdef LIBXMP_CORE_PLAYER
+#ifdef LIBXMP_CORE_PLAYER
 	if (libxmp_load_sample(m, f, flags, &mod->xxs[i], NULL) < 0)
 		return -1;
-	#else
+#else
 	if (ptsong) {
 	    HIO_HANDLE *s;
 	    char sn[XMP_MAXPATH];
 	    char tmpname[32];
 	    const char *instname = mod->xxi[i].name;
 
-	    if (!instname[0] || !m->dirname)
+	    if (libxmp_copy_name_for_fopen(tmpname, instname, 32) != 0)
 		continue;
 
-	    if (libxmp_copy_name_for_fopen(tmpname, instname, 32))
+	    if (!libxmp_find_instrument_file(m, sn, sizeof(sn), tmpname))
 		continue;
 
-	    snprintf(sn, XMP_MAXPATH, "%s%s", m->dirname, tmpname);
+	    if ((s = hio_open(sn, "rb")) == NULL)
+		continue;
 
-	    if ((s = hio_open(sn, "rb")) != NULL) {
-	        if (libxmp_load_sample(m, s, flags, &mod->xxs[i], NULL) < 0) {
-		    hio_close(s);
-		    return -1;
-		}
+	    if (libxmp_load_sample(m, s, flags, &mod->xxs[i], NULL) < 0) {
 		hio_close(s);
+		return -1;
 	    }
+	    hio_close(s);
 	} else {
 	    uint8 buf[5];
 	    long pos;
@@ -981,7 +1053,7 @@ skip_test:
 	    if (libxmp_load_sample(m, f, flags, &mod->xxs[i], NULL) < 0)
 		return -1;
 	}
-	#endif
+#endif
     }
 
     #ifdef LIBXMP_CORE_PLAYER

--- a/contrib/libxmp/src/loaders/s3m.h
+++ b/contrib/libxmp/src/loaders/s3m.h
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2021 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/contrib/libxmp/src/loaders/s3m_load.c
+++ b/contrib/libxmp/src/loaders/s3m_load.c
@@ -387,6 +387,7 @@ static int s3m_load(struct module_data *m, HIO_HANDLE * f, const int start)
 	}
 
 	m->c4rate = C4_NTSC_RATE;
+	m->flow_mode = FLOW_MODE_ST3_321;
 
 	if (sfh.version == 0x1300) {
 		m->quirk |= QUIRK_VSALL;
@@ -402,6 +403,7 @@ static int s3m_load(struct module_data *m, HIO_HANDLE * f, const int start)
 				/* MPT 1.0 alpha5 doesn't set the stereo flag, but MPT 1.0 alpha6 does. */
 				strcpy(tracker_name, "ModPlug Tracker 1.0 alpha");
 			}
+			m->flow_mode = FLOW_MODE_MPT_116;
 		} else if(sfh.version == 0x1320 && sfh.special == 0 && sfh.uc == 0 && sfh.flags == 0 && sfh.dp == 0) {
 			if (sfh.gv == 64 && sfh.mv == 48) {
 				strcpy(tracker_name, "PlayerPRO");
@@ -412,6 +414,9 @@ static int s3m_load(struct module_data *m, HIO_HANDLE * f, const int start)
 			snprintf(tracker_name, 40, "Scream Tracker %d.%02x",
 				 (sfh.version & 0x0f00) >> 8, sfh.version & 0xff);
 			m->quirk |= QUIRK_ST3BUGS;
+			if (sfh.version < 0x1303) {
+				m->flow_mode = FLOW_MODE_ST3_301;
+			}
 		}
 		break;
 	case 2:
@@ -420,9 +425,11 @@ static int s3m_load(struct module_data *m, HIO_HANDLE * f, const int start)
 		} else {
 			snprintf(tracker_name, 40, "Imago Orpheus %d.%02x",
 				 (sfh.version & 0x0f00) >> 8, sfh.version & 0xff);
+			m->flow_mode = FLOW_MODE_ORPHEUS;
 		}
 		break;
 	case 3:
+		m->flow_mode = FLOW_MODE_IT_210;
 		if (sfh.version == 0x3216) {
 			strcpy(tracker_name, "Impulse Tracker 2.14v3");
 		} else if (sfh.version == 0x3217) {

--- a/contrib/libxmp/src/loaders/sample.c
+++ b/contrib/libxmp/src/loaders/sample.c
@@ -66,13 +66,13 @@ static void convert_7bit_to_8bit(uint8 *p, int l)
 static void convert_vidc_to_linear(uint8 *p, int l)
 {
 	int i;
+	int8 amp;
 	uint8 x;
 
 	for (i = 0; i < l; i++) {
 		x = p[i];
-		p[i] = vdic_table[x >> 1];
-		if (x & 0x01)
-			p[i] *= -1;
+		amp = vdic_table[x >> 1];
+		p[i] = (uint8)((x & 0x01) ? -amp : amp);
 	}
 }
 
@@ -131,7 +131,7 @@ static void convert_signal(uint8 *p, int l, int r)
 			*w += 0x8000;
 	} else {
 		for (; l--; p++)
-			*p += (char)0x80;	/* cast needed by MSVC++ */
+			*p += (unsigned char)0x80;
 	}
 }
 
@@ -212,10 +212,31 @@ int libxmp_load_sample(struct module_data *m, HIO_HANDLE *f, int flags, struct x
 		return 0;
 	}
 
+	/* Patches with samples
+	 * Allocate extra sample for interpolation.
+	 */
+	bytelen = xxs->len;
+	framelen = 1;
+	extralen = 4;
+
+	if (xxs->flg & XMP_SAMPLE_16BIT) {
+		bytelen *= 2;
+		extralen *= 2;
+		framelen *= 2;
+	}
+	if (xxs->flg & XMP_SAMPLE_STEREO) {
+		bytelen *= 2;
+		extralen *= 2;
+		framelen *= 2;
+		channels = 2;
+	}
+
 	/* If this sample starts at or after EOF, skip it entirely.
 	 */
 	if (~flags & SAMPLE_FLAG_NOLOAD) {
 		long file_pos, file_len;
+		long remaining = 0;
+		long over = 0;
 		if (!f) {
 			return 0;
 		}
@@ -226,10 +247,37 @@ int libxmp_load_sample(struct module_data *m, HIO_HANDLE *f, int flags, struct x
 			return 0;
 		}
 		/* If this sample goes past EOF, truncate it. */
-		if (file_pos + xxs->len > file_len && (~flags & SAMPLE_FLAG_ADPCM)) {
+		remaining = file_len - file_pos;
+#ifndef LIBXMP_CORE_PLAYER
+		if (flags & SAMPLE_FLAG_ADPCM) {
+			long bound = 16 + ((bytelen + 1) >> 1);
+			if (remaining < 16) {
+				D_(D_WARN "ignoring truncated ADPCM sample");
+				return 0;
+			}
+			if (bound > remaining) {
+				over = bound - remaining;
+				bytelen = (remaining - 16) << 1;
+			}
+		} else
+#endif
+		if (bytelen > remaining) {
+			over = bytelen - remaining;
+			bytelen = remaining;
+		}
+
+		if (over) {
 			D_(D_WARN "sample would extend %ld bytes past EOF; truncating to %ld",
-				file_pos + xxs->len - file_len, file_len - file_pos);
-			xxs->len = file_len - file_pos;
+				over, remaining);
+
+			/* Trim extra bytes non-aligned to sample frame. */
+			bytelen -= bytelen & (framelen - 1);
+
+			xxs->len = bytelen;
+			if (xxs->flg & XMP_SAMPLE_16BIT)
+				xxs->len >>= 1;
+			if (xxs->flg & XMP_SAMPLE_STEREO)
+				xxs->len >>= 1;
 		}
 	}
 
@@ -246,13 +294,6 @@ int libxmp_load_sample(struct module_data *m, HIO_HANDLE *f, int flags, struct x
 		xxs->flg &= ~(XMP_SAMPLE_LOOP | XMP_SAMPLE_LOOP_BIDIR);
 	}
 
-	/* Patches with samples
-	 * Allocate extra sample for interpolation.
-	 */
-	bytelen = xxs->len;
-	framelen = 1;
-	extralen = 4;
-
 	/* Disable bidirectional loop flag if sample is not looped
 	 */
 	if (xxs->flg & XMP_SAMPLE_LOOP_BIDIR) {
@@ -262,18 +303,6 @@ int libxmp_load_sample(struct module_data *m, HIO_HANDLE *f, int flags, struct x
 	if (xxs->flg & XMP_SAMPLE_SLOOP_BIDIR) {
 		if (~xxs->flg & XMP_SAMPLE_SLOOP)
 			xxs->flg &= ~XMP_SAMPLE_SLOOP_BIDIR;
-	}
-
-	if (xxs->flg & XMP_SAMPLE_16BIT) {
-		bytelen *= 2;
-		extralen *= 2;
-		framelen *= 2;
-	}
-	if (xxs->flg & XMP_SAMPLE_STEREO) {
-		bytelen *= 2;
-		extralen *= 2;
-		framelen *= 2;
-		channels = 2;
 	}
 
 	/* add guard bytes before the buffer for higher order interpolation */

--- a/contrib/libxmp/src/loaders/xm_load.c
+++ b/contrib/libxmp/src/loaders/xm_load.c
@@ -35,6 +35,9 @@
 
 #include "loader.h"
 #include "xm.h"
+#if 0
+#include "vorbis.h"
+#endif
 
 static int xm_test(HIO_HANDLE *, char *, const int);
 static int xm_load(struct module_data *, HIO_HANDLE *, const int);
@@ -997,6 +1000,8 @@ static int xm_load(struct module_data *m, HIO_HANDLE * f, const int start)
 		libxmp_set_type(m, "ModPlug Tracker 1.16 XM %d.%02d",
 				xfh.version >> 8, xfh.version & 0xff);
 
+		m->quirk &= ~QUIRK_FT2BUGS;
+		m->flow_mode = FLOW_MODE_MPT_116;
 		m->mvolbase = 48;
 		m->mvol = 48;
 		libxmp_apply_mpt_preamp(m);

--- a/contrib/libxmp/src/memio.c
+++ b/contrib/libxmp/src/memio.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2021 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/contrib/libxmp/src/mixer.c
+++ b/contrib/libxmp/src/mixer.c
@@ -111,7 +111,7 @@ MIX_FN(stereoout_mono_a500);
 MIX_FN(stereoout_mono_a500_filter);
 #endif
 
-typedef void (*MIX_FP) (struct mixer_voice *, int32 *, int, int, int, int, int, int, int);
+typedef void (*MIX_FP) (struct mixer_voice* LIBXMP_RESTRICT, int32* LIBXMP_RESTRICT, int, int, int, int, int, int, int);
 
 static const MIX_FP nearest_mixers[] = {
 	LIST_MIX_FUNCTIONS(nearest),
@@ -442,7 +442,41 @@ static int loop_reposition(struct context_data *ctx, struct mixer_voice *vi,
 			vi->pos = vi->start * 2 - vi->pos;
 		}
 	}
+	/* Safety check: pos should not be excessively past the sample end.
+	 * This only seems to happen with very low sample rates. */
+	if (vi->pos > xxs->len + 1) {
+		vi->pos = xxs->len + 1;
+	}
 	return loop_changed;
+}
+
+static void hotswap_sample(struct context_data *ctx, struct mixer_voice *vi,
+ int voc, int smp)
+{
+	int vol = vi->vol;
+	int pan = vi->pan;
+	libxmp_mixer_setpatch(ctx, voc, smp, 0);
+	vi->flags |= SAMPLE_LOOP;
+	vi->vol = vol;
+	vi->pan = pan;
+}
+
+static void get_current_sample(struct context_data *ctx, struct mixer_voice *vi,
+ struct xmp_sample **xxs, struct extra_sample_data **xtra, int *c5spd)
+{
+	struct module_data *m = &ctx->m;
+	struct xmp_module *mod = &m->mod;
+
+	if (vi->smp < mod->smp) {
+		*xxs = &mod->xxs[vi->smp];
+		*xtra = &m->xtra[vi->smp];
+		*c5spd = m->xtra[vi->smp].c5spd;
+	} else {
+		*xxs = &ctx->smix.xxs[vi->smp - mod->smp];
+		*xtra = NULL;
+		*c5spd = m->c4rate;
+	}
+	adjust_voice_end(ctx, vi, *xxs, *xtra);
 }
 
 /* Calculate the required number of sample frames to render a tick.
@@ -591,14 +625,17 @@ void libxmp_mixer_softmixer(struct context_data *ctx)
 			vol_r = vol * (0x80 + vi->pan);
 		}
 
-		if (vi->smp < mod->smp) {
-			xxs = &mod->xxs[vi->smp];
-			xtra = &m->xtra[vi->smp];
-			c5spd = m->xtra[vi->smp].c5spd;
+		/* Sample is paused - skip channel unless a new sample is queued. */
+		if (vi->flags & SAMPLE_PAUSED) {
+			if ((~vi->flags & SAMPLE_QUEUED) || vi->queued.smp < 0) {
+				vi->flags &= ~SAMPLE_QUEUED;
+				continue;
+			}
+			hotswap_sample(ctx, vi, voc, vi->queued.smp);
+			get_current_sample(ctx, vi, &xxs, &xtra, &c5spd);
+			vi->pos = vi->start;
 		} else {
-			xxs = &ctx->smix.xxs[vi->smp - mod->smp];
-			xtra = NULL;
-			c5spd = m->c4rate;
+			get_current_sample(ctx, vi, &xxs, &xtra, &c5spd);
 		}
 
 		step = C4_PERIOD * c5spd / s->freq / vi->period;
@@ -610,7 +647,6 @@ void libxmp_mixer_softmixer(struct context_data *ctx)
 			continue;
 		}
 
-		adjust_voice_end(ctx, vi, xxs, xtra);
 		init_sample_wraparound(s, &loop_data, vi, xxs);
 
 		rampsize = s->ticksize >> ANTICLICK_SHIFT;
@@ -722,38 +758,58 @@ void libxmp_mixer_softmixer(struct context_data *ctx)
 			}
 
 			vi->pos += step_dir * samples;
-
-			/* No more samples in this tick */
 			size -= samples;
-			if (size <= 0) {
-				if (has_active_loop(ctx, vi, xxs)) {
-					/* This isn't particularly important for
-					 * forward loops, but reverse loops need
-					 * to be corrected here to avoid their
-					 * negative positions getting clamped
-					 * in later ticks. */
-					if (((~vi->flags & VOICE_REVERSE) && vi->pos >= vi->end) ||
-					    ((vi->flags & VOICE_REVERSE) && vi->pos <= vi->start)) {
-						if (loop_reposition(ctx, vi, xxs, xtra)) {
-							reset_sample_wraparound(&loop_data);
-							init_sample_wraparound(s, &loop_data, vi, xxs);
-						}
-					}
-				}
-				continue;
-			}
 
-			/* First sample loop run */
-			if (!has_active_loop(ctx, vi, xxs) || split_noloop) {
-				do_anticlick(ctx, voc, buf_pos, size);
-				set_sample_end(ctx, voc, 1);
+			/* One-shot samples do not loop. */
+			if ((!has_active_loop(ctx, vi, xxs) || split_noloop) &&
+			    !(vi->flags & SAMPLE_QUEUED)) {
+				if (size > 0) {
+					do_anticlick(ctx, voc, buf_pos, size);
+					set_sample_end(ctx, voc, 1);
+					/* Next sample should ramp. */
+					vol_l = vol_r = 0;
+				}
 				size = 0;
 				continue;
 			}
 
-			if (loop_reposition(ctx, vi, xxs, xtra)) {
-				reset_sample_wraparound(&loop_data);
-				init_sample_wraparound(s, &loop_data, vi, xxs);
+			/* Loop before continuing to the next channel if the
+			 * tick is complete. This is particularly important
+			 * for reverse loops to avoid position clamping. */
+			if (size > 0 ||
+			    ((~vi->flags & VOICE_REVERSE) && vi->pos >= vi->end) ||
+			     ((vi->flags & VOICE_REVERSE) && vi->pos <= vi->start)) {
+				if (vi->flags & SAMPLE_QUEUED) {
+					/* Protracker sample swap */
+					do_anticlick(ctx, voc, buf_pos, size);
+					if (vi->queued.smp < 0 ||
+					    (!has_active_loop(ctx, vi, xxs) &&
+					     !(mod->xxs[vi->queued.smp].flg & XMP_SAMPLE_LOOP))) {
+						/* Invalid samples and one-shots that
+						 * are being replaced by one-shots
+						 * (OpenMPT PTStoppedSwap.mod) stop
+						 * the current sample. If the current
+						 * sample is looped, it needs to be paused.
+						 */
+						vi->flags &= ~SAMPLE_QUEUED;
+						vi->flags |= SAMPLE_PAUSED;
+						set_sample_end(ctx, voc, 1);
+						/* Next sample should ramp. */
+						vol_l = vol_r = 0;
+						size = 0;
+						continue;
+					}
+					reset_sample_wraparound(&loop_data);
+					hotswap_sample(ctx, vi, voc, vi->queued.smp);
+					get_current_sample(ctx, vi, &xxs, &xtra, &c5spd);
+					init_sample_wraparound(s, &loop_data, vi, xxs);
+					vi->pos = vi->start;
+					continue;
+				}
+				if (loop_reposition(ctx, vi, xxs, xtra)) {
+					reset_sample_wraparound(&loop_data);
+					init_sample_wraparound(s, &loop_data, vi, xxs);
+				}
 			}
 		}
 
@@ -791,6 +847,18 @@ void libxmp_mixer_voicepos(struct context_data *ctx, int voc, double pos, int ac
 	struct mixer_voice *vi = &p->virt.voice_array[voc];
 	struct xmp_sample *xxs;
 	struct extra_sample_data *xtra;
+
+	/* Position changes e.g. retrigger make the new sample take effect
+	 * if queued (OpenMPT InstrSwapRetrigger.mod). */
+	if (vi->flags & SAMPLE_QUEUED) {
+		vi->flags &= ~SAMPLE_QUEUED;
+		if (vi->queued.smp < 0) {
+			vi->flags |= SAMPLE_PAUSED;
+		} else if (vi->smp != vi->queued.smp) {
+			hotswap_sample(ctx, vi, voc, vi->queued.smp);
+		}
+		vi->flags |= SAMPLE_LOOP;
+	}
 
 	if (vi->smp < m->mod.smp) {
 		xxs = &m->mod.xxs[vi->smp];
@@ -853,7 +921,7 @@ void libxmp_mixer_setpatch(struct context_data *ctx, int voc, int smp, int ac)
 	vi->smp = smp;
 	vi->vol = 0;
 	vi->pan = 0;
-	vi->flags &= ~(SAMPLE_LOOP | VOICE_REVERSE | VOICE_BIDIR);
+	vi->flags &= ~(SAMPLE_LOOP | SAMPLE_QUEUED | SAMPLE_PAUSED | VOICE_REVERSE | VOICE_BIDIR);
 
 	vi->fidx = 0;
 
@@ -882,6 +950,25 @@ void libxmp_mixer_setpatch(struct context_data *ctx, int voc, int smp, int ac)
 	}
 
 	libxmp_mixer_voicepos(ctx, voc, 0, ac);
+}
+
+/**
+ * Replace the current playing sample when it reaches the end of its
+ * sample loop, a la Protracker 1/2. The new sample will begin playing
+ * at the start of its loop if it is looped, the start of the sample if
+ * it is a one-shot, and it will not play and instead pause the channel
+ * if both the original and the new sample are one-shots or if the new
+ * sample is empty/invalid/-1.
+ */
+void libxmp_mixer_queuepatch(struct context_data *ctx, int voc, int smp)
+{
+	struct player_data *p = &ctx->p;
+	struct mixer_voice *vi = &p->virt.voice_array[voc];
+
+	if (smp != vi->smp || (vi->flags & SAMPLE_PAUSED)) {
+		vi->queued.smp = smp;
+		vi->flags |= SAMPLE_QUEUED;
+	}
 }
 
 void libxmp_mixer_setnote(struct context_data *ctx, int voc, int note)

--- a/contrib/libxmp/src/mixer.h
+++ b/contrib/libxmp/src/mixer.h
@@ -44,11 +44,17 @@ struct mixer_voice {
 #define SAMPLE_LOOP	(1 << 2)
 #define VOICE_REVERSE	(1 << 3)
 #define VOICE_BIDIR	(1 << 4)
+#define SAMPLE_QUEUED	(1 << 5)
+#define SAMPLE_PAUSED	(1 << 6)
 	int flags;		/* flags */
 	void *sptr;		/* sample pointer */
 #ifdef LIBXMP_PAULA_SIMULATOR
 	struct paula_state *paula; /* paula simulation state */
 #endif
+
+	struct {		/* Protracker queued instrument change */
+		int smp;
+	} queued;
 
 #ifndef LIBXMP_CORE_DISABLE_IT
 	struct {
@@ -74,6 +80,7 @@ int	libxmp_mixer_numvoices	(struct context_data *, int);
 void	libxmp_mixer_softmixer	(struct context_data *);
 void	libxmp_mixer_reset	(struct context_data *);
 void	libxmp_mixer_setpatch	(struct context_data *, int, int, int);
+void	libxmp_mixer_queuepatch	(struct context_data *, int, int);
 void	libxmp_mixer_voicepos	(struct context_data *, int, double, int);
 double	libxmp_mixer_getvoicepos(struct context_data *, int);
 void	libxmp_mixer_setnote	(struct context_data *, int, int);

--- a/contrib/libxmp/src/period.c
+++ b/contrib/libxmp/src/period.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2021 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/contrib/libxmp/src/player.h
+++ b/contrib/libxmp/src/player.h
@@ -201,6 +201,7 @@ struct channel_data {
 		int slide;	/* Frequency slide value */
 		double fslide;	/* Fine frequency slide value */
 		int memory;	/* Portamento effect memory */
+		int down_memory;/* Portamento down effect memory (XM) */
 	} freq;
 
 	struct {
@@ -214,6 +215,8 @@ struct channel_data {
 	struct {
 		int up_memory;	/* FT2 has separate memories for these */
 		int down_memory;/* cases (see Porta-LinkMem.xm) */
+		int xf_up_memory;
+		int xf_down_memory;
 	} fine_porta;
 
 	struct {
@@ -276,6 +279,8 @@ struct channel_data {
 
 void	libxmp_process_fx	(struct context_data *, struct channel_data *,
 				 int, struct xmp_event *, int);
+void	libxmp_process_pattern_loop	(struct context_data *,
+					 struct flow_control *f, int, int, int);
 void	libxmp_filter_setup	(int, int, int, int*, int*, int *);
 int	libxmp_read_event	(struct context_data *, struct xmp_event *, int);
 

--- a/contrib/libxmp/src/read_event.c
+++ b/contrib/libxmp/src/read_event.c
@@ -176,7 +176,13 @@ static void set_period(struct context_data *ctx, int note,
 {
 	struct module_data *m = &ctx->m;
 
-	if (sub != NULL && note >= 0) {
+	/* TODO: blocking period updates on whether or not the event has a
+	 * valid instrument seems suspicious, but almost every format uses
+	 * this. Only allow Protracker to update without it for now. */
+	if (sub == NULL && !HAS_QUIRK(QUIRK_PROTRACK))
+		return;
+
+	if (note >= 0) {
 		double per = libxmp_note_to_period(ctx, note, xc->finetune,
 							xc->per_adj);
 
@@ -221,6 +227,8 @@ static void set_period_ft2(struct context_data *ctx, int note,
 #define IS_TONEPORTA(x) ((x) == FX_TONEPORTA || (x) == FX_TONE_VSLIDE)
 #endif
 
+#define IS_MOD_RETRIG(x,p) ((x) == FX_EXTENDED && MSN(p) == EX_RETRIG && LSN(p) != 0)
+
 #define set_patch(ctx,chn,ins,smp,note) \
 	libxmp_virt_setpatch(ctx, chn, ins, smp, note, 0, 0, 0, 0)
 
@@ -231,18 +239,24 @@ static int read_event_mod(struct context_data *ctx, struct xmp_event *e, int chn
 	struct xmp_module *mod = &m->mod;
 	struct channel_data *xc = &p->xc_data[chn];
 	int note;
-	struct xmp_subinstrument *sub;
+	struct xmp_subinstrument *sub = NULL;
 	int new_invalid_ins = 0;
+	int new_swap_ins = 0;
 	int is_toneporta;
+	int is_retrig;
 	int use_ins_vol;
 
 	xc->flags = 0;
 	note = -1;
 	is_toneporta = 0;
+	is_retrig = 0;
 	use_ins_vol = 0;
 
 	if (IS_TONEPORTA(e->fxt) || IS_TONEPORTA(e->f2t)) {
 		is_toneporta = 1;
+	}
+	if (IS_MOD_RETRIG(e->fxt, e->fxp) || IS_MOD_RETRIG(e->f2t, e->f2p)) {
+		is_retrig = 1;
 	}
 
 	/* Check instrument */
@@ -259,6 +273,18 @@ static int read_event_mod(struct context_data *ctx, struct xmp_event *e, int chn
 		if (IS_VALID_INSTRUMENT(ins)) {
 			sub = get_subinstrument(ctx, ins, e->note - 1);
 
+			if (sub != NULL) {
+				new_swap_ins = 1;
+
+				/* Finetune is always loaded, but only applies
+				 * when the period is updated by a note/porta
+				 * (OpenMPT finetune.mod, PortaSwapPT.mod). */
+				if (HAS_QUIRK(QUIRK_PROTRACK)) {
+					xc->finetune = sub->fin;
+					xc->ins = ins;
+				}
+			}
+
 			if (is_toneporta) {
 				/* Get new instrument volume */
 				if (sub != NULL) {
@@ -273,16 +299,26 @@ static int read_event_mod(struct context_data *ctx, struct xmp_event *e, int chn
 			} else {
 				xc->ins = ins;
 				xc->ins_fade = mod->xxi[ins].rls;
-
-				if (sub != NULL) {
-					if (HAS_QUIRK(QUIRK_PROTRACK)) {
-						xc->finetune = sub->fin;
-					}
-				}
 			}
 		} else {
 			new_invalid_ins = 1;
-			libxmp_virt_resetchannel(ctx, chn);
+
+			/* Invalid instruments do not reset the channel in
+			 * Protracker; instead, they set the current sample
+			 * to the invalid sample, which stops the current
+			 * sample at the end of its loop.
+			 *
+			 * OpenMPT PTInstrSwap.mod: uses a null sample to pause
+			 * a looping sample, plays several on a channel with no note.
+			 *
+			 * OpenMPT PTSwapEmpty.mod: repeatedly pauses and
+			 * restarts a sample using a null sample.
+			 */
+			if (!HAS_QUIRK(QUIRK_PROTRACK) || is_retrig) {
+				libxmp_virt_resetchannel(ctx, chn);
+			} else {
+				libxmp_virt_queuepatch(ctx, chn, -1, -1, 0);
+			}
 		}
 	}
 
@@ -300,26 +336,46 @@ static int read_event_mod(struct context_data *ctx, struct xmp_event *e, int chn
 
 			sub = get_subinstrument(ctx, xc->ins, xc->key);
 
-			if (!new_invalid_ins && sub != NULL) {
+			if (sub != NULL) {
 				int transp = mod->xxi[xc->ins].map[xc->key].xpo;
 				int smp;
 
 				note = xc->key + sub->xpo + transp;
 				smp = sub->sid;
 
-				if (!IS_VALID_SAMPLE(smp)) {
+				if (new_invalid_ins || !IS_VALID_SAMPLE(smp)) {
 					smp = -1;
 				}
 
 				if (smp >= 0 && smp < mod->smp) {
 					set_patch(ctx, chn, xc->ins, smp, note);
+					new_swap_ins = 0;
 					xc->smp = smp;
 				}
 			} else {
 				xc->flags = 0;
 				use_ins_vol = 0;
+				note = xc->key;
 			}
 		}
+
+		if (note >= 0) {
+			xc->note = note;
+			SET_NOTE(NOTE_SET);
+		}
+	}
+
+	/* Protracker 1/2 sample swap occurs when a sample number is
+	 * encountered without a note or with a note and toneporta. The new
+	 * instrument is switched to when the current sample reaches its loop
+	 * end. A valid note must have been played in this channel before.
+	 *
+	 * Empty samples can also be set, which stops the sample at the end
+	 * of its loop (see above).
+	 */
+	if (new_swap_ins && sub && HAS_QUIRK(QUIRK_PROTRACK) && TEST_NOTE(NOTE_SET)) {
+		libxmp_virt_queuepatch(ctx, chn, e->ins - 1, sub->sid, xc->note);
+		xc->smp = sub->sid;
 	}
 
 	sub = get_subinstrument(ctx, xc->ins, xc->key);
@@ -354,9 +410,13 @@ static int read_event_mod(struct context_data *ctx, struct xmp_event *e, int chn
 		return 0;
 	}
 
-	if (note >= 0) {
-		xc->note = note;
+	if (note >= 0 && !new_invalid_ins) {
 		libxmp_virt_voicepos(ctx, chn, xc->offset.val);
+	} else if (new_swap_ins && is_retrig && HAS_QUIRK(QUIRK_PROTRACK)) {
+		/* Protracker: an instrument number with no note and retrigger
+		 * triggers the new sample on tick 0. Other effects that set
+		 * RETRIG should not. (OpenMPT InstrSwapRetrigger.mod) */
+		libxmp_virt_voicepos(ctx, chn, 0);
 	}
 
 	if (TEST(OFFSET)) {

--- a/contrib/libxmp/src/scan.c
+++ b/contrib/libxmp/src/scan.c
@@ -40,6 +40,7 @@
 
 #include "common.h"
 #include "effects.h"
+#include "player.h"
 #include "mixer.h"
 
 #ifndef LIBXMP_CORE_PLAYER
@@ -64,11 +65,11 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
     int orders_since_last_valid, any_valid;
     int gvl, bpm, speed, base_time, chn;
     int frame_count;
-    double time, start_time;
-    int loop_chn, loop_num, inside_loop, line_jump;
+    double time, start_time, time_calc;
+    int inside_loop, line_jump;
     int pdelay = 0;
-    int loop_count[XMP_MAX_CHANNELS];
-    int loop_row[XMP_MAX_CHANNELS];
+    struct flow_control f;
+    struct pattern_loop loop[XMP_MAX_CHANNELS];
     int i, pat;
     int has_marker;
     struct ord_data *info;
@@ -89,12 +90,19 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
 			mod->xxp[pat]->rows ? mod->xxp[pat]->rows : 1);
     }
 
+    /* Use a temporary flow_control so the scan can borrow the player's
+     * Pattern Loop handler. */
+    memset(&f, 0, sizeof(f));
+    f.loop = loop;
     for (i = 0; i < mod->chn; i++) {
-	loop_count[i] = 0;
-	loop_row[i] = -1;
+	loop[i].start = 0;
+	loop[i].count = 0;
     }
-    loop_num = 0;
-    loop_chn = -1;
+    f.loop_dest = -1;
+    f.loop_param = -1;
+    f.loop_start = -1;
+    f.loop_count = 0;
+    f.loop_active_num = 0;
     line_jump = 0;
 
     gvl = mod->gvl;
@@ -203,6 +211,16 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
             break_row = 0;
         }
 
+	/* Changing patterns may reset loop vars. */
+	if (HAS_FLOW_MODE(FLOW_LOOP_PATTERN_RESET)) {
+	    f.loop_start = -1;
+	    f.loop_count = 0;
+	    for (i = 0; i < mod->chn; i++) {
+		f.loop[i].start = 0;
+		f.loop[i].count = 0;
+	    }
+	}
+
         /* Loops can cross pattern boundaries, so check if we're not looping */
         if (m->scan_cnt[ord][break_row] && !inside_loop) {
             break;
@@ -218,7 +236,9 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
             info->gvl = gvl;
             info->bpm = bpm;
             info->speed = speed;
-            info->time = time + m->time_factor * frame_count * base_time / bpm;
+	    /* TODO: double ord_data::time */
+	    time_calc = time + m->time_factor * frame_count * base_time / bpm;
+            info->time = time_calc > (double)INT_MAX ? INT_MAX : (int)time_calc;
 #ifndef LIBXMP_CORE_PLAYER
             info->st26_speed = st26_speed;
 #endif
@@ -262,7 +282,7 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
 		goto end_module;
 	    }
 
-	    if (!loop_num && !line_jump && m->scan_cnt[ord][row]) {
+	    if (!f.loop_active_num && !line_jump && m->scan_cnt[ord][row]) {
 		row_count--;
 		goto end_module;
 	    }
@@ -407,6 +427,44 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
 				bpm = far_bpm;
 			}
 		}
+
+		/* ULT tempo processing */
+
+		if (f1 == FX_ULT_TEMPO || f2 == FX_ULT_TEMPO) {
+		    int parm2 = 0;
+		    parm = 0;
+		    if (f2 == FX_ULT_TEMPO) {
+			if (p2 == 0) {
+				parm = 6;
+				parm2 = 125;
+			} else if (p2 < 0x30) {
+				parm = p2;
+			} else {
+				parm2 = p2;
+			}
+		    }
+		    if (f1 == FX_ULT_TEMPO) {
+			if (p1 == 0) {
+				parm = 6;
+				parm2 = 125;
+			} else if (p1 < 0x30) {
+				parm = p1;
+			} else {
+				parm2 = p1;
+			}
+		    }
+		    frame_count += row_count * speed;
+		    row_count = 0;
+		    if (parm > 0) {
+			speed = parm;
+			st26_speed = 0;
+		    }
+		    if (parm2 > 0) {
+			time += m->time_factor * frame_count * base_time / bpm;
+			frame_count = 0;
+			bpm = parm2;
+		    }
+		}
 #endif
 
 		if ((f1 == FX_S3M_SPEED && p1) || (f2 == FX_S3M_SPEED && p2)) {
@@ -476,7 +534,9 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
 			frame_count += (p1 & 0x0f) * speed;
 		}
 
-		if (f1 == FX_IT_BREAK) {
+		/* IT break is not applied if a lower channel looped (2.00+).
+		 * (Labyrinth of Zeux ZX_11.it "Raceway"). */
+		if (f1 == FX_IT_BREAK && f.loop_dest < 0) {
 		    break_row = p1;
 		    last_row = 0;
 		}
@@ -516,43 +576,35 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
 		    if ((parm >> 4) == EX_PATT_DELAY) {
 			if (m->read_event_type != READ_EVENT_ST3 || !pdelay) {
 			    pdelay = parm & 0x0f;
-			    frame_count += pdelay * speed;
                         }
 		    }
 
 		    if ((parm >> 4) == EX_PATTERN_LOOP) {
-			if (parm &= 0x0f) {
-			    /* Loop end */
-			    if (loop_count[chn]) {
-				if (--loop_count[chn]) {
-				    /* next iteration */
-				    loop_chn = chn;
-				} else {
-				    /* finish looping */
-				    loop_num--;
-				    inside_loop = 0;
-				    if (m->quirk & QUIRK_S3MLOOP)
-					loop_row[chn] = row;
-				}
-			    } else {
-				loop_count[chn] = parm;
-				loop_chn = chn;
-				loop_num++;
-			    }
-			} else {
-			    /* Loop start */
-			    loop_row[chn] = row - 1;
+			/* QUIRK_FT2BUGS may set break_row */
+			f.jumpline = break_row;
+			libxmp_process_pattern_loop(ctx, &f, chn, row, LSN(parm));
+			break_row = f.jumpline;
+
+			/* Attempt to detect the inside of a loop.
+			 * TODO: this won't detect all cases. */
+			if (LSN(parm) > 0 && f.loop_dest < 0) {
+			    inside_loop = 0;
+			} else if (LSN(parm) == 0) {
 			    inside_loop = 1;
-			    if (HAS_QUIRK(QUIRK_FT2BUGS))
-				break_row = row;
 			}
 		    }
 		}
 	    }
 
-	    if (loop_chn >= 0) {
-		row = loop_row[loop_chn];
-		loop_chn = -1;
+	    if (pdelay > 0) {
+		frame_count += pdelay * speed;
+	    }
+
+	    f.loop_param = -1;
+	    if (f.loop_dest >= 0) {
+		/* -1 as it will be incremented immediately by the loop. */
+		row = f.loop_dest - 1;
+		f.loop_dest = -1;
 	    }
 
 #ifndef LIBXMP_CORE_PLAYER
@@ -604,7 +656,9 @@ end_module:
     time -= start_time;
     frame_count += row_count * speed;
 
-    return (time + m->time_factor * frame_count * base_time / bpm);
+    /* TODO: double scan_data::time */
+    time_calc = time + m->time_factor * frame_count * base_time / bpm;
+    return time_calc > (double)INT_MAX ? INT_MAX : (int)time_calc;
 }
 
 static void reset_scan_data(struct context_data *ctx)

--- a/contrib/libxmp/src/virtual.h
+++ b/contrib/libxmp/src/virtual.h
@@ -16,6 +16,7 @@ void	libxmp_virt_off		(struct context_data *);
 int	libxmp_virt_mute	(struct context_data *, int, int);
 int	libxmp_virt_setpatch	(struct context_data *, int, int, int, int,
 				 int, int, int, int);
+int	libxmp_virt_queuepatch	(struct context_data *, int, int, int, int);
 int	libxmp_virt_cvt8bit	(void);
 void	libxmp_virt_setnote	(struct context_data *, int, int);
 void	libxmp_virt_setsmp	(struct context_data *, int, int);

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -111,6 +111,7 @@ DEVELOPERS
   libpng to 1.6.44, libogg to 1.3.5, and libvorbis to 1.3.7.
 + Enabled 16k pages on Android to hopefully future-proof
   MegaZeux against Android 15.0. (asie)
++ Updated libxmp to 4.6.1+sample rate patch.
 
 
 September 10th, 2024 - MZX 2.93b


### PR DESCRIPTION
Changes since the last update:
* Pattern Loop support for several formats where it was not correctly implemented.
* Protracker instrument swapping support.
* Bugfixes for restart bytes in some MODs.
* Bugfixes for Protracker EFx Invert Loop.
* XM effect memory fixes for 1xx, 2xx, X1x, X2x.
* Fixes for MED FF1, FF3 to only retrigger once. Fixes for MED3/4 FF2. Might negatively affect 1Fxx, which is already broken...
* Support for Ultra Tracker tempo.
* Other misc. fixes.