### PR TITLE
Fix misc. BSD and SDL 1.2 warnings.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ endif
 endif
 
 SDL_PREFIX  ?= $(shell ${SDL_CONFIG} --prefix)
-SDL_CFLAGS  ?= $(shell ${SDL_CONFIG} --prefix=${SDL_PREFIX} --cflags)
+SDL_CFLAGS  ?= $(shell ${SDL_CONFIG} --prefix=${SDL_PREFIX} --cflags | sed 's,-I,-isystem ,g')
 SDL_LDFLAGS ?= $(shell ${SDL_CONFIG} --prefix=${SDL_PREFIX} --libs)
 endif # SDL1
 

--- a/arch/unix/Makefile.in
+++ b/arch/unix/Makefile.in
@@ -12,8 +12,9 @@ DSOSONAME  = -Wl,-soname,
 # This fixes issues with readdir() failing with EOVERFLOW when called from a
 # 32-bit executable running on a large filesystem.
 # This also enables 64-bit file support on 32-bit platforms.
-ARCH_CFLAGS   = -D_FILE_OFFSET_BITS=64
-ARCH_CXXFLAGS = -D_FILE_OFFSET_BITS=64
+# _LARGEFILE_SOURCE enables fseeko/ftello for very old glibc versions.
+ARCH_CFLAGS   = -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
+ARCH_CXXFLAGS = -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
 
 # Allow ZIP for portable unix-devel packages.
 include arch/zip.inc

--- a/contrib/libxmp/Makefile.megazeux
+++ b/contrib/libxmp/Makefile.megazeux
@@ -24,7 +24,6 @@ libxmp_cflags := \
 #
 libxmp_cflags += \
  -Wno-missing-prototypes -Wno-unused-macros -Wno-sign-compare \
- -Wno-missing-field-initializers
 
 ifeq (${HAS_W_NO_UNUSED_BUT_SET_VARIABLE},1)
 libxmp_cflags += -Wno-unused-but-set-variable

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -29,7 +29,8 @@ DEVELOPERS
   GNU extended options remaining where required).
 + Fix compilation with glibc versions prior to 2.17 caused by
   clock_gettime (disabling for now until -lrt can be tested).
-+ Fix compilation with libpng versions missing png_const_bytep.
++ Fix compilation with libpng versions missing png_const_bytep
+  and png_set_add_alpha.
 + Remove -Wno-missing-field-initializers to fix GCC 3 support.
 + Remove redundant order-only prerequisites in src/Makefile.in
   to fix building with older versions of GNU Make.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -31,6 +31,8 @@ DEVELOPERS
   clock_gettime (disabling for now until -lrt can be tested).
 + Fix compilation with libpng versions missing png_const_bytep.
 + Remove -Wno-missing-field-initializers to fix GCC 3 support.
++ Remove redundant order-only prerequisites in src/Makefile.in
+  to fix building with older versions of GNU Make.
 
 
 February 28th, 2025 - MZX 2.93c

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -27,6 +27,10 @@ DEVELOPERS
 + manifest.sh no longer requires bash. All scripts and Makefiles
   should now be fully compatible with POSIX sh (with only a few
   GNU extended options remaining where required).
++ Fix compilation with glibc versions prior to 2.17 caused by
+  clock_gettime (disabling for now until -lrt can be tested).
++ Fix compilation with libpng versions missing png_const_bytep.
++ Remove -Wno-missing-field-initializers to fix GCC 3 support.
 
 
 February 28th, 2025 - MZX 2.93c

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -31,9 +31,14 @@ DEVELOPERS
   clock_gettime (disabling for now until -lrt can be tested).
 + Fix compilation with libpng versions missing png_const_bytep
   and png_set_add_alpha.
-+ Remove -Wno-missing-field-initializers to fix GCC 3 support.
++ Remove -Wno-missing-field-initializers to fix GCC 3.4 support.
 + Remove redundant order-only prerequisites in src/Makefile.in
   to fix building with older versions of GNU Make.
