### PR TITLE
Fix OS detection, unit tests, and testworlds for Haiku.

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -558,6 +558,9 @@ elif [ "$PLATFORM" = "unix" ] || [ "$PLATFORM" = "unix-devel" ] ||
 		"NetBSD")
 			UNIX="netbsd"
 			;;
+		"Haiku")
+			UNIX="haiku"
+			;;
 		"Darwin")
 			UNIX="darwin"
 			DIRNAME="darwin"

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -40,6 +40,8 @@ DEVELOPERS
 + Numerous warnings fixes/workarounds affecting macOS, NetBSD,
   OpenBSD, 3DS, GCC 4.x, SDL 1.2, and old versions of libpng.
 + Fixed OS detection, unit tests, and testworlds for Haiku.
++ Replaced return values of all VFS functions to fix issues with
+  using errno values here on Haiku.
 
 
 February 28th, 2025 - MZX 2.93c

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -39,6 +39,7 @@ DEVELOPERS
   predate _FILE_OFFSET_BITS.
 + Numerous warnings fixes/workarounds affecting macOS, NetBSD,
   OpenBSD, 3DS, GCC 4.x, SDL 1.2, and old versions of libpng.
++ Fixed OS detection, unit tests, and testworlds for Haiku.
 
 
 February 28th, 2025 - MZX 2.93c

--- a/src/io/vfs.h
+++ b/src/io/vfs.h
@@ -49,10 +49,31 @@ __M_BEGIN_DECLS
 #define VIRTUAL_FILESYSTEM_PARALLEL
 #endif
 
