### PR TITLE
Minor tweaks for vvolumelist patch.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -15,6 +15,9 @@ USERS
   flood fill the player in the editor.
 + Fixed checkres testing of 2.90X through 2.92X worlds with
   custom sound effects tables.
++ Added file manager support for listing volumes on Amiga.
++ The file manager now correctly ignores rename/delete when used
+  on volumes in the directory list for Wii, PS Vita, and Amiga.
 
 DEVELOPERS
 

--- a/src/io/vio.c
+++ b/src/io/vio.c
@@ -2383,12 +2383,20 @@ static void vvolumelist_free(vvolumelist *volumes)
   free(volumes);
 }
 
+/**
+ * Open the system volume list for reading. This function will read the volume
+ * list in one go and allocate a copy to memory, as some platforms require
+ * locking the volume list (Amiga) or temporarily changing the disk (DOS).
+ * For most POSIX platforms, this list will consist of "/" and nothing else.
+ *
+ * @return an opaque volume list on success, otherwise NULL.
+ */
 vvolumelist *vvolumelist_open(void)
 {
   struct vvolumelist_handle vh;
   vvolumelist *ret;
   int sz;
-  char buf[MAX_PATH];
+  char buf[256]; /* Amiga BCPL strings max at 255, other platforms are less. */
 
   trace("--VIO-- vvolumelist_open\n");
 
@@ -2418,12 +2426,24 @@ err:
   return NULL;
 }
 
+/**
+ * Release resources associated with an opened system volume list and free it.
+ *
+ * @param volumes   system volume list to destroy.
+ * @return          0 on success.
+ */
 int vvolumelist_close(vvolumelist *volumes)
 {
   vvolumelist_free(volumes);
   return 0;
 }
 
+/**
+ * Get the next volume from an opened system volume list.
+ *
+ * @param volumes   system volume list to read.
+ * @return          the name of the next volume, or NULL (end of list).
+ */
 const char *vvolumelist_read(vvolumelist *volumes)
 {
   if(volumes->pos >= volumes->num_total)

--- a/src/io/vio_volume.h
+++ b/src/io/vio_volume.h
@@ -80,28 +80,42 @@ static inline int platform_vvolumelist_read(struct vvolumelist_handle *vh,
 struct vvolumelist_handle
 {
   struct DosList *dl;
+  size_t pos;
 };
 
 static inline boolean platform_vvolumelist_open(struct vvolumelist_handle *vh)
 {
   vh->dl = LockDosList(LDF_VOLUMES | LDF_READ);
+  vh->pos = 0;
   return true;
 }
 
 static inline void platform_vvolumelist_close(struct vvolumelist_handle *vh)
 {
-  UnlockDosList(LDF_VOLUMES | LDF_READ);
+  UnLockDosList(LDF_VOLUMES | LDF_READ);
 }
 
 static inline int platform_vvolumelist_read(struct vvolumelist_handle *vh,
  char *buf, size_t buf_sz)
 {
+  /* Patch in SYS: after the reported list. */
+  static const char * const extras[] =
+  {
+    "SYS"
+  };
+
   while((vh->dl = NextDosEntry(vh->dl, LDF_VOLUMES)))
   {
     uint8_t *bname = (uint8_t *)BADDR(vh->dl->dol_Name);
     int len = bname[0];
 
     return snprintf(buf, buf_sz, "%*.*s:", len, len, (char *)bname + 1);
+  }
+
+  while(vh->pos < ARRAY_SIZE(extras))
+  {
+    size_t num = (vh->pos++);
+    return snprintf(buf, buf_sz, "%s:", extras[num]);
   }
   return 0;
 }

--- a/src/window.c
+++ b/src/window.c
@@ -3315,6 +3315,7 @@ __editor_maybe_static int file_manager(struct world *mzx_world,
   int list_length = 17 - ext_height;
   int last_element = FILESEL_FILE_LIST;
   boolean return_dir_is_base_dir = true;
+  int volumes_pos;
   int i;
 
   // Buffers for the return file's path and name.
@@ -3478,6 +3479,7 @@ skip_dir:
     qsort(file_list, num_files, sizeof(char *), sort_function);
     qsort(dir_list, num_dirs, sizeof(char *), sort_function);
 
+    volumes_pos = num_dirs;
     if(allow_dirs == ALLOW_ALL_DIRS)
     {
       vvolumelist *volumes = vvolumelist_open();
@@ -3778,7 +3780,8 @@ skip_dir:
       case 6:
       {
         if(strcmp(dir_list[chosen_dir], "..") &&
-         strcmp(dir_list[chosen_dir], ".") && dir_list[chosen_dir][1] != ':')
+         strcmp(dir_list[chosen_dir], ".") &&
+         strcmp(dir_list[chosen_dir], "/") && chosen_dir < volumes_pos)
         {
           char confirm_string[70];
           snprintf(confirm_string, 70, "Delete %s: are you sure?",
@@ -3813,7 +3816,8 @@ skip_dir:
       case 7:
       {
         if(strcmp(dir_list[chosen_dir], "..") &&
-         strcmp(dir_list[chosen_dir], ".") && dir_list[chosen_dir][1] != ':')
+         strcmp(dir_list[chosen_dir], ".") &&
+         strcmp(dir_list[chosen_dir], "/") && chosen_dir < volumes_pos)
         {
           char *old_path = cmalloc(MAX_PATH);
           char *new_path = cmalloc(MAX_PATH);

--- a/unit/Makefile.in
+++ b/unit/Makefile.in
@@ -83,9 +83,11 @@ unit_objs += \
   ${unit_obj}/world${unit_ext}         \
 
 unit_ldflags += -L. -lcore
+${unit_objs}: ${core_target}
 
 ifneq (${BUILD_EDITOR},)
 unit_ldflags += -L. -leditor
+${unit_objs}: ${editor_target}
 endif
 
 ifneq (${BUILD_NETWORK},)


### PR DESCRIPTION
- File manager: reject directory list rename/delete for "/" (root for POSIX, parent for Amiga) and entries added after the dirent sort (always volumes).
- vvolumelist: fix UnLockDosList compilation on Amiga.
- vvolumelist: patch in "SYS:" on Amiga.
- vvolumelist: use a smaller buffer (largest possible is 255 via Amiga BCPL strings, everything else should be smaller).
- vvolumelist: add doc comments.