++ Define _LARGEFILE_SOURCE in addition to _FILE_OFFSET_BITS=64
+  in the unix Makefile to fix builds with old glibcs that
+  predate _FILE_OFFSET_BITS.
++ Numerous warnings fixes/workarounds affecting macOS, NetBSD,
+  OpenBSD, 3DS, GCC 4.x, SDL 1.2, and old versions of libpng.
 
 
 February 28th, 2025 - MZX 2.93c

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -460,10 +460,10 @@ core_objs := ${core_cobjs} ${core_cxxobjs}
 
 -include ${core_objs:.o=.d}
 
-${core_objs}: | $(filter-out $(wildcard ${core_obj}), ${core_obj})
-${core_objs}: | $(filter-out $(wildcard ${audio_obj}), ${audio_obj})
-${core_objs}: | $(filter-out $(wildcard ${io_obj}), ${io_obj})
-${core_objs}: | $(filter-out $(wildcard ${network_obj}), ${network_obj})
+${core_objs}: $(filter-out $(wildcard ${core_obj}), ${core_obj})
+${core_objs}: $(filter-out $(wildcard ${audio_obj}), ${audio_obj})
+${core_objs}: $(filter-out $(wildcard ${io_obj}), ${io_obj})
+${core_objs}: $(filter-out $(wildcard ${network_obj}), ${network_obj})
 
 ifeq (${BUILD_MODULAR},1)
 

--- a/src/about.c
+++ b/src/about.c
@@ -59,8 +59,8 @@
 #ifdef CONFIG_PNG
 static char *png_version_string(char version_str[16], png_uint_32 version)
 {
-  snprintf(version_str, 16, "%d.%d.%d",
-   version / 10000, (version / 100) % 100, version % 100);
+  int v = (int)version;
+  snprintf(version_str, 16, "%d.%d.%d", v / 10000, (v / 100) % 100, v % 100);
 
   return version_str;
 }

--- a/src/event_sdl.c
+++ b/src/event_sdl.c
@@ -940,6 +940,7 @@ static inline void read_key_event(int *key, int *mod, int *scancode,
 #endif
 }
 
+#if SDL_VERSION_ATLEAST(2,0,0)
 static inline uint32_t utf8_next_char(uint8_t **_src)
 {
   uint8_t *src = *_src;
@@ -990,6 +991,7 @@ err_invalid:
   *_src = src;
   return 0;
 }
