### PR TITLE
Move volume list reading from window.c to vio.c.

### DIFF
--- a/src/io/vfile.h
+++ b/src/io/vfile.h
@@ -1,6 +1,6 @@
 /* MegaZeux
  *
- * Copyright (C) 2019-2023 Alice Rowan <petrifiedrowan@gmail.com>
+ * Copyright (C) 2019-2026 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -31,6 +31,7 @@ __M_BEGIN_DECLS
 
 typedef struct vfile vfile;
 typedef struct vdir vdir;
+typedef struct vvolumelist vvolumelist;
 typedef struct vfilesystem vfilesystem;
 struct memfile;
 struct stat;

--- a/src/io/vio.c
+++ b/src/io/vio.c
@@ -31,7 +31,7 @@
 #include "vfs.h"
 //#include "zip.h"
 
-#ifdef __WIN32__
+#ifdef _WIN32
 #include "vio_win32.h"
 #else
 #include "vio_posix.h"
@@ -2205,7 +2205,7 @@ boolean vdir_read(vdir *dir, char *buffer, size_t len, enum vdir_type *type)
         return false;
     }
     if(type)
-      *type = f->type;
+      *type = (enum vdir_type)f->type;
 
     dir->position++;
     return true;
@@ -2306,4 +2306,128 @@ long vdir_tell(vdir *dir)
 long vdir_length(vdir *dir)
 {
   return dir->num_total;
+}
+
+
+/************************************************************************
+ * Volume listing function wrappers.
+ * For DOS/Amiga-style volumes, this will append ':' (but no slash).
+ */
+
+struct vvolumelist
+{
+  char **names;
+  size_t num_total;
+  size_t num_alloc;
+  size_t pos;
+};
+
+static vvolumelist *vvolumelist_alloc(void)
+{
+  vvolumelist *volumes = (vvolumelist *)malloc(sizeof(vvolumelist));
+  if(!volumes)
+    return NULL;
+
+  volumes->pos = 0;
+  volumes->num_total = 0;
+  volumes->num_alloc = 16;
+  volumes->names = (char **)malloc(volumes->num_alloc * sizeof(char *));
+  if(!volumes->names)
+  {
+    free(volumes);
+    return NULL;
+  }
+  return volumes;
+}
+
+static boolean vvolumelist_append(vvolumelist *volumes,
+ const char *name, size_t name_len)
+{
+  char *n;
+
+  trace("--VIO-- vvolumelist_append: %s\n", name);
+
+  if(volumes->num_total == volumes->num_alloc)
+  {
+    char **tmp;
+    size_t new_num = volumes->num_alloc << 1u;
+
+    if(new_num <= volumes->num_alloc)
+      return false;
+
+    tmp = (char **)realloc(volumes->names, new_num * sizeof(char *));
+    if(!tmp)
+      return false;
+
+    volumes->names = tmp;
+    volumes->num_alloc = new_num;
+  }
+
+  n = (char *)malloc(name_len + 1);
+  if(!n)
+    return false;
+
+  memcpy(n, name, name_len);
+  n[name_len] = '\0';
+  volumes->names[volumes->num_total++] = n;
+  return true;
+}
+
+static void vvolumelist_free(vvolumelist *volumes)
+{
+  size_t i;
+  for(i = 0; i < volumes->num_total; i++)
+    free(volumes->names[i]);
+
+  free(volumes->names);
+  free(volumes);
+}
+
+vvolumelist *vvolumelist_open(void)
+{
+  struct vvolumelist_handle vh;
+  vvolumelist *ret;
+  int sz;
+  char buf[MAX_PATH];
+
+  trace("--VIO-- vvolumelist_open\n");
+
+  if(!platform_vvolumelist_open(&vh))
+  {
+    trace("--VIO-- vvolumelist_open: failed to open platform volume list\n");
+    return NULL;
+  }
+
+  ret = vvolumelist_alloc();
+  if(!ret)
+    goto err;
+
+  while((sz = platform_vvolumelist_read(&vh, buf, sizeof(buf))))
+    if((size_t)sz < sizeof(buf) && !vvolumelist_append(ret, buf, sz))
+      goto err2;
+
+  platform_vvolumelist_close(&vh);
+
+  /* TODO: virtual roots */
+  return ret;
+
+err2:
+  vvolumelist_free(ret);
+err:
+  platform_vvolumelist_close(&vh);
+  return NULL;
+}
+
+int vvolumelist_close(vvolumelist *volumes)
+{
+  vvolumelist_free(volumes);
+  return 0;
+}
+
+const char *vvolumelist_read(vvolumelist *volumes)
+{
+  if(volumes->pos >= volumes->num_total)
+    return NULL;
+
+  return volumes->names[volumes->pos++];
 }

