### PR TITLE
Disable the screen keyboard gamepad action by default on Linux.

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -651,8 +651,9 @@
 #
 # (3) By default, this action will be intercepted and used to show/hide the
 # onscreen keyboard for platforms that support it. This is supported on Android,
-# Vita, NDS, 3DS, and Linux machines with no hardware keyboard active (e.g.
-# Steam Deck). This will globally override any press of this action.
+# Vita, NDS, and 3DS, and can also be enabled for Linux machines with no
+# hardware keyboard active (e.g. Steam Deck). This will globally override
+# any press of this action.
 
 # To map a joystick action to a different key for gameplay, use the setting
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -16,7 +16,8 @@ USERS
   or, in Android, by performing a 3-point touch on the screen.
 + Added config option "joy#.show_screen_keyboard" to configure
   which button (if any) is used to open the screen keyboard for
-  platforms that support it (set to act_rshoulder by default).
+  platforms that support it (set to act_rshoulder by default,
+  except for Linux, where it's disabled by default).
 + Added config options "key_left_alt_is_altgr" and
   "key_right_alt_is_altgr". When set to 1, these prevent their
   respective Alt keys from activating built-in UI and editor

--- a/src/event.c
+++ b/src/event.c
@@ -40,6 +40,18 @@
 #define JOYSTICK_REPEAT_START KEY_REPEAT_START
 #define JOYSTICK_REPEAT_RATE  KEY_REPEAT_RATE
 
+#if defined(__linux__) && !defined(__ANDROID__)
+/* TODO: Steam Deck hack. SteamOS apparently broke this and the fix has
+ * not been backported to SDL2. Additionally, SteamOS has its own shortcut
+ * to open the screen keyboard, so it's not necessary to sacrifice a button.
+ * Platforms that don't support this don't need to worry about it.
+ * If Linux SDL ever gets another source of screen keyboard this will
+ * need to be revised. */
+#define DEFAULT_SCREEN_KEYBOARD_ACTION JOY_NO_ACTION
+#else
+#define DEFAULT_SCREEN_KEYBOARD_ACTION JOY_RSHOULDER
+#endif
+
 static uint32_t last_update_time;
 
 struct input_status input;
@@ -160,7 +172,8 @@ void init_event(struct config_info *conf)
 
   for(i = 0; i < MAX_JOYSTICKS; i++)
     if(!input.joystick_global_map.show_keyboard_is_conf[i])
-      input.joystick_global_map.show_screen_keyboard_action[i] = JOY_RSHOULDER;
+      input.joystick_global_map.show_screen_keyboard_action[i] =
+       DEFAULT_SCREEN_KEYBOARD_ACTION;
 
   if(!input.joystick_axis_threshold)
     input.joystick_axis_threshold = AXIS_DEFAULT_THRESHOLD;


### PR DESCRIPTION
SDL's SteamOS screen keyboard trigger currently seems nonfunctional for org.freedesktop.Platform 24.08/SDL2 2.32.4 (possibly related: https://github.com/libsdl-org/SDL/issues/12595) and SteamOS already has a shortcut for this, meaning MegaZeux doesn't need to sacrifice a gamepad button to open the screen keyboard in Linux.