### PR TITLE
Add ICONFILE to MZX resource system.

### DIFF
--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1775,10 +1775,6 @@ static void set_window_ratio(struct video_window *window, enum ratio_type ratio)
   }
 }
 
-#ifndef ICONFILE
-#define ICONFILE NULL
-#endif
-
 unsigned video_create_window(void)
 {
   struct video_window *window = &(graphics.window);
@@ -1809,7 +1805,7 @@ unsigned video_create_window(void)
   {
     window->is_init = true;
     video_set_window_caption(window, graphics.default_caption);
-    video_set_window_icon(window, ICONFILE);
+    video_set_window_icon(window, mzx_res_get_by_id(MZX_ICON_PNG));
 
     // Make sure a BPP was selected by the renderer (if applicable).
     if(window->bits_per_pixel == BPP_AUTO)

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -638,8 +638,7 @@ boolean sdl_set_window_icon(struct graphics_data *graphics,
     else
       debug("failed to open embedded icon\n");
   }
-#else // !_WIN32
-#if defined(CONFIG_PNG) && defined(ICONFILE)
+#elif defined(CONFIG_PNG) // !_WIN32
   {
     SDL_Surface *icon;
     if(!icon_path)
@@ -648,7 +647,7 @@ boolean sdl_set_window_icon(struct graphics_data *graphics,
       return false;
     }
 
-    icon = png_read_icon(ICONFILE);
+    icon = png_read_icon(icon_path);
     if(icon)
     {
 #if SDL_VERSION_ATLEAST(3,0,0)
@@ -664,10 +663,9 @@ boolean sdl_set_window_icon(struct graphics_data *graphics,
       return true;
     }
     else
-      warn("failed to open icon file '%s'\n", ICONFILE);
+      warn("failed to open icon file '%s'\n", icon_path);
   }
-#endif // CONFIG_PNG
-#endif // !_WIN32
+#endif // !_WIN32 && !CONFIG_PNG
 #endif // CONFIG_ICON
   return false;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -62,6 +62,7 @@ enum resource_id
 {
   MZX_EXECUTABLE_DIR = 0,
   CONFIG_TXT,
+  MZX_ICON_PNG,
   MZX_DEFAULT_CHR,
   MZX_EDIT_CHR,
   SMZX_PAL,


### PR DESCRIPTION
Fixes unix-devel issues where a missing icon warning would be printed when changing the renderer after changing out of `SHAREDIR`.