### PR TITLE
Remove bashisms and other issues from manifest.sh.

### DIFF
--- a/arch/manifest.sh
+++ b/arch/manifest.sh
@@ -5,12 +5,15 @@ if [ "$1" = "" ]; then
 	echo "usage: $0 [build dir]"
 	exit 0
 fi
+
 if command -v sha256sum >/dev/null 2>/dev/null; then
-	export sha256cmd="sha256sum"
-elif command -v shasum >/dev/null 2>/dev/null; then
-	export sha256cmd="shasum -a256"
+	export sha256cmd="sha256sum -b"
 elif command -v gsha256sum >/dev/null 2>/dev/null; then
-	export sha256cmd="gsha256sum"
+	export sha256cmd="gsha256sum -b"
+elif command -v shasum >/dev/null 2>/dev/null; then
+	export sha256cmd="shasum -a256 -b"
+elif command -v sha256 >/dev/null 2>/dev/null; then
+	export sha256cmd="sha256 -q"
 else
 	echo "error: install sha256sum (coreutils, BusyBox) or shasum (perl)."
 	exit 1
@@ -32,7 +35,7 @@ find . -mindepth 1 -type f				\
 	-print0						\
 | xargs -0 -n1 -P24 /bin/sh -c				\
 	'size=$(($(wc -c <"$1")));			\
-	 sha=$($sha256cmd -b "$1" | cut -f1 -d" ");	\
+	 sha=$($sha256cmd "$1" | cut -f1 -d" ");	\
 	 name=$(echo "$1" | sed "s,\\.\\/,,");		\
 	 echo "$sha" "$size" "$name"' "$0"		\
 | sort -k3						\

--- a/arch/manifest.sh
+++ b/arch/manifest.sh
@@ -5,6 +5,14 @@ if [ "$1" = "" ]; then
 	echo "usage: $0 [build dir]"
 	exit 0
 fi
+if command -v sha256sum >/dev/null 2>/dev/null; then
+	export sha256cmd="sha256sum"
+elif command -v shasum >/dev/null 2>/dev/null; then
+	export sha256cmd="shasum -a256"
+else
+	echo "error: install sha256sum (coreutils, BusyBox) or shasum (perl)."
+	exit 1
+fi
 
 echo "Generating manifest..."
 
@@ -21,8 +29,8 @@ find . -mindepth 1 -type f				\
 	! -name '*.debug' 				\
 	-print0						\
 | xargs -0 -n1 -P24 /bin/sh -c				\
-	'size=$(du -b "$1" | cut -f1);			\
-	 sha=$(sha256sum -b "$1" | cut -f1 -d" ");	\
+	'size=$(($(wc -c <"$1")));			\
+	 sha=$($sha256cmd -b "$1" | cut -f1 -d" ");	\
 	 name=$(echo "$1" | sed "s,\\.\\/,,");		\
 	 echo "$sha" "$size" "$name"' "$0"		\
 | sort -k3						\

--- a/arch/manifest.sh
+++ b/arch/manifest.sh
@@ -10,10 +10,10 @@ if command -v sha256sum >/dev/null 2>/dev/null; then
 	export sha256cmd="sha256sum -b"
 elif command -v gsha256sum >/dev/null 2>/dev/null; then
 	export sha256cmd="gsha256sum -b"
-elif command -v shasum >/dev/null 2>/dev/null; then
-	export sha256cmd="shasum -a256 -b"
 elif command -v sha256 >/dev/null 2>/dev/null; then
 	export sha256cmd="sha256 -q"
+elif command -v shasum >/dev/null 2>/dev/null; then
+	export sha256cmd="shasum -a256 -b"
 else
 	echo "error: install sha256sum (coreutils, BusyBox) or shasum (perl)."
 	exit 1

