### PR TITLE
Software layer renderer clipping and unaligned enhancements.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -12,11 +12,11 @@ USERS
 + Software layer renderer performance enhancements for repeat
   colors, clipping, and unaligned renderering.
 + Unaligned software layer rendering using 64-bit writes is
-  now enabled for x86-64 and Emscripten, and optimizes out up to
-  48 renderers on x86-64.
+  now enabled for x86-64, POWER8, Emscripten, and probably most
+  AArch64 builds. This optimizes out up to 48 renderers.
 + Unaligned software layer rendering using 32-bit writes is
-  now enabled for x86, PowerPC, and M68k, and optimizes out up to
-  24 renderers on these architectures.
+  now enabled for x86, PowerPC, M68k, and potentially some ARMv7
+  builds. This optimizes out up to 24 renderers.
 + Fixed date and time counters on NDS (missing IRQ_NETWORK).
 
 DEVELOPERS

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -13,10 +13,13 @@ USERS
   colors, clipping, and unaligned renderering.
 + Unaligned software layer rendering using 64-bit writes is
   now enabled for x86-64, POWER8, Emscripten, and probably most
-  AArch64 builds. This optimizes out up to 48 renderers.
+  AArch64 builds. This optimizes out up to 48 renderers for
+  these architectures, and improves 8-bit, 16-bit, and 32-bit
+  rendering performance.
 + Unaligned software layer rendering using 32-bit writes is
-  now enabled for x86, PowerPC, M68k, and potentially some ARMv7
-  builds. This optimizes out up to 24 renderers.
+  now enabled for x86, PowerPC, and M68k. This optimizes out up
+  to 24 renderers for these architectures, and improves 8-bit
+  and 16-bit rendering performance.
 + Fixed date and time counters on NDS (missing IRQ_NETWORK).
 
 DEVELOPERS

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -9,6 +9,14 @@ GIT - MZX 2.93d
 
 USERS
 
++ Software layer renderer performance enhancements for repeat
+  colors, clipping, and unaligned renderering.
++ Unaligned software layer rendering using 64-bit writes is
+  now enabled for x86-64 and Emscripten, and optimizes out up to
+  48 renderers on x86-64.
++ Unaligned software layer rendering using 32-bit writes is
+  now enabled for x86, PowerPC, and M68k, and optimizes out up to
+  24 renderers on these architectures.
 + Fixed date and time counters on NDS (missing IRQ_NETWORK).
 
 DEVELOPERS

--- a/src/platform_endian.h
+++ b/src/platform_endian.h
@@ -148,6 +148,17 @@
 #endif
 #endif
 
+/* ARMv7+ can access 32-bit (AArch64: and 64-bit) integers unaligned if
+ * the system allows this. This is almost always (but not necessarily) enabled
+ * for AArch64, and sometimes for ARMv7 and AArch32. Currently trusting
+ * __ARM_FEATURE_UNALIGNED to be accurate for any relevant environment. */
+#if defined(PLATFORM_IS_ARM) && defined(__ARM_FEATURE_UNALIGNED)
+#define PLATFORM_UNALIGN_32 0x01
+#if ARCHITECTURE_BITS >= 64
+#define PLATFORM_UNALIGN_64 0x01
+#endif
+#endif
+
 /* PowerPC can access 32-bit ints unaligned, but 64-bit ints must be aligned.
  * POWER8 and up have safe unaligned access for 64-bit ints. */
 #if defined(PLATFORM_IS_PPC)

--- a/src/platform_endian.h
+++ b/src/platform_endian.h
@@ -40,7 +40,9 @@
  defined(__ppc64__) || defined(_ARCH_PPC64)
 #define PLATFORM_IS_PPC64
 #endif
-#if defined(__ppc__) || defined(__POWERPC__) || defined(PLATFORM_IS_PPC64)
+#if defined(__powerpc__) || defined(__PPC__) || \
+ defined(__ppc__) || defined(_ARCH_PPC) || defined(__POWERPC__) || \
+ defined(PLATFORM_IS_PPC64)
 #define PLATFORM_IS_PPC
 #endif
 

