### PR TITLE
Add AppStream metainfo.xml file and config.sh --metainfodir.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,11 +33,11 @@ jobs:
       - name: Install
         run: sudo $MZX_MAKE install V=1
       - name: Check install
-        run: command -v megazeux && [ -f "/usr/share/doc/megazeux/LICENSE" ] && [ -f "/etc/megazeux-config" ]
+        run: command -v megazeux && [ -f "/usr/share/licenses/megazeux/LICENSE" ] && [ -f "/etc/megazeux-config" ]
       - name: Uninstall
         run: sudo $MZX_MAKE uninstall V=1
       - name: Check uninstall
-        run: true && [ ! -f "/usr/bin/megazeux" ] && [ ! -f "/usr/share/doc/megazeux/LICENSE" ] && [ ! -f "/etc/megazeux-config" ]
+        run: true && [ ! -f "/usr/bin/megazeux" ] && [ ! -f "/usr/share/licenses/megazeux/LICENSE" ] && [ ! -f "/etc/megazeux-config" ]
       - name: Package source .tar.xz
         run: make source
 

--- a/arch/install.inc
+++ b/arch/install.inc
@@ -48,6 +48,10 @@ endif
 ifeq (${LICENSEDIR},.)
 	$(error ${ERROR_PLATFORM} (LICENSEDIR))
 endif
+	@echo METAINFODIR: ${METAINFODIR}
+ifeq (${METAINFODIR},.)
+	$(error ${ERROR_PLATFORM} (METAINFODIR))
+endif
 ifneq (${BUILD_MODULAR},)
 	@echo LIBDIR: ${LIBDIR}
 ifeq (${LIBDIR},.)
@@ -79,7 +83,8 @@ install: install-check install-arch
 		${DESTDIR}${SHAREDIR}/megazeux \
 		${DESTDIR}${SHAREDIR}/megazeux/assets \
 		${DESTDIR}${LICENSEDIR} \
-		${DESTDIR}${LICENSEDIR}/megazeux
+		${DESTDIR}${LICENSEDIR}/megazeux \
+		${DESTDIR}${METAINFODIR}
 	${install} -m 0644 \
 		assets/default.chr \
 		assets/edit.chr \
@@ -119,6 +124,11 @@ endif
 ifeq (${BUILD_MZXRUN},1)
 	${install} -m 0755 -d ${DESTDIR}${GAMESDIR}
 	${install} -m 0755 ${mzxrun} ${DESTDIR}${GAMESDIR}/
+ifneq (${BUILD_EDITOR},1)
+	${install} -m 0644 -T \
+		arch/unix/megazeux.metainfo.xml \
+		${DESTDIR}${METAINFODIR}/mzxrun.metainfo.xml
+endif
 endif
 ifeq (${BUILD_EDITOR},1)
 	${install} -m 0755 -d ${DESTDIR}${GAMESDIR}
@@ -129,6 +139,9 @@ ifeq (${BUILD_EDITOR},1)
 		assets/smzx.chr \
 		assets/smzx2.chr \
 		${DESTDIR}${SHAREDIR}/megazeux/assets
+	${install} -m 0644 \
+		arch/unix/megazeux.metainfo.xml \
+		${DESTDIR}${METAINFODIR}
 endif
 ifeq (${BUILD_UTILS},1)
 	${install} -m 0755 -d ${DESTDIR}${BINDIR}
@@ -204,10 +217,14 @@ endif
 ifeq (${BUILD_MZXRUN},1)
 	${RM} \
 		${DESTDIR}${GAMESDIR}/${mzxrun}
+ifneq (${BUILD_EDITOR},1)
+	${RM} -f ${DESTDIR}${METAINFODIR}/mzxrun.metainfo.xml
+endif
 endif
 ifeq (${BUILD_EDITOR},1)
 	${RM} \
 		${DESTDIR}${GAMESDIR}/${mzx}
+	${RM} -f ${DESTDIR}${METAINFODIR}/megazeux.metainfo.xml
 endif
 ifeq (${BUILD_UTILS},1)
 	${RM} \

