### PR TITLE
Add workarounds for misc. PSPSDK issues.

### DIFF
--- a/arch/psp/Makefile.in
+++ b/arch/psp/Makefile.in
@@ -21,9 +21,13 @@ ARCH_CFLAGS   += -G0 -isystem ${PREFIX}/sdk/include -DPATH_MAX=4096
 ARCH_CXXFLAGS += ${ARCH_CFLAGS}
 ARCH_LDFLAGS  += -L${PREFIX}/sdk/lib
 
+ifeq (${BUILD_SDL},3)
+SDL_CFLAGS = -I${PREFIX}/include/SDL3
+SDL_LDFLAGS = -lSDL3 -lpspvram
+endif
 ifeq (${BUILD_SDL},2)
 SDL_CFLAGS = -I${PREFIX}/include/SDL2
-SDL_LDFLAGS = -lSDL2 -lpspvram
+SDL_LDFLAGS = -lSDL2 -lSDL2main -lpspvram
 endif
 ifeq (${BUILD_SDL},1)
 SDL_CFLAGS = -I${PREFIX}/include/SDL
@@ -42,7 +46,7 @@ LIBPNG_LDFLAGS = -lpng
 
 package: mzx
 	psp-fixup-imports ${mzxrun}
-	mksfo 'MegaZeux ${VERSION}' PARAM.SFO
+	mksfo 'MegaZeux '${VERSION} PARAM.SFO
 	${STRIP} ${mzxrun} -o ${mzxrun}.strip
 	convert -scale 80x80 -border 32x0 -bordercolor transparent \
 	        contrib/icons/quantump.png ICON0.PNG

--- a/arch/psp/platform.c
+++ b/arch/psp/platform.c
@@ -25,6 +25,10 @@
 #include <pspdebug.h>
 #include <pspctrl.h>
 
+#include "../../src/config.h"
+
+#if CONFIG_SDL < 2
 PSP_MODULE_INFO("MegaZeux", 0, 1, 1);
 PSP_MAIN_THREAD_ATTR(THREAD_ATTR_USER | THREAD_ATTR_VFPU);
+#endif
 PSP_MAIN_THREAD_STACK_SIZE_KB(512);

--- a/src/io/vio.c
+++ b/src/io/vio.c
@@ -392,15 +392,15 @@ size_t vio_filesystem_total_memory_usage(void)
  */
 boolean vio_virtual_file(const char *path)
 {
-  int err;
+  enum vfs_error code;
   if(!vfs_base)
     return false;
 
   if(!vio_cache_parent_recursively(vfs_base, path))
     return false;
 
-  err = vfs_create_file_at_path(vfs_base, path);
-  if(err != 0 && err != -EEXIST)
+  code = vfs_create_file_at_path(vfs_base, path);
+  if(code != 0 && code != VFS_EEXIST)
     return false;
 
   return true;
@@ -420,15 +420,15 @@ boolean vio_virtual_file(const char *path)
  */
 boolean vio_virtual_directory(const char *path)
 {
-  int err;
+  enum vfs_error code;
   if(!vfs_base)
     return false;
 
   if(!vio_cache_parent_recursively(vfs_base, path))
     return false;
 
-  err = vfs_mkdir(vfs_base, path, 0755);
-  if(err != 0 && err != -EEXIST)
+  code = vfs_mkdir(vfs_base, path, 0755);
+  if(code != 0 && code != VFS_EEXIST)
     return false;
 
   return true;
@@ -443,12 +443,12 @@ boolean vio_invalidate_at_least(size_t *amount_to_free)
 #ifdef DEBUG
   size_t init = amount_to_free ? *amount_to_free : 0;
 #endif
-  int err;
+  enum vfs_error code;
   if(!vfs_base || !amount_to_free)
     return false;
 
-  err = vfs_invalidate_at_least(vfs_base, amount_to_free);
-  if(err)
+  code = vfs_invalidate_at_least(vfs_base, amount_to_free);
+  if(code != 0)
     return false;
 
   debug("vio_invalidate_at_least freed >= %zu buffered\n", init - *amount_to_free);
@@ -467,7 +467,7 @@ boolean vio_invalidate_all(void)
     return false;
 
   debug("vio_invalidate_all\n");
-  if(vfs_invalidate_all(vfs_base) < 0)
+  if(vfs_invalidate_all(vfs_base) != 0)
     return false;
 
   return true;

--- a/src/io/vio_posix.h
+++ b/src/io/vio_posix.h
@@ -148,6 +148,13 @@ static inline boolean platform_readdir(struct dir_handle dh, char *buffer,
   if(!d)
     return false;
 
+#ifdef CONFIG_PSP
+  // SCE IO does this instead for some reason. This issue is only present in
+  // post-devkitPSP builds for some reason. FIXME: bandaid, upstream fix needed?
+  if(d->d_name[0] == '\0')
+    return false;
+#endif
+
   if(buffer && buffer_len)
     snprintf(buffer, buffer_len, "%s", d->d_name);
 

--- a/src/util.c
+++ b/src/util.c
@@ -216,7 +216,12 @@ static ssize_t find_executable_dir(char *dest, size_t dest_len, const char *argv
 
   if(argv0)
   {
+#ifdef CONFIG_PSP
+    // FIXME: EBOOT.PBP may be treated as a directory, always get the parent.
+    ssize_t len = path_get_parent(dest, dest_len, argv0);
+#else
     ssize_t len = path_get_directory(dest, dest_len, argv0);
+#endif
     if(len > 0)
     {
       // Change to the executable dir and get it as an absolute path.


### PR DESCRIPTION
* Remove quotes from MZX version in application title.
* Work around broken PSPSDK readdir never returning NULL; the PSP port treats "" as a sentinel for now.
* Work around EBOOT.PBP being treated as a directory in find_executable_dir.
* Disable PSP_MODULE_INFO for SDL2+, link libSDL2main.
* Support SDL3 on PSP.

The PSP port post-devkitPSP is still unusably broken due to numerous filesystem issues, including:

* Files are length zero most of the time. This prevents CAVERNS.MZX from loading in any build, and prevents the charsets and config.txt from being loaded in SDL2 and SDL3 builds (but not SDL 1.2???).
* Directories are always length zero, breaking the file manager.
* stat unconditionally returns a success; non-existent files are treated identically to directories.