### PR TITLE
Mark all new worlds created in the editor as active.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -14,6 +14,9 @@ USERS
   longer sent for 1.x worlds when the char is outside of the A-Z
   range. (Previously checked version for the KEY counter only.)
 + The KEYENTER label is no longer sent for pre-2.62 worlds.
++ Fixed bug where, after Alt+R or failure to reload __TEST.MZX,
+  the editor would not mark the new blank world as active. This
+  would cause the screen to not be drawn during Alt+T testing.
 + Software layer renderer performance enhancements for repeat
   colors, clipping, and unaligned renderering.
 + Unaligned software layer rendering using 64-bit writes is

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -3931,7 +3931,6 @@ static void __edit_world(context *parent, boolean reload_curr_file)
       clear_world(mzx_world);
       clear_global_data(mzx_world);
     }
-    mzx_world->active = 1;
 
     create_blank_world(mzx_world);
 

--- a/src/editor/world.c
+++ b/src/editor/world.c
@@ -459,6 +459,7 @@ void create_blank_world(struct world *mzx_world)
   int i;
 
   mzx_world->version = MZX_VERSION;
+  mzx_world->active = 1;
 
   mzx_world->num_boards = 1;
   mzx_world->num_boards_allocated = 1;


### PR DESCRIPTION
The editor would mark the blank world created on initialization as active, but not any blank worlds created afterward during editing. This would cause blank worlds created by Alt+R and failed __TEST.MZX reloads to be "inactive", which as of 2.91g, has special handling in the game.c draw function to skip drawing the screen and instead constantly display the intro timer.

The fix is to just set this flag in create_blank_world where it should have been doing it anyway.

While the most noticeable issue this caused started in 2.91g, the underlying bug has existed since 2.80, and affected various other minor things that used `mzx_world->active` as well.