--- a/src/io/vio.h
+++ b/src/io/vio.h
@@ -1,6 +1,6 @@
 /* MegaZeux
  *
- * Copyright (C) 2019-2023 Alice Rowan <petrifiedrowan@gmail.com>
+ * Copyright (C) 2019-2026 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -137,6 +137,10 @@ UTILS_LIBSPEC boolean vdir_seek(vdir *dir, long position);
 UTILS_LIBSPEC boolean vdir_rewind(vdir *dir);
 UTILS_LIBSPEC long vdir_tell(vdir *dir);
 UTILS_LIBSPEC long vdir_length(vdir *dir);
+
+UTILS_LIBSPEC vvolumelist *vvolumelist_open(void);
+UTILS_LIBSPEC int vvolumelist_close(vvolumelist *volumes);
+UTILS_LIBSPEC const char *vvolumelist_read(vvolumelist *volumes);
 
 __M_END_DECLS
 

--- a/src/io/vio_posix.h
+++ b/src/io/vio_posix.h
@@ -1,6 +1,6 @@
 /* MegaZeux
  *
- * Copyright (C) 2020-2025 Alice Rowan <petrifiedrowan@gmail.com>
+ * Copyright (C) 2020-2026 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -35,6 +35,8 @@ __M_BEGIN_DECLS
 #include <stdio.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
+#include "vio_volume.h"
 
 // pspdev/devkitPSP historically does not have a rewinddir implementation.
 // libctru (3DS) and libnx (Switch) have rewinddir but it doesn't work.

--- a/src/io/vio_volume.h
+++ b/src/io/vio_volume.h
@@ -1,0 +1,192 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2026 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef __IO_VIO_VOLUME_H
+#define __IO_VIO_VOLUME_H
+
+#include "../compat.h"
+#include "../util.h"
+#include "path.h"
+
+__M_BEGIN_DECLS
+
+/* Volume list reading implementations for vio_posix.h
+ * These are more involved than the rest of vio_posix.h
+ * but generally not worth their own compilation units. */
+
+#if defined(CONFIG_DJGPP)
+
+#include <dir.h>
+
+struct vvolumelist_handle
+{
+  int current_disk;
+  int max_disk;
+  int pos;
+};
+
+static inline boolean platform_vvolumelist_open(struct vvolumelist_handle *vh)
+{
+  vh->current_disk = getdisk();
+  vh->max_disk = setdisk(vh->current_disk);
+  vh->pos = 0;
+  return true;
+}
+
+static inline void platform_vvolumelist_close(struct vvolumelist_handle *vh)
+{
+  setdisk(vh->current_disk);
+}
+
+static inline int platform_vvolumelist_read(struct vvolumelist_handle *vh,
+ char *buf, size_t buf_sz)
+{
+  while(vh->pos < vh->max_disk)
+  {
+    int num = (vh->pos++);
+
+    setdisk(num);
+    if(getdisk() != num)
+      continue;
+
+    return snprintf(buf, buf_sz, "%c:", 'A' + (char)num);
+  }
+  return 0;
+}
+
+
+#elif defined(CONFIG_AMIGA)
+
+#include <dos/dos.h>
+#include <dos/dosextens.h>
+#include <proto/dos.h>
+
+struct vvolumelist_handle
+{
+  struct DosList *dl;
+};
+
+static inline boolean platform_vvolumelist_open(struct vvolumelist_handle *vh)
+{
+  vh->dl = LockDosList(LDF_VOLUMES | LDF_READ);
+  return true;
+}
+
+static inline void platform_vvolumelist_close(struct vvolumelist_handle *vh)
+{
+  UnlockDosList(LDF_VOLUMES | LDF_READ);
+}
+
+static inline int platform_vvolumelist_read(struct vvolumelist_handle *vh,
+ char *buf, size_t buf_sz)
+{
+  while((vh->dl = NextDosEntry(vh->dl, LDF_VOLUMES)))
+  {
+    uint8_t *bname = (uint8_t *)BADDR(vh->dl->dol_Name);
+    int len = bname[0];
+
+    return snprintf(buf, buf_sz, "%*.*s:", len, len, (char *)bname + 1);
+  }
+  return 0;
+}
+
+
+#elif defined(CONFIG_WII)
+
+#include <sys/iosupport.h>
+
+struct vvolumelist_handle
+{
+  int pos;
+};
+
+static inline boolean platform_vvolumelist_open(struct vvolumelist_handle *vh)
+{
+  vh->pos = 0;
+  return true;
+}
+
+static inline void platform_vvolumelist_close(struct vvolumelist_handle *vh)
+{
+  /* nop */
+  (void)vh;
+}
+
+static inline int platform_vvolumelist_read(struct vvolumelist_handle *vh,
+ char *buf, size_t buf_sz)
+{
+  while(vh->pos < STD_MAX)
+  {
+    int num = (vh->pos++);
+
+    if(devoptab_list[num] && devoptab_list[num]->chdir_r)
+      return snprintf(buf, buf_sz, "%s:", devoptab_list[num]->name);
+  }
+  return 0;
+}
+
+
+#else /* Use a list of hardcoded roots. */
+
+static const char * const volume_list[] =
+{
+#if defined(CONFIG_PSVITA)
+  "app0:",
+  "imc0:",
+  "uma0:",
+  "ux0:"
+#else /* Normal POSIX--patch in / and nothing else. */
+  DIR_SEPARATOR
+#endif
+};
+
+struct vvolumelist_handle
+{
+  unsigned pos;
+};
+
+static inline boolean platform_vvolumelist_open(struct vvolumelist_handle *vh)
+{
+  vh->pos = 0;
+  return true;
+}
+
+static inline void platform_vvolumelist_close(struct vvolumelist_handle *vh)
+{
+  /* nop */
+  (void)vh;
+}
+
+static inline int platform_vvolumelist_read(struct vvolumelist_handle *vh,
+ char *buf, size_t buf_sz)
+{
+  while(vh->pos < ARRAY_SIZE(volume_list))
+  {
+    unsigned num = (vh->pos++);
+
+    return snprintf(buf, buf_sz, "%s", volume_list[num]);
+  }
+  return 0;
+}
+
+#endif
+
+__M_END_DECLS
+
+#endif /* __IO_VIO_VOLUME_H */

