### PR TITLE
Fix OpenGL renderer alpha bugs affecting Wayland, white edge lines.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -75,6 +75,11 @@ USERS
   and 16-bit rendering performance.
 + Fixed slow softscale rendering for some drivers. Texture
   streaming is now used for direct3d/consoles/software only.
++ Fixed OpenGL rendering issues in Wayland caused by OpenGL's
+  transparent default clear color.
++ Fixed opengl1 renderer colors missing alpha component.
++ Fixed glsl, glslscale, opengl2 renderers sometimes showing a
+  thin white line on the edges of the screen.
 + Fixed date and time counters on NDS (missing IRQ_NETWORK).
 + Fixed VFS cache failing to init caused by getcwd returning
   a root with no trailing slash.


### PR DESCRIPTION
* Explicitly set OpenGL clear color in all OpenGL renderers and explicitly clear the entire frame with it every resize to fix transparent letterbox areas in Wayland and possibly other places.
* Fix opengl1 renderer not setting a transparent color in the flat palette, causing some (but not all) colors to be transparent in Wayland.
* Change initial screen texture fill in opengl2, glsl renderers to transparent instead of white to fix white edge line bugs in most environments.