### PR TITLE
Misc. warnings fixes.

### DIFF
--- a/src/editor/ansi.c
+++ b/src/editor/ansi.c
@@ -315,15 +315,18 @@ boolean export_ansi(struct world *mzx_world, const char *filename,
 
     total_len = vftell(vf);
 
+// macOS makes snprintf a macro for some reason so define this separately.
+#ifdef VERSION_DATE
+#define COMMENT_LINE "Created with MegaZeux " VERSION VERSION_DATE "."
+#else
+#define COMMENT_LINE "Created with MegaZeux " VERSION "."
+#endif
+
     // SAUCE record.
     vfputc(0x1A, vf);
     snprintf(buffer, ARRAY_SIZE(buffer),
       "COMNT%-64.64sSAUCE00%-35.35s%-20.20s%-20.20s%-8.8s",
-#ifdef VERSION_DATE
-      "Created with MegaZeux " VERSION VERSION_DATE ".", // Comment line 1.
-#else
-      "Created with MegaZeux " VERSION ".",
-#endif
+      COMMENT_LINE, // Comment line 1.
       title,
       author,
       "",     // Group

--- a/src/nostdc++.cpp
+++ b/src/nostdc++.cpp
@@ -46,7 +46,7 @@ extern "C" CORE_LIBSPEC void __cxa_deleted_virtual()
   exit(1);
 }
 
-CORE_LIBSPEC void *operator new(size_t count) noexcept
+CORE_LIBSPEC void *operator new(size_t count)
 {
   void *ptr = cmalloc(count);
   if(!ptr)
@@ -59,7 +59,7 @@ CORE_LIBSPEC void *operator new(size_t count) noexcept
   return ptr;
 }
 
-CORE_LIBSPEC void *operator new[](size_t count) noexcept
+CORE_LIBSPEC void *operator new[](size_t count)
 {
   void *ptr = cmalloc(count);
   if(!ptr)


### PR DESCRIPTION
+ Fix ansi.c warning caused by macOS defining snprintf as a macro.
+ Fix nostdc++.cpp GCC 15 warning caused by noexcept.