--- a/src/platform_endian.h
+++ b/src/platform_endian.h
@@ -146,9 +146,13 @@
 #endif
 #endif
 
-/* PowerPC can access 32-bit ints unaligned, but 64-bit ints must be aligned. */
+/* PowerPC can access 32-bit ints unaligned, but 64-bit ints must be aligned.
+ * POWER8 and up have safe unaligned access for 64-bit ints. */
 #if defined(PLATFORM_IS_PPC)
 #define PLATFORM_UNALIGN_32 0x01
+#if defined(_ARCH_PWR8)
+#define PLATFORM_UNALIGN_64 0x01
+#endif
 #endif
 
 /* Motorola 68000 has limited unaligned safety, see above. */

--- a/src/platform_endian.h
+++ b/src/platform_endian.h
@@ -1,7 +1,7 @@
 /* MegaZeux
  *
  * Copyright (C) 2008 Alistair John Strachan <alistair@devzero.co.uk
- * Copyright (C) 2020, 2024 Alice Rowan <petrifiedrowan@gmail.com>
+ * Copyright (C) 2020, 2024-2025 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as

--- a/src/platform_endian.h
+++ b/src/platform_endian.h
@@ -151,8 +151,10 @@
 /* ARMv7+ can access 32-bit (AArch64: and 64-bit) integers unaligned if
  * the system allows this. This is almost always (but not necessarily) enabled
  * for AArch64, and sometimes for ARMv7 and AArch32. Currently trusting
- * __ARM_FEATURE_UNALIGNED to be accurate for any relevant environment. */
-#if defined(PLATFORM_IS_ARM) && defined(__ARM_FEATURE_UNALIGNED)
+ * __ARM_FEATURE_UNALIGNED to be accurate for any relevant environment.
+ * This is currently disabled for 32-bit ARM because clang 19 -O3 will emit
+ * STM instructions that trap even if __ARM_FEATURE_UNALIGNED is defined. */
+#if defined(PLATFORM_IS_ARM64) && defined(__ARM_FEATURE_UNALIGNED)
 #define PLATFORM_UNALIGN_32 0x01
 #if ARCHITECTURE_BITS >= 64
 #define PLATFORM_UNALIGN_64 0x01

--- a/src/render_layer.cpp
+++ b/src/render_layer.cpp
@@ -21,6 +21,7 @@
 #include <assert.h>
 
 #include "graphics.h"
+#include "platform_endian.h"
 #include "render_layer.h"
 
 // Skip unused variants to reduce compile time on these platforms.
@@ -186,6 +187,10 @@ static inline void reference_renderer(uint32_t * RESTRICT pixels,
 }
 #endif
 