--- a/arch/unix/megazeux.metainfo.xml
+++ b/arch/unix/megazeux.metainfo.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2025 Lachesis -->
+<component type="desktop-application">
+  <id>megazeux</id>
+  <metadata_license>CC-BY-SA-4.0</metadata_license>
+  <project_license>GPL-2.0-or-later</project_license>
+  <name>MegaZeux</name>
+  <summary>Text mode game creation system</summary>
+  <developer id="com.digitalmzx">
+    <name>MegaZeux developers</name>
+  </developer>
+  <description>
+    <p>
+      MegaZeux is a spiritual successor to ZZT originally written for DOS
+      in 1994. MegaZeux allows playing and creating games based
+      on&#x2104;but no longer limited to&#x2104;VGA 80x25 text mode graphics.
+      MegaZeux includes a built-in editor and supports rudimentary scripting.
+    </p>
+    <p>
+      Hundreds of games have been created for MegaZeux,
+      and are available for download at no charge from DigitalMZX.
+    </p>
+    <p>
+      Supported platforms include Linux/BSD, Windows, macOS, MS-DOS, Wasm,
+      Android, Haiku, and numerous games consoles and handhelds.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">megazeux.desktop</launchable>
+
+  <branding>
+    <color type="primary" scheme_preference="light">#99bbbb</color>
+    <color type="primary" scheme_preference="dark">#181830</color>
+  </branding>
+  <content_rating type="oars-1.1" />
+
+  <url type="homepage">https://www.digitalmzx.com</url>
+  <url type="bugtracker">https://github.com/AliceLR/megazeux</url>
+  <url type="help">https://www.digitalmzx.com/mzx_help.html</url>
+
+  <screenshots>
+    <screenshot type="default">
+      <caption>
+        A typical MegaZeux game with text mode graphics (Weirdness, Chapter I by Alexis Janson)
+      </caption>
+      <image>https://www.digitalmzx.com/metainfo/gameplay.png</image>
+    </screenshot>
+
+    <screenshot>
+      <caption>
+        Example of a game using extended graphical features (Pandemonium Buster by Lancer-X and Maxim)
+      </caption>
+      <image>https://www.digitalmzx.com/metainfo/gameplay2.png</image>
+    </screenshot>
+
+    <screenshot>
+      <caption>
+        MegaZeux editor with a game open for editing (MegaZeux Tutorial by Alexis Janson)
+      </caption>
+      <image>https://www.digitalmzx.com/metainfo/editor.png</image>
+    </screenshot>
+
+    <screenshot>
+      <caption>
+        MegaZeux graphics are based on editing text mode characters (xxy by Lachesis)
+      </caption>
+      <image>https://www.digitalmzx.com/metainfo/charedit.png</image>
+    </screenshot>
+
+    <screenshot>
+      <caption>
+        Robot editor showing an example Robotic script (Zeux II: Caverns of Zeux by Alexis Janson)
+      </caption>
+      <image>https://www.digitalmzx.com/metainfo/robotic.png</image>
+    </screenshot>
+  </screenshots>
+
+  <provides>
+    <binary>megazeux</binary>
+    <binary>mzxrun</binary>
+  </provides>
+
+  <recommends>
+    <control>keyboard</control>
+    <control>gamepad</control>
+  </recommends>
+  <supports>
+    <control>pointing</control>
+    <control>touch</control>
+  </supports>
+
+  <releases>
+    <release version="2.93c" date="2025-02-28">
+      <description>
+        <p>
+          A bugfix release focused primarily on portability fixes. Longstanding
+          bugs related to window resizing that affect Linux in particular have
+          been fixed. Regressions involving the editor "show thing" shortcuts
+          and text input have been fixed. New features include SDL3 support and
+          restored support for some older Sound Blaster cards in the DOS port.
+        </p>
+      </description>
+    </release>
+
+    <!-- See the MegaZeux help file or docs/changelog.txt for all releases
+         from Aug. 2004 onward.
+
+         See the MegaZeux help file or release notes bundled with old
+         version archives for releases from Dec. 1994 to July 2004. -->
+  </releases>
+
+  <update_contact>petrifiedrowan_AT_gmail.com</update_contact>
+</component>

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -58,6 +58,7 @@ USERS
 + Fixed VFS cache failing to init caused by getcwd returning
   a root with no trailing slash.
 + Unsupported mouse button presses are now ignored.
++ Fixed the window icon for Flatpak builds.
 
 DEVELOPERS
 
@@ -84,6 +85,12 @@ DEVELOPERS
   using errno values here on Haiku.
 + Add Emscripten Makefile support for SDL3.
 + Add PS Vita Makefile support for SDL3 and SDL 1.2.
++ make install now installs an AppStream .metainfo.xml file.
++ Added --metainfodir [dir] option to config.sh. This setting
+  defaults to [sharedir]/metainfo for relevant platforms.
++ --licensedir now defaults to [sharedir]/licenses instead of
+  [prefix]/share/doc.
++ Fixed ansi.c compilation failure with --disable-datestamp.
 + Updated libxmp to 4.6.3+sample rate patch.
 
 

--- a/megazeux.spec
+++ b/megazeux.spec
@@ -14,6 +14,7 @@ BuildRequires:	SDL3-devel
 BuildRequires:	libvorbis-devel
 BuildRequires:	libpng-devel
 BuildRequires:	zlib-devel
+BuildRequires:	libappstream-glib
 
 %description
 
@@ -38,7 +39,8 @@ See https://www.digitalmzx.com/ for more information.
             --libdir %{_libdir} \
             --gamesdir %{_bindir} \
             --sharedir %{_datadir} \
-            --licensedir %{_datadir}/license \
+            --licensedir %{_datadir}/licenses \
+            --metainfodir %{_metainfodir} \
             --bindir %{_datadir}/megazeux/bin \
             --sysconfdir %{_sysconfdir}
 %make_build
@@ -46,6 +48,7 @@ See https://www.digitalmzx.com/ for more information.
 %install
 rm -rf "$RPM_BUILD_ROOT"
 %make_install V=1
+appstream-util validate-relax %{buildroot}%{_metainfodir}/megazeux.metainfo.xml
 
 %check
 %make_build test