--- a/arch/manifest.sh
+++ b/arch/manifest.sh
@@ -9,6 +9,8 @@ if command -v sha256sum >/dev/null 2>/dev/null; then
 	export sha256cmd="sha256sum"
 elif command -v shasum >/dev/null 2>/dev/null; then
 	export sha256cmd="shasum -a256"
+elif command -v gsha256sum >/dev/null 2>/dev/null; then
+	export sha256cmd="gsha256sum"
 else
 	echo "error: install sha256sum (coreutils, BusyBox) or shasum (perl)."
 	exit 1

--- a/arch/manifest.sh
+++ b/arch/manifest.sh
@@ -1,32 +1,29 @@
-#!/bin/bash
+#!/bin/sh
 
+set -e
 if [ "$1" = "" ]; then
 	echo "usage: $0 [build dir]"
 	exit 0
 fi
 
-function getManifestEntry
-{
-	size=`du -b $1 | cut -f1`
-	sha256sum=`sha256sum -b $1 | cut -f1 -d\ `
-	echo $sha256sum $size `echo $1 | sed 's,\.\/,,'`
-}
-
-# can't execute the above function via xargs unless it is exported
-export -f getManifestEntry
-
 echo "Generating manifest..."
 
-cd $1
+cd "$1"
 
 rm -f manifest.txt
 
-find -mindepth 1 -type f				\
-	-not -name config.txt				\
-	-not -name manifest.txt				\
-	-not -name pad.config				\
-	-not -name '*.debug' 				\
+# -P24 is a GNU-ism but also the entire point of using xargs here.
+# Most BSD xargs seem to support it; BusyBox gracefully ignores it.
+find . -mindepth 1 -type f				\
+	! -name config.txt				\
+	! -name manifest.txt				\
+	! -name pad.config				\
+	! -name '*.debug' 				\
 	-print0						\
-| xargs -0 -n1 -I{} -P24 bash -c 'getManifestEntry {}'	\
-| sort --key=3						\
+| xargs -0 -n1 -P24 /bin/sh -c				\
+	'size=$(du -b "$1" | cut -f1);			\
+	 sha=$(sha256sum -b "$1" | cut -f1 -d" ");	\
+	 name=$(echo "$1" | sed "s,\\.\\/,,");		\
+	 echo "$sha" "$size" "$name"' "$0"		\
+| sort -k3						\
 >> manifest.txt

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -24,6 +24,10 @@ USERS
 
 DEVELOPERS
 
++ manifest.sh no longer requires bash. All scripts and Makefiles
+  should now be fully compatible with POSIX sh (with only a few
+  GNU extended options remaining where required).
+
 
 February 28th, 2025 - MZX 2.93c
 

--- a/scripts/buildscripts/mzx-scripts/crlf.sh
+++ b/scripts/buildscripts/mzx-scripts/crlf.sh
@@ -69,7 +69,7 @@ crlf_convert_repository()
 	#
 	[ -z "$MSYSTEM" ] || { return; }
 
-	FILES=$(find config.txt LICENSE assets docs arch/mingw arch/*/pad.config arch/emscripten/web/res/index.html \
+	FILES=$(find config.txt LICENSE* assets docs arch/mingw arch/*/pad.config arch/emscripten/web/res/index.html \
 		-name "*.txt" -o \
 		-name "*.frag" -o \
 		-name "*.vert" -o \


### PR DESCRIPTION
* Removed Bash-style function declaration. (Bash extension)
* Removed function export. (Bash extension)
* Explicitly provide . to find. (ShellCheck)
* Use ! instead of -not for find. (some BusyBox builds apparently)
* Rewrite xargs invocation to use -n1 instead of -I{}. (xargs warning)
* The manifest entry script is now provided directly to xargs instead of in a function, which looks worse, but is POSIX-compatible.
* Replace legacy backtick usage with $(). (ShellCheck)
* Double quote all variable expansions. (ShellCheck)
* Double quote space separator argument to cut. (ShellCheck)
* Use set -e for cd. (ShellCheck)
* Use sort -k3 instead of --key=3. (BusyBox)