### PR TITLE
Add ANSi import/export support for Doorway mode, strip char 26.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,6 +56,12 @@ USERS
   Pusher, Missile, Spike, Bullet, Fire, Life, RicochetPanel.
 + Fixed out-of-bounds array reads when reading the color of or
   displaying (no compat checks): Energizer, Fire, Life.
++ ANSi export now replaces char 26 with a dash to avoid import
+  bugs and conflicts with other software.
++ Added ANSi export support for Doorway mode, a non-standard
+  ANSI extension that allows displaying control characters that
+  would otherwise get stripped out. MegaZeux now supports
+  loading ANSi files that use Doorway mode, as well.
 + Software layer renderer performance enhancements for repeat
   colors, clipping, and unaligned renderering.
 + Unaligned software layer rendering using 64-bit writes is

--- a/src/editor/ansi.h
+++ b/src/editor/ansi.h
@@ -34,7 +34,7 @@ boolean import_ansi(struct world *mzx_world, const char *filename,
 
 boolean export_ansi(struct world *mzx_world, const char *filename,
  enum editor_mode mode, int start_x, int start_y, int width, int height,
- boolean text_only, const char *title, const char *author);
+ boolean text_only, boolean doorway_mode, const char *title, const char *author);
 
 __M_END_DECLS
 

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -199,6 +199,7 @@ struct editor_context
   int ansi_line_wrap_column; // = 80
   boolean ansi_line_wrap;
   boolean ansi_save_text_only;
+  boolean ansi_save_doorway_mode;
   char ansi_save_title[36];
   char ansi_save_author[21];
 
@@ -2485,10 +2486,15 @@ static boolean editor_key(context *ctx, int *key)
             char author[ARRAY_SIZE(editor->ansi_save_author)];
             char export_name[MAX_PATH];
             int text_only = editor->ansi_save_text_only;
+            int doorway_mode = editor->ansi_save_doorway_mode;
             static const char *radio_strings[] =
             {
               "Save ANSi",
               "Save TXT"
+            };
+            static const char *checkbox_strings[] =
+            {
+              "Doorway mode"
             };
             struct element *elements[] =
             {
@@ -2496,6 +2502,8 @@ static boolean editor_key(context *ctx, int *key)
                9, &text_only),
               construct_input_box(23, 19, "Title (ANSi):", ARRAY_SIZE(title) - 1, title),
               construct_input_box(22, 20, "Author (ANSi):", ARRAY_SIZE(author) - 1, author),
+              construct_check_box(58, 20, checkbox_strings, ARRAY_SIZE(checkbox_strings),
+               12, &doorway_mode),
             };
 
             memcpy(export_name, editor->mzm_name_buffer, MAX_PATH);
@@ -2511,9 +2519,11 @@ static boolean editor_key(context *ctx, int *key)
               memcpy(editor->ansi_save_title, title, ARRAY_SIZE(title));
               memcpy(editor->ansi_save_author, author, ARRAY_SIZE(author));
               editor->ansi_save_text_only = text_only;
+              editor->ansi_save_doorway_mode = doorway_mode;
 
               export_ansi(mzx_world, export_name, editor->mode, block->src_x,
-               block->src_y, block->width, block->height, text_only, title, author);
+               block->src_y, block->width, block->height, text_only, doorway_mode,
+               title, author);
             }
             block->selected = false;
             editor->cursor_mode = CURSOR_PLACE;


### PR DESCRIPTION
Implements [issue 889](https://www.digitalmzx.com/forums/index.php?app=tracker&showissue=889) and (most likely) resolves another issue someone was having with char 26.