### PR TITLE
PlayStation Vita keyboard bugfixes.

### DIFF
--- a/src/event.h
+++ b/src/event.h
@@ -31,7 +31,7 @@ __M_BEGIN_DECLS
 #define UPDATE_DELAY 16
 
 #define KEY_REPEAT_STACK_SIZE 32
-#define KEY_UNICODE_MAX 16
+#define KEY_UNICODE_MAX 1024
 
 #define STATUS_NUM_KEYCODES 512
 
@@ -66,10 +66,11 @@ struct buffered_status
   enum keycode key;
   enum keycode key_repeat;
   enum keycode key_release;
-  uint32_t unicode[KEY_UNICODE_MAX];
+  uint32_t *unicode;
   uint32_t unicode_repeat;
   int unicode_pos;
   int unicode_length;
+  int unicode_alloc;
   uint32_t keypress_time;
   int mouse_x;
   int mouse_y;

--- a/src/event_sdl.c
+++ b/src/event_sdl.c
@@ -1367,6 +1367,13 @@ static boolean process_event(SDL_Event *event)
       }
 #endif
 
+#ifdef CONFIG_PSVITA
+      // Vita SDL keyboard will send an enter press immediately following
+      // text input, which screws up several things. Suppress this:
+      if(ckey == IKEY_RETURN && has_unicode_input())
+        break;
+#endif
+
       // Some platforms don't implement SDL_TEXTINPUT (SDL 2.0) or the unicode
       // field (SDL 1.2); until usage of those is detected, fake the text key
       // using the internal keycode.


### PR DESCRIPTION
* Suppress the automatic IKEY_RETURN presses the Vita screen keyboard sends for no good reason after text input.
* Expand the maximum size of the unicode text buffer to 1024.