@@ -63,11 +66,15 @@ rm -rf "$RPM_BUILD_ROOT"
 %{_datadir}/applications/megazeux.desktop
 %{_datadir}/applications/mzxrun.desktop
 %{_datadir}/doc/megazeux
-%{_datadir}/license/megazeux
+%{_datadir}/licenses/megazeux
 %{_datadir}/icons/hicolor/128x128/apps/megazeux.png
+%{_metainfodir}/megazeux.metainfo.xml
 %{_sysconfdir}/megazeux-config
 
 %changelog
+#* TBA May 00 2025 Alice Rowan <petrifiedrowan@gmail.com> 2.93d-1
+#- new upstream version, add megazeux.metainfo.xml, fix licenses dir.
+
 * Fri Feb 28 2025 Alice Rowan <petrifiedrowan@gmail.com> 2.93c-1
 - new upstream version, switch to SDL3
 

--- a/scripts/pkg/README.md
+++ b/scripts/pkg/README.md
@@ -8,6 +8,7 @@ See /megazeux.spec and /debian for Fedora and Debian/Ubuntu, respectively.
 |---------------|-----------------------|-----------------------|---------------|
 | alpine	| asie			| orphaned		| https://gitlab.alpinelinux.org/alpine/aports/-/tree/master/testing/megazeux
 | archlinux	| CyberShadow/GetDizzy	| ok			| https://aur.archlinux.org/packages/megazeux/
+| flatpak	| Lachesis		| not submitted		| —
 | macports	| Lachesis		| not submitted		| —
 | nix		| Why-Fi		| not submitted		| —
 | voidlinux	| asie			| orphaned		| https://github.com/void-linux/void-packages/tree/master/srcpkgs/megazeux

--- a/scripts/pkg/flatpak/com.digitalmzx.MegaZeux.yml
+++ b/scripts/pkg/flatpak/com.digitalmzx.MegaZeux.yml
@@ -1,0 +1,47 @@
+app-id: com.digitalmzx.MegaZeux
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+command: megazeux
+rename-desktop-file: megazeux.desktop
+rename-appdata-file: megazeux.metainfo.xml
+rename-icon: megazeux
+cleanup:
+  - /share/doc
+
+finish-args:
+  # SDL application that expects OpenGL, Wayland, audio, gamepads to work.
+  # Network support exists but is currently disabled in Linux (not used yet).
+  - --device=dri
+  - --device=all
+  - --share=ipc
+  #- --share=network
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+  # MegaZeux is both a game engine and development kit and
+  # users may store game folders or create games anywhere.
+  - --filesystem=home
+  - --filesystem=/media
+  - --filesystem=/run/media
+
+modules:
+  - name: MegaZeux
+    buildsystem: simple
+    build-commands:
+      - ./config.sh --platform unix --enable-release --enable-lto
+          --prefix /app
+          --sysconfdir /app/etc
+          --gamesdir /app/bin
+          --bindir /app/bin
+          --libdir /app/lib
+          --sharedir /app/share
+          --licensedir /app/share/licenses
+          --metainfodir /app/share/metainfo
+      - make -j${FLATPAK_BUILDER_N_JOBS}
+      - make -j${FLATPAK_BUILDER_N_JOBS} test
+      - make install
+    sources:
+       - type: git
+         url: https://github.com/AliceLR/megazeux.git
+         tag: v2.93d

--- a/src/editor/ansi.c
+++ b/src/editor/ansi.c
@@ -319,7 +319,11 @@ boolean export_ansi(struct world *mzx_world, const char *filename,
     vfputc(0x1A, vf);
     snprintf(buffer, ARRAY_SIZE(buffer),
       "COMNT%-64.64sSAUCE00%-35.35s%-20.20s%-20.20s%-8.8s",
+#ifdef VERSION_DATE
       "Created with MegaZeux " VERSION VERSION_DATE ".", // Comment line 1.
+#else
+      "Created with MegaZeux " VERSION ".",
+#endif
       title,
       author,
       "",     // Group


### PR DESCRIPTION
- [x] Flathub requires release descriptions, i.e. the backported releases may need to go because I'm not writing 45 descriptions.
- [x] Redo all screenshots as window screenshots.
  - [x] [Gameplay 1 (classic game)](https://www.digitalmzx.com/metainfo/gameplay.png)
  - [x] [Gameplay 2 (modern game)](https://www.digitalmzx.com/metainfo/gameplay2.png)
  - [x] [Editor](https://www.digitalmzx.com/metainfo/editor.png)
  - [x] [Character editor](https://www.digitalmzx.com/metainfo/charedit.png)
  - [x] [Robot editor](https://www.digitalmzx.com/metainfo/robotic.png)
- [x] Need to preview this somewhere to verify colors et al. (Discover with a local install is unable to correctly preview it.)
- [x] freedesktop requirements.
  - `update_contact`?
- [x] Fedora requirements.
- [x] Flathub requirements.
- [x] Flathub quality guidelines.
  - Icon doesn't meet spec, can replace at a later date.
- [x] Add com.digitalmzx.MegaZeux.yml to scripts/.
- [x] Fix icon for Flatpak builds.