### PR TITLE
Misc. minor fixes.

### DIFF
--- a/scripts/deps/Makefile
+++ b/scripts/deps/Makefile
@@ -411,7 +411,7 @@ else
 	cd build/${VORBIS}; \
 	set -e; \
 	${ARCH_INIT}; \
-	${CONFIGURE}; \
+	${CONFIGURE} --disable-oggtest; \
 	${MAKE}; \
 	${MAKE} install;
 endif

--- a/src/expr.c
+++ b/src/expr.c
@@ -1,5 +1,6 @@
 /* MegaZeux
  *
+ * Copyright (C) 1996 Greg Janson (original tr_msg only)
  * Copyright (C) 2002 Gilead Kutnick <exophase@adelphia.net>
  * Copyright (C) 2017-2025 Alice Rowan <petrifiedrowan@gmail.com>
  *

--- a/src/expr.c
+++ b/src/expr.c
@@ -600,8 +600,11 @@ int parse_expression(struct world *mzx_world, char **_expression, int *error,
         len = buf_alloc - buf_pos;
       }
 
-      memcpy(buf_pos, src, len);
-      buf_pos += len;
+      if(len)
+      {
+        memcpy(buf_pos, src, len);
+        buf_pos += len;
+      }
       continue;
     }
 
@@ -1863,8 +1866,8 @@ int parse_string_expression(struct world *mzx_world, char **_expression,
 
         if(is_string(name_translated))
         {
-          get_string(mzx_world, name_translated, &string, id);
-          output_string(&output, &output_left, string.value, string.length);
+          if(get_string(mzx_world, name_translated, &string, id))
+            output_string(&output, &output_left, string.value, string.length);
         }
         else
         {
@@ -1898,8 +1901,8 @@ int parse_string_expression(struct world *mzx_world, char **_expression,
 
         if(is_string(name_translated))
         {
-          get_string(mzx_world, name_translated, &string, id);
-          output_string(&output, &output_left, string.value, string.length);
+          if(get_string(mzx_world, name_translated, &string, id))
+            output_string(&output, &output_left, string.value, string.length);
           expression = next;
         }
         else
@@ -2091,15 +2094,16 @@ char *tr_msg_ext(struct world *mzx_world, char *mesg, int id, char *buffer,
           // Write the value of the counter name
           struct string str_src;
 
-          get_string(mzx_world, name_buffer, &str_src, 0);
+          if(get_string(mzx_world, name_buffer, &str_src, 0))
+          {
+            name_length = str_src.length;
 
-          name_length = str_src.length;
+            if(dest_pos + name_length >= ROBOT_MAX_TR)
+              name_length = ROBOT_MAX_TR - dest_pos - 1;
 
-          if(dest_pos + name_length >= ROBOT_MAX_TR)
-            name_length = ROBOT_MAX_TR - dest_pos - 1;
-
-          memcpy(buffer + dest_pos, str_src.value, name_length);
-          dest_pos += name_length;
+            memcpy(buffer + dest_pos, str_src.value, name_length);
+            dest_pos += name_length;
+          }
         }
         else
 

--- a/src/intake.c
+++ b/src/intake.c
@@ -236,28 +236,19 @@ int intake(struct world *mzx_world, char *string, int max_len, int display_len,
           // Find nearest space to the left
           if(currx)
           {
-            char *current_position = string + currx;
+            char *next_position = string + currx - 1;
 
-            if(currx)
-              current_position--;
-
-            if(!isalnum((int)*current_position))
+            while(currx && !isalnum((int)*next_position))
             {
-              while(currx && !isalnum((int)*current_position))
-              {
-                current_position--;
-                currx--;
-              }
+              next_position--;
+              currx--;
             }
 
-            do
+            while(currx && isalnum((int)*next_position))
             {
-              current_position--;
+              next_position--;
               currx--;
-            } while(currx && isalnum((int)*current_position));
-
-            if(currx < 0)
-              currx = 0;
+            }
           }
         }
         else

--- a/src/intake.c
+++ b/src/intake.c
@@ -345,18 +345,11 @@ int intake(struct world *mzx_world, char *string, int max_len, int display_len,
           {
             int old_position = currx;
 
-            if(!isalnum((int)string[currx]))
-            {
-              while(currx && !isalnum((int)string[currx]))
-              {
-                currx--;
-              }
-            }
+            while(currx && !isalnum((int)string[currx]))
+              currx--;
 
             while(currx && isalnum((int)string[currx]))
-            {
               currx--;
-            }
 
             curr_len -= old_position - currx;
 
@@ -583,33 +576,24 @@ void intake_sync(subcontext *sub)
  */
 static void intake_skip_back(struct intake_subcontext *intk)
 {
-  char *current_position;
+  char *next_position;
   int pos = intk->pos;
 
   if(pos)
   {
-    current_position = intk->dest + pos;
+    next_position = intk->dest + pos - 1;
 
-    if(pos)
-      current_position--;
-
-    if(!isalnum((int)*current_position))
+    while(pos && !isalnum((int)*next_position))
     {
-      while(pos && !isalnum((int)*current_position))
-      {
-        current_position--;
-        pos--;
-      }
+      next_position--;
+      pos--;
     }
 
-    do
+    while(pos && isalnum((int)*next_position))
     {
-      current_position--;
+      next_position--;
       pos--;
-    } while(pos && isalnum((int)*current_position));
-
-    if(pos < 0)
-      pos = 0;
+    }
 
     intake_set_pos(intk, pos);
   }

--- a/src/render_sdl.c
+++ b/src/render_sdl.c
@@ -654,6 +654,7 @@ boolean sdl_set_window_icon(struct graphics_data *graphics,
       if(!SDL_SetWindowIcon(render_data->window, icon))
       {
         debug("failed SDL_SetWindowIcon: %s\n", SDL_GetError());
+        SDL_DestroySurface(icon);
         return false;
       }
 #else

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -129,7 +129,7 @@ unit_cflags += ${UNIT_OPTIMIZE_FLAGS} -UDEBUG -UNDEBUG -DMZX_UNIT_TESTS
 unit_cflags += -fexceptions -funsigned-char -std=gnu++11
 unit_ldflags += ${UNIT_OPTIMIZE_FLAGS}
 
-unit_cflags += ${SDL_CFLAGS} -Umain
+unit_cflags += ${SDL_CFLAGS} ${ZLIB_CFLAGS} -Umain
 unit_ldflags += ${SDL_LDFLAGS} ${ZLIB_LDFLAGS}
 
 # Required for image_file test.


### PR DESCRIPTION
* Disable Vorbis ogg linking test for scripts/deps. Fixes libvorbis compilation issues for `PLATFORM=linux-msan` found in an Ubuntu chroot.
* Regression tests were missing `ZLIB_CFLAGS` (found in Ubuntu chroot MSan builds).
* SDL icon surfaces could be leaked when failing to set the surface (occurs with the SDL dummy renderer).
* Fixed case where intake Ctrl+Left could cause out-of-bounds reads.
* Added guards for `get_string` calls in expr.c.
* Copyright for original `tr_msg` in expr.c.