--- a/src/io/vio_win32.h
+++ b/src/io/vio_win32.h
@@ -1,6 +1,6 @@
 /* MegaZeux
  *
- * Copyright (C) 2018-2024 Alice Rowan <petrifiedrowan@gmail.com>
+ * Copyright (C) 2018-2026 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -336,6 +336,38 @@ static inline boolean platform_rewinddir(struct dir_handle dh)
 
   rewinddir(dh.dir);
   return true;
+}
+
+struct vvolumelist_handle
+{
+  DWORD drives;
+  DWORD pos;
+};
+
+static inline boolean platform_vvolumelist_open(struct vvolumelist_handle *vh)
+{
+  vh->drives = GetLogicalDrives();
+  vh->pos = 0;
+  return true;
+}
+
+static inline void platform_vvolumelist_close(struct vvolumelist_handle *vh)
+{
+  /* nop */
+  (void)vh;
+}
+
+static inline int platform_vvolumelist_read(struct vvolumelist_handle *vh,
+ char *buf, size_t buf_sz)
+{
+  while(vh->pos < 32)
+  {
+    DWORD num = (vh->pos++);
+
+    if(vh->drives & (1u << num))
+      return snprintf(buf, buf_sz, "%c:", 'A' + (char)num);
+  }
+  return 0;
 }
 
 static inline int platform_fseek(FILE *fp, int64_t offset, int whence)

--- a/src/window.c
+++ b/src/window.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 1996 Alexis Janson
  * Copyright (C) 2004 Gilead Kutnick <exophase@adelphia.net>
