### PR TITLE
Fix numerous bugs involving the robot blocked array.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -3,6 +3,12 @@ GIT - MZX 2.94
 FIXES
 
 + TODO: 2.94 enables board message clipping bugfixes from 2.93b.
++ TODO: 2.94 fixes update_blocked never being cleared.
++ TODO: 2.94 fixes player position being tested every command.
++ TODO: 2.94 fixes IF DIR OF PLAYER using the robot blocked
+  flags instead of blocked flags generated from the player pos.
++ TODO: 2.94 fixes DUPLICATE SELF X Y and DUPLICATE SELF DIR
+  not updating the blocked array.
 
 
 GIT - MZX 2.93d


### PR DESCRIPTION
Probably do not merge until 2.94 due to how sketchy this is.

* The blocked array update flag is now cleared when the blocked array is updated (compatibility for 2.80 until 2.94).
* The blocked array update flag is now set for DUPLICATE SELF XY and DUPLICATE SELF DIR (compatibility for 2.80 until 2.94).
* SPITFIRE, SHOOTSEEKER, and SHOOTMISSILE now set the blocked array update flag instead of manually recalculating it (compatibility for 2.83 until 2.94).
* IF DIR OF PLAYER now uses the player's blocked status instead of the current robot's (compatibility for 1.x until 2.94).
* find_player() is no longer called in run_robot() unless the blocked array update flag is set.

TODO:

- [ ] `SET`/`INC`/`DEC`/`SET RANDOM`/`INC RANDOM`/`DEC RANDOM`/`MULTIPLY`/`DIVIDE`/`MODULO`/`DOUBLE`/`HALF` need to set `update_blocked` if they write to a board counter.
- [ ] Prove beyond any doubt that it's safe to move `find_player()` back into the `update_blocked` branch for all version variants. This is *probably* true, but it's the most dangerous change in this patch.
- [ ] Regression tests:
  - [ ] 1.00 if testable.
  - [ ] 2.00
  - [ ] 2.80
  - [ ] 2.83
  - [ ] 2.94
- [ ] Changelog entries.