### PR TITLE
Use SDL_ScreenKeyboardShown instead of internal state.

### DIFF
--- a/arch/3ds/event.c
+++ b/arch/3ds/event.c
@@ -347,6 +347,11 @@ boolean platform_hide_screen_keyboard(void)
   return true;
 }
 
+boolean platform_is_screen_keyboard_active(void)
+{
+  return input.showing_screen_keyboard;
+}
+
 void platform_init_event(void)
 {
   struct buffered_status *status = store_status();

--- a/arch/djgpp/event.c
+++ b/arch/djgpp/event.c
@@ -567,6 +567,11 @@ boolean platform_hide_screen_keyboard(void)
   return false;
 }
 
+boolean platform_is_screen_keyboard_active(void)
+{
+  return false;
+}
+
 static void init_kbd(void)
 {
   __dpmi_paddr handler;

--- a/arch/dreamcast/event.c
+++ b/arch/dreamcast/event.c
@@ -45,6 +45,11 @@ boolean platform_hide_screen_keyboard(void)
   return false;
 }
 
+boolean platform_is_screen_keyboard_active(void)
+{
+  return false;
+}
+
 void __warp_mouse(int x, int y)
 {
 }

--- a/arch/nds/event.c
+++ b/arch/nds/event.c
@@ -94,6 +94,11 @@ boolean platform_hide_screen_keyboard(void)
   return true;
 }
 
+boolean platform_is_screen_keyboard_active(void)
+{
+  return input.showing_screen_keyboard;
+}
+
 void platform_init_event(void)
 {
   struct buffered_status *status = store_status();

--- a/arch/wii/event.c
+++ b/arch/wii/event.c
@@ -1129,6 +1129,11 @@ boolean platform_hide_screen_keyboard(void)
   return false;
 }
 
+boolean platform_is_screen_keyboard_active(void)
+{
+  return false;
+}
+
 void platform_init_event(void)
 {
   struct buffered_status *status = store_status();

--- a/src/event.c
+++ b/src/event.c
@@ -1,7 +1,7 @@
 /* MegaZeux
  *
  * Copyright (C) 2004 Gilead Kutnick <exophase@adelphia.net>
- * Copyright (C) 2019 Alice Rowan <petrifiedrowan@gmail.com>
+ * Copyright (C) 2019-2025 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -1194,7 +1194,7 @@ boolean set_exit_status(boolean value)
  */
 boolean screen_keyboard_is_active(void)
 {
-  return input.showing_screen_keyboard;
+  return platform_is_screen_keyboard_active();
 }
 
 /**
@@ -1212,7 +1212,7 @@ boolean screen_keyboard_toggle_state(void)
 {
   if(platform_has_screen_keyboard())
   {
-    if(!input.showing_screen_keyboard)
+    if(!platform_is_screen_keyboard_active())
     {
       if(platform_show_screen_keyboard())
         return true;

--- a/src/event.h
+++ b/src/event.h
@@ -148,7 +148,7 @@ struct input_status
   boolean unfocus_pause;
   boolean left_alt_is_altgr;
   boolean right_alt_is_altgr;
-  boolean showing_screen_keyboard;
+  boolean showing_screen_keyboard; /* optional, used by platform drivers */
 };
 
 // regular keycode_internal treats numpad keys as unique keys
@@ -210,6 +210,7 @@ void platform_init_event(void);
 boolean platform_has_screen_keyboard(void);
 boolean platform_show_screen_keyboard(void);
 boolean platform_hide_screen_keyboard(void);
+boolean platform_is_screen_keyboard_active(void);
 boolean __update_event_status(void);
 boolean __peek_exit_input(void);
 void __wait_event(void);

--- a/src/event_sdl.c
+++ b/src/event_sdl.c
@@ -1872,6 +1872,13 @@ boolean platform_hide_screen_keyboard(void)
   return true;
 }
 
+boolean platform_is_screen_keyboard_active(void)
+{
+  SDL_Window *window = SDL_GetWindowFromID(last_text_window_id);
+  (void)window; /* SDL2 */
+  return SDL_ScreenKeyboardShown(window);
+}
+
 void platform_init_event(void)
 {
 #ifdef NO_JOYSTICK_ADDED_EVENTS

--- a/src/platform_dummy.c
+++ b/src/platform_dummy.c
@@ -86,6 +86,12 @@ boolean platform_hide_screen_keyboard(void)
   return false;
 }
 
+boolean platform_is_screen_keyboard_active(void)
+{
+  // stub
+  return false;
+}
+
 boolean __update_event_status(void)
 {
   // stub


### PR DESCRIPTION
Fixes screen keyboard triggers failing the first time they're used after the screen keyboard is closed via the OS user interface e.g. Android's back button.