### PR TITLE
Android: don't overwrite assets with newer modified times.

### DIFF
--- a/arch/android/project/app/src/main/java/net/digitalmzx/megazeux/MainActivity.java
+++ b/arch/android/project/app/src/main/java/net/digitalmzx/megazeux/MainActivity.java
@@ -120,7 +120,7 @@ public class MainActivity extends Activity
         {
           if(target.exists())
           {
-            if(target.lastModified() == entry.getTime())
+            if(target.lastModified() >= entry.getTime())
               continue;
           }
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -11,6 +11,8 @@ GIT - MZX 2.93d
 
 USERS
 
++ MegaZeux on Android no longer overwrites config.txt if it has
+  more recent changes than the copy in assets.zip.
 + Added support for system screen keyboards for SDL. This allows
   opening the system screen keyboards with the Android and Vita
   ports, as well as some Linux configurations e.g. Steam Deck.


### PR DESCRIPTION
Fixes #507.