-/* Unknown internal error. */
-#define VFS_ERR_UNKNOWN   65536
-/* An operation failed because it does not work on cached files. */
-#define VFS_ERR_IS_CACHED 65537
+/* errno-equivalent codes since some platforms have non-POSIX conformant
+ * values that broke things before (seen with Haiku ENOENT).
+ * Use `vfs_error_to_errno` to convert to real errno values.
+ */
+enum vfs_error
+{
+  VFS_EPERM         = 1,
+  VFS_ENOENT        = 2,
+  VFS_EBADF         = 9,
+  VFS_ENOMEM        = 12,
+  VFS_EACCES        = 13,
+  VFS_EBUSY         = 16,
+  VFS_EEXIST        = 17,
+  VFS_ENOTDIR       = 20,
+  VFS_EISDIR        = 21,
+  VFS_EINVAL        = 22,
+  VFS_ENOSPC        = 28,
+  VFS_ERANGE        = 34,
+  VFS_ENAMETOOLONG  = 36,
+  VFS_ENOTEMPTY     = 39,
+  /* Unknown internal error. */
+  VFS_ERR_UNKNOWN   = 65536,
+  /* An operation failed because it does not work on cached files. */
+  VFS_ERR_IS_CACHED = 65537
+};
 
 struct vfs_dir_file
 {
@@ -71,89 +92,114 @@ UTILS_LIBSPEC void vfs_free(vfilesystem *vfs);
 
 #ifdef VIRTUAL_FILESYSTEM
 
-UTILS_LIBSPEC int vfs_make_root(vfilesystem *vfs, const char *name);
-UTILS_LIBSPEC int vfs_create_file_at_path(vfilesystem *vfs, const char *path);
+UTILS_LIBSPEC enum vfs_error vfs_make_root(vfilesystem *vfs, const char *name);
+UTILS_LIBSPEC enum vfs_error vfs_create_file_at_path(vfilesystem *vfs, const char *path);
 
-UTILS_LIBSPEC int vfs_open_if_exists(vfilesystem *vfs,
+UTILS_LIBSPEC enum vfs_error vfs_open_if_exists(vfilesystem *vfs,
  const char *path, boolean is_write, uint32_t *inode);
-UTILS_LIBSPEC int vfs_close(vfilesystem *vfs, uint32_t inode);
-UTILS_LIBSPEC int vfs_truncate(vfilesystem *vfs, uint32_t inode);
+UTILS_LIBSPEC enum vfs_error vfs_close(vfilesystem *vfs, uint32_t inode);
+UTILS_LIBSPEC enum vfs_error vfs_truncate(vfilesystem *vfs, uint32_t inode);
 UTILS_LIBSPEC ssize_t vfs_filelength(vfilesystem *vfs, uint32_t inode);
-UTILS_LIBSPEC int vfs_lock_file_read(vfilesystem *vfs, uint32_t inode,
+UTILS_LIBSPEC enum vfs_error vfs_lock_file_read(vfilesystem *vfs, uint32_t inode,
  const unsigned char **data, size_t *data_length);
-UTILS_LIBSPEC int vfs_unlock_file_read(vfilesystem *vfs, uint32_t inode);
-UTILS_LIBSPEC int vfs_lock_file_write(vfilesystem *vfs, uint32_t inode,
+UTILS_LIBSPEC enum vfs_error vfs_unlock_file_read(vfilesystem *vfs, uint32_t inode);
+UTILS_LIBSPEC enum vfs_error vfs_lock_file_write(vfilesystem *vfs, uint32_t inode,
  unsigned char ***data, size_t **data_length, size_t **data_alloc);
-UTILS_LIBSPEC int vfs_unlock_file_write(vfilesystem *vfs, uint32_t inode);
+UTILS_LIBSPEC enum vfs_error vfs_unlock_file_write(vfilesystem *vfs, uint32_t inode);
 
-UTILS_LIBSPEC int vfs_chdir(vfilesystem *vfs, const char *path);
-UTILS_LIBSPEC int vfs_getcwd(vfilesystem *vfs, char *dest, size_t dest_len);
-UTILS_LIBSPEC int vfs_mkdir(vfilesystem *vfs, const char *path, int mode);
-UTILS_LIBSPEC int vfs_rename(vfilesystem *vfs, const char *oldpath, const char *newpath);
-UTILS_LIBSPEC int vfs_unlink(vfilesystem *vfs, const char *path);
-UTILS_LIBSPEC int vfs_rmdir(vfilesystem *vfs, const char *path);
-UTILS_LIBSPEC int vfs_access(vfilesystem *vfs, const char *path, int mode);
-UTILS_LIBSPEC int vfs_stat(vfilesystem *vfs, const char *path, struct stat *st);
+UTILS_LIBSPEC enum vfs_error vfs_chdir(vfilesystem *vfs, const char *path);
+UTILS_LIBSPEC enum vfs_error vfs_getcwd(vfilesystem *vfs, char *dest, size_t dest_len);
+UTILS_LIBSPEC enum vfs_error vfs_mkdir(vfilesystem *vfs, const char *path, int mode);
+UTILS_LIBSPEC enum vfs_error vfs_rename(vfilesystem *vfs, const char *oldpath,
+ const char *newpath);
+UTILS_LIBSPEC enum vfs_error vfs_unlink(vfilesystem *vfs, const char *path);
+UTILS_LIBSPEC enum vfs_error vfs_rmdir(vfilesystem *vfs, const char *path);
+UTILS_LIBSPEC enum vfs_error vfs_access(vfilesystem *vfs, const char *path, int mode);
+UTILS_LIBSPEC enum vfs_error vfs_stat(vfilesystem *vfs, const char *path, struct stat *st);
 
-UTILS_LIBSPEC int vfs_readdir(vfilesystem *vfs, const char *path, struct vfs_dir *d);
-UTILS_LIBSPEC int vfs_readdir_free(struct vfs_dir *d);
+UTILS_LIBSPEC enum vfs_error vfs_readdir(vfilesystem *vfs, const char *path, struct vfs_dir *d);
+UTILS_LIBSPEC enum vfs_error vfs_readdir_free(struct vfs_dir *d);
 
-UTILS_LIBSPEC int vfs_invalidate_at_path(vfilesystem *vfs, const char *path);
-UTILS_LIBSPEC int vfs_invalidate_at_least(vfilesystem *vfs, size_t *amount_to_free);
-UTILS_LIBSPEC int vfs_invalidate_all(vfilesystem *vfs);
-UTILS_LIBSPEC int vfs_cache_directory(vfilesystem *vfs, const char *path,
- const struct stat *st);
-UTILS_LIBSPEC int vfs_cache_file(vfilesystem *vfs, const char *path,
+UTILS_LIBSPEC enum vfs_error vfs_invalidate_at_path(vfilesystem *vfs, const char *path);
+UTILS_LIBSPEC enum vfs_error vfs_invalidate_at_least(vfilesystem *vfs, size_t *amount_to_free);
+UTILS_LIBSPEC enum vfs_error vfs_invalidate_all(vfilesystem *vfs);
+UTILS_LIBSPEC enum vfs_error vfs_cache_directory(vfilesystem *vfs,
+ const char *path, const struct stat *st);
+UTILS_LIBSPEC enum vfs_error vfs_cache_file(vfilesystem *vfs, const char *path,
  const void *data, size_t data_length);
-UTILS_LIBSPEC int vfs_cache_file_callback(vfilesystem *vfs, const char *path,
- size_t (*readfn)(void * RESTRICT, size_t, void * RESTRICT),
+UTILS_LIBSPEC enum vfs_error vfs_cache_file_callback(vfilesystem *vfs,
+ const char *path, size_t (*readfn)(void * RESTRICT, size_t, void * RESTRICT),
  void *priv, size_t data_length);
 UTILS_LIBSPEC size_t vfs_get_cache_total_size(vfilesystem *vfs);
 UTILS_LIBSPEC size_t vfs_get_total_memory_usage(vfilesystem *vfs);
 UTILS_LIBSPEC void vfs_set_timestamps_enabled(vfilesystem *vfs, boolean enable);
 
+UTILS_LIBSPEC int vfs_error_to_errno(enum vfs_error err);
+
 #else /* !VIRTUAL_FILESYSTEM */
 
-static inline int vfs_make_root(vfilesystem *v, const char *n) { return -1; }
-static inline int vfs_create_file_at_path(vfilesystem *v, const char *p) { return -1; }
+static inline enum vfs_error vfs_make_root(vfilesystem *v, const char *n)
+{ return VFS_EINVAL; }
+static inline enum vfs_error vfs_create_file_at_path(vfilesystem *v, const char *p)
+{ return VFS_EINVAL; }
 
-static inline int vfs_open_if_exists(vfilesystem *v,
- const char *p, boolean w, uint32_t *i) { return -1; }
-static inline int vfs_close(vfilesystem *v, uint32_t i) { return -1; }
-static inline int vfs_truncate(vfilesystem *v, uint32_t i) { return -1; }
-static inline ssize_t vfs_filelength(vfilesystem *v, uint32_t i) { return -1; }
-static inline int vfs_lock_file_read(vfilesystem *v, uint32_t i,
- const unsigned char **d, size_t *l) { return -1; }
-static inline int vfs_unlock_file_read(vfilesystem *v, uint32_t i) { return -1; }
-static inline int vfs_lock_file_write(vfilesystem * v, uint32_t i,
- unsigned char ***d, size_t **l, size_t **a) { return -1; }
-static inline int vfs_unlock_file_write(vfilesystem *v, uint32_t i) { return -1; }
+static inline enum vfs_error  vfs_open_if_exists(vfilesystem *v,
+ const char *p, boolean w, uint32_t *i) { return VFS_EINVAL; }
+static inline enum vfs_error vfs_close(vfilesystem *v, uint32_t i)
+{ return VFS_EINVAL; }
+static inline enum vfs_error vfs_truncate(vfilesystem *v, uint32_t i)
+{ return VFS_EINVAL; }
+static inline ssize_t vfs_filelength(vfilesystem *v, uint32_t i)
+{ return -VFS_EINVAL; }
+static inline enum vfs_error vfs_lock_file_read(vfilesystem *v, uint32_t i,
+ const unsigned char **d, size_t *l) { return VFS_EINVAL; }
+static inline enum vfs_error vfs_unlock_file_read(vfilesystem *v, uint32_t i)
+{ return VFS_EINVAL; }
+static inline enum vfs_error vfs_lock_file_write(vfilesystem * v, uint32_t i,
+ unsigned char ***d, size_t **l, size_t **a) { return VFS_EINVAL; }
+static inline enum vfs_error vfs_unlock_file_write(vfilesystem *v, uint32_t i)
+{ return VFS_EINVAL; }
 
-static inline int vfs_chdir(vfilesystem *v, const char *p) { return -1; }
-static inline int vfs_getcwd(vfilesystem *v, char *d, size_t l) { return -1; }
-static inline int vfs_mkdir(vfilesystem *v, const char *p, int m) { return -1; }
-static inline int vfs_rename(vfilesystem *v, const char *o, const char *n) { return -1; }
-static inline int vfs_unlink(vfilesystem *v, const char *p) { return -1; }
-static inline int vfs_rmdir(vfilesystem *v, const char *p) { return -1; }
-static inline int vfs_access(vfilesystem *v, const char *p, int m) { return -1; }
-static inline int vfs_stat(vfilesystem *v, const char *p, struct stat *s) { return -1; }
+static inline enum vfs_error vfs_chdir(vfilesystem *v, const char *p)
+{ return VFS_EINVAL; }
+static inline enum vfs_error vfs_getcwd(vfilesystem *v, char *d, size_t l)
+{ return VFS_EINVAL; }
+static inline enum vfs_error vfs_mkdir(vfilesystem *v, const char *p, int m)
+{ return VFS_EINVAL; }
+static inline enum vfs_error vfs_rename(vfilesystem *v, const char *o, const char *n)
+{ return VFS_EINVAL; }
+static inline enum vfs_error vfs_unlink(vfilesystem *v, const char *p)
+{ return VFS_EINVAL; }
+static inline enum vfs_error vfs_rmdir(vfilesystem *v, const char *p)
+{ return VFS_EINVAL; }
+static inline enum vfs_error vfs_access(vfilesystem *v, const char *p, int m)
+{ return VFS_EINVAL; }
+static inline enum vfs_error vfs_stat(vfilesystem *v, const char *p, struct stat *s)
+{ return VFS_EINVAL; }
 
-static inline int vfs_readdir(vfilesystem *v, const char *p, struct vfs_dir *d) { return -1; }
-static inline int vfs_readdir_free(struct vfs_dir *d) { return -1; }
+static inline enum vfs_error vfs_readdir(vfilesystem *v, const char *p,
+ struct vfs_dir *d) { return VFS_EINVAL; }
+static inline enum vfs_error vfs_readdir_free(struct vfs_dir *d)
+{ return VFS_EINVAL; }
 
-static inline int vfs_invalidate_at_path(vfilesystem *v, const char *p) { return -1; }
-static inline int vfs_invalidate_at_least(vfilesystem *v, size_t *a) { return -1; }
-static inline int vfs_invalidate_all(vfilesystem *v) { return -1; }
-static inline int vfs_cache_directory(vfilesystem *v, const char *p,
- const struct stat *st) { return -1; }
-static inline int vfs_cache_file(vfilesystem *v, const char *p,
- const void *d, size_t l) { return -1; }
-static inline int vfs_cache_file_callback(vfilesystem *v, const char *p,
- size_t (*r)(void * RESTRICT, size_t, void * RESTRICT),
- void *pr, size_t l) { return -1; }
+static inline enum vfs_error vfs_invalidate_at_path(vfilesystem *v, const char *p)
+{ return VFS_EINVAL; }
+static inline enum vfs_error vfs_invalidate_at_least(vfilesystem *v, size_t *a)
+{ return VFS_EINVAL; }
+static inline enum vfs_error vfs_invalidate_all(vfilesystem *v)
+{ return VFS_EINVAL; }
+static inline enum vfs_error vfs_cache_directory(vfilesystem *v, const char *p,
+ const struct stat *st) { return VFS_EINVAL; }
+static inline enum vfs_error vfs_cache_file(vfilesystem *v, const char *p,
+ const void *d, size_t l) { return VFS_EINVAL; }
+static inline enum vfs_error vfs_cache_file_callback(vfilesystem *v,
+ const char *p, size_t (*r)(void * RESTRICT, size_t, void * RESTRICT),
+ void *pr, size_t l) { return VFS_EINVAL; }
 static inline size_t vfs_get_cache_total_size(vfilesystem *v) { return 0; }
 static inline size_t vfs_get_total_memory_usage(vfilesystem *vfs) { return 0; }
 static inline void vfs_set_timestamps_enabled(vfilesystem *v, boolean e) { }
+
+static inline int vfs_error_to_errno(enum vfs_error err) { return 0; }
 
 #endif /* !VIRTUAL_FILESYSTEM */
 

--- a/testworlds/run.sh
+++ b/testworlds/run.sh
@@ -69,8 +69,12 @@ rm -f log/summary
 rm -f log/failures
 
 # Force mzxrun to use the libraries in its own directory.
+# Linux/BSD
 export LD_LIBRARY_PATH="."
+# macOS
 export DYLD_FALLBACK_LIBRARY_PATH="."
+# Haiku
+export LIBRARY_PATH="$LIBRARY_PATH:."
 
 preload=""
 if [ -n "$2" ];
@@ -119,12 +123,14 @@ i="0"
 # -A is equivalent to -e in POSIX, but NetBSD uses -e for something else.
 # MSYS2 only supports -e (not -A) but it doesn't need it either.
 if ps -A 1>/dev/null 2>/dev/null; then psopt='-A'; fi
+# Haiku has completely different formatting and needs reordered fields:
+if [ "$(uname -s 2>/dev/null)" = "Haiku" ]; then psopt='-o Id Team'; fi
 
 # In some versions of MSYS2, mzxrun doesn't always appear in ps right away. :(
 sleep 1
 [ "$quiet" = "yes" ] || printf "."
 
-while ps "$psopt" | grep -q "$mzxrun_pid .*[m]zxrun"
+while ps $psopt | grep -q "[ \t]*$mzxrun_pid .*[m]zxrun"
 do
 	sleep 1
 	i=$((i+1))

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -199,7 +199,7 @@ ${unit_objs} ${unit_common_objs}: | $(filter-out $(wildcard ${unit_obj_utils}), 
 unit unittest: ${unit_objs}
 	@failcount=0; \
 	for t in ${unit_objs}; do \
-		LD_LIBRARY_PATH="." ./$$t ; \
+		LD_LIBRARY_PATH="." LIBRARY_PATH="$$LIBRARY_PATH:." ./$$t ; \
 		if [ "$$?" != "0" ] ; then \
 			failcount=$$(($$failcount + 1)); \
 		fi; \

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -189,12 +189,12 @@ ${unit_obj_utils}/%${unit_ext}: ${unit_src_utils}/%.cpp
 -include ${unit_objs:${unit_ext}=.d}
 -include ${unit_common_objs:.o=.d}
 
-${unit_objs} ${unit_common_objs}: | $(filter-out $(wildcard ${unit_obj}), ${unit_obj})
-${unit_objs} ${unit_common_objs}: | $(filter-out $(wildcard ${unit_obj_audio}), ${unit_obj_audio})
-${unit_objs} ${unit_common_objs}: | $(filter-out $(wildcard ${unit_obj_editor}), ${unit_obj_editor})
-${unit_objs} ${unit_common_objs}: | $(filter-out $(wildcard ${unit_obj_io}), ${unit_obj_io})
-${unit_objs} ${unit_common_objs}: | $(filter-out $(wildcard ${unit_obj_network}), ${unit_obj_network})
-${unit_objs} ${unit_common_objs}: | $(filter-out $(wildcard ${unit_obj_utils}), ${unit_obj_utils})
+${unit_objs} ${unit_common_objs}: $(filter-out $(wildcard ${unit_obj}), ${unit_obj})
+${unit_objs} ${unit_common_objs}: $(filter-out $(wildcard ${unit_obj_audio}), ${unit_obj_audio})
+${unit_objs} ${unit_common_objs}: $(filter-out $(wildcard ${unit_obj_editor}), ${unit_obj_editor})
+${unit_objs} ${unit_common_objs}: $(filter-out $(wildcard ${unit_obj_io}), ${unit_obj_io})
+${unit_objs} ${unit_common_objs}: $(filter-out $(wildcard ${unit_obj_network}), ${unit_obj_network})
+${unit_objs} ${unit_common_objs}: $(filter-out $(wildcard ${unit_obj_utils}), ${unit_obj_utils})
 
 unit unittest: ${unit_objs}
 	@failcount=0; \


### PR DESCRIPTION
- [x] Failing two regression tests due to Haiku having a non-POSIX-compatible value for `ENOENT`, possibly other codes.