+#endif /* SDL_VERSION_ATLEAST(2,0,0) */
 
 static boolean process_event(SDL_Event *event)
 {

--- a/src/io/vfs.c
+++ b/src/io/vfs.c
@@ -1110,7 +1110,7 @@ static boolean vfs_move_inode(vfilesystem *vfs, uint32_t old_parent,
   struct vfs_inode *new_p;
   struct vfs_inode *n;
   uint32_t old_pos_in_parent;
-  uint32_t new_pos_in_parent;
+  uint32_t new_pos_in_parent = 0;
   uint32_t pos;
 
   if(inode == VFS_NO_INODE)

--- a/src/io/zip.c
+++ b/src/io/zip.c
@@ -1352,7 +1352,7 @@ err_out:
 enum zip_error zip_get_next_uncompressed_size(struct zip_archive *zp,
  size_t *u_size)
 {
-  uint64_t tmp;
+  uint64_t tmp = 0;
   enum zip_error result = zip_get_next_uncompressed_size64(zp, &tmp);
   if(result)
     return result;

--- a/src/io/zip.c
+++ b/src/io/zip.c
@@ -2644,6 +2644,9 @@ static enum zip_error zip_read_directory(struct zip_archive *zp)
     goto err_out;
   }
 
+  // Fix bogus old GCC warnings
+  memset(&eocd, 0, sizeof(eocd));
+
   result = zip_read_eocd(zp, &eocd);
   if(result != ZIP_SUCCESS)
     goto err_out;

--- a/src/legacy_board.c
+++ b/src/legacy_board.c
@@ -153,8 +153,8 @@ int legacy_load_board_direct(struct world *mzx_world, struct board *cur_board,
   int num_robots, num_scrolls, num_sensors, num_robots_active;
   int overlay_mode, size, board_width, board_height, i;
   int viewport_x, viewport_y, viewport_width, viewport_height;
-  int overlay_width;
-  int overlay_height;
+  int overlay_width = 0;
+  int overlay_height = 0;
   boolean truncated = false;
 
   struct robot *cur_robot;

--- a/src/legacy_world.c
+++ b/src/legacy_world.c
@@ -1006,7 +1006,7 @@ static void legacy_load_world_v1(struct world *mzx_world, vfile *vf, const char 
   int protection_method;
   int num_boards;
   long offset;
-  int score;
+  int score = 0;
   int i;
   char buf[4];
 

--- a/src/platform_time.c
+++ b/src/platform_time.c
@@ -93,10 +93,14 @@ static boolean system_time_win32(int64_t *epoch, int32_t *nano)
 /**
  * Get the system timestamp via `clock_gettime(CLOCK_REALTIME)`.
  * Disable for MinGW (implemented by winpthread); not supported by MSVC.
+ * TODO: glibc prior to 2.17 requires manually linking librt, which can't
+ * be linked safely currently (no equivalent to autoconf to check for it).
  */
 static boolean system_time_clock_gettime(int64_t *epoch, int32_t *nano)
 {
-#if !defined(_WIN32) && defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0
+#if !defined(_WIN32) && defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0 && \
+ (!defined(__GLIBC__) || !defined(__GLIBC_MINOR__) || __GLIBC__ >= 3 || \
+  (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 17))
   struct timespec tp;
 
   if(clock_gettime(CLOCK_REALTIME, &tp))

--- a/src/pngops.c
+++ b/src/pngops.c
@@ -35,6 +35,15 @@
 
 #include <png.h>
 
+/* Prior to libpng 1.5.16, png_write_row takes a non-const pointer despite
+ * it never modifying the row data. In some very old libpng versions, the
+ * type png_const_bytep does not even exist (encountered in 1.2.49). */
+#if defined(PNG_LIBPNG_VER) && PNG_LIBPNG_VER >= 10516
+typedef png_const_bytep png_maybeconst_bytep;
+#else
+typedef png_bytep png_maybeconst_bytep;
+#endif
+
 static void png_write_vfile(png_struct *png_ptr, png_byte *data, png_size_t length)
 {
   vfile *vf = (vfile *)png_get_io_ptr(png_ptr);
@@ -112,7 +121,7 @@ int png_write_image_8bpp(const char *name, size_t w, size_t h,
     if(!row)
       goto exit_free_close;
 
-    png_write_row(png_ptr, (png_const_bytep)row);
+    png_write_row(png_ptr, (png_maybeconst_bytep)row);
   }
   png_write_end(png_ptr, info_ptr);
 
@@ -178,7 +187,7 @@ int png_write_image_32bpp(const char *name, size_t w, size_t h, void *priv,
     if(!row)
       goto exit_free_close;
 
-    png_write_row(png_ptr, (png_const_bytep)row);
+    png_write_row(png_ptr, (png_maybeconst_bytep)row);
   }
   png_write_end(png_ptr, info_ptr);
 

--- a/src/pngops.c
+++ b/src/pngops.c
@@ -431,10 +431,12 @@ void *png_read_stream(FILE *fp, png_uint_32 *_w, png_uint_32 *_h, boolean checke
   {
     png_set_tRNS_to_alpha(png_ptr);
   }
+#if PNG_LIBPNG_VER >= 10207
   else
 
   if(!(type & PNG_COLOR_MASK_ALPHA))
     png_set_add_alpha(png_ptr, 0xff, PNG_FILLER_AFTER);
+#endif
 
   // FIXME: Are these necessary?
   png_read_update_info(png_ptr, info_ptr);

--- a/src/render_gl.h
+++ b/src/render_gl.h
@@ -34,9 +34,6 @@ __M_BEGIN_DECLS
 
 #ifdef CONFIG_SDL
 # include "SDLmzx.h"
-# if !SDL_VERSION_ATLEAST(2,0,0) && !defined(_WIN32)
-#   define NO_SDL_GLEXT /* Include glext.h instead of oudated SDL 1.2 defines */
-# endif
 # ifdef CONFIG_GLES
 #   ifdef CONFIG_RENDER_GL_FIXED
 #     if SDL_VERSION_ATLEAST(3,0,0)

--- a/src/render_gl.h
+++ b/src/render_gl.h
@@ -34,6 +34,9 @@ __M_BEGIN_DECLS
 
 #ifdef CONFIG_SDL
 # include "SDLmzx.h"
+# if !SDL_VERSION_ATLEAST(2,0,0) && !defined(_WIN32)
+#   define NO_SDL_GLEXT /* Include glext.h instead of oudated SDL 1.2 defines */
+# endif
 # ifdef CONFIG_GLES
 #   ifdef CONFIG_RENDER_GL_FIXED
 #     if SDL_VERSION_ATLEAST(3,0,0)

--- a/src/robot.c
+++ b/src/robot.c
@@ -765,7 +765,7 @@ void save_robot(struct world *mzx_world, struct robot *cur_robot,
   struct memfile mf;
   void *buffer = NULL;
   size_t actual_size = 0;
-  enum zip_error ret = ZIP_SUCCESS;
+  boolean is_stream = false;
 
   if(cur_robot->used)
   {
@@ -784,9 +784,11 @@ void save_robot(struct world *mzx_world, struct robot *cur_robot,
     if(zp->is_memory)
     {
       // The regular way works with memory zips too, but this is faster.
-      ret = zip_write_open_mem_stream(zp, &mf, name, actual_size);
+      if(zip_write_open_mem_stream(zp, &mf, name, actual_size) == ZIP_SUCCESS)
+        is_stream = true;
     }
-    if(!zp->is_memory || ret != ZIP_SUCCESS)
+
+    if(!is_stream)
     {
       buffer = cmalloc(actual_size);
 
@@ -795,7 +797,7 @@ void save_robot(struct world *mzx_world, struct robot *cur_robot,
 
     save_robot_to_memory(cur_robot, &mf, savegame, file_version);
 
-    if(zp->is_memory)
+    if(is_stream)
     {
       zip_write_close_mem_stream(zp, &mf);
     }

--- a/src/robot.c
+++ b/src/robot.c
@@ -765,6 +765,7 @@ void save_robot(struct world *mzx_world, struct robot *cur_robot,
   struct memfile mf;
   void *buffer = NULL;
   size_t actual_size = 0;
+  enum zip_error ret = ZIP_SUCCESS;
 
   if(cur_robot->used)
   {
@@ -783,9 +784,9 @@ void save_robot(struct world *mzx_world, struct robot *cur_robot,
     if(zp->is_memory)
     {
       // The regular way works with memory zips too, but this is faster.
-      zip_write_open_mem_stream(zp, &mf, name, actual_size);
+      ret = zip_write_open_mem_stream(zp, &mf, name, actual_size);
     }
-    else
+    if(!zp->is_memory || ret != ZIP_SUCCESS)
     {
       buffer = cmalloc(actual_size);
 

--- a/src/thread_dummy.h
+++ b/src/thread_dummy.h
@@ -40,7 +40,8 @@ __M_BEGIN_DECLS
 #endif
 #endif
 
-#if defined(__GNUC__) && !defined(THREAD_ERROR)
+#if defined(__GNUC__) && !defined(THREAD_ERROR) && \
+ (__GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
 #define THREAD_ERROR __attribute__((error(THREAD_ERROR_MSG)))
 #endif
 

--- a/src/utils/ccv.c
+++ b/src/utils/ccv.c
@@ -192,41 +192,23 @@ static void Error(const char *string, ...)
   exit(1);
 }
 
-/*
-static inline int lc_strcmp(const char *A, const char *B)
-{
-  const char *a = A;
-  const char *b = B;
-
-  if (A == NULL) return -1;
-  if (B == NULL) return 1;
-  for (;;) {
-    if (tolower(*a) < tolower(*b)) return -1;
-    if (tolower(*a) > tolower(*b)) return 1;
-    if (*a == '\0') return 0;
-    a++;
-    b++;
-  }
-}
-*/
-
 static inline int lc_strncmp(const char *A, const char *B, int n)
 {
-  const char *a = A;
-  const char *b = B;
-  int i = 0;
+  const unsigned char *a = (const unsigned char *)A;
+  const unsigned char *b = (const unsigned char *)B;
+  int i;
 
-  if (A == NULL) return -1;
-  if (B == NULL) return 1;
-  for (;;) {
-    if (i >= n) return 0;
-    if (tolower(*a) < tolower(*b)) return -1;
-    if (tolower(*a) > tolower(*b)) return 1;
-    if (*a == '\0') return 0;
+  if(A == NULL) return -1;
+  if(B == NULL) return 1;
+  for(i = 0; i < n; i++)
+  {
+    if(tolower(*a) < tolower(*b)) return -1;
+    if(tolower(*a) > tolower(*b)) return 1;
+    if(*a == '\0') return 0;
     a++;
     b++;
-    i++;
   }
+  return 0;
 }
 
 static inline void file_write32(int val, FILE *fp)

--- a/src/utils/ccv.c
+++ b/src/utils/ccv.c
@@ -753,14 +753,15 @@ static char *OutputPath(const char *input, Config *cfg, const char *ext)
   size_t output_len;
   if(cfg->output[0] == '\0')
   {
-    if(strcmp(input, "-"))
-      snprintf(buf, MAX_PATH, "%s", input);
-    else
-      strcpy(buf, "out");
+    if(!strcmp(input, "-"))
+      input = "out";
 
+    snprintf(buf, MAX_PATH, "%s", input);
     buf[MAX_PATH] = '\0';
+
     buf_e = strrchr(buf, '.');
-    if (buf_e) *buf_e = '\0';
+    if(buf_e)
+      *buf_e = '\0';
 
     output_len = strlen(buf) + strlen(ext) + 1;
     output_path = cmalloc(output_len);

--- a/src/utils/checkres.c
+++ b/src/utils/checkres.c
@@ -3249,7 +3249,7 @@ static enum status parse_file(const char *file_name,
   ext = len >= 4 ? (char *)file_name + len - 4 : NULL;
 
   if(!_get_path(file_dir, file_name))
-    strcpy(file_dir, ".");
+    snprintf(file_dir, sizeof(file_dir), ".");
 
   if(vf && ext && !strcasecmp(ext, ".MZX"))
   {

--- a/src/utils/checkres.c
+++ b/src/utils/checkres.c
@@ -305,7 +305,7 @@ static boolean is_simple_path(const char *src, boolean allow_expressions)
     {
       while(*(++tpos))
       {
-        if(isdigit(*tpos)) continue;
+        if(isdigit((unsigned char)*tpos)) continue;
         if(*tpos == '.' || *tpos == '\0')
           return false;
       }
@@ -415,9 +415,9 @@ static boolean get_wildcard_path(char dest[MAX_PATH], const char *src)
     {
       // Truncated DOS filename--replace ~### with wildcard
       size_t backup = i;
-      if(i + 1 < len && isdigit(src[i + 1]))
+      if(i + 1 < len && isdigit((unsigned char)src[i + 1]))
       {
-        while(i + 1 < len && isdigit(src[i + 1])) i++;
+        while(i + 1 < len && isdigit((unsigned char)src[i + 1])) i++;
         if(i + 1 >= len || src[i + 1] == '.')
         {
           dest[j++] = '*';
@@ -534,7 +534,7 @@ static boolean check_wildcard_path(const char *path, const char *wildcard)
         for(i = p; i < MIN(p + 10, path_len); i++)
         {
           if(pos == MAX_STATE - 1) break;
-          if(isdigit(path[i]))
+          if(isdigit((unsigned char)path[i]))
           {
             pos++;
             state[pos].p = i + 1;

--- a/src/utils/image_file.c
+++ b/src/utils/image_file.c
@@ -2334,14 +2334,14 @@ static enum image_error pam_header(uint32_t *width, uint32_t *height,
   while(next_line(linebuf, 256, s))
   {
     value = linebuf;
-    while(isspace(*value))
+    while(isspace((uint8_t )*value))
       value++;
 
     if(!*value || *value == '#')
       continue;
 
     key = value;
-    while(*value && !isspace(*value))
+    while(*value && !isspace((uint8_t)*value))
       value++;
 
     if(*value)

--- a/src/utils/image_file.c
+++ b/src/utils/image_file.c
@@ -316,8 +316,10 @@ static enum image_error load_png(imageinfo *s)
     png_set_palette_to_rgb(png);
   if(!(color_type & PNG_COLOR_MASK_COLOR))
     png_set_gray_to_rgb(png);
+#if PNG_LIBPNG_VER >= 10207
   if(!(color_type & PNG_COLOR_MASK_ALPHA))
     png_set_add_alpha(png, 0xff, PNG_FILLER_AFTER);
+#endif
   if(png_get_valid(png, info, PNG_INFO_tRNS))
     png_set_tRNS_to_alpha(png);
 

--- a/src/utils/image_file.c
+++ b/src/utils/image_file.c
@@ -2400,8 +2400,7 @@ static enum image_error pam_header(uint32_t *width, uint32_t *height,
       if(!*value || has_tu)
         return IMAGE_ERROR_PAM_BAD_TUPLTYPE;
 
-      // NOTE: tuplstr size MUST be >= linebuf size.
-      strcpy(tuplstr, value);
+      snprintf(tuplstr, sizeof(tuplstr), "%s", value);
       has_tu = true;
     }
   }

--- a/src/utils/txt2hlp.c
+++ b/src/utils/txt2hlp.c
@@ -362,8 +362,10 @@ int main(int argc, char *argv[])
         file_len += (str_len + 1);
 
         //Is this a context-link?
-        if((str_len == 3) && isdigit(tstr[0]) &&
-           isdigit(tstr[1]) && isdigit(tstr[2]))
+        if((str_len == 3) &&
+         isdigit((unsigned char)tstr[0]) &&
+         isdigit((unsigned char)tstr[1]) &&
+         isdigit((unsigned char)tstr[2]))
         {
           //Yep.
           link_numbers[curr_link_ref] = atoi(tstr);

--- a/unit/intake.cpp
+++ b/unit/intake.cpp
@@ -449,7 +449,7 @@ UNITTEST(EventFixed)
     for(const event_input_data &d : insert_data)
     {
       int expected_len = strlen(d.expected);
-      strcpy(dest, d.base);
+      snprintf(dest, sizeof(dest), "%s", d.base);
       intake_set_length(&intk, strlen(dest));
       intake_set_pos(&intk, d.start_pos);
 
@@ -466,7 +466,7 @@ UNITTEST(EventFixed)
     // Special: prevent inserting beyond the maximum length.
     intk.max_length = 8;
     intk.current_length = 7;
-    strcpy(dest, "abcdefg");
+    snprintf(dest, sizeof(dest), "abcdefg");
 
     intk.pos = 7;
     result = intake_apply_event_fixed(sub, INTK_INSERT, intk.pos + 1, 'h', nullptr);
@@ -486,7 +486,7 @@ UNITTEST(EventFixed)
     for(const event_input_data &d : overwrite_data)
     {
       int expected_len = strlen(d.expected);
-      strcpy(dest, d.base);
+      snprintf(dest, sizeof(dest), "%s", d.base);
       intake_set_length(&intk, strlen(dest));
       intake_set_pos(&intk, d.start_pos);
 
@@ -502,7 +502,7 @@ UNITTEST(EventFixed)
     // Special: prevent inserting beyond the maximum length.
     intk.max_length = 8;
     intk.current_length = 7;
-    strcpy(dest, "abcdefg");
+    snprintf(dest, sizeof(dest), "abcdefg");
 
     intk.pos = 7;
     result = intake_apply_event_fixed(sub, INTK_OVERWRITE, intk.pos + 1, 'h', nullptr);
@@ -532,7 +532,7 @@ UNITTEST(EventFixed)
     for(const event_repeat_data &d : data)
     {
       int expected_len = strlen(d.expected);
-      strcpy(dest, d.base);
+      snprintf(dest, sizeof(dest), "%s", d.base);
       intake_set_length(&intk, strlen(dest));
       intake_set_pos(&intk, d.start_pos);
 
@@ -561,7 +561,7 @@ UNITTEST(EventFixed)
     for(const event_repeat_data &d : data)
     {
       int expected_len = strlen(d.expected);
-      strcpy(dest, d.base);
+      snprintf(dest, sizeof(dest), "%s", d.base);
       intake_set_length(&intk, strlen(dest));
       intake_set_pos(&intk, d.start_pos);
 
@@ -599,7 +599,7 @@ UNITTEST(EventFixed)
     for(const event_repeat_data &d : data)
     {
       int expected_len = strlen(d.expected);
-      strcpy(dest, d.base);
+      snprintf(dest, sizeof(dest), "%s", d.base);
       intake_set_length(&intk, strlen(dest));
       intake_set_pos(&intk, d.start_pos);
 
@@ -626,7 +626,7 @@ UNITTEST(EventFixed)
 
     for(const event_repeat_data &d : data)
     {
-      strcpy(dest, d.base);
+      snprintf(dest, sizeof(dest), "%s", d.base);
       intake_set_length(&intk, strlen(dest));
       intake_set_pos(&intk, d.start_pos);
 
@@ -642,7 +642,7 @@ UNITTEST(EventFixed)
   {
     for(const event_input_data &d : insert_data)
     {
-      strcpy(dest, d.base);
+      snprintf(dest, sizeof(dest), "%s", d.base);
       intake_set_length(&intk, strlen(dest));
       intake_set_pos(&intk, d.start_pos);
 
@@ -660,7 +660,7 @@ UNITTEST(EventFixed)
   {
     for(const event_input_data &d : overwrite_data)
     {
-      strcpy(dest, d.base);
+      snprintf(dest, sizeof(dest), "%s", d.base);
       intake_set_length(&intk, strlen(dest));
       intake_set_pos(&intk, d.start_pos);
 
@@ -682,7 +682,7 @@ UNITTEST(EventFixed)
      */
     for(const input_string_data &d : input_data)
     {
-      strcpy(dest, d.base);
+      snprintf(dest, sizeof(dest), "%s", d.base);
       intake_set_length(&intk, strlen(dest));
       intake_set_pos(&intk, d.start_pos);
       intake_set_insert(d.insert_on);
@@ -797,7 +797,7 @@ UNITTEST(EventCallback)
       event_cb_data priv = { d.base, &pos_external, 0 };
       intk.event_priv = &priv;
       intk.pos = d.old_pos;
-      strcpy(dest, d.base);
+      snprintf(dest, sizeof(dest), "%s", d.base);
       intake_event_ext(&intk, d.type, d.old_pos, d.new_pos, d.value, dummy_data);
       ASSERTEQ(priv.call_count, 1, "%s", d.base);
       ASSERTEQ(intk.pos, d.new_pos, "%s", d.base);


### PR DESCRIPTION
* Fix various ctypes.h char array subscript warnings in the utilities (NetBSD).
* "Fix" several OpenBSD ld nags about safe uses of `strcpy`.
* Fix unused `utf8_next_char` warning for SDL 1.2 builds.
* Suppress SDL 1.2 glext.h `GL_GLEXT_VERSION` redefinition warnings caused
  by outdated defines in SDL_opengl.h by replacing `sdl-config` `-I` with `-isystem`.
* Fix GCC 4.6.2 and older bogus eocd uninitialized warnings.
* Fix errors from old libpng versions predating `png_set_add_alpha`.
* Fix warnings/errors from old libpng versions predating `png_const_bytep`.
* Fix compilation failures from old glibc versions where `clock_gettime` is in `-lrt`.
* Remove `-Wno-missing-field-initializers` from libxmp to fix GCC 3.4 compilation.
* Remove redundant order-only prerequisite usage in src/Makefile.in which broke
  building with very old GNU Make versions (3.79/CentOS 3 oldest tested).
* Define `_LARGEFILE_SOURCE` in arch/unix/Makefile.in to fix builds for very old
  glibc versions predating `_FILE_OFFSET_BITS=64`.
* Fix 3DS LTO warnings in `save_robot`.
* Fix ignored attribute error warnings pre-GCC 4.3.
* Fix Objective C pedantic warnings in the Cocoa clipboard handler.
* Fix bogus `-Wmaybe-uninitialized` warnings affecting GCC 4.3 and 4.2.
  Not bothering with the much more numerious spurious GCC 4.0 warnings.