### PR TITLE
Initial SDL screen keyboard support and common functions.

### DIFF
--- a/arch/3ds/event.c
+++ b/arch/3ds/event.c
@@ -265,18 +265,13 @@ boolean update_hid(void)
   retval |= check_joy(status, down, up, KEY_X, 2);
   retval |= check_joy(status, down, up, KEY_Y, 3);
   retval |= check_joy(status, down, up, KEY_L, 4);
+  retval |= check_joy(status, down, up, KEY_R, 5);
   retval |= check_joy(status, down, up, KEY_SELECT, 6);
   retval |= check_joy(status, down, up, KEY_START, 7);
   retval |= check_joy(status, down, up, KEY_ZL, 8);
   retval |= check_joy(status, down, up, KEY_ZR, 9);
 
   last_cpad = cpad;
-
-  if(down & KEY_R)
-  {
-    b_mode = (b_mode + 1) % BOTTOM_SCREEN_MODE_MAX;
-    retval = true;
-  }
 
   if((down | held | up) & KEY_TOUCH)
   {
@@ -333,8 +328,28 @@ int ctr_get_subscreen_height(void)
   }
 }
 
+boolean platform_has_screen_keyboard(void)
+{
+  return true;
+}
+
+boolean platform_show_screen_keyboard(void)
+{
+  input.showing_screen_keyboard = true;
+  b_mode = BOTTOM_SCREEN_MODE_KEYBOARD;
+  return true;
+}
+
+boolean platform_hide_screen_keyboard(void)
+{
+  input.showing_screen_keyboard = false;
+  b_mode = BOTTOM_SCREEN_MODE_PREVIEW;
+  return true;
+}
+
 void platform_init_event(void)
 {
   struct buffered_status *status = store_status();
   joystick_set_active(status, 0, true);
+  joystick_map_fallback_keyboard_button(0, 5);
 }

--- a/arch/3ds/keyboard.c
+++ b/arch/3ds/keyboard.c
@@ -203,7 +203,9 @@ boolean ctr_keyboard_update(struct buffered_status *status)
     {
       force_zoom_out = !force_zoom_out;
     }