- * Copyright (C) 2012-2025 Alice Rowan <petrifiedrowan@gmail.com>
+ * Copyright (C) 2012-2026 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -29,16 +29,6 @@
 #include <sys/stat.h>
 #include <assert.h>
 
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
-
-#ifdef __WIN32__
-// Required for GetLogicalDrives()
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#endif
-
 #include "board.h"
 #include "configure.h" // TODO for help file only
 #include "const.h"
@@ -60,15 +50,6 @@
 #include "io/vio.h"
 
 #include "audio/sfx.h"
-
-#ifdef CONFIG_DJGPP
-// Required for getdisk()/setdisk()
-#include <dir.h>
-#endif
-
-#ifdef CONFIG_WII
-#include <sys/iosupport.h>
-#endif
 
 #ifdef CONFIG_NDS
 // Should be sufficient with a disabled editor.
@@ -3304,16 +3285,6 @@ static boolean remove_files(char *directory_name, boolean remove_recursively)
   return success;
 }
 
-#ifdef CONFIG_PSVITA
-static const char *psvita_drives[] = {
-  "app0:",
-  "imc0:",
-  "uma0:",
-  "ux0:"
-};
-#define PSVITA_DRIVES_COUNT 4
-#endif
-
 __editor_maybe_static int file_manager(struct world *mzx_world,
  const char *const *wildcards, const char *default_ext, char *ret,
  const char *title, enum allow_dirs allow_dirs, enum allow_new allow_new,
@@ -3345,10 +3316,6 @@ __editor_maybe_static int file_manager(struct world *mzx_world,
   int last_element = FILESEL_FILE_LIST;
   boolean return_dir_is_base_dir = true;
   int i;
-
-#ifdef __WIN32__
-  int drive_letter_bitmap;
-#endif
 
   // Buffers for the return file's path and name.
   char ret_path[MAX_PATH];
@@ -3511,18 +3478,26 @@ skip_dir:
     qsort(file_list, num_files, sizeof(char *), sort_function);
     qsort(dir_list, num_dirs, sizeof(char *), sort_function);
 
-#ifdef __WIN32__
     if(allow_dirs == ALLOW_ALL_DIRS)
     {
-      drive_letter_bitmap = GetLogicalDrives();
-
-      for(i = 0; i < 32; i++)
+      vvolumelist *volumes = vvolumelist_open();
+      if(volumes)
       {
-        if(drive_letter_bitmap & (1 << i))
-        {
-          dir_list[num_dirs] = cmalloc(3);
-          sprintf(dir_list[num_dirs], "%c:", 'A' + i);
+        const char *dir;
 
+        while((dir = vvolumelist_read(volumes)))
+        {
+          size_t sz = strlen(dir) + 1;
+
+          /* Strip out / for now. */
+          if(!strcmp(dir, DIR_SEPARATOR))
+            continue;
+
+          dir_list[num_dirs] = (char *)cmalloc(sz);
+          if(!dir_list[num_dirs])
+            break;
+
+          memcpy(dir_list[num_dirs], dir, sz);
           num_dirs++;
 
           if(num_dirs == total_dirnames_allocated)
@@ -3534,87 +3509,9 @@ skip_dir:
             total_dirnames_allocated *= 2;
           }
         }
+        vvolumelist_close(volumes);
       }
     }
-#endif
-
-#ifdef CONFIG_DJGPP
-    if(allow_dirs == ALLOW_ALL_DIRS)
-    {
-      int current_disk = getdisk();
-      int max_disk = setdisk(current_disk);
-      for(i = 0; i < max_disk; i++)
-      {
-        setdisk(i);
-        if(getdisk() != i)
-          continue;
-
-        dir_list[num_dirs] = cmalloc(3);
-        sprintf(dir_list[num_dirs], "%c:", 'A' + i);
-        num_dirs++;
-
-        if(num_dirs == total_dirnames_allocated)
-        {
-          dir_list = crealloc(dir_list, sizeof(char *) *
-           total_dirnames_allocated * 2);
-          memset(dir_list + total_dirnames_allocated, 0,
-           sizeof(char *) * total_dirnames_allocated);
-          total_dirnames_allocated *= 2;
-        }
-      }
-      setdisk(current_disk);
-    }
-#endif
-
-#ifdef CONFIG_WII
-    if(allow_dirs == ALLOW_ALL_DIRS)
-    {
-      for(i = 0; i < STD_MAX; i++)
-      {
-        if(devoptab_list[i] && devoptab_list[i]->chdir_r)
-        {
-          dir_list[num_dirs] = cmalloc(strlen(devoptab_list[i]->name) + 3);
-          sprintf(dir_list[num_dirs], "%s:/", devoptab_list[i]->name);
-
-          num_dirs++;
-
-          if(num_dirs == total_dirnames_allocated)
-          {
-            dir_list = crealloc(dir_list, sizeof(char *) *
-             total_dirnames_allocated * 2);
-            memset(dir_list + total_dirnames_allocated, 0,
-             sizeof(char *) * total_dirnames_allocated);
-            total_dirnames_allocated *= 2;
-          }
-        }
-      }
-    }
-#endif
-
-#ifdef CONFIG_PSVITA
-    if(allow_dirs == ALLOW_ALL_DIRS)
-    {
-      for(i = 0; i < PSVITA_DRIVES_COUNT; i++)
-      {
-        if(vstat(psvita_drives[i], &file_info) >= 0)
-        {
-          dir_list[num_dirs] = cmalloc(strlen(psvita_drives[i]) + 2);
-          sprintf(dir_list[num_dirs], "%s/", psvita_drives[i]);
-
-          num_dirs++;
-
-          if(num_dirs == total_dirnames_allocated)
-          {
-            dir_list = crealloc(dir_list, sizeof(char *) *
-             total_dirnames_allocated * 2);
-            memset(dir_list + total_dirnames_allocated, 0,
-             sizeof(char *) * total_dirnames_allocated);
-            total_dirnames_allocated *= 2;
-          }
-        }
-      }
-    }
-#endif
 
     current_dir_length = strlen(current_dir_name);
 

--- a/unit/io/vio.cpp
+++ b/unit/io/vio.cpp
@@ -1361,6 +1361,42 @@ UNITTEST(dirent)
   }
 }
 
