### PR TITLE
Debian changelog entries for 2.93c (also back-changed version numbers…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,16 @@
-megazeux (2.93b) unstable; urgency=low
+megazeux (2.93.2) unstable; urgency=low
+
+  * Updated for 2.93c.
+
+ -- Dylan "Dizzy" J Morrison <dizzy@domad.science>  Fri, 28 Feb 2025 19:06:00 -0500
+
+megazeux (2.93.1) unstable; urgency=low
 
   * Updated for 2.93b.
 
  -- Dylan "Dizzy" J Morrison <dizzy@domad.science>  Tue, 10 Sep 2024 20:09:00 -0500
 
-megazeux (2.93) unstable; urgency=low
+megazeux (2.93.0) unstable; urgency=low
 
   * Updated for 2.93.
 


### PR DESCRIPTION
… for 2.93, 2.93b to new Debian versioning for consistency)