+/* Return the alignment of a particular value (typically pixel array address).
+ * Multiple addresses can be ORed together to get the lowest-common alignment
+ * for multiple inputs. This function should not take architecture unalignment
+ * capabilities or vector rendering into consideration. */
 static size_t get_align_for_offset(size_t value)
 {
 #ifndef SKIP_64_ALIGN

--- a/src/render_layer.cpp
+++ b/src/render_layer.cpp
@@ -185,7 +185,8 @@ static inline void reference_renderer(uint32_t * RESTRICT pixels,
 /* Return the alignment of a particular value (typically pixel array address).
  * Multiple addresses can be ORed together to get the lowest-common alignment
  * for multiple inputs. This function should not take architecture unalignment
- * capabilities or vector rendering into consideration. */
+ * capabilities or vector rendering into consideration.
+ */
 static size_t get_align_for_offset(size_t value)
 {
 #ifndef SKIP_64_ALIGN
@@ -277,7 +278,7 @@ void render_layer(void * RESTRICT pixels,
  const struct graphics_data *graphics, const struct video_layer *layer)
 {
 #if defined(BUILD_REFERENCE_RENDERER) && !defined(MZX_UNIT_TESTS)
-  reference_renderer((uint32_t * RESTRICT)pixels,
+  reference_renderer(reinterpret_cast<uint32_t * RESTRICT>(pixels),
    width_px, height_px, pitch, graphics, layer);
   return;
 #endif

--- a/src/render_layer_code.hpp
+++ b/src/render_layer_code.hpp
@@ -646,8 +646,11 @@ static inline void render_layer_func(
       c = select_char(src, layer);
       if(c != INVISIBLE_CHAR)
       {
+        /* For 4PPW and 8PPW, only update the color arrays if the palette has
+         * actually changed. This optimization is negligible or worse for lower
+         * write sizes since it blocks other compiler optimizations. */
         unsigned both_cols = both_colors(src);
-        if(prev != both_cols)
+        if(PPW <= 2 || prev != both_cols)
         {
           prev = both_cols;
           if(SMZX)

--- a/src/render_layer_code.hpp
+++ b/src/render_layer_code.hpp
@@ -1,7 +1,7 @@
 /* MegaZeux
  *
  * Copyright (C) 2017 Dr Lancer-X <drlancer@megazeux.org>
- * Copyright (C) 2020, 2024 Alice Rowan <petrifiedrowan@gmail.com>
+ * Copyright (C) 2020, 2024-2025 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -494,7 +494,6 @@ static inline ALIGNTYPE get_colors(ALIGNTYPE (&set_colors)[16], unsigned idx)
 #endif
     }
   }
-  // Very old compilers also complain about this unreachable return.
   return 0;
 }
 

--- a/src/render_layer_code.hpp
+++ b/src/render_layer_code.hpp
@@ -781,10 +781,6 @@ static inline void render_layer_func(
         // the case without edge clipping isn't at the mercy of old compilers.
         if(CLIP && clip_x)
         {
-          int write_start = (pix_x < 0) ? (-pix_x / PPW) : 0;
-          int write_end = (pix_x + CHAR_W > width_px) ?
-           (width_px - pix_x) / PPW : CHAR_W / PPW;
-
           for(row = 0; row < CHAR_H; row++, out_ptr += pix_pitch)
           {
             current_char_byte = char_ptr[row];
@@ -796,8 +792,12 @@ static inline void render_layer_func(
 
             ALIGNTYPE *write_ptr = reinterpret_cast<ALIGNTYPE *>(out_ptr);
 
-            for(write_pos = write_start; write_pos < write_end; write_pos++)
+            for(write_pos = 0; write_pos < CHAR_W / PPW; write_pos++)
             {
+              if(pix_x + write_pos * PPW < 0 ||
+               pix_x + write_pos * PPW + PPW - 1 >= width_px)
+                continue;
+
               if(SMZX && PPW == 2)
               {
                 ALIGNTYPE shift = write_pos * PPW;

--- a/src/render_layer_code.hpp
+++ b/src/render_layer_code.hpp
@@ -27,6 +27,7 @@
 // stream to a file.
 
 #include "graphics.h"
+#include "platform_attribute.h"
 #include "platform_endian.h"
 #include "render_layer_common.hpp"
 #include "util.h"
@@ -68,7 +69,12 @@ static void render_layer_func(
 template<typename PIXTYPE, typename ALIGNTYPE, int SMZX, int TR, int CLIP>
 static void render_layer_func(
  void * RESTRICT pixels, int width_px, int height_px, size_t pitch,
- const struct graphics_data *graphics, const struct video_layer *layer);
+ const struct graphics_data *graphics, const struct video_layer *layer)
+#if defined(PLATFORM_UNALIGN_32) || defined(PLATFORM_UNALIGN_64)
+/* May be using intentional unaligned accesses; tell UBSan to calm down. */
+ATTRIBUTE_NO_SANITIZE("alignment")
+#endif
+;
 
 /**
  * Alignment of pixel buffer (8bpp).

--- a/src/render_layer_code.hpp
+++ b/src/render_layer_code.hpp
@@ -603,19 +603,14 @@ static inline void render_layer_func(
      width_px, height_px, layer))
     {
       // Precalculate clipping boundaries.
-      // This only needs to be done when the layer isn't char-aligned.
-      int dest_last_x = layer->x + (int)layer->w * CHAR_W;
-      if((layer->x < 0 || dest_last_x > width_px) && (dest_x & 7))
-      {
-        if(layer->x < 0)
-          clip_xl = start_x;
-        if(dest_last_x > width_px)
-          clip_xr = end_x - 1;
-      }
+      if(layer->x + start_x * CHAR_W < 0)
+        clip_xl = start_x;
+      if(layer->x + end_x * CHAR_W > width_px)
+        clip_xr = end_x - 1;
 
-      if(layer->y < 0)
+      if(layer->y + start_y * CHAR_H < 0)
         clip_yt = start_y;
-      if(layer->y + (int)layer->h * CHAR_H > height_px)
+      if(layer->y + end_y * CHAR_H > height_px)
         clip_yb = end_y - 1;
     }
     src_skip = layer->w - (end_x - start_x);

--- a/src/render_layer_code.hpp
+++ b/src/render_layer_code.hpp
@@ -42,6 +42,13 @@
 #include <cstdio>
 #endif
 
+#if defined(PLATFORM_UNALIGN_32) || defined(PLATFORM_UNALIGN_64)
+/* May be using intentional unaligned accesses; tell UBSan to calm down. */
+#define RENDER_EXTRA_ATTRIBUTES ATTRIBUTE_NO_SANITIZE("alignment")
+#else
+#define RENDER_EXTRA_ATTRIBUTES
+#endif
+
 template<typename PIXTYPE>
 static void render_layer_func(
  void * RESTRICT pixels, int width_px, int height_px, size_t pitch,
@@ -70,11 +77,7 @@ template<typename PIXTYPE, typename ALIGNTYPE, int SMZX, int TR, int CLIP>
 static void render_layer_func(
  void * RESTRICT pixels, int width_px, int height_px, size_t pitch,
  const struct graphics_data *graphics, const struct video_layer *layer)
-#if defined(PLATFORM_UNALIGN_32) || defined(PLATFORM_UNALIGN_64)
-/* May be using intentional unaligned accesses; tell UBSan to calm down. */
-ATTRIBUTE_NO_SANITIZE("alignment")
-#endif
-;
+ RENDER_EXTRA_ATTRIBUTES;
 
 /**
  * Alignment of pixel buffer (8bpp).

--- a/src/render_layer_common.hpp
+++ b/src/render_layer_common.hpp
@@ -1,0 +1,136 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2024 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef __RENDER_LAYER_COMMON_HPP
+#define __RENDER_LAYER_COMMON_HPP
+
+#include "graphics.h"
+#include "platform_endian.h"
+
+/**
+ * Select the real display character for a char element.
+ * TODO: this should be done at draw time.
+ */
+static inline int select_char(const struct char_element *src,
+ const struct video_layer *layer)
+{
+  int ch = src->char_value;
+  if(ch >= INVISIBLE_CHAR)
+    return INVISIBLE_CHAR;
+
+  // Char values >= 256, prior to offsetting, are from the protected charset.
+  if(ch > 0xff)
+  {
+    return (ch & 0xff) + PROTECTED_CHARSET_POSITION;
+  }
+  else
+    return ((ch & 0xff) + layer->offset) % PROTECTED_CHARSET_POSITION;
+}
+
+/**
+ * Mode 0 and UI layer color selection function.
+ * This needs to be done for both colors.
+ */
+static inline int select_color_16(uint8_t color, int ppal)
+{
+  // Palette values >= 16, prior to offsetting, are from the protected palette.
+  if(color >= 16)
+  {
+    return (color - 16) % 16 + ppal;
+  }
+  else
+    return color;
+}
+
+/**
+ * Precompute clipping ranges for a layer.
+ * Because the precision of the input is in chars (not pixels),
+ * the destination x/y may be negative, and the effective final
+ * destination x/y may extend beyond the screen. The caller is
+ * responsible for correctly handling these clip areas.
+ *
+ * @param start_x   starting x within the layer, in chars.
+ * @param start_y   starting y within the layer, in chars.
+ * @param end_x     last x + 1 within the layer, in chars.
+ * @param end_y     last y + 1 within the layer, in chars.
+ * @param dest_x    first x to draw, in pixels. May be negative.
+ * @param dest_y    first y to draw, in pixels. May be negative.
+ */
+static inline boolean precompute_clip(int &start_x, int &start_y,
+ int &end_x, int &end_y, int &dest_x, int &dest_y,
+ int width_px, int height_px, const struct video_layer *layer)
+{
+  int dest_last_x = layer->x + layer->w * CHAR_W;
+  int dest_last_y = layer->y + layer->h * CHAR_H;
+  boolean ret = false;
+
+  if(layer->x < 0)
+  {
+    start_x = -(layer->x / CHAR_W);
+    dest_x = layer->x % CHAR_W; // intentional truncated modulo
+    ret = true;
+  }
+  else
+  {
+    start_x = 0;
+    dest_x = layer->x;
+  }
+
+  if(layer->y < 0)
+  {
+    start_y = -(layer->y / CHAR_H);
+    dest_y = layer->y % CHAR_H; // intentional truncated modulo
+    ret = true;
+  }
+  else
+  {
+    start_y = 0;
+    dest_y = layer->y;
+  }
+
+  end_x = layer->w;
+  end_y = layer->h;
+
+  if(dest_last_x > width_px)
+  {
+    end_x -= (dest_last_x - width_px) / CHAR_W;
+    ret = true;
+  }
+
+  if(dest_last_y > height_px)
+  {
+    end_y -= (dest_last_y - height_px) / CHAR_H;
+    ret = true;
+  }
+  return ret;
+}
+
+/**
+ * Get the combined colors value from a char_element.
+ */
+static inline unsigned both_colors(const char_element *src)
+{
+#ifdef IS_CXX_11
+  static_assert(offsetof(char_element, bg_color) == 2, "");
+  static_assert(offsetof(char_element, fg_color) == 3, "");
+#endif
+  return reinterpret_cast<const uint16_t *>(src)[1];
+}
+
+#endif /* __RENDER_LAYER_COMMON_HPP */

--- a/unit/render.cpp
+++ b/unit/render.cpp
@@ -1039,6 +1039,146 @@ UNITTEST(render_layer_smzx32)
   SECTION(large)        test::large(DIR "32sxl.tga.gz");
 }
 
+/* Manual layer renderer dispatch to ensure every valid alignment combination
+ * is instantiated. Calls to render_layer may instead dispatch to unaligned
+ * or vector renderers--making the lower-alignment renderers impossible to
+ * reach--so the regular tests aren't sufficient for coverage.
+ */
+static void render_layer_no_unalign(void * RESTRICT pixels,
+ size_t width_px, size_t height_px, size_t pitch, int bpp,
+ const struct graphics_data *graphics, const struct video_layer *layer)
+{
+  /* Copied from render_layer. */
+  int smzx = layer->mode;
+  int trans = layer->transparent_col != -1;
+  size_t drawStart;
+  int align;
+  int clip = 0;
+
+  if(layer->x < 0 || layer->y < 0 ||
+   (layer->x + layer->w * CHAR_W) > width_px ||
+   (layer->y + layer->h * CHAR_H) > height_px)
+    clip = 1;
+
+  if(bpp == -1)
+    bpp = graphics->bits_per_pixel;
+
+  drawStart =
+   (size_t)((char *)pixels + layer->y * (ptrdiff_t)pitch + (layer->x * bpp / 8));
+
+  /* See render_layer. Do not perform any extra handling for unalignment. */
+  align = get_align_for_offset(sizeof(size_t) | drawStart | pitch);
+
+  render_layer_func(pixels, width_px, height_px, pitch, graphics, layer,
+   bpp, align, smzx, trans, clip);
+}
+
+UNITTEST(render_layer_mzx8_all)
+{
+#ifdef SKIP_8BPP
+  SKIP();
+#else
+  using test = render_layer_tester<uint8_t, MZX, FLAT32, 0, render_layer_no_unalign>;
+  SECTION(graphic)      test::graphic(DIR "8.tga.gz");
+  SECTION(align)        test::align(DIR "8a.tga.gz");
+  SECTION(align_tr)     test::align_tr(DIR "8ta.tga.gz");
+  SECTION(clip)         test::clip(DIR "8c.tga.gz");
+  SECTION(clip_tr)      test::clip_tr(DIR "8tc.tga.gz");
+  SECTION(misalign)     test::misalign(DIR "8a.tga.gz");
+  SECTION(misalign_tr)  test::misalign_tr(DIR "8ta.tga.gz");
+  SECTION(misclip)      test::misclip(DIR "8c.tga.gz");
+  SECTION(misclip_tr)   test::misclip_tr(DIR "8tc.tga.gz");
+  SECTION(large)        test::large(DIR "8xl.tga.gz");
+#endif
+}
+
+UNITTEST(render_layer_smzx8_all)
+{
+#ifdef SKIP_8BPP
+  SKIP();
+#else
+  using test = render_layer_tester<uint8_t, SMZX, FLAT32, 0, render_layer_no_unalign>;
+  SECTION(graphic)      test::graphic(DIR "8s.tga.gz");
+  SECTION(align)        test::align(DIR "8sa.tga.gz");
+  SECTION(align_tr)     test::align_tr(DIR "8sta.tga.gz");
+  SECTION(clip)         test::clip(DIR "8sc.tga.gz");
+  SECTION(clip_tr)      test::clip_tr(DIR "8stc.tga.gz");
+  SECTION(misalign)     test::misalign(DIR "8sa.tga.gz");
+  SECTION(misalign_tr)  test::misalign_tr(DIR "8sta.tga.gz");
+  SECTION(misclip)      test::misclip(DIR "8sc.tga.gz");
+  SECTION(misclip_tr)   test::misclip_tr(DIR "8stc.tga.gz");
+  SECTION(large)        test::large(DIR "8sxl.tga.gz");
+#endif
+}
+
+UNITTEST(render_layer_mzx16_all)
+{
+#ifdef SKIP_16BPP
+  SKIP();
+#else
+  using test = render_layer_tester<uint16_t, MZX, FLAT16, 0, render_layer_no_unalign>;
+  SECTION(graphic)      test::graphic(DIR "16.tga.gz");
+  SECTION(align)        test::align(DIR "16a.tga.gz");
+  SECTION(align_tr)     test::align_tr(DIR "16ta.tga.gz");
+  SECTION(clip)         test::clip(DIR "16c.tga.gz");
+  SECTION(clip_tr)      test::clip_tr(DIR "16tc.tga.gz");
+  SECTION(misalign)     test::misalign(DIR "16a.tga.gz");
+  SECTION(misalign_tr)  test::misalign_tr(DIR "16ta.tga.gz");
+  SECTION(misclip)      test::misclip(DIR "16c.tga.gz");
+  SECTION(misclip_tr)   test::misclip_tr(DIR "16tc.tga.gz");
+  SECTION(large)        test::large(DIR "16xl.tga.gz");
+#endif
+}
+
+UNITTEST(render_layer_smzx16_all)
+{
+#ifdef SKIP_16BPP
+  SKIP();
+#else
+  using test = render_layer_tester<uint16_t, SMZX, FLAT16, 0, render_layer_no_unalign>;
+  SECTION(graphic)      test::graphic(DIR "16s.tga.gz");
+  SECTION(align)        test::align(DIR "16sa.tga.gz");
+  SECTION(align_tr)     test::align_tr(DIR "16sta.tga.gz");
+  SECTION(clip)         test::clip(DIR "16sc.tga.gz");
+  SECTION(clip_tr)      test::clip_tr(DIR "16stc.tga.gz");
+  SECTION(misalign)     test::misalign(DIR "16sa.tga.gz");
+  SECTION(misalign_tr)  test::misalign_tr(DIR "16sta.tga.gz");
+  SECTION(misclip)      test::misclip(DIR "16sc.tga.gz");
+  SECTION(misclip_tr)   test::misclip_tr(DIR "16stc.tga.gz");
+  SECTION(large)        test::large(DIR "16sxl.tga.gz");
+#endif
+}
+
+UNITTEST(render_layer_mzx32_all)
+{
+  using test = render_layer_tester<uint32_t, MZX, FLAT32, 0, render_layer_no_unalign>;
+  SECTION(graphic)      test::graphic(DIR "32.tga.gz");
+  SECTION(align)        test::align(DIR "32a.tga.gz");
+  SECTION(align_tr)     test::align_tr(DIR "32ta.tga.gz");
+  SECTION(clip)         test::clip(DIR "32c.tga.gz");
+  SECTION(clip_tr)      test::clip_tr(DIR "32tc.tga.gz");
+  SECTION(misalign)     test::misalign(DIR "32a.tga.gz");
+  SECTION(misalign_tr)  test::misalign_tr(DIR "32ta.tga.gz");
+  SECTION(misclip)      test::misclip(DIR "32c.tga.gz");
+  SECTION(misclip_tr)   test::misclip_tr(DIR "32tc.tga.gz");
+  SECTION(large)        test::large(DIR "32xl.tga.gz");
+}
+
+UNITTEST(render_layer_smzx32_all)
+{
+  using test = render_layer_tester<uint32_t, SMZX, FLAT32, 0, render_layer_no_unalign>;
+  SECTION(graphic)      test::graphic(DIR "32s.tga.gz");
+  SECTION(align)        test::align(DIR "32sa.tga.gz");
+  SECTION(align_tr)     test::align_tr(DIR "32sta.tga.gz");
+  SECTION(clip)         test::clip(DIR "32sc.tga.gz");
+  SECTION(clip_tr)      test::clip_tr(DIR "32stc.tga.gz");
+  SECTION(misalign)     test::misalign(DIR "32sa.tga.gz");
+  SECTION(misalign_tr)  test::misalign_tr(DIR "32sta.tga.gz");
+  SECTION(misclip)      test::misclip(DIR "32sc.tga.gz");
+  SECTION(misclip_tr)   test::misclip_tr(DIR "32stc.tga.gz");
+  SECTION(large)        test::large(DIR "32sxl.tga.gz");
+}
+
 static void reference_renderer_wrap(void * RESTRICT pixels,
  size_t width_px, size_t height_px, size_t pitch, int bpp,
  const struct graphics_data *graphics, const struct video_layer *layer)


### PR DESCRIPTION
* Port same subpalette optimization for 4PPW and 8PPW renderers from render_layer32x4.
* Port precalculated clip boundaries optimization from render_layer32x4.
* Implement unaligned rendering optimization comparable to most vector renderers.
  Improves all layer renderers for x86-64, AArch64 (if supported), POWER8, and Emscripten;
  improves 8-bit and 16-bit layer renderers for x86, PowerPC, and M68k.

- [x] Final cleanup.
- [x] UBSan?
- [ ] Report clang -O3 emitting unaligned STM when `__ARM_FEATURE_UNALIGNED` is defined bug to LLVM?