### PR TITLE
Remove make clean Bashisms from most arch Makefile fragments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ arch/djgpp/*.d
 arch/djgpp/*.o
 arch/dreamcast/*.d
 arch/dreamcast/*.o
-arch/emscripten/web/mzxrun_web.js
+arch/emscripten/web/mzxrun_web.js*
 arch/emscripten/web/node_modules
 arch/emscripten/web/package-lock.json
 arch/mingw/pefix
@@ -180,6 +180,7 @@ unit/utils/.build/
 *.sav
 *.mzm
 *~
+.clangd
 .vscode
 .DS_Store
 xcuserdata/

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ arch/msvc/MegaZeux.v12.suo
 arch/msvc/obj
 arch/msvc/version.h
 arch/nds/mzxrun.arm7.elf
+arch/nds/protected_palette_bin.c
 arch/nds/protected_palette_bin.h
 arch/nds/*.S
 arch/nds/*.d

--- a/arch/3ds/Makefile.in
+++ b/arch/3ds/Makefile.in
@@ -119,8 +119,8 @@ ifneq (${BUILD_EDITOR},)
 endif
 
 clean:
-	${RM} ${mzxrun}.{smdh,3dsx} ${mzx}.{smdh,3dsx}
-	${RM} arch/3ds/*.{d,o} arch/3ds/*shbin*
+	${RM} ${mzxrun}.smdh ${mzxrun}.3dsx ${mzx}.smdh ${mzx}.3dsx
+	${RM} arch/3ds/*.d arch/3ds/*.o arch/3ds/*shbin*
 
 build := ${build_root}/3ds/megazeux
 build: package ${build}

--- a/arch/dreamcast/Makefile.in
+++ b/arch/dreamcast/Makefile.in
@@ -63,7 +63,7 @@ package: mzx
 	${KOS_BASE}/utils/scramble/scramble ${mzxrun}.bin 1ST_READ.BIN
 
 clean:
-	@rm -f ${mzxrun}.bin 1ST_READ.BIN arch/dreamcast/*.{d,o}
+	${RM} -f ${mzxrun}.bin 1ST_READ.BIN arch/dreamcast/*.d arch/dreamcast/*.o
 
 build: package ${build}
 	${CP} 1ST_READ.BIN ${build}

--- a/arch/emscripten/Makefile.in
+++ b/arch/emscripten/Makefile.in
@@ -56,12 +56,16 @@ EMSCRIPTEN_FRONTEND_BUILD_PROFILE = build-release
 endif
 
 clean:
-	$(if ${V},,@echo "  RM       mzxrun.js.orig.js")
-	$(if ${V},,@echo "  RM       mzxrun.js.mem")
-	$(if ${V},,@echo "  RM       mzxrun.wasm")
-	$(if ${V},,@echo "  RM       mzxrun.wasm.map")
-	$(if ${V},,@echo "  RM       emzip.js")
-	@rm -rf mzxrun.js.mem mzxrun.js.orig.js mzxrun.wasm mzxrun.wasm.map emzip.js* emzip.wasm
+	$(if ${V},,@echo "  RM      " arch/emscripten/web/mzxrun_web.js"*")
+	$(if ${V},,@echo "  RM      " mzxrun.js.orig.js)
+	$(if ${V},,@echo "  RM      " mzxrun.js.mem)
+	$(if ${V},,@echo "  RM      " mzxrun.wasm)
+	$(if ${V},,@echo "  RM      " mzxrun.wasm.map)
+	$(if ${V},,@echo "  RM      " emzip.js)
+	$(if ${V},,@echo "  RM      " emzip.wasm)
+	${RM} -f arch/emscripten/web/mzxrun_web.js*
+	${RM} -f mzxrun.js.mem mzxrun.js.orig.js mzxrun.wasm mzxrun.wasm.map
+	${RM} -f emzip.js* emzip.wasm
 
 all: emzip.js
 

--- a/arch/mingw/Makefile.in
+++ b/arch/mingw/Makefile.in
@@ -77,11 +77,13 @@ pefix_clean:
 
 # Clean up MSVC files just in case; they break linking MinGW.
 msvc_clean:
-	$(if ${V},,@echo "  RM      " *.exp *.ilk *.lib *.pdb)
-	${RM} Core.{exp,ilk,lib,pdb}
-	${RM} Editor.{exp,ilk,lib,pdb}
-	${RM} MZXRun.{exp,ilk,lib,pdb}
-	${RM} MegaZeux.{exp,ilk,lib,pdb}
+	$(if ${V},,@echo "  RM      " "*.exp" "*.ilk" "*.lib" "*.pdb")
+	$(if ${V},,@echo "  RM      " arch/msvc/.vs arch/msvc/obj)
+	${RM} -r arch/msvc/.vs arch/msvc/obj
+	${RM} Core.exp Editor.exp MZXRun.exp MegaZeux.exp
+	${RM} Core.ilk Editor.ilk MZXRun.ilk MegaZeux.ilk
+	${RM} Core.lib Editor.lib MZXRun.lib MegaZeux.lib
+	${RM} Core.pdb Editor.pdb MZXRun.pdb MegaZeux.pdb
 
 #
 # Windows builds must copy $SDL_DLL

--- a/arch/nds-blocksds/Makefile.in
+++ b/arch/nds-blocksds/Makefile.in
@@ -97,8 +97,9 @@ arch/nds/arm7/source/%.c.o: arch/nds/arm7/source/%.c
 # Misc. helpers.
 #
 clean:
-	@rm -f ${mzxrun}.nds arch/nds/*.{d,o} ${ARM7_DEPEND_FILES} ${ARM7_OBJECT_FILES} ${ARM7_BINARY}
-	@rm -f arch/nds/protected_palette.bin.S arch/nds/protected_palette_bin.h
+	${RM} -f ${mzxrun}.nds arch/nds/*.d arch/nds/*.o
+	${RM} -f ${ARM7_DEPEND_FILES} ${ARM7_OBJECT_FILES} ${ARM7_BINARY}
+	${RM} -f arch/nds/protected_palette.bin.S arch/nds/protected_palette_bin.h
 
 #
 # We're only interested in our packaged binary; remove the ELF intermediaries

--- a/arch/nds-blocksds/Makefile.in
+++ b/arch/nds-blocksds/Makefile.in
@@ -97,9 +97,10 @@ arch/nds/arm7/source/%.c.o: arch/nds/arm7/source/%.c
 # Misc. helpers.
 #
 clean:
-	${RM} -f ${mzxrun}.nds arch/nds/*.d arch/nds/*.o
+	${RM} -f ${mzxrun}.nds arch/nds/*.d arch/nds/*.o arch/nds/*.elf
 	${RM} -f ${ARM7_DEPEND_FILES} ${ARM7_OBJECT_FILES} ${ARM7_BINARY}
 	${RM} -f arch/nds/protected_palette.bin.S arch/nds/protected_palette_bin.h
+	${RM} -f arch/nds/protected_palette_bin.c
 
 #
 # We're only interested in our packaged binary; remove the ELF intermediaries

--- a/arch/nds/Makefile.in
+++ b/arch/nds/Makefile.in
@@ -74,8 +74,8 @@ package: mzx
 
 clean:
 	@${MAKE} -C arch/nds TARGET=${mzxrun} clean
-	@rm -f ${mzxrun}.nds arch/nds/*.{d,o}
-	@rm -f arch/nds/protected_palette.bin.S arch/nds/protected_palette_bin.h
+	${RM} -f ${mzxrun}.nds arch/nds/*.d arch/nds/*.o
+	${RM} -f arch/nds/protected_palette.bin.S arch/nds/protected_palette_bin.h
 
 #
 # We're only interested in our packaged binary; remove the ELF intermediaries

--- a/arch/nds/Makefile.in
+++ b/arch/nds/Makefile.in
@@ -74,8 +74,9 @@ package: mzx
 
 clean:
 	@${MAKE} -C arch/nds TARGET=${mzxrun} clean
-	${RM} -f ${mzxrun}.nds arch/nds/*.d arch/nds/*.o
+	${RM} -f ${mzxrun}.nds arch/nds/*.d arch/nds/*.o arch/nds/*.elf
 	${RM} -f arch/nds/protected_palette.bin.S arch/nds/protected_palette_bin.h
+	${RM} -f arch/nds/protected_palette_bin.c
 
 #
 # We're only interested in our packaged binary; remove the ELF intermediaries

--- a/arch/psp/Makefile.in
+++ b/arch/psp/Makefile.in
@@ -51,7 +51,7 @@ package: mzx
 	rm -f ${mzxrun}.strip
 
 clean:
-	@rm -f EBOOT.PBP PARAM.SFO ICON0.PNG arch/psp/*.{o,d}
+	${RM} -f EBOOT.PBP PARAM.SFO ICON0.PNG arch/psp/*.o arch/psp/*.d
 
 build: package ${build}
 	${CP} arch/psp/pad.config ${build}

--- a/arch/psvita/Makefile.in
+++ b/arch/psvita/Makefile.in
@@ -63,8 +63,9 @@ endif
 		mzxrun.vpk
 
 clean:
-	@${RM} -f arch/psvita/*.{o,d} mzxrun mzxrun.elf mzxrun.velf mzxrun.vpk \
-		megazeux megazeux.elf megazeux.velf megazeux.vpk eboot.bin param.sfo
+	${RM} -f arch/psvita/*.o arch/psvita/*.d eboot.bin param.sfo
+	${RM} -f mzxrun mzxrun.elf mzxrun.velf mzxrun.vpk
+	${RM} -f megazeux megazeux.elf megazeux.velf megazeux.vpk
 
 build: package ${build}
 	${CP} ${mzx}.vpk ${build}

--- a/arch/switch/Makefile.in
+++ b/arch/switch/Makefile.in
@@ -74,7 +74,8 @@ ARCH_LDFLAGS  += ${EXTRA_LIBS} ${MACHDEP} -specs=$(DEVKITPRO)/libnx/switch.specs
 package: mzx mzxrun.nro megazeux.nro mzxrun.nso megazeux.nso mzxrun.nacp megazeux.nacp
 
 clean:
-	@rm -f mzxrun.{nacp,nro,nso,pfs0,elf} megazeux.{nacp,nro,nso,pfs0,elf}
+	${RM} -f mzxrun.nacp mzxrun.nro mzxrun.nso mzxrun.pfs0 mzxrun.elf
+	${RM} -f megazeux.nacp megazeux.nro megazeux.nso megazeux.pfs0 megazeux.elf
 
 build := ${build_root}/switch/megazeux
 build: package ${build}

--- a/arch/unix/Makefile.in
+++ b/arch/unix/Makefile.in
@@ -37,10 +37,10 @@ endif
 
 # linux os specific install files
 uninstall-arch: install-check
-	@${RM} -f \
+	${RM} -f \
 		${DESTDIR}${SHAREDIR}/icons/hicolor/128x128/apps/megazeux.png \
 		${DESTDIR}${SHAREDIR}/applications/megazeux.desktop
 ifeq (${BUILD_MZXRUN},1)
-	@${RM} -f \
+	${RM} -f \
 		${DESTDIR}${SHAREDIR}/applications/mzxrun.desktop
 endif

--- a/arch/wii/Makefile.in
+++ b/arch/wii/Makefile.in
@@ -57,7 +57,7 @@ else
 endif
 
 clean:
-	@rm -f boot.dol mzxrun.dol arch/wii/*.d arch/wii/*.o
+	${RM} -f boot.dol mzxrun.dol arch/wii/*.d arch/wii/*.o
 
 #
 # Vile hack, remove me ASAP

--- a/arch/wiiu/Makefile.in
+++ b/arch/wiiu/Makefile.in
@@ -58,7 +58,7 @@ ARCH_LDFLAGS  += ${EXTRA_LIBS} ${MACHDEP} ${RPXSPECS}
 package: mzx mzxrun.rpx megazeux.rpx
 
 clean:
-	@rm -f mzxrun.{rpx,elf} megazeux.{rpx,elf}
+	${RM} -f mzxrun.rpx mzxrun.elf megazeux.rpx megazeux.elf
 
 build := build/${SUBPLATFORM}/wiiu/apps/megazeux
 build: package ${build}


### PR DESCRIPTION
Revert the creeping introduction of Bash-only globs to several architecture `clean` rules. This should fix `make clean` for MinGW and console platforms in Linux/BSD/etc. environments where `/bin/sh` is not Bash (Alpine, Debian, every BSD). Also fixes several instances of misusing or not using `${RM}`.