+static constexpr const char *expected_real_roots[] =
+{
+#if defined(_WIN32) || defined(CONFIG_DJGPP)
+  /* The only guaranteed root for these is C: */
+  "C:",
+#elif defined(CONFIG_AMIGA)
+  "sys:",
+#else
+  DIR_SEPARATOR
+#endif
+};
+
+UNITTEST(vvolumelist)
+{
+  boolean found[arraysize(expected_real_roots)]{};
+
+  ScopedFile<vvolumelist, vvolumelist_close> volumes = vvolumelist_open();
+  const char *file;
+
+  ASSERT(volumes, "failed to open volume list");
+
+  while((file = vvolumelist_read(volumes)))
+  {
+    for(int i = 0; i < arraysize(expected_real_roots); i++)
+    {
+      if(!strcasecmp(file, expected_real_roots[i]))
+      {
+        ASSERT(!found[i], "root '%s' duplicated in volume list", expected_real_roots[i]);
+        found[i] = true;
+      }
+    }
+  }
+  for(int i = 0; i < arraysize(found); i++)
+    ASSERT(found[i], "root '%s' missing from volume list", expected_real_roots[i]);
+}
+
 
 /**********************************************************************
  * Virtual filesystem tests.
@@ -1846,6 +1882,14 @@ UNITTEST(VirtualFilesystem)
     ASSERT(dir2, "");
     while(vdir_read(dir2, buf, MAX_PATH, &type)) {}
     ASSERTEQ(vdir_tell(dir2), vdir_length(dir2), "");
+  }
+
+  SECTION(vvolumelist)
+  {
+    // Straightforward--if there are virtual roots, list them after the real
+    // roots. Do not list cached roots twice.
+    // TODO: there is no function to add roots to the vio VFS yet.
+    SKIP();
   }
 
   SECTION(DeleteOpenFile)


### PR DESCRIPTION
Adds an API similar to vdir for reading the system volume list. In addition to all of the platforms that were handled in window.c before, this also adds support for Amiga (untested) and POSIX (simply returns a hardcoded "/", which is filtered from the file manager for now).

It should be easy to add virtual roots to this function when/if vio.c gets support for them.