-    else if(ctr_supports_wide() && pos.px >= 284 && pos.py >= 2 &&
+    else
+
+    if(ctr_supports_wide() && pos.px >= 284 && pos.py >= 2 &&
      pos.px < 300 && pos.py < 18)
     {
       ctr_request_set_wide(!gfxIsWide());

--- a/arch/3ds/pad.config
+++ b/arch/3ds/pad.config
@@ -5,7 +5,7 @@
 # Button3: X
 # Button4: Y
 # Button5: Left shoulder
-# Button6: Right shoulder (NOTE: currently hardcoded to toggle keyboard)
+# Button6: Right shoulder
 # Button7: Select
 # Button8: Start
 # Button9: ZL (NOTE: New 3DS only)
@@ -21,6 +21,7 @@ joy1button2 = act_b
 joy1button3 = act_x
 joy1button4 = act_y
 joy1button5 = act_lshoulder
+joy1button6 = act_rshoulder
 joy1button7 = act_select
 joy1button8 = act_start
 joy1button9 = act_ltrigger

--- a/arch/android/README.md
+++ b/arch/android/README.md
@@ -50,6 +50,11 @@ The build process for the MegaZeux port is as follows:
 
 ## Environment Setup
 
+The Android build system currently targets Java SE 7 to support
+Android Jelly Bean (4.1). Make sure JDK <=17 is installed and selected by
+setting `JAVA_HOME`. (Fedora users: As of Fedora 42, OpenJDK 17 must be
+installed from a 3rd party repository.)
+
 1. Install the latest version of both the Android SDK and NDK. The easiest way
   to do this is to install these through Android Studio. MegaZeux requires
   a version of the NDK between r19 and r23 (version r24 and above drop support
@@ -115,19 +120,21 @@ Issues **KNOWN** to be caused by MegaZeux bugs:
 * The GLSL renderer relies on precise addressing of a 512x1024 texture in the
   tilemap fragment shaders, which is generally hard or impossible to do unless
   highp floats are available (or alternatively, mediump floats have more than
-  10 bits of precision). This renderer is generally slower than softscale so
-  it is not selected by default.
+  10 bits of precision). This renderer is generally slower than software
+  rendering (`glslscale`, `softscale`) on Android, so it is not selected by default.
 
 Issues **PROBABLY** caused by compatibility issues between Android and SDL:
 
-* When text input is enabled, some keys may spontaneously stop working or stick.
-  Because of this, text input has been disabled for Android, which means certain
-  international keybord layouts probably won't work properly.
-  (Moto G5 Plus, Android 8.1, arm64-v8a)
-* Keys which would usually produce both a scancode and text will generate a key
-  press and release on the same frame for some devices, meaning certain MZX
-  features relying on the held status of a key (including shooting, the KEY#
-  counters) will not work. (Nexus 7 (2013), Android 6.0, armeabi-v7a)
+* Hardware keyboards: space, but no other keys, will emit `SDL_EVENT_KEY_DOWN`,
+  `SDL_EVENT_KEY_UP`, and `SDL_EVENT_TEXT_INPUT` simultaneously. This breaks
+  built-in shooting, `spacepressed`, etc. Only encountered in Android 15 (so far).
+  (Google Pixel 8a, Android 15.0, arm64-v8a)
+* Hardware keyboards: any key which usually produces both a scancode and text
+  will emit `SDL_EVENT_KEY_DOWN`, `SDL_EVENT_KEY_UP`, and `SDL_EVENT_TEXT_INPUT`
+  simultaneously. This breaks built-in shooting, `KEY#`, and anything else that
+  relies on the held status of a key. (Nexus 7 (2013), Android 6.0, armeabi-v7a)
+  Note: at least one earlier version of android (4.3) does not have this issue
+  on the same hardware.
 * The function keys (Fn) may not work as expected. (Xiaomi Mi 8 SE, Android 8.1, arm64-v8a)
 * RGBA components may be reversed to ARBG, causing serious graphical issues.
   This can be worked around by turning on the "Disable HW Overlays" developer

--- a/arch/djgpp/event.c
+++ b/arch/djgpp/event.c
@@ -552,6 +552,21 @@ boolean __peek_exit_input(void)
   return false;
 }
 
+boolean platform_has_screen_keyboard(void)
+{
+  return false;
+}
+
+boolean platform_show_screen_keyboard(void)
+{
+  return false;
+}
+
+boolean platform_hide_screen_keyboard(void)
+{
+  return false;
+}
+
 static void init_kbd(void)
 {
   __dpmi_paddr handler;

--- a/arch/dreamcast/event.c
+++ b/arch/dreamcast/event.c
@@ -30,6 +30,21 @@ void platform_init_event(void)
 {
 }
 
+boolean platform_has_screen_keyboard(void)
+{
+  return false;
+}
+
+boolean platform_show_screen_keyboard(void)
+{
+  return false;
+}
+
+boolean platform_hide_screen_keyboard(void)
+{
+  return false;
+}
+
 void __warp_mouse(int x, int y)
 {
 }

--- a/arch/nds/event.c
+++ b/arch/nds/event.c
@@ -73,10 +73,32 @@ enum focus_mode get_allow_focus_changes(void)
   return allow_focus_changes;
 }
 
+boolean platform_has_screen_keyboard(void)
+{
+  return true;
+}
+
+boolean platform_show_screen_keyboard(void)
+{
+  if(nds_subscreen_keyboard())
+    input.showing_screen_keyboard = true;
+  // Always treat as handled, even if the state doesn't change.
+  return true;
+}
+
+boolean platform_hide_screen_keyboard(void)
+{
+  if(nds_subscreen_preview())
+    input.showing_screen_keyboard = false;
+  // Always treat as handled, even if the state doesn't change.
+  return true;
+}
+
 void platform_init_event(void)
 {
   struct buffered_status *status = store_status();
   joystick_set_active(status, 0, true);
+  joystick_map_fallback_keyboard_button(0, 5);
 }
 
 static int nds_map_joystick(int nds_button, boolean *is_hat)
@@ -162,14 +184,6 @@ static boolean process_event(NDSEvent *event)
     {
       boolean is_hat;
       int button;
-
-      // Special case- R is currently hardcoded to the keyboard.
-      if(event->key == KEY_R)
-      {
-        nds_subscreen_switch();
-        retval = false;
-        break;
-      }
 
       button = nds_map_joystick(event->key, &is_hat);
       if(button >= 0)

--- a/arch/nds/pad.config
+++ b/arch/nds/pad.config
@@ -4,7 +4,7 @@
 # Button3: X
 # Button4: Y
 # Button5: Left shoulder
-# Button6: Right shoulder (NOTE: currently hardcoded to toggle the keyboard)
+# Button6: Right shoulder
 # Button7: Select
 # Button8: Start
 
@@ -14,5 +14,6 @@ joy1button2 = act_b
 joy1button3 = act_x
 joy1button4 = act_y
 joy1button5 = act_lshoulder
+joy1button6 = act_rshoulder
 joy1button7 = act_select
 joy1button8 = act_start

--- a/arch/nds/render.c
+++ b/arch/nds/render.c
@@ -864,22 +864,33 @@ void render_nds_register(struct renderer *renderer)
   renderer->focus_pixel = nds_focus_pixel;
 }
 
-void nds_subscreen_switch(void)
+boolean nds_subscreen_preview(void)
 {
   // Don't switch during a transition.
   if(transition.state != TRANSITION_NONE)
-    return;
+    return false;
 
   // Call appropriate exit function.
-  if(subscreen_mode == SUBSCREEN_KEYBOARD)
+  if(subscreen_mode != SUBSCREEN_SCALED)
+  {
+    last_subscreen_mode = subscreen_mode;
+    subscreen_mode = SUBSCREEN_SCALED;
     nds_subscreen_keyboard_exit();
+  }
+  return true;
+}
 
-  // Cycle between modes.
-  last_subscreen_mode = subscreen_mode;
-  if(++subscreen_mode == SUBSCREEN_MODE_COUNT)
-    subscreen_mode = 0;
+boolean nds_subscreen_keyboard(void)
+{
+  // Don't switch during a transition.
+  if(transition.state != TRANSITION_NONE)
+    return false;
 
-  // Call the appropriate init function.
-  if(subscreen_mode == SUBSCREEN_KEYBOARD)
+  if(subscreen_mode != SUBSCREEN_KEYBOARD)
+  {
+    last_subscreen_mode = subscreen_mode;
+    subscreen_mode = SUBSCREEN_KEYBOARD;
     nds_subscreen_keyboard_init();
+  }
+  return true;
 }

--- a/arch/nds/render.h
+++ b/arch/nds/render.h
@@ -46,7 +46,8 @@ void nds_video_rasterhack(void);
 void nds_video_do_transition(void);
 
 // Toggle to the next subscreen mode.
-void nds_subscreen_switch(void);
+boolean nds_subscreen_preview(void);
+boolean nds_subscreen_keyboard(void);
 
 __M_END_DECLS
 

--- a/arch/wii/event.c
+++ b/arch/wii/event.c
@@ -1114,6 +1114,21 @@ void __warp_mouse(int x, int y)
   // Mouse warping doesn't work too well with the Wiimote
 }
 
+boolean platform_has_screen_keyboard(void)
+{
+  return false;
+}
+
+boolean platform_show_screen_keyboard(void)
+{
+  return false;
+}
+
+boolean platform_hide_screen_keyboard(void)
+{
+  return false;
+}
+
 void platform_init_event(void)
 {
   struct buffered_status *status = store_status();

--- a/config.txt
+++ b/config.txt
@@ -636,7 +636,7 @@
 #  select         Main menu       Cancel          Game menu (2)
 #  start          Play game       Select          Game menu (2)
 #  lshoulder      Settings        Next element    Insert (switch bombs)
-#  rshoulder      Settings        Settings        P (Caverns: altar)
+#  rshoulder(3)   Settings        Settings        P (Caverns: altar)
 #  ltrigger       Load world      Page up         F3 (save game)
 #  rtrigger       Reload save     Page down       F4 (load save)
 #  lstick                         Home
@@ -648,6 +648,11 @@
 #
 # (2) These buttons will always open the game menu directly unless both the
 # enter menu and the escape menu have been disabled through Robotic.
+#
+# (3) By default, this action will be intercepted and used to show/hide the
+# onscreen keyboard for platforms that support it. This is supported on Android,
+# Vita, NDS, 3DS, and Linux machines with no hardware keyboard active (e.g.
+# Steam Deck). This will globally override any press of this action.
 
 # To map a joystick action to a different key for gameplay, use the setting
 
@@ -657,6 +662,11 @@
 # (e.g. "lshoulder"), and A is the number (or name) of the key to assign. The
 # joystick number 'X' can be substituted with a range '[Z,W]', which will
 # assign the control for all joysticks numbered Z through W (inclusive).
+
+# To change the action that shows/hides the onscreen keyboard (0 to disable),
+# use the setting
+
+# joy[1,16].show_screen_keyboard = act_rshoulder
 
 # Automatic mapping for actions is handled using SDL's gamepad API.
 # Supported gamepads should generally "just work" when they're plugged in.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -9,6 +9,14 @@ GIT - MZX 2.93d
 
 USERS
 
++ Added support for system screen keyboards for SDL. This allows
+  opening the system screen keyboards with the Android and Vita
+  ports, as well as some Linux configurations e.g. Steam Deck.
+  The screen keyboard can be toggled with rshoulder (see below)
+  or, in Android, by performing a 3-point touch on the screen.
++ Added config option "joy#.show_screen_keyboard" to configure
+  which button (if any) is used to open the screen keyboard for
+  platforms that support it (set to act_rshoulder by default).
 + Added config options "key_left_alt_is_altgr" and
   "key_right_alt_is_altgr". When set to 1, these prevent their
   respective Alt keys from activating built-in UI and editor
@@ -48,6 +56,7 @@ USERS
 + Fixed date and time counters on NDS (missing IRQ_NETWORK).
 + Fixed VFS cache failing to init caused by getcwd returning
   a root with no trailing slash.
++ Unsupported mouse button presses are now ignored.
 
 DEVELOPERS
 

--- a/docs/joystick.html
+++ b/docs/joystick.html
@@ -482,8 +482,10 @@
       </p>
 
       <p>
-        <sup>2</sup>The <code>rshoulder</code> action is replaced by some
-        consoles with a hardcoded button to open an onscreen keyboard. The
+        <sup>2</sup>The <code>rshoulder</code> action is overriden by some
+        devices to toggle the state of the onscreen keyboard. To support
+        these devices, it's generally helpful to double controls mapped to
+        this button onto a second button or onto the keyboard. The
         availability of some other actions may vary between consoles and
         controllers (for example, some controllers may have a left analog
         stick but no dpad, and many controllers lack the stick press

--- a/src/SDLmzx.h
+++ b/src/SDLmzx.h
@@ -182,6 +182,9 @@ static inline void *SDL_GetWindowProperty_HWND(SDL_Window *window)
  * SDL_event.h
  */
 #if !SDL_VERSION_ATLEAST(3,0,0)
+#define SDL_EVENT_FINGER_DOWN           SDL_FINGERDOWN
+#define SDL_EVENT_FINGER_MOTION         SDL_FINGERMOTION
+#define SDL_EVENT_FINGER_UP             SDL_FINGERUP
 #define SDL_EVENT_GAMEPAD_AXIS_MOTION   SDL_CONTROLLERAXISMOTION
 #define SDL_EVENT_JOYSTICK_ADDED        SDL_JOYDEVICEADDED
 #define SDL_EVENT_JOYSTICK_REMOVED      SDL_JOYDEVICEREMOVED
@@ -199,6 +202,10 @@ static inline void *SDL_GetWindowProperty_HWND(SDL_Window *window)
 #define SDL_EVENT_QUIT                  SDL_QUIT
 #define SDL_EVENT_FIRST                 SDL_FIRSTEVENT
 #define SDL_EVENT_LAST                  SDL_LASTEVENT
+#define TFINGER_TOUCH_ID(tfinger)       ((tfinger).touchId)
+#endif
+#if SDL_VERSION_ATLEAST(3,0,0)
+#define TFINGER_TOUCH_ID(tfinger)       ((tfinger).touchID)
 #endif
 
 /**
@@ -275,6 +282,10 @@ static inline void SDL_SetJoystickEventsEnabled(boolean enabled)
 /**
  * SDL_keyboard.h and SDL_keycode.h
  */
+#if !SDL_VERSION_ATLEAST(2,0,0)
+#define SDL_HasScreenKeyboardSupport()  (0)
+#define SDL_IsScreenKeyboardShown(w)    (0)
+#endif
 #if !SDL_VERSION_ATLEAST(3,0,0)
 #define SDLK_A                SDLK_a
 #define SDLK_B                SDLK_b
@@ -309,6 +320,9 @@ static inline void SDL_SetJoystickEventsEnabled(boolean enabled)
 #define SDL_KMOD_NUM          KMOD_NUM
 #define SDL_KMOD_CAPS         KMOD_CAPS
 #define SDL_KMOD_MODE         KMODE_MODE
+#define SDL_StartTextInput(w) SDL_StartTextInput()
+#define SDL_StopTextInput(w)  SDL_StopTextInput()
+#define SDL_ScreenKeyboardShown(w) SDL_IsScreenKeyboardShown(w)
 #endif
 
 /**
@@ -448,6 +462,28 @@ typedef SDL_sem   SDL_Semaphore;
 #define SDL_WaitSemaphore(s)            SDL_SemWait(s)
 #define SDL_SignalSemaphore(s)          SDL_SemPost(s)
 #define SDL_GetCurrentThreadID()        SDL_ThreadID()
+#endif
+
+/**
+ * SDL_touch.h
+ */
+#if SDL_VERSION_ATLEAST(2,0,0) && !SDL_VERSION_ATLEAST(3,0,0)
+static inline SDL_Finger **SDL_GetTouchFingers(SDL_TouchID touchID, int *count)
+{
+  SDL_Finger **ret;
+  int num = SDL_GetNumTouchFingers(touchID);
+  int i;
+
+  if(num <= 0)
+    return NULL;
+
+  ret = (SDL_Finger **)SDL_calloc(num + 1, sizeof(SDL_Finger *));
+  for(i = 0; i < num; i++)
+    ret[i] = SDL_GetTouchFinger(touchID, i);
+
+  *count = num;
+  return ret;
+}
 #endif
 
 /**

--- a/src/event.h
+++ b/src/event.h
@@ -122,11 +122,13 @@ struct joystick_map
   int16_t hat[MAX_JOYSTICKS][4];
   int16_t action[MAX_JOYSTICKS][NUM_JOYSTICK_ACTIONS];
   uint8_t special_axis[MAX_JOYSTICKS][MAX_JOYSTICK_AXES];
+  int16_t show_screen_keyboard_action[MAX_JOYSTICKS];
 
   boolean button_is_conf[MAX_JOYSTICKS][MAX_JOYSTICK_BUTTONS];
   boolean axis_is_conf[MAX_JOYSTICKS][MAX_JOYSTICK_AXES];
   boolean hat_is_conf[MAX_JOYSTICKS];
   boolean action_is_conf[MAX_JOYSTICKS][NUM_JOYSTICK_ACTIONS];
+  boolean show_keyboard_is_conf[MAX_JOYSTICKS];
 };
 
 struct input_status
@@ -146,6 +148,7 @@ struct input_status
   boolean unfocus_pause;
   boolean left_alt_is_altgr;
   boolean right_alt_is_altgr;
+  boolean showing_screen_keyboard;
 };
 
 // regular keycode_internal treats numpad keys as unique keys
@@ -204,6 +207,9 @@ uint32_t convert_internal_unicode(enum keycode key, boolean caps_lock);
 
 // Implemented by "drivers" (SDL, Wii, NDS, 3DS, etc.)
 void platform_init_event(void);
+boolean platform_has_screen_keyboard(void);
+boolean platform_show_screen_keyboard(void);
+boolean platform_hide_screen_keyboard(void);
 boolean __update_event_status(void);
 boolean __peek_exit_input(void);
 void __wait_event(void);
@@ -234,6 +240,8 @@ void key_press(struct buffered_status *status, enum keycode key);
 void key_press_unicode(struct buffered_status *status,
  uint32_t unicode, boolean repeating);
 void key_release(struct buffered_status *status, enum keycode key);
+boolean screen_keyboard_is_active(void);
+boolean screen_keyboard_toggle_state(void);
 
 boolean joystick_parse_map_value(const char *value, int16_t *binding);
 void joystick_map_button(int first, int last, int button, const char *value,
@@ -244,6 +252,7 @@ void joystick_map_hat(int first, int last, const char *up, const char *down,
  const char *left, const char *right, boolean is_global);
 void joystick_map_action(int first, int last, const char *action,
  const char *value, boolean is_global);
+void joystick_map_fallback_keyboard_button(int joystick, int button);
 void joystick_reset_game_map(void);
 void joystick_set_game_mode(boolean enable);
 void joystick_set_game_bindings(boolean enable);

--- a/src/platform_dummy.c
+++ b/src/platform_dummy.c
@@ -68,6 +68,24 @@ void platform_init_event(void)
   // stub
 }
 
+boolean platform_has_screen_keyboard(void)
+{
+  // stub
+  return false;
+}
+
+boolean platform_show_screen_keyboard(void)
+{
+  // stub
+  return false;
+}
+
+boolean platform_hide_screen_keyboard(void)
+{
+  // stub
+  return false;
+}
+
 boolean __update_event_status(void)
 {
   // stub


### PR DESCRIPTION
+ Added common screen keyboard functions and a port-independent configuration option "joy#.show_screen_keyboard" to select a joystick action to display the screen keyboard. If the platform's screen keyboard supported function indicates that a screen keyboard is currently supported, MegaZeux will hijack this joystick button for toggling the screen keyboard instead.
+ Added support for SDL screen keyboards. Currently, SDL supports system screen keyboard triggers for Android and Vita, plus some cases in Windows and Linux (only really care about Steam Deck and stuff like postmarketOS out of these).
+ NDS and 3DS ports now use common screen keyboard support functions for toggling instead of their own custom triggers.
+ Added Android 3-point touch screen keyboard trigger (hack).
+ Misc. trace maintenance in event_sdl.c: stop printing axis events for now (NOISY in Windows), print touch events, disable joystick/gamepad update notification events altogether (spammy and serve no purpose in MZX's usage).
+ Don't attempt to handle unrecognized mouse buttons. Previously, this was causing left shifts by negative exponents.
+ Update Android port bugs list.
+ Configuration unit test now tests joy#.axis_* and joy#.show_screen_keyboard.