### PR TITLE
Do not use reserved identifiers for include guards/decl wrappers.

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -547,25 +547,25 @@ General format is:
 ```
 [GPL Copyright notice/license - see LICENSE]
 
-#ifndef __[YOUR FILE HERE]_H
-#define __[YOUR FILE HERE]_H
+#ifndef MEGAZEUX_[YOUR FILE HERE]_H
+#define MEGAZEUX_[YOUR FILE HERE]_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 [all other contents]
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __[YOUR FILE HERE]_H */
+#endif /* MEGAZEUX_[YOUR FILE HERE]_H */
 ```
 
 Notes:
 1) The GPL notice must be in every source file. See LICENSE for more information.
 2) Each header needs a unique include guard to ensure that it isn't included multiple times.
-3) `src/compat.h` defines some required compatibility macros, including `__M_BEGIN_DECLS`
-and `__M_END_DECLS`. These macros are used to provide portability when the MZX headers
+3) `src/compat.h` defines some required compatibility macros, including `MEGAZEUX_BEGIN_DECLS`
+and `MEGAZEUX_END_DECLS`. These macros are used to provide portability when the MZX headers
 are included in C++ files.
 4) Functions/structs/variables in these MUST be required elsewhere; otherwise, use static and
 put it in the C/CPP file!

--- a/src/about.h
+++ b/src/about.h
@@ -17,17 +17,17 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __ABOUT_H
-#define __ABOUT_H
+#ifndef MEGAZEUX_ABOUT_H
+#define MEGAZEUX_ABOUT_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "core.h"
 
 void about_megazeux(context *parent);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __ABOUT_H
+#endif /* MEGAZEUX_ABOUT_H */

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -18,14 +18,14 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-// Definitions for audio.c
+/* Audio subsystem externally visible functions. */
 
-#ifndef __AUDIO_H
-#define __AUDIO_H
+#ifndef MEGAZEUX_AUDIO_H
+#define MEGAZEUX_AUDIO_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #ifdef CONFIG_AUDIO
 
@@ -134,6 +134,6 @@ static inline int audio_legacy_translate(const char *path,
 
 #endif // CONFIG_AUDIO
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __AUDIO_H
+#endif /* MEGAZEUX_AUDIO_H */

--- a/src/audio/audio_mikmod.h
+++ b/src/audio/audio_mikmod.h
@@ -19,15 +19,15 @@
 
 /* Declarations */
 
-#ifndef __AUDIO_MIKMOD_H
-#define __AUDIO_MIKMOD_H
+#ifndef MEGAZEUX_AUDIO_MIKMOD_H
+#define MEGAZEUX_AUDIO_MIKMOD_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 void init_mikmod(struct config_info *conf);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif  // __AUDIO_MIKMOD_H
+#endif  /* MEGAZEUX_AUDIO_MIKMOD_H */

--- a/src/audio/audio_modplug.h
+++ b/src/audio/audio_modplug.h
@@ -19,15 +19,15 @@
 
 /* Declarations */
 
-#ifndef __AUDIO_MODPLUG_H
-#define __AUDIO_MODPLUG_H
+#ifndef MEGAZEUX_AUDIO_MODPLUG_H
+#define MEGAZEUX_AUDIO_MODPLUG_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 void init_modplug(struct config_info *conf);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif  // __AUDIO_MODPLUG_H
+#endif  /* MEGAZEUX_AUDIO_MODPLUG_H */

--- a/src/audio/audio_openmpt.h
+++ b/src/audio/audio_openmpt.h
@@ -19,15 +19,15 @@
 
 /* Declarations */
 
-#ifndef __AUDIO_OPENMPT_H
-#define __AUDIO_OPENMPT_H
+#ifndef MEGAZEUX_AUDIO_OPENMPT_H
+#define MEGAZEUX_AUDIO_OPENMPT_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 void init_openmpt(struct config_info *conf);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif  // __AUDIO_OPENMPT_H
+#endif  /* MEGAZEUX_AUDIO_OPENMPT_H */

--- a/src/audio/audio_pcs.h
+++ b/src/audio/audio_pcs.h
@@ -19,15 +19,15 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __AUDIO_PCS_H
-#define __AUDIO_PCS_H
+#ifndef MEGAZEUX_AUDIO_PCS_H
+#define MEGAZEUX_AUDIO_PCS_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 void init_pc_speaker(struct config_info *conf);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __AUDIO_PCS_H */
+#endif /* MEGAZEUX_AUDIO_PCS_H */

--- a/src/audio/audio_reality.h
+++ b/src/audio/audio_reality.h
@@ -17,15 +17,15 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __AUDIO_REALITY_H
-#define __AUDIO_REALITY_H
+#ifndef MEGAZEUX_AUDIO_REALITY_H
+#define MEGAZEUX_AUDIO_REALITY_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 void init_reality(struct config_info *conf);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif
+#endif /* MEGAZEUX_AUDIO_REALITY_H */

--- a/src/audio/audio_struct.h
+++ b/src/audio/audio_struct.h
@@ -18,12 +18,14 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __AUDIO_STRUCT_H
-#define __AUDIO_STRUCT_H
+/* Audio subsystem internal defines and types. */
+
+#ifndef MEGAZEUX_AUDIO_STRUCT_H
+#define MEGAZEUX_AUDIO_STRUCT_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <stdint.h>
 
@@ -142,6 +144,6 @@ struct audio
 
 extern struct audio audio;
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __AUDIO_STRUCT_H */
+#endif /* MEGAZEUX_AUDIO_STRUCT_H */

--- a/src/audio/audio_vorbis.h
+++ b/src/audio/audio_vorbis.h
@@ -17,15 +17,15 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __AUDIO_VORBIS_H
-#define __AUDIO_VORBIS_H
+#ifndef MEGAZEUX_AUDIO_VORBIS_H
+#define MEGAZEUX_AUDIO_VORBIS_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 void init_vorbis(struct config_info *conf);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __AUDIO_VORBIS_H */
+#endif /* MEGAZEUX_AUDIO_VORBIS_H */

--- a/src/audio/audio_wav.h
+++ b/src/audio/audio_wav.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __AUDIO_WAV_H
-#define __AUDIO_WAV_H
+#ifndef MEGAZEUX_AUDIO_WAV_H
+#define MEGAZEUX_AUDIO_WAV_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 // For use by audio_spot_sample.
 struct audio_stream *construct_wav_stream_direct(struct wav_info *w_info,
@@ -30,6 +30,6 @@ struct audio_stream *construct_wav_stream_direct(struct wav_info *w_info,
 
 void init_wav(struct config_info *conf);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __AUDIO_WAV_H */
+#endif /* MEGAZEUX_AUDIO_WAV_H */

--- a/src/audio/audio_xmp.h
+++ b/src/audio/audio_xmp.h
@@ -19,15 +19,15 @@
 
 /* Declarations */
 
-#ifndef __AUDIO_XMP_H
-#define __AUDIO_XMP_H
+#ifndef MEGAZEUX_AUDIO_XMP_H
+#define MEGAZEUX_AUDIO_XMP_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 void init_xmp(struct config_info *conf);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif  // __AUDIO_XMP_H
+#endif  /* MEGAZEUX_AUDIO_XMP_H */

--- a/src/audio/djgpp/audio_sb.h
+++ b/src/audio/djgpp/audio_sb.h
@@ -17,8 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __AUDIO_SB_H
-#define __AUDIO_SB_H
+#ifndef MEGAZEUX_AUDIO_SB_H
+#define MEGAZEUX_AUDIO_SB_H
 
 #define SB_VERSION_ATLEAST(cfg, ver) \
  (((cfg.version_major << 8) | (cfg.version_minor)) >= (ver))
@@ -58,4 +58,4 @@
 #define SB16_FORMAT_SIGNED        0x10
 #define SB16_FORMAT_STEREO        0x20
 
-#endif /* __AUDIO_SB_H */
+#endif /* MEGAZEUX_AUDIO_SB_H */

--- a/src/audio/ext.h
+++ b/src/audio/ext.h
@@ -19,12 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __AUDIO_EXT_H
-#define __AUDIO_EXT_H
+#ifndef MEGAZEUX_AUDIO_EXT_H
+#define MEGAZEUX_AUDIO_EXT_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "audio.h"
 #include "../io/vfile.h"
@@ -39,6 +39,6 @@ void audio_ext_free_registry(void);
 struct audio_stream *audio_ext_construct_stream(const char *filename,
  uint32_t frequency, unsigned int volume, boolean repeat);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __AUDIO_EXT_H */
+#endif /* MEGAZEUX_AUDIO_EXT_H */

--- a/src/audio/sampled_stream.h
+++ b/src/audio/sampled_stream.h
@@ -19,12 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __AUDIO_SAMPLED_STREAM_H
-#define __AUDIO_SAMPLED_STREAM_H
+#ifndef MEGAZEUX_AUDIO_SAMPLED_STREAM_H
+#define MEGAZEUX_AUDIO_SAMPLED_STREAM_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "audio_struct.h"
 
@@ -86,6 +86,6 @@ void initialize_sampled_stream(struct sampled_stream *s_src,
  struct sampled_stream_spec *s_spec, uint32_t input_frequency,
  uint32_t relative_frequency, uint32_t channels, boolean use_volume);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __AUDIO_SAMPLED_STREAM_H */
+#endif /* MEGAZEUX_AUDIO_SAMPLED_STREAM_H */

--- a/src/audio/sfx.h
+++ b/src/audio/sfx.h
@@ -17,14 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* Prototypes for SFX.CPP */
-
-#ifndef __AUDIO_SFX_H
-#define __AUDIO_SFX_H
+#ifndef MEGAZEUX_SFX_H
+#define MEGAZEUX_SFX_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 // Number of unique sound effects and length of sound effects
 // SFX sizes include the \0 terminator.
@@ -143,6 +141,6 @@ CORE_LIBSPEC size_t sfx_save_to_memory(const struct sfx_list *sfx_list,
 CORE_LIBSPEC boolean sfx_load_from_memory(struct sfx_list *sfx_list,
  int file_version, const char *src, size_t src_len);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __AUDIO_SFX_H
+#endif /* MEGAZEUX_SFX_H */

--- a/src/block.h
+++ b/src/block.h
@@ -19,12 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __BLOCK_H
-#define __BLOCK_H
+#ifndef MEGAZEUX_BLOCK_H
+#define MEGAZEUX_BLOCK_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "data.h"
 #include "world_struct.h"
@@ -61,6 +61,6 @@ CORE_LIBSPEC void move_board_block(struct world *mzx_world,
 
 #endif //CONFIG_EDITOR
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __BLOCK_H
+#endif /* MEGAZEUX_BLOCK_H */

--- a/src/board.h
+++ b/src/board.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __BOARD_H
-#define __BOARD_H
+#ifndef MEGAZEUX_BOARD_H
+#define MEGAZEUX_BOARD_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "world_struct.h"
 
@@ -57,6 +57,6 @@ CORE_LIBSPEC void board_set_palette_path(struct board *cur_board,
  const char *path, size_t path_len);
 #endif // CONFIG_EDITOR
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __BOARD_H
+#endif /* MEGAZEUX_BOARD_H */

--- a/src/board_struct.h
+++ b/src/board_struct.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __BOARD_STRUCT_H
-#define __BOARD_STRUCT_H
+#ifndef MEGAZEUX_BOARD_STRUCT_H
+#define MEGAZEUX_BOARD_STRUCT_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "robot_struct.h"
 
@@ -113,6 +113,6 @@ struct board
 #endif
 };
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __BOARD_STRUCT_H
+#endif /* MEGAZEUX_BOARD_STRUCT_H */

--- a/src/caption.h
+++ b/src/caption.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __CAPTION_H
-#define __CAPTION_H
+#ifndef MEGAZEUX_CAPTION_H
+#define MEGAZEUX_CAPTION_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "world_struct.h"
 
@@ -88,6 +88,6 @@ CORE_LIBSPEC void caption_set_updates_available(boolean available);
 void caption_set_fps(double fps);
 #endif
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __CAPTION_H
+#endif /* MEGAZEUX_CAPTION_H */

--- a/src/compat.h
+++ b/src/compat.h
@@ -19,15 +19,15 @@
 
 // Provide some compatibility macros for combined C/C++ binary
 
-#ifndef __COMPAT_H
-#define __COMPAT_H
+#ifndef MEGAZEUX_COMPAT_H
+#define MEGAZEUX_COMPAT_H
 
 #include "config.h"
 
 #ifdef __cplusplus
 
-#define __M_BEGIN_DECLS extern "C" {
-#define __M_END_DECLS   }
+#define MEGAZEUX_BEGIN_DECLS extern "C" {
+#define MEGAZEUX_END_DECLS   }
 
 /**
  * Compatibility define for restrict in C++, where it is a (commonly supported)
@@ -62,8 +62,8 @@
 
 #else
 
-#define __M_BEGIN_DECLS
-#define __M_END_DECLS
+#define MEGAZEUX_BEGIN_DECLS
+#define MEGAZEUX_END_DECLS
 
 #if !defined(CONFIG_WII) && !defined(CONFIG_NDS) && !defined(CONFIG_3DS) && \
  !defined(CONFIG_DREAMCAST)
@@ -212,7 +212,7 @@ typedef unsigned char boolean;
 #define UPDATER_LIBSPEC
 #endif
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #ifdef __GNUC__
 
@@ -314,6 +314,6 @@ static inline void *crealloc(void *ptr, size_t size)
 
 #endif /* CONFIG_CHECK_ALLOC */
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __COMPAT_H
+#endif /* MEGAZEUX_COMPAT_H */

--- a/src/configure.h
+++ b/src/configure.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __CONFIGURE_H
-#define __CONFIGURE_H
+#ifndef MEGAZEUX_CONFIGURE_H
+#define MEGAZEUX_CONFIGURE_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <stdint.h>
 
@@ -239,6 +239,6 @@ CORE_LIBSPEC boolean _config_string(char *dest, size_t dest_len, const char *val
 
 #endif // CONFIG_EDITOR
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __CONFIGURE_H
+#endif /* MEGAZEUX_CONFIGURE_H */

--- a/src/const.h
+++ b/src/const.h
@@ -20,12 +20,12 @@
  */
 
 /* Constants */
-#ifndef __CONST_H
-#define __CONST_H
+#ifndef MEGAZEUX_CONST_H
+#define MEGAZEUX_CONST_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 enum
 {
@@ -124,6 +124,6 @@ enum
 
 #define ROBOT_MAX_TR 512
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __CONST_H
+#endif /* MEGAZEUX_CONST_H */

--- a/src/core.h
+++ b/src/core.h
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __CORE_H
-#define __CORE_H
+#ifndef MEGAZEUX_CORE_H
+#define MEGAZEUX_CORE_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "world_struct.h"
 
@@ -303,6 +303,6 @@ CORE_LIBSPEC extern void (*debug_robot_reset)(struct world *mzx_world);
 CORE_LIBSPEC extern boolean (*check_for_updates)(context *ctx,
  boolean is_automatic);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __CORE_H */
+#endif /* MEGAZEUX_CORE_H */

--- a/src/core_task.h
+++ b/src/core_task.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __CORE_TASK_H
-#define __CORE_TASK_H
+#ifndef MEGAZEUX_CORE_TASK_H
+#define MEGAZEUX_CORE_TASK_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "core.h"
 
@@ -33,6 +33,6 @@ CORE_LIBSPEC void core_task_context(context *parent, const char *title,
  boolean (*task_callback)(context *ctx, void *priv),
  void (*task_complete)(void *priv, boolean ret), void *priv);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __CORE_TASK_H */
+#endif /* MEGAZEUX_CORE_TASK_H */

--- a/src/counter.h
+++ b/src/counter.h
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __COUNTER_H
-#define __COUNTER_H
+#ifndef MEGAZEUX_COUNTER_H
+#define MEGAZEUX_COUNTER_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "counter_struct.h"
 #include "world_struct.h"
@@ -63,6 +63,6 @@ void clear_counter_list(struct counter_list *counter_list);
 // Even old games tended to use at least this many.
 #define MIN_COUNTER_ALLOCATE 32
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __COUNTER_H
+#endif /* MEGAZEUX_COUNTER_H */

--- a/src/counter_struct.h
+++ b/src/counter_struct.h
@@ -19,12 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __COUNTER_STRUCT_H
-#define __COUNTER_STRUCT_H
+#ifndef MEGAZEUX_COUNTER_STRUCT_H
+#define MEGAZEUX_COUNTER_STRUCT_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <inttypes.h>
 
@@ -139,6 +139,6 @@ enum special_counter_return
   FOPEN_SAVE_BC
 };
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __COUNTER_STRUCT_H
+#endif /* MEGAZEUX_COUNTER_STRUCT_H */

--- a/src/data.h
+++ b/src/data.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __DATA_H
-#define __DATA_H
+#ifndef MEGAZEUX_DATA_H
+#define MEGAZEUX_DATA_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "const.h"
 #include <stdio.h>
@@ -594,6 +594,6 @@ enum robot_command_name
   ROBOTIC_CMD_ENABLE_MESG_EDGE                          = 255
 };
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __DATA_H
+#endif /* MEGAZEUX_DATA_H */

--- a/src/editor/ansi.h
+++ b/src/editor/ansi.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#ifndef __EDITOR_ANSI_H
-#define __EDITOR_ANSI_H
+#ifndef MEGAZEUX_EDITOR_ANSI_H
+#define MEGAZEUX_EDITOR_ANSI_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "edit.h"
 
@@ -36,6 +36,6 @@ boolean export_ansi(struct world *mzx_world, const char *filename,
  enum editor_mode mode, int start_x, int start_y, int width, int height,
  boolean text_only, boolean doorway_mode, const char *title, const char *author);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __EDITOR_ANSI_H */
+#endif /* MEGAZEUX_EDITOR_ANSI_H */

--- a/src/editor/block.h
+++ b/src/editor/block.h
@@ -19,12 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EDITOR_BLOCK_H
-#define __EDITOR_BLOCK_H
+#ifndef MEGAZEUX_EDITOR_BLOCK_H
+#define MEGAZEUX_EDITOR_BLOCK_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../world_struct.h"
 #include "edit.h"
@@ -75,6 +75,6 @@ boolean select_block_command(struct world *mzx_world, struct block_info *block,
  enum editor_mode mode);
 enum thing layer_to_board_object_type(struct world *mzx_world);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif  // __EDITOR_BLOCK_H
+#endif  /* MEGAZEUX_EDITOR_BLOCK_H */

--- a/src/editor/board.h
+++ b/src/editor/board.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EDITOR_BOARD_H
-#define __EDITOR_BOARD_H
+#ifndef MEGAZEUX_EDITOR_BOARD_H
+#define MEGAZEUX_EDITOR_BOARD_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../world_struct.h"
 
@@ -34,6 +34,6 @@ struct board *create_buffer_board(int width, int height);
 void save_board_file(struct world *mzx_world, struct board *cur_board, const char *name);
 void change_board_size(struct board *src_board, int new_width, int new_height);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_BOARD_H
+#endif /* MEGAZEUX_EDITOR_BOARD_H */

--- a/src/editor/buffer.h
+++ b/src/editor/buffer.h
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EDITOR_BUFFER_H
-#define __EDITOR_BUFFER_H
+#ifndef MEGAZEUX_EDITOR_BUFFER_H
+#define MEGAZEUX_EDITOR_BUFFER_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../core.h"
 #include "../world_struct.h"
@@ -59,6 +59,6 @@ void thing_menu(context *parent, enum thing_menu_id menu_number,
  struct buffer_info *buffer, boolean use_default_color, int x, int y,
  struct undo_history *history);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __EDITOR_BUFFER_H */
+#endif /* MEGAZEUX_EDITOR_BUFFER_H */

--- a/src/editor/buffer_struct.h
+++ b/src/editor/buffer_struct.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EDITOR_BUFFER_STRUCT_H
-#define __EDITOR_BUFFER_STRUCT_H
+#ifndef MEGAZEUX_EDITOR_BUFFER_STRUCT_H
+#define MEGAZEUX_EDITOR_BUFFER_STRUCT_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../data.h"
 #include "../robot_struct.h"
@@ -37,6 +37,6 @@ struct buffer_info
   int param;
 };
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __EDITOR_BUFFER_STRUCT_H */
+#endif /* MEGAZEUX_EDITOR_BUFFER_STRUCT_H */

--- a/src/editor/char_ed.h
+++ b/src/editor/char_ed.h
@@ -20,17 +20,17 @@
 
 // Declaration
 
-#ifndef __EDITOR_CHAR_ED_H
-#define __EDITOR_CHAR_ED_H
+#ifndef MEGAZEUX_EDITOR_CHAR_ED_H
+#define MEGAZEUX_EDITOR_CHAR_ED_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../world_struct.h"
 
 int char_editor(struct world *mzx_world);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_CHAR_ED_H
+#endif /* MEGAZEUX_EDITOR_CHAR_ED_H */

--- a/src/editor/configure.h
+++ b/src/editor/configure.h
@@ -18,13 +18,13 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EDITOR_CONFIGURE_H
-#define __EDITOR_CONFIGURE_H
+#ifndef MEGAZEUX_EDITOR_CONFIGURE_H
+#define MEGAZEUX_EDITOR_CONFIGURE_H
 
 #include "../compat.h"
 #include "../const.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "macro.h"
 
@@ -144,6 +144,6 @@ size_t get_local_editor_config_name(char *dest, size_t dest_len,
 void save_local_editor_config(struct editor_config_info *conf,
  const char *mzx_file_path);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_CONFIGURE_H
+#endif /* MEGAZEUX_EDITOR_CONFIGURE_H */

--- a/src/editor/debug.h
+++ b/src/editor/debug.h
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __DEBUG_H
-#define __DEBUG_H
+#ifndef MEGAZEUX_DEBUG_H
+#define MEGAZEUX_DEBUG_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../core.h"
 
@@ -33,6 +33,6 @@ void __debug_counters(context *ctx);
 void __draw_debug_box(struct world *mzx_world, int x, int y, int d_x, int d_y,
  int show_keys);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __DEBUG_H
+#endif /* MEGAZEUX_DEBUG_H */

--- a/src/editor/edit.h
+++ b/src/editor/edit.h
@@ -17,14 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* Declarations for EDIT.CPP */
-
-#ifndef __EDITOR_EDIT_H
-#define __EDITOR_EDIT_H
+#ifndef MEGAZEUX_EDITOR_EDIT_H
+#define MEGAZEUX_EDITOR_EDIT_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../world_struct.h"
 
@@ -67,6 +65,6 @@ EDITOR_LIBSPEC boolean is_editor(void);
 #define EC_DEFAULT_COLOR      28
 #define EC_NA_FILL            1
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_EDIT_H
+#endif /* MEGAZEUX_EDITOR_EDIT_H */

--- a/src/editor/edit_di.h
+++ b/src/editor/edit_di.h
@@ -17,14 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-//EDIT_DI.CPP prototypes
-
-#ifndef __EDITOR_EDIT_DI_H
-#define __EDITOR_EDIT_DI_H
+#ifndef MEGAZEUX_EDITOR_EDIT_DI_H
+#define MEGAZEUX_EDITOR_EDIT_DI_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../core.h"
 #include "../window.h"
@@ -39,6 +37,6 @@ int size_pos_vlayer(struct world *mzx_world);
 void set_confirm_buttons(struct element **elements);
 void status_counter_info(struct world *mzx_world);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_EDIT_DI_H
+#endif /* MEGAZEUX_EDITOR_EDIT_DI_H */

--- a/src/editor/edit_export.h
+++ b/src/editor/edit_export.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EDITOR_EDIT_EXPORT_H
-#define __EDITOR_EDIT_EXPORT_H
+#ifndef MEGAZEUX_EDITOR_EDIT_EXPORT_H
+#define MEGAZEUX_EDITOR_EDIT_EXPORT_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../core.h"
 
@@ -31,6 +31,6 @@ void export_board_image(context *parent, struct board *src_board,
 void export_vlayer_image(context *parent, struct world *mzx_world,
  const char *file);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __EDITOR_EDIT_EXPORT_H */
+#endif /* MEGAZEUX_EDITOR_EDIT_EXPORT_H */

--- a/src/editor/edit_menu.h
+++ b/src/editor/edit_menu.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EDITOR_EDIT_MENU_H
-#define __EDITOR_EDIT_MENU_H
+#ifndef MEGAZEUX_EDITOR_EDIT_MENU_H
+#define MEGAZEUX_EDITOR_EDIT_MENU_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../core.h"
 #include "buffer_struct.h"
@@ -36,6 +36,6 @@ void update_edit_menu(subcontext *ctx, enum editor_mode mode,
 void edit_menu_show_board_mod(subcontext *ctx);
 void edit_menu_show_robot_memory(subcontext *ctx);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_EDIT_MENU_H
+#endif /* MEGAZEUX_EDITOR_EDIT_MENU_H */

--- a/src/editor/fill.h
+++ b/src/editor/fill.h
@@ -17,14 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* Declaration for FILL.CPP */
-
-#ifndef __EDITOR_FILL_H
-#define __EDITOR_FILL_H
+#ifndef MEGAZEUX_EDITOR_FILL_H
+#define MEGAZEUX_EDITOR_FILL_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "buffer.h"
 #include "edit.h"
@@ -35,6 +33,6 @@ __M_BEGIN_DECLS
 void fill_area(struct world *mzx_world, struct buffer_info *buffer,
  int x, int y, enum editor_mode mode, struct undo_history *history);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_FILL_H
+#endif /* MEGAZEUX_EDITOR_FILL_H */

--- a/src/editor/graphics.h
+++ b/src/editor/graphics.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EDITOR_GRAPHICS_H
-#define __EDITOR_GRAPHICS_H
+#ifndef MEGAZEUX_EDITOR_GRAPHICS_H
+#define MEGAZEUX_EDITOR_GRAPHICS_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../graphics.h"
 
@@ -48,6 +48,6 @@ void ec_load_char_ascii(uint16_t char_number);
 void ec_load_char_mzx(uint16_t char_number);
 unsigned int compare_char(uint16_t chr_a, uint16_t chr_b);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_GRAPHICS_H
+#endif /* MEGAZEUX_EDITOR_GRAPHICS_H */

--- a/src/editor/macro.h
+++ b/src/editor/macro.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EDITOR_MACRO_H
-#define __EDITOR_MACRO_H
+#ifndef MEGAZEUX_EDITOR_MACRO_H
+#define MEGAZEUX_EDITOR_MACRO_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 struct ext_macro;
 struct macro_type;
@@ -41,6 +41,6 @@ char *skip_whitespace(char *src);
 char *skip_to_next(char *src, char t, char a, char b);
 #endif
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_MACRO_H
+#endif /* MEGAZEUX_EDITOR_MACRO_H */

--- a/src/editor/macro_struct.h
+++ b/src/editor/macro_struct.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EDITOR_MACRO_STRUCT_H
-#define __EDITOR_MACRO_STRUCT_H
+#ifndef MEGAZEUX_EDITOR_MACRO_STRUCT_H
+#define MEGAZEUX_EDITOR_MACRO_STRUCT_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 enum variable_type
 {
@@ -81,6 +81,6 @@ struct ext_macro
   char *text;
 };
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_MACRO_STRUCT_H
+#endif /* MEGAZEUX_EDITOR_MACRO_STRUCT_H */

--- a/src/editor/pal_ed.h
+++ b/src/editor/pal_ed.h
@@ -17,14 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* Declaration for PAL_ED.CPP */
-
-#ifndef __EDITOR_PAL_ED_H
-#define __EDITOR_PAL_ED_H
+#ifndef MEGAZEUX_EDITOR_PAL_ED_H
+#define MEGAZEUX_EDITOR_PAL_ED_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../core.h"
 
@@ -32,6 +30,6 @@ void palette_editor(context *parent);
 void import_palette(context *ctx);
 void export_palette(context *ctx);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_PAL_ED_H
+#endif /* MEGAZEUX_EDITOR_PAL_ED_H */

--- a/src/editor/param.h
+++ b/src/editor/param.h
@@ -17,14 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/* Declarations for PARAM.CPP */
-
-#ifndef __EDITOR_PARAM_H
-#define __EDITOR_PARAM_H
+#ifndef MEGAZEUX_EDITOR_PARAM_H
+#define MEGAZEUX_EDITOR_PARAM_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../core.h"
 
@@ -34,6 +32,6 @@ int edit_sensor(struct world *mzx_world, struct sensor *cur_sensor);
 void edit_robot(context *ctx, struct robot *cur_robot, int *ret_value);
 void edit_global_robot(context *ctx);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_PARAM_H
+#endif /* MEGAZEUX_EDITOR_PARAM_H */

--- a/src/editor/robo_debug.h
+++ b/src/editor/robo_debug.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EDITOR_ROBO_DEBUG_H
-#define __EDITOR_ROBO_DEBUG_H
+#ifndef MEGAZEUX_EDITOR_ROBO_DEBUG_H
+#define MEGAZEUX_EDITOR_ROBO_DEBUG_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../core.h"
 
@@ -38,6 +38,6 @@ EDITOR_LIBSPEC void free_breakpoints(void);
 
 void update_watchpoint_last_values(struct world *mzx_world);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_ROBO_DEBUG_H
+#endif /* MEGAZEUX_EDITOR_ROBO_DEBUG_H */

--- a/src/editor/robo_ed.h
+++ b/src/editor/robo_ed.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EDITOR_ROBO_ED_H
-#define __EDITOR_ROBO_ED_H
+#ifndef MEGAZEUX_EDITOR_ROBO_ED_H
+#define MEGAZEUX_EDITOR_ROBO_ED_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../core.h"
 #include "../intake.h"
@@ -133,6 +133,6 @@ void robo_ed_goto_line(struct robot_editor_context *rstate, int line, int column
 void robo_ed_delete_current_line(struct robot_editor_context *rstate, int move);
 void robo_ed_add_line(struct robot_editor_context *rstate, char *value, int relation);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_ROBO_ED_H
+#endif /* MEGAZEUX_EDITOR_ROBO_ED_H */

--- a/src/editor/robot.h
+++ b/src/editor/robot.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EDITOR_ROBOT_H
-#define __EDITOR_ROBOT_H
+#ifndef MEGAZEUX_EDITOR_ROBOT_H
+#define MEGAZEUX_EDITOR_ROBOT_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../world_struct.h"
 
@@ -72,6 +72,6 @@ static inline void replace_robot_source(struct world *mzx_world,
 void prepare_robot_source(struct robot *cur_robot);
 #endif
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_ROBOT_H
+#endif /* MEGAZEUX_EDITOR_ROBOT_H */

--- a/src/editor/select.h
+++ b/src/editor/select.h
@@ -19,12 +19,12 @@
 
 /* Declarations */
 
-#ifndef __EDITOR_SELECT_H
-#define __EDITOR_SELECT_H
+#ifndef MEGAZEUX_EDITOR_SELECT_H
+#define MEGAZEUX_EDITOR_SELECT_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../world_struct.h"
 
@@ -33,6 +33,6 @@ int choose_char_set(struct world *mzx_world);
 int export_type(struct world *mzx_world);
 int import_type(struct world *mzx_world);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif  // __EDITOR_BLOCK_H
+#endif  /* MEGAZEUX_EDITOR_SELECT_H */

--- a/src/editor/sfx_edit.h
+++ b/src/editor/sfx_edit.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EDITOR_SFX_EDIT_H
-#define __EDITOR_SFX_EDIT_H
+#ifndef MEGAZEUX_EDITOR_SFX_EDIT_H
+#define MEGAZEUX_EDITOR_SFX_EDIT_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../core.h"
 
@@ -31,6 +31,6 @@ void sfx_edit(struct world *mzx_world);
 void import_sfx(context *parent, boolean *modified);
 void export_sfx(context *parent);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_SFX_EDIT_H
+#endif /* MEGAZEUX_EDITOR_SFX_EDIT_H */

--- a/src/editor/stringsearch.h
+++ b/src/editor/stringsearch.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EDITOR_STRINGSEARCH_H
-#define __EDITOR_STRINGSEARCH_H
+#ifndef MEGAZEUX_EDITOR_STRINGSEARCH_H
+#define MEGAZEUX_EDITOR_STRINGSEARCH_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <stddef.h>
 
@@ -41,6 +41,6 @@ const void *string_search(const void *A, const size_t a_len,
  const void *B, const size_t b_len, const struct string_search_data *data,
  boolean ignore_case);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __EDITOR_STRINGSEARCH_H */
+#endif /* MEGAZEUX_EDITOR_STRINGSEARCH_H */

--- a/src/editor/undo.h
+++ b/src/editor/undo.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EDITOR_UNDO_H
-#define __EDITOR_UNDO_H
+#ifndef MEGAZEUX_EDITOR_UNDO_H
+#define MEGAZEUX_EDITOR_UNDO_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../world_struct.h"
 #include "buffer_struct.h"
@@ -71,6 +71,6 @@ void add_robot_editor_undo_line(struct undo_history *h, enum text_undo_line_type
  int line, int pos, char *value, size_t length);
 enum text_undo_line_type robot_editor_undo_frame_type(struct undo_history *h);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_UNDO_H
+#endif /* MEGAZEUX_EDITOR_UNDO_H */

--- a/src/editor/window.h
+++ b/src/editor/window.h
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EDITOR_WINDOW_H
-#define __EDITOR_WINDOW_H
+#ifndef MEGAZEUX_EDITOR_WINDOW_H
+#define MEGAZEUX_EDITOR_WINDOW_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../window.h"
 #include "../world_struct.h"
@@ -55,6 +55,6 @@ int choose_board(struct world *mzx_world, int current, const char *title,
 int choose_file(struct world *mzx_world, const char *const *wildcards,
  char *ret, const char *title, enum allow_dirs allow_dirs);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_WINDOW_H
+#endif /* MEGAZEUX_EDITOR_WINDOW_H */

--- a/src/editor/world.h
+++ b/src/editor/world.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EDITOR_WORLD_H
-#define __EDITOR_WORLD_H
+#ifndef MEGAZEUX_EDITOR_WORLD_H
+#define MEGAZEUX_EDITOR_WORLD_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../world_struct.h"
 
@@ -34,6 +34,6 @@ void move_current_board(struct world *mzx_world, int new_position);
 
 char get_default_id_char(int id);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_WORLD_H
+#endif /* MEGAZEUX_EDITOR_WORLD_H */

--- a/src/error.h
+++ b/src/error.h
@@ -19,8 +19,8 @@
 
 /* Declaration for ERROR.CPP */
 
-#ifndef __ERROR_H
-#define __ERROR_H
+#ifndef MEGAZEUX_ERROR_H
+#define MEGAZEUX_ERROR_H
 
 #include "compat.h"
 
@@ -31,7 +31,7 @@
 #define ERROR_OPT_NO_HELP  16
 #define ERROR_OPT_SUPPRESS 32
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 enum error_type
 {
@@ -117,6 +117,6 @@ CORE_LIBSPEC void set_error_suppression(enum error_code id, boolean enable);
 int get_and_reset_error_count(void);
 void reset_error_suppression(void);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __ERROR_H
+#endif /* MEGAZEUX_ERROR_H */

--- a/src/event/3ds/event_3ds.h
+++ b/src/event/3ds/event_3ds.h
@@ -19,12 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __3DS_EVENT_H__
-#define __3DS_EVENT_H__
+#ifndef MEGAZEUX_EVENT_3DS_H
+#define MEGAZEUX_EVENT_3DS_H
 
 #include "../../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 enum bottom_screen_mode
 {
@@ -44,6 +44,6 @@ enum bottom_screen_mode get_bottom_screen_mode(void);
 enum focus_mode get_allow_focus_changes(void);
 int ctr_get_subscreen_height(void);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __3DS_EVENT_H__ */
+#endif /* MEGAZEUX_EVENT_3DS_H */

--- a/src/event/3ds/keyboard.h
+++ b/src/event/3ds/keyboard.h
@@ -19,12 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __3DS_KEYBOARD_H__
-#define __3DS_KEYBOARD_H__
+#ifndef MEGAZEUX_KEYBOARD_3DS_H
+#define MEGAZEUX_KEYBOARD_3DS_H
 
 #include "../../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../event.h"
 
@@ -42,6 +42,6 @@ void ctr_keyboard_draw(struct ctr_render_data *render_data);
 boolean ctr_keyboard_update(struct buffered_status *status);
 boolean ctr_keyboard_force_zoom_out(void);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __3DS_KEYBOARD_H__ */
+#endif /* MEGAZEUX_KEYBOARD_3DS_H */

--- a/src/event/event.h
+++ b/src/event/event.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EVENT_H
-#define __EVENT_H
+#ifndef MEGAZEUX_EVENT_H
+#define MEGAZEUX_EVENT_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "keysym.h"
 
@@ -276,6 +276,6 @@ void joystick_clear(struct buffered_status *status, int joystick);
 boolean joystick_is_active(int joystick, boolean *is_active);
 boolean joystick_get_status(int joystick, char *name, int16_t *value);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EVENT_H
+#endif /* MEGAZEUX_EVENT_H */

--- a/src/event/keysym.h
+++ b/src/event/keysym.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __KEYSYM_H
-#define __KEYSYM_H
+#ifndef MEGAZEUX_KEYSYM_H
+#define MEGAZEUX_KEYSYM_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 enum keycode
 {
@@ -207,6 +207,6 @@ enum joystick_hat
   NUM_JOYSTICK_HAT_DIRS
 };
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __KEYSYM_H
+#endif /* MEGAZEUX_KEYSYM_H */

--- a/src/event/nds/event_nds.h
+++ b/src/event/nds/event_nds.h
@@ -19,12 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __NDS_EVENT_H__
-#define __NDS_EVENT_H__
+#ifndef MEGAZEUX_EVENT_NDS_H
+#define MEGAZEUX_EVENT_NDS_H
 
 #include "../../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 enum focus_mode
 {
@@ -35,6 +35,6 @@ enum focus_mode
 
 enum focus_mode get_allow_focus_changes(void);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __NDS_EVENT_H__ */
+#endif /* MEGAZEUX_EVENT_NDS_H */

--- a/src/event/nds/evq.h
+++ b/src/event/nds/evq.h
@@ -20,12 +20,12 @@
 
 /* Simple event queue for NDS input events */
 
-#ifndef __ARCH_NDS_EVQ_H
-#define __ARCH_NDS_EVQ_H
+#ifndef MEGAZEUX_EVENT_NDS_EVQ_H
+#define MEGAZEUX_EVENT_NDS_EVQ_H
 
 #include "../../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 enum NDSEventType
 {
@@ -71,6 +71,6 @@ void nds_event_fill_touch_down(NDSEvent *dest);
 void nds_event_fill_touch_move(NDSEvent *dest, int x, int y);
 void nds_event_fill_touch_up(NDSEvent *dest);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __ARCH_NDS_EVQ_H */
+#endif /* MEGAZEUX_EVENT_NDS_EVQ_H */

--- a/src/expr.h
+++ b/src/expr.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EXPR_H
-#define __EXPR_H
+#ifndef MEGAZEUX_EXPR_H
+#define MEGAZEUX_EXPR_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <limits.h>
 #include <stddef.h>
@@ -142,6 +142,6 @@ static inline char *tr_int_to_hex_string(char dest[9], int value, size_t *len)
   return pos;
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EXPR_H
+#endif /* MEGAZEUX_EXPR_H */

--- a/src/extmem.h
+++ b/src/extmem.h
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __EXTMEM_H
-#define __EXTMEM_H
+#ifndef MEGAZEUX_EXTMEM_H
+#define MEGAZEUX_EXTMEM_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "board_struct.h"
 #include "world_struct.h"
@@ -104,6 +104,6 @@ static inline void real_set_current_board_ext(struct world *mzx_world,
   }
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __BOARD_H
+#endif /* MEGAZEUX_EXTMEM_H */

--- a/src/game.h
+++ b/src/game.h
@@ -21,12 +21,12 @@
 
 /* Declarations for GAME.CPP */
 
-#ifndef __GAME_H
-#define __GAME_H
+#ifndef MEGAZEUX_GAME_H
+#define MEGAZEUX_GAME_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "core.h"
 #include "world_struct.h"
@@ -43,6 +43,6 @@ void draw_intro_mesg(struct world *mzx_world);
 CORE_LIBSPEC void play_game(context *parent, boolean *_fade_in);
 #endif
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __GAME_H
+#endif /* MEGAZEUX_GAME_H */

--- a/src/game_menu.h
+++ b/src/game_menu.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __GAME_MENU_H
-#define __GAME_MENU_H
+#ifndef MEGAZEUX_GAME_MENU_H
+#define MEGAZEUX_GAME_MENU_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "core.h"
 #include "event/keysym.h"
@@ -41,6 +41,6 @@ void game_menu(context *parent, boolean start_selected, enum keycode *retval,
  boolean *retval_alt);
 void main_menu(context *parent, boolean start_selected, enum keycode *retval);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __GAME_MENU_H
+#endif /* MEGAZEUX_GAME_MENU_H */

--- a/src/game_ops.h
+++ b/src/game_ops.h
@@ -19,12 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __GAME_OPS_H
-#define __GAME_OPS_H
+#ifndef MEGAZEUX_GAME_OPS_H
+#define MEGAZEUX_GAME_OPS_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "data.h"
 #include "world_struct.h"
@@ -83,6 +83,6 @@ static inline int xy_shift_dir(struct board *src_board, int x, int y,
   return 0;
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __GAME_OPS_H
+#endif /* MEGAZEUX_GAME_OPS_H */

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -20,12 +20,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __GAME_PLAYER_H
-#define __GAME_PLAYER_H
+#ifndef MEGAZEUX_GAME_PLAYER_H
+#define MEGAZEUX_GAME_PLAYER_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "world_struct.h"
 
@@ -46,6 +46,6 @@ void grab_item(struct world *mzx_world, int item_x, int item_y, int src_dir);
 void move_player(struct world *mzx_world, int dir);
 void entrance(struct world *mzx_world, int x, int y);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __GAME_PLAYER_H
+#endif /* MEGAZEUX_GAME_PLAYER_H */

--- a/src/game_update.h
+++ b/src/game_update.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __GAME_UPDATE_H
-#define __GAME_UPDATE_H
+#ifndef MEGAZEUX_GAME_UPDATE_H
+#define MEGAZEUX_GAME_UPDATE_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "core.h"
 
@@ -36,6 +36,6 @@ boolean draw_world(context *ctx, boolean is_title);
 boolean update_resolve_target(struct world *mzx_world,
  boolean *fade_in_next_cycle);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __GAME_UPDATE_H
+#endif /* MEGAZEUX_GAME_UPDATE_H */

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __GRAPHICS_H
-#define __GRAPHICS_H
+#ifndef MEGAZEUX_GRAPHICS_H
+#define MEGAZEUX_GRAPHICS_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <stdint.h>
 
@@ -400,6 +400,6 @@ CORE_LIBSPEC boolean dump_layer_to_image(const char *filename,
 void dump_screen(void);
 #endif
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __GRAPHICS_H
+#endif /* MEGAZEUX_GRAPHICS_H */

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -47,12 +47,12 @@
  * See contrib/khash.h for the original example and changelog from this file.
  */
 
-#ifndef __HASHTABLE_H
-#define __HASHTABLE_H
+#ifndef MEGAZEUX_HASHTABLE_H
+#define MEGAZEUX_HASHTABLE_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <stddef.h>
 #include <stdint.h>
@@ -721,6 +721,6 @@ static inline uint32_t fnv_1a_hash_string_len(const void *_str, uint32_t len)
     (size) = 0;                                                   \
 } while(0)
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __HASHTABLE_H */
+#endif /* MEGAZEUX_HASHTABLE_H */

--- a/src/helpsys.h
+++ b/src/helpsys.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __HELPSYS_H
-#define __HELPSYS_H
+#ifndef MEGAZEUX_HELPSYS_H
+#define MEGAZEUX_HELPSYS_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #ifdef CONFIG_HELPSYS
 
@@ -35,6 +35,6 @@ CORE_LIBSPEC void help_system(context *ctx, struct world *mzx_world);
 
 #endif
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __HELPSYS_H
+#endif /* MEGAZEUX_HELPSYS_H */

--- a/src/idarray.h
+++ b/src/idarray.h
@@ -19,12 +19,12 @@
 
 /* Declarations for IDARRAY.ASM */
 
-#ifndef __IDARRAY_H
-#define __IDARRAY_H
+#ifndef MEGAZEUX_IDARRAY_H
+#define MEGAZEUX_IDARRAY_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "data.h"
 #include "world_struct.h"
@@ -39,6 +39,6 @@ void offs_place_id(struct world *mzx_world, unsigned int offset,
 void offs_remove_id(struct world *mzx_world, unsigned int offset);
 void id_remove_under(struct world *mzx_world, int array_x, int array_y);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __IDARRAY_H
+#endif /* MEGAZEUX_IDARRAY_H */

--- a/src/idput.h
+++ b/src/idput.h
@@ -19,12 +19,12 @@
 
 /* Declarations for IDPUT.ASM */
 
-#ifndef __IDPUT_H
-#define __IDPUT_H
+#ifndef MEGAZEUX_IDPUT_H
+#define MEGAZEUX_IDPUT_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "world_struct.h"
 #include "data.h"
@@ -72,6 +72,6 @@ CORE_LIBSPEC extern unsigned char id_dmg[ID_DMG_SIZE];
 CORE_LIBSPEC extern unsigned char bullet_color[ID_BULLET_COLOR_SIZE];
 CORE_LIBSPEC extern unsigned char missile_color;
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __IDPUT_H
+#endif /* MEGAZEUX_IDPUT_H */

--- a/src/intake.h
+++ b/src/intake.h
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __INTAKE_H
-#define __INTAKE_H
+#ifndef MEGAZEUX_INTAKE_H
+#define MEGAZEUX_INTAKE_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "core.h"
 
@@ -69,7 +69,7 @@ CORE_LIBSPEC void intake_event_callback(subcontext *intk, void *priv,
 CORE_LIBSPEC boolean intake_apply_event_fixed(subcontext *sub,
  enum intake_event_type type, int new_pos, int value, const char *data);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __INTAKE_H
+#endif /* MEGAZEUX_INTAKE_H */
 

--- a/src/intake_num.h
+++ b/src/intake_num.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __INTAKE_NUM_H
-#define __INTAKE_NUM_H
+#ifndef MEGAZEUX_INTAKE_NUM_H
+#define MEGAZEUX_INTAKE_NUM_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "core.h"
 
@@ -47,6 +47,6 @@ CORE_LIBSPEC
 context *intake_num(context *parent, int value, int min_val, int max_val,
  int x, int y, int min_width, int color, void (*callback)(context *, int));
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __INTAKE_NUM_H
+#endif /* MEGAZEUX_INTAKE_NUM_H */

--- a/src/io/bitstream.h
+++ b/src/io/bitstream.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __IO_BITSTREAM_H
-#define __IO_BITSTREAM_H
+#ifndef MEGAZEUX_IO_BITSTREAM_H
+#define MEGAZEUX_IO_BITSTREAM_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <inttypes.h>
 #include <stdio.h>
@@ -116,6 +116,6 @@ static inline int bs_read(struct bitstream *b, BS_BUFTYPE mask, BS_BUFTYPE bits)
 
 #define BS_READ(b,bits) bs_read(b, (0xFFFF >> (16 - bits)), bits)
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __IO_BITSTREAM_H */
+#endif /* MEGAZEUX_IO_BITSTREAM_H */

--- a/src/io/fsafeopen.h
+++ b/src/io/fsafeopen.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __IO_FSAFEOPEN_H
-#define __IO_FSAFEOPEN_H
+#ifndef MEGAZEUX_IO_FSAFEOPEN_H
+#define MEGAZEUX_IO_FSAFEOPEN_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "vfile.h"
 
@@ -45,6 +45,6 @@ enum
 int fsafetranslate(const char *path, char *newpath, size_t buffer_len);
 vfile *fsafeopen(const char *path, const char *mode);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __IO_FSAFEOPEN_H
+#endif /* MEGAZEUX_IO_FSAFEOPEN_H */

--- a/src/io/memfile.h
+++ b/src/io/memfile.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __IO_MEMFILE_H
-#define __IO_MEMFILE_H
+#ifndef MEGAZEUX_IO_MEMFILE_H
+#define MEGAZEUX_IO_MEMFILE_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <assert.h>
 #include <stdint.h>
@@ -386,6 +386,6 @@ static inline ptrdiff_t mftell(struct memfile *mf)
   return mf->current - mf->start;
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __IO_MEMFILE_H
+#endif /* MEGAZEUX_IO_MEMFILE_H */

--- a/src/io/path.h
+++ b/src/io/path.h
@@ -19,12 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __IO_PATH_H
-#define __IO_PATH_H
+#ifndef MEGAZEUX_IO_PATH_H
+#define MEGAZEUX_IO_PATH_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <stddef.h>
 
@@ -166,6 +166,6 @@ UTILS_LIBSPEC ssize_t path_navigate_no_check(char *path, size_t path_len,
 UTILS_LIBSPEC enum path_create_error path_create_parent_recursively(
  const char *filename);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __IO_PATH_H */
+#endif /* MEGAZEUX_IO_PATH_H */

--- a/src/io/pngops.h
+++ b/src/io/pngops.h
@@ -17,19 +17,19 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __PNGOPS_H
-#define __PNGOPS_H
+#ifndef MEGAZEUX_PNGOPS_H
+#define MEGAZEUX_PNGOPS_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #if defined(CONFIG_EDITOR) || defined(CONFIG_ENABLE_SCREENSHOTS)
 #define NEED_PNG_WRITE_SCREEN
 #endif
 
 #ifdef CONFIG_PNG
-#if (defined(CONFIG_SDL) && defined(CONFIG_ICON) && !defined(__WIN32__)) || \
+#if (defined(CONFIG_SDL) && defined(CONFIG_ICON) && !defined(_WIN32)) || \
     defined(CONFIG_UTILS) || defined(CONFIG_3DS)
 #define NEED_PNG_READ_FILE
 #endif
@@ -68,6 +68,6 @@ void *png_read_file(const char *name, png_uint_32 *_w, png_uint_32 *_h,
 
 #endif // NEED_PNG_READ_FILE
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __PNGOPS_H
+#endif /* MEGAZEUX_PNGOPS_H */

--- a/src/io/vfile.h
+++ b/src/io/vfile.h
@@ -22,12 +22,12 @@
  * world_struct.h and other high-traffic headers.
  */
 
-#ifndef __IO_VFILE_H
-#define __IO_VFILE_H
+#ifndef MEGAZEUX_IO_VFILE_H
+#define MEGAZEUX_IO_VFILE_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 typedef struct vfile vfile;
 typedef struct vdir vdir;
@@ -39,6 +39,6 @@ struct stat;
 /* Dummy device for stat on a virtual file. */
 #define VFS_MZX_DEVICE (dev_t)(('M'<<24u) | ('Z'<<16u) | ('X'<<8u) | ('V'))
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __IO_VFILE_H */
+#endif /* MEGAZEUX_IO_VFILE_H */

--- a/src/io/vfs.h
+++ b/src/io/vfs.h
@@ -22,12 +22,12 @@
  * to be used internally by vio.c, but can also be used by itself.
  */
 
-#ifndef __IO_VFS_H
-#define __IO_VFS_H
+#ifndef MEGAZEUX_IO_VFS_H
+#define MEGAZEUX_IO_VFS_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -207,6 +207,6 @@ static inline int vfs_error_to_errno(enum vfs_error err) { return 0; }
 
 #endif /* !VIRTUAL_FILESYSTEM */
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __IO_VFS_H */
+#endif /* MEGAZEUX_IO_VFS_H */

--- a/src/io/vio.h
+++ b/src/io/vio.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __IO_VIO_H
-#define __IO_VIO_H
+#ifndef MEGAZEUX_IO_VIO_H
+#define MEGAZEUX_IO_VIO_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "vfile.h"
 #include "../platform/platform_attribute.h" /* ATTRIBUTE_PRINTF */
@@ -142,6 +142,6 @@ UTILS_LIBSPEC vvolumelist *vvolumelist_open(void);
 UTILS_LIBSPEC int vvolumelist_close(vvolumelist *volumes);
 UTILS_LIBSPEC const char *vvolumelist_read(vvolumelist *volumes);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __IO_VIO_H */
+#endif /* MEGAZEUX_IO_VIO_H */

--- a/src/io/vio_posix.h
+++ b/src/io/vio_posix.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __IO_VIO_POSIX_H
-#define __IO_VIO_POSIX_H
+#ifndef MEGAZEUX_IO_VIO_POSIX_H
+#define MEGAZEUX_IO_VIO_POSIX_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 /**
  * Standard path function and dirent wrappers.
@@ -235,6 +235,6 @@ static inline int64_t platform_filelength(FILE *fp)
 
 #endif /* fstat */
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __IO_VIO_POSIX_H */
+#endif /* MEGAZEUX_IO_VIO_POSIX_H */

--- a/src/io/vio_volume.h
+++ b/src/io/vio_volume.h
@@ -17,14 +17,14 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __IO_VIO_VOLUME_H
-#define __IO_VIO_VOLUME_H
+#ifndef MEGAZEUX_IO_VIO_VOLUME_H
+#define MEGAZEUX_IO_VIO_VOLUME_H
 
 #include "../compat.h"
 #include "../util.h"
 #include "path.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 /* Volume list reading implementations for vio_posix.h
  * These are more involved than the rest of vio_posix.h
@@ -201,6 +201,6 @@ static inline int platform_vvolumelist_read(struct vvolumelist_handle *vh,
 
 #endif
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __IO_VIO_VOLUME_H */
+#endif /* MEGAZEUX_IO_VIO_VOLUME_H */

--- a/src/io/vio_win32.h
+++ b/src/io/vio_win32.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __IO_VIO_WIN32_H
-#define __IO_VIO_WIN32_H
+#ifndef MEGAZEUX_IO_VIO_WIN32_H
+#define MEGAZEUX_IO_VIO_WIN32_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 /**
  * Win32 UTF-8 stdio, unistd, and dirent path function wrappers.
@@ -414,6 +414,6 @@ static inline int64_t platform_filelength(FILE *fp)
   return fd >= 0 ? _filelengthi64(fd) : -1;
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __IO_VIO_WIN32_H */
+#endif /* MEGAZEUX_IO_VIO_WIN32_H */

--- a/src/io/zip.h
+++ b/src/io/zip.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __ZIP_H
-#define __ZIP_H
+#ifndef MEGAZEUX_ZIP_H
+#define MEGAZEUX_ZIP_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <stdint.h>
 
@@ -318,6 +318,6 @@ UTILS_LIBSPEC struct zip_archive *zip_open_mem_write(void *src, size_t len,
 UTILS_LIBSPEC struct zip_archive *zip_open_mem_write_ext(void **external_buffer,
  size_t *external_buffer_size, size_t start_pos);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif //__ZIP_H
+#endif /* MEGAZEUX_ZIP_H */

--- a/src/io/zip_deflate.h
+++ b/src/io/zip_deflate.h
@@ -21,12 +21,12 @@
  * Deflate (zip compression method 8) compressor and decompressor via zlib.
  */
 
-#ifndef __ZIP_DEFLATE_H
-#define __ZIP_DEFLATE_H
+#ifndef MEGAZEUX_ZIP_DEFLATE_H
+#define MEGAZEUX_ZIP_DEFLATE_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <assert.h>
 #include <stdlib.h>
@@ -290,6 +290,6 @@ static inline enum zip_error deflate_bound(struct zip_stream_data *zs,
   return ZIP_SUCCESS;
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __ZIP_DEFLATE_H */
+#endif /* MEGAZEUX_ZIP_DEFLATE_H */

--- a/src/io/zip_deflate64.h
+++ b/src/io/zip_deflate64.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __ZIP_DEFLATE64_H
-#define __ZIP_DEFLATE64_H
+#ifndef MEGAZEUX_ZIP_DEFLATE64_H
+#define MEGAZEUX_ZIP_DEFLATE64_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <assert.h>
 #include <stdlib.h>
@@ -139,6 +139,6 @@ static inline enum zip_error inflate64_file(struct zip_stream_data *zs)
   return ZIP_DECOMPRESS_FAILED;
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif
+#endif /* MEGAZEUX_ZIP_DEFLATE64_H */

--- a/src/io/zip_dict.h
+++ b/src/io/zip_dict.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __ZIP_DICT_H
-#define __ZIP_DICT_H
+#ifndef MEGAZEUX_ZIP_DICT_H
+#define MEGAZEUX_ZIP_DICT_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../util.h"
 
@@ -64,6 +64,6 @@ static inline void sliding_dictionary_copy(uint8_t *start, uint8_t **_pos,
   *_pos = pos;
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __ZIP_DICT_H */
+#endif /* MEGAZEUX_ZIP_DICT_H */

--- a/src/io/zip_implode.h
+++ b/src/io/zip_implode.h
@@ -21,12 +21,12 @@
  * Implode (zip compression method 6) decompressor.
  */
 
-#ifndef __ZIP_IMPLODE_H
-#define __ZIP_IMPLODE_H
+#ifndef MEGAZEUX_ZIP_IMPLODE_H
+#define MEGAZEUX_ZIP_IMPLODE_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <assert.h>
 #include <inttypes.h>
@@ -448,4 +448,6 @@ static inline enum zip_error expl_file(struct zip_stream_data *zs)
   return ZIP_STREAM_FINISHED;
 }
 
-#endif /* __ZIP_IMPLODE_H */
+MEGAZEUX_END_DECLS
+
+#endif /* MEGAZEUX_ZIP_IMPLODE_H */

--- a/src/io/zip_reduce.h
+++ b/src/io/zip_reduce.h
@@ -21,12 +21,12 @@
  * Reduce (zip compression methods 2-5) decompressor.
  */
 
-#ifndef __ZIP_REDUCE_H
-#define __ZIP_REDUCE_H
+#ifndef MEGAZEUX_ZIP_REDUCE_H
+#define MEGAZEUX_ZIP_REDUCE_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <assert.h>
 #include <inttypes.h>
@@ -271,6 +271,6 @@ err_free:
   return ZIP_DECOMPRESS_FAILED;
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __ZIP_REDUCE_H */
+#endif /* MEGAZEUX_ZIP_REDUCE_H */

--- a/src/io/zip_shrink.h
+++ b/src/io/zip_shrink.h
@@ -21,12 +21,12 @@
  * Shrink (zip compression method 1) decompressor.
  */
 
-#ifndef __ZIP_SHRINK_H
-#define __ZIP_SHRINK_H
+#ifndef MEGAZEUX_ZIP_SHRINK_H
+#define MEGAZEUX_ZIP_SHRINK_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <assert.h>
 #include <inttypes.h>
@@ -418,6 +418,6 @@ static inline enum zip_error unshrink_file(struct zip_stream_data *zs)
   return ZIP_STREAM_FINISHED;
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __ZIP_SHRINK_H */
+#endif /* MEGAZEUX_ZIP_SHRINK_H */

--- a/src/io/zip_stream.h
+++ b/src/io/zip_stream.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __ZIP_STREAM_H
-#define __ZIP_STREAM_H
+#ifndef MEGAZEUX_ZIP_STREAM_H
+#define MEGAZEUX_ZIP_STREAM_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <inttypes.h>
 #include "zip.h"
@@ -81,6 +81,6 @@ struct zip_method_handler
 UTILS_LIBSPEC
 extern const struct zip_method_handler * const zip_method_handlers[ZIP_M_MAX_SUPPORTED + 1];
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __ZIP_STREAM_H */
+#endif /* MEGAZEUX_ZIP_STREAM_H */

--- a/src/legacy_board.h
+++ b/src/legacy_board.h
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __LEGACY_BOARD_H
-#define __LEGACY_BOARD_H
+#ifndef MEGAZEUX_LEGACY_BOARD_H
+#define MEGAZEUX_LEGACY_BOARD_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "const.h"
 #include "world_struct.h"
@@ -35,6 +35,6 @@ CORE_LIBSPEC int legacy_load_board_direct(struct world *mzx_world,
 CORE_LIBSPEC struct board *legacy_load_board_allocate(struct world *mzx_world,
  vfile *vf, int data_offset, int data_size, int savegame, int file_version);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __LEGACY_BOARD_H
+#endif /* MEGAZEUX_LEGACY_BOARD_H */

--- a/src/legacy_rasm.h
+++ b/src/legacy_rasm.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __LEGACY_RASM_H
-#define __LEGACY_RASM_H
+#ifndef MEGAZEUX_LEGACY_RASM_H
+#define MEGAZEUX_LEGACY_RASM_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <stdio.h>
 
@@ -104,6 +104,6 @@ CORE_LIBSPEC int unescape_char(char *dest, char c);
 
 #endif // !CONFIG_DEBYTECODE
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __LEGACY_RASM_H
+#endif /* MEGAZEUX_LEGACY_RASM_H */

--- a/src/legacy_robot.h
+++ b/src/legacy_robot.h
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __LEGACY_ROBOT_H
-#define __LEGACY_ROBOT_H
+#ifndef MEGAZEUX_LEGACY_ROBOT_H
+#define MEGAZEUX_LEGACY_ROBOT_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "const.h"
 #include "world_struct.h"
@@ -48,6 +48,6 @@ struct scroll *legacy_load_scroll_allocate(vfile *vf, int file_version);
 
 struct sensor *legacy_load_sensor_allocate(vfile *vf, int file_version);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __LEGACY_ROBOT_H
+#endif /* MEGAZEUX_LEGACY_ROBOT_H */

--- a/src/legacy_world.h
+++ b/src/legacy_world.h
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __LEGACY_WORLD_H
-#define __LEGACY_WORLD_H
+#ifndef MEGAZEUX_LEGACY_WORLD_H
+#define MEGAZEUX_LEGACY_WORLD_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "world.h"
 #include "world_struct.h"
@@ -100,6 +100,6 @@ void legacy_load_world(struct world *mzx_world, vfile *vf, const char *file,
 vfile *validate_legacy_world_file(struct world *mzx_world,
  const char *file, boolean savegame);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif //__LEGACY_WORLD_H
+#endif /* MEGAZEUX_LEGACY_WORLD_H */

--- a/src/memcasecmp.h
+++ b/src/memcasecmp.h
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __MEMCASECMP_H
-#define __MEMCASECMP_H
+#ifndef MEGAZEUX_MEMCASECMP_H
+#define MEGAZEUX_MEMCASECMP_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <assert.h>
 #include <inttypes.h>
@@ -315,6 +315,6 @@ static inline int memcasecmp32(const void *A, const void *B, size_t cmp_length)
   return 0;
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __MEMCASECMP_H */
+#endif /* MEGAZEUX_MEMCASECMP_H */

--- a/src/mzm.h
+++ b/src/mzm.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __MZM_H
-#define __MZM_H
+#ifndef MEGAZEUX_MZM_H
+#define MEGAZEUX_MZM_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "world_struct.h"
 
@@ -69,6 +69,6 @@ CORE_LIBSPEC int load_mzm_memory(struct world *mzx_world, char *name, int start_
  const void *buffer, size_t length);
 CORE_LIBSPEC boolean load_mzm_header(char *name, struct mzm_header *mzm_header);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __MZM_H
+#endif /* MEGAZEUX_MZM_H */

--- a/src/network/DNS.hpp
+++ b/src/network/DNS.hpp
@@ -17,8 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __DNS_HPP
-#define __DNS_HPP
+#ifndef MEGAZEUX_DNS_HPP
+#define MEGAZEUX_DNS_HPP
 
 #include "../compat.h"
 
@@ -57,4 +57,4 @@ public:
    const struct addrinfo *hints, struct addrinfo **res, uint32_t timeout);
 };
 
-#endif /* __DNS_HPP */
+#endif /* MEGAZEUX_DNS_HPP */

--- a/src/network/HTTPHost.hpp
+++ b/src/network/HTTPHost.hpp
@@ -18,8 +18,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __HTTPHOST_HPP
-#define __HTTPHOST_HPP
+#ifndef MEGAZEUX_HTTPHOST_HPP
+#define MEGAZEUX_HTTPHOST_HPP
 
 #include "../compat.h"
 #include "../io/vfile.h"
@@ -194,4 +194,4 @@ public:
 
 };
 
-#endif /* __HTTPHOST_HPP */
+#endif /* MEGAZEUX_HTTPHOST_HPP */

--- a/src/network/Host.hpp
+++ b/src/network/Host.hpp
@@ -18,8 +18,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __HOST_HPP
-#define __HOST_HPP
+#ifndef MEGAZEUX_HOST_HPP
+#define MEGAZEUX_HOST_HPP
 
 #include "../compat.h"
 #include "../configure.h"
@@ -376,4 +376,4 @@ namespace std
   }
 }
 
-#endif /* __HOST_HPP */
+#endif /* MEGAZEUX_HOST_HPP */

--- a/src/network/Manifest.hpp
+++ b/src/network/Manifest.hpp
@@ -18,8 +18,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __MANIFEST_HPP
-#define __MANIFEST_HPP
+#ifndef MEGAZEUX_MANIFEST_HPP
+#define MEGAZEXU_MANIFEST_HPP
 
 #include "../compat.h"
 #include "../io/vfile.h"
@@ -159,4 +159,4 @@ public:
    Manifest &delete_list);
 };
 
-#endif /* __MANIFEST_HPP */
+#endif /* MEGAZEUX_MANIFEST_HPP */

--- a/src/network/Scoped.hpp
+++ b/src/network/Scoped.hpp
@@ -21,8 +21,8 @@
  * RAII wrappers for misc. data types used in MZX.
  */
 
-#ifndef __SCOPED_HPP
-#define __SCOPED_HPP
+#ifndef MEGAZEUX_SCOPED_HPP
+#define MEGAZEUX_SCOPED_HPP
 
 #include "../compat.h"
 #include "../util.h"
@@ -271,4 +271,4 @@ public:
   }
 };
 
-#endif /* __SCOPED_HPP */
+#endif /* MEGAZEUX_SCOPED_HPP */

--- a/src/network/Socket.hpp
+++ b/src/network/Socket.hpp
@@ -18,8 +18,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __SOCKET_HPP
-#define __SOCKET_HPP
+#ifndef MEGAZEUX_SOCKET_HPP
+#define MEGAZEUX_SOCKET_HPP
 
 #include "../compat.h"
 #include "../util.h"
@@ -31,7 +31,7 @@
 #include <unistd.h>
 #endif
 
-#ifdef __WIN32__
+#ifdef _WIN32
 
 // Winsock symbols are dynamically loaded, so disable the inline versions.
 #define UNIX_INLINE(x)
@@ -67,7 +67,7 @@ struct pollfd
   u32 revents;
 };
 
-#else // !__WIN32__ && !CONFIG_WII
+#else // !_WIN32 && !CONFIG_WII
 
 #include <netinet/in.h>
 #include <sys/socket.h>
@@ -84,7 +84,7 @@ struct pollfd
 // Commenting out for now until it's needed (if at all).
 //#include <net/if.h>
 
-#endif // __WIN32__
+#endif // _WIN32
 
 #if defined(CONFIG_GETADDRINFO) && (!defined(EAI_AGAIN) && !defined(EAI_FAMILY))
 #error "Missing getaddrinfo() support; configure with --disable-getaddrinfo."
@@ -341,7 +341,7 @@ public:
     return ::recvfrom(sockfd, (char *)buf, len, flags, from, fromlen);
   });
 
-#ifdef __WIN32__
+#ifdef _WIN32
   static int __WSAFDIsSet(int sockfd, fd_set *set);
 #undef  FD_ISSET
 #define FD_ISSET(fd,set) Socket::__WSAFDIsSet((int)fd, (fd_set *)(set))
@@ -388,7 +388,7 @@ public:
   };
 
 private:
-#ifndef __WIN32__
+#ifndef _WIN32
   static boolean is_last_errno_fatal()
   {
     switch(Socket::get_errno())
@@ -405,4 +405,4 @@ private:
 #endif
 };
 
-#endif /* __SOCKET_HPP */
+#endif /* MEGAZEUX_SOCKET_HPP */

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __NETWORK_H
-#define __NETWORK_H
+#ifndef MEGAZEUX_NETWORK_H
+#define MEGAZEUX_NETWORK_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../configure.h"
 
@@ -42,6 +42,6 @@ static inline void network_layer_exit(struct config_info *conf) {}
 
 #endif /* CONFIG_NETWORK */
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __NETWORK_H
+#endif /* MEGAZEUX_NETWORK_H */

--- a/src/network/sha256.h
+++ b/src/network/sha256.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __SHA256_H
-#define __SHA256_H
+#ifndef MEGAZEUX_SHA256_H
+#define MEGAZEUX_SHA256_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <stdint.h>
 
@@ -39,6 +39,6 @@ void SHA256_init(struct SHA256_ctx *ctx);
 void SHA256_update(struct SHA256_ctx *ctx, const void *vdata, size_t data_len);
 void SHA256_final(struct SHA256_ctx *ctx);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __SHA256_H
+#endif /* MEGAZEUX_SHA256_H */

--- a/src/old/legacy_save.h
+++ b/src/old/legacy_save.h
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __LEGACY_WORLD_SAVE_H
-#define __LEGACY_WORLD_SAVE_H
+#ifndef MEGAZEUX_LEGACY_WORLD_SAVE_H
+#define MEGAZEUX_LEGACY_WORLD_SAVE_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "const.h"
 #include "world_struct.h"
@@ -48,6 +48,6 @@ int legacy_save_board(struct world *mzx_world,
 
 int legacy_save_world(struct world *mzx_world, const char *file, int savegame);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __LEGACY_WORLD_SAVE_H
+#endif /* MEGAZEUX_LEGACY_WORLD_SAVE_H */

--- a/src/platform/3ds/platform_3ds.h
+++ b/src/platform/3ds/platform_3ds.h
@@ -19,8 +19,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __3DS_PLATFORM_H__
-#define __3DS_PLATFORM_H__
+#ifndef MEGAZEUX_PLATFORM_3DS_H
+#define MEGAZEUX_PLATFORM_3DS_H
 
 #include "../../compat.h"
 
@@ -28,7 +28,7 @@
 #include <3ds.h>
 #include <citro3d.h>
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 boolean ctr_is_2d(void);
 boolean ctr_supports_wide(void);
@@ -52,6 +52,6 @@ static inline void *clinearAlloc(size_t size)
 
 #endif /* CONFIG_CHECK_ALLOC */
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __3DS_PLATFORM_H__ */
+#endif /* MEGAZEUX_PLATFORM_3DS_H */

--- a/src/platform/3ds/thread_3ds.h
+++ b/src/platform/3ds/thread_3ds.h
@@ -17,14 +17,14 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __THREAD_3DS_H
-#define __THREAD_3DS_H
+#ifndef MEGAZEUX_THREAD_3DS_H
+#define MEGAZEUX_THREAD_3DS_H
 
 #include "../../compat.h"
 
 #define STACK_SIZE_CTR 8096
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <3ds.h>
 
@@ -160,6 +160,6 @@ static inline boolean platform_is_same_thread(platform_thread_id a,
   return a == b;
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __THREAD_3DS_H
+#endif /* MEGAZEUX_THREAD_3DS_H */

--- a/src/platform/djgpp/platform_djgpp.h
+++ b/src/platform/djgpp/platform_djgpp.h
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __PLATFORM_DJGPP_H
-#define __PLATFORM_DJGPP_H
+#ifndef MEGAZEUX_PLATFORM_DJGPP_H
+#define MEGAZEUX_PLATFORM_DJGPP_H
 
 #include "../../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <stdint.h>
 
@@ -128,6 +128,6 @@ static inline void djgpp_restore_x87(const uint8_t fpustate[108])
           "frstor %0" : : "m"(fpustate));
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __PLATFORM_DJGPP_H
+#endif /* MEGAZEUX_PLATFORM_DJGPP_H */

--- a/src/platform/djgpp/thread_djgpp.h
+++ b/src/platform/djgpp/thread_djgpp.h
@@ -20,15 +20,15 @@
 
 // This isn't really a mutex. Audio is handled via interrupt.
 
-#ifndef __MUTEX_DJGPP_H
-#define __MUTEX_DJGPP_H
+#ifndef MEGAZEUX_THREAD_DJGPP_H
+#define MEGAZEUX_THREAD_DJGPP_H
 
 #define delay delay_dos
 #include <dos.h>
 #undef delay
 #include "../../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #define PLATFORM_NO_THREADING
 #define THREAD_RES void *
@@ -74,6 +74,6 @@ static inline boolean platform_is_same_thread(platform_thread_id a,
   return true;
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __MUTEX_DJGPP_H
+#endif /* MEGAZEUX_THREAD_DJGPP_H */

--- a/src/platform/dreamcast/thread_dreamcast.h
+++ b/src/platform/dreamcast/thread_dreamcast.h
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __THREAD_DREAMCAST_H
-#define __THREAD_DREAMCAST_H
+#ifndef MEGAZEUX_THREAD_DREAMCAST_H
+#define MEGAZEUX_THREAD_DREAMCAST_H
 
 #include "../../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <kos.h>
 #include <stdbool.h>
@@ -168,6 +168,6 @@ static inline boolean platform_is_same_thread(platform_thread_id a,
   return a == b;
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __THREAD_DREAMCAST_H
+#endif /* MEGAZEUX_THREAD_DREAMCAST_H */

--- a/src/platform/nds/extmem_nds.h
+++ b/src/platform/nds/extmem_nds.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#ifndef MEGAZEUX_EXTMEM_NDS_H
+#define MEGAZEUX_EXTMEM_NDS_H
+
 #include "../../compat.h"
 
-#ifndef NDS_EXTMEM_H
-#define NDS_EXTMEM_H
-
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 boolean nds_ram_init(void);
 
@@ -32,6 +32,6 @@ void platform_extram_free(void *buffer);
 void platform_extram_lock(void);
 void platform_extram_unlock(void);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* NDS_EXTMEM_H */
+#endif /* MEGAZEUX_EXTMEM_NDS_H */

--- a/src/platform/nds/platform_nds.h
+++ b/src/platform/nds/platform_nds.h
@@ -19,10 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __3DS_PLATFORM_H__
-#define __3DS_PLATFORM_H__
+#ifndef MEGAZEUX_PLATFORM_NDS_H
+#define MEGAZEUX_PLATFORM_NDS_H
 
 #include "../../compat.h"
+
+MEGAZEUX_BEGIN_DECLS
 
 #include <nds.h>
 
@@ -46,4 +48,6 @@ void profile_end(void);
 void nds_audio_vblank(void);
 #endif
 
-#endif /* __3DS_PLATFORM_H__ */
+MEGAZEUX_END_DECLS
+
+#endif /* MEGAZEUX_PLATFORM_NDS_H */

--- a/src/platform/nds/ram.h
+++ b/src/platform/nds/ram.h
@@ -8,8 +8,8 @@ Dual licensed under the MIT (http://www.opensource.org/licenses/mit-license.php)
 and GPLv2 (http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt) licenses. 
 
 ***********************************/
-#ifndef __RAM
-#define __RAM
+#ifndef MEGAZEUX_PLATFORM_NDS_RAM_H
+#define MEGAZEUX_PLATFORM_NDS_RAM_H
 
 #include <nds/ndstypes.h>
 
@@ -46,4 +46,4 @@ void  ram_turbo (bool enable);
 }
 #endif
 #endif
-#endif
+#endif /* MEGAZEUX_PLATFORM_NDS_RAM_H */

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __PLATFORM_H
-#define __PLATFORM_H
+#ifndef MEGAZEUX_PLATFORM_H
+#define MEGAZEUX_PLATFORM_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "platform_clipboard.h"
 #include "platform_dso.h"
@@ -34,6 +34,6 @@ __M_BEGIN_DECLS
 CORE_LIBSPEC boolean platform_init(void);
 CORE_LIBSPEC void platform_quit(void);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __PLATFORM_H
+#endif /* MEGAZEUX_PLATFORM_H */

--- a/src/platform/platform_attribute.h
+++ b/src/platform/platform_attribute.h
@@ -17,8 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __PLATFORM_ATTRIBUTE_H
-#define __PLATFORM_ATTRIBUTE_H
+#ifndef MEGAZEUX_PLATFORM_ATTRIBUTE_H
+#define MEGAZEUX_PLATFORM_ATTRIBUTE_H
 
 /**
  * Header for misc. compiler-specific attributes.
@@ -68,4 +68,4 @@
 
 #undef HAS_ATTRIBUTE
 
-#endif // __PLATFORM_ATTRIBUTE_H
+#endif /* MEGAZEUX_PLATFORM_ATTRIBUTE_H */

--- a/src/platform/platform_clipboard.h
+++ b/src/platform/platform_clipboard.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __PLATFORM_CLIPBOARD_H
-#define __PLATFORM_CLIPBOARD_H
+#ifndef MEGAZEUX_PLATFORM_CLIPBOARD_H
+#define MEGAZEUX_PLATFORM_CLIPBOARD_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 CORE_LIBSPEC void copy_buffer_to_clipboard(char **buffer, int lines,
  int total_length);
@@ -30,6 +30,6 @@ CORE_LIBSPEC void copy_buffer_to_clipboard(char **buffer, int lines,
 CORE_LIBSPEC char *get_clipboard_buffer(void);
 CORE_LIBSPEC void free_clipboard_buffer(char *buffer);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __EDITOR_CLIPBOARD_H
+#endif /* MEGAZEUX_PLATFORM_CLIPBOARD_H */

--- a/src/platform/platform_dso.h
+++ b/src/platform/platform_dso.h
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __PLATFORM_DSO_H
-#define __PLATFORM_DSO_H
+#ifndef MEGAZEUX_PLATFORM_DSO_H
+#define MEGAZEUX_PLATFORM_DSO_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 /* Use as (dso_fn_ptr *) to store a loaded void(*)(void) to a function pointer. */
 typedef void (*dso_fn_ptr)(void);
@@ -56,6 +56,6 @@ CORE_LIBSPEC void platform_unload_library(struct dso_library *library);
 CORE_LIBSPEC boolean platform_load_function(struct dso_library *library,
  const struct dso_syms_map *syms_map);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __PLATFORM_DSO_H */
+#endif /* MEGAZEUX_PLATFORM_DSO_H */

--- a/src/platform/platform_endian.h
+++ b/src/platform/platform_endian.h
@@ -18,8 +18,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __ENDIAN_H
-#define __ENDIAN_H
+#ifndef MEGAZEUX_PLATFORM_ENDIAN_H
+#define MEGAZEUX_PLATFORM_ENDIAN_H
 
 /* Specific architecture defines. */
 #if defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64)
@@ -175,4 +175,4 @@
 #define PLATFORM_UNALIGN_32 0x02
 #endif
 
-#endif // __ENDIAN_H
+#endif /* MEGAZEUX_PLATFORM_ENDIAN_H */

--- a/src/platform/platform_main.h
+++ b/src/platform/platform_main.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __PLATFORM_MAIN_H
-#define __PLATFORM_MAIN_H
+#ifndef MEGAZEUX_PLATFORM_MAIN_H
+#define MEGAZEUX_PLATFORM_MAIN_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #ifdef CONFIG_REPLACE_MAIN
 
@@ -31,6 +31,6 @@ int real_main(int argc, char *argv[]);
 
 #endif /* CONFIG_REPLACE_MAIN */
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __PLATFORM_MAIN_H */
+#endif /* MEGAZEUX_PLATFORM_MAIN_H */

--- a/src/platform/platform_thread.h
+++ b/src/platform/platform_thread.h
@@ -17,8 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __PLATFORM_THREAD_H
-#define __PLATFORM_THREAD_H
+#ifndef MEGAZEUX_PLATFORM_THREAD_H
+#define MEGAZEUX_PLATFORM_THREAD_H
 
 /**
  * Audio, networking, and other misc. optional features require threading
@@ -49,4 +49,4 @@
 #include "thread_dummy.h"
 #endif
 
-#endif /* __PLATFORM_THREAD_H */
+#endif /* MEGAZEUX_PLATFORM_THREAD_H */

--- a/src/platform/platform_time.h
+++ b/src/platform/platform_time.h
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __PLATFORM_TIME_H
-#define __PLATFORM_TIME_H
+#ifndef MEGAZEUX_PLATFORM_TIME_H
+#define MEGAZEUX_PLATFORM_TIME_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <stdint.h>
 #include <time.h>
@@ -36,6 +36,6 @@ CORE_LIBSPEC uint64_t get_ticks(void);
 CORE_LIBSPEC boolean platform_system_time(struct tm *tm,
  int64_t *epoch, int32_t *nano);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __PLATFORM_TIME_H */
+#endif /* MEGAZEUX_PLATFORM_TIME_H */

--- a/src/platform/sdl/SDLmzx.h
+++ b/src/platform/sdl/SDLmzx.h
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __SDLMZX_H
-#define __SDLMZX_H
+#ifndef MEGAZEUX_SDLMZX_H
+#define MEGAZEUX_SDLMZX_H
 
 #include "../../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #if defined(CONFIG_SDL)
 #if CONFIG_SDL == 3
@@ -537,6 +537,6 @@ static inline int sdl_linked_version(void)
 
 #endif /* CONFIG_SDL */
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __SDLMZX_H */
+#endif /* MEGAZEUX_SDLMZX_H */

--- a/src/platform/sdl/thread_sdl.h
+++ b/src/platform/sdl/thread_sdl.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __THREAD_SDL_H
-#define __THREAD_SDL_H
+#ifndef MEGAZEUX_THREAD_SDL_H
+#define MEGAZEUX_THREAD_SDL_H
 
 #include "../../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "SDLmzx.h"
 
@@ -185,6 +185,6 @@ static inline boolean platform_is_same_thread(platform_thread_id a,
   return a == b;
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __THREAD_SDL_H
+#endif /* MEGAZEUX_THREAD_SDL_H */

--- a/src/platform/thread_debug.h
+++ b/src/platform/thread_debug.h
@@ -22,12 +22,12 @@
  * Functions for debugging mutexes.
  */
 
-#ifndef __THREAD_DEBUG_H
-#define __THREAD_DEBUG_H
+#ifndef MEGAZEUX_THREAD_DEBUG_H
+#define MEGAZEUX_THREAD_DEBUG_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "platform.h"
 #include "../util.h"
@@ -105,6 +105,6 @@ static inline void platform_mutex_unlock_debug(platform_mutex *mutex,
   platform_mutex_unlock(mutex);
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __THREAD_DEBUG_H */
+#endif /* MEGAZEUX_THREAD_DEBUG_H */

--- a/src/platform/thread_dummy.h
+++ b/src/platform/thread_dummy.h
@@ -23,12 +23,12 @@
  * not available, see platform.h.
  */
 
-#ifndef __THREAD_DUMMY_H
-#define __THREAD_DUMMY_H
+#ifndef MEGAZEUX_THREAD_DUMMY_H
+#define MEGAZEUX_THREAD_DUMMY_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #define PLATFORM_NO_THREADING
 
@@ -157,6 +157,6 @@ static inline boolean platform_is_same_thread(platform_thread_id a,
   return true;
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __THREAD_DUMMY_H */
+#endif /* MEGAZEUX_THREAD_DUMMY_H */

--- a/src/platform/thread_pthread.h
+++ b/src/platform/thread_pthread.h
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __THREAD_PTHREAD_H
-#define __THREAD_PTHREAD_H
+#ifndef MEGAZEUX_THREAD_PTHREAD_H
+#define MEGAZEUX_THREAD_PTHREAD_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <sched.h>
 #include <semaphore.h>
@@ -177,6 +177,6 @@ static inline void platform_yield(void)
   sched_yield();
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __THREAD_PTHREAD_H
+#endif /* MEGAZEUX_THREAD_PTHREAD_H */

--- a/src/platform/wii/thread_wii.h
+++ b/src/platform/wii/thread_wii.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __MUTEX_WII_H
-#define __MUTEX_WII_H
+#ifndef MEGAZEUX_THREAD_WII_H
+#define MEGAZEUX_THREAD_WII_H
 
 #include "../../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <limits.h>
 #include <time.h>
@@ -196,6 +196,6 @@ static inline void platform_yield(void)
   LWP_YieldThread();
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __MUTEX_WII_H
+#endif /* MEGAZEUX_THREAD_WII_H */

--- a/src/platform/win32/thread_win32.h
+++ b/src/platform/win32/thread_win32.h
@@ -24,12 +24,12 @@
  * Only use this when SDL isn't available, e.g. for the utils.
  */
 
-#ifndef __THREAD_WIN32_H
-#define __THREAD_WIN32_H
+#ifndef MEGAZEUX_THREAD_WIN32_H
+#define MEGAZEUX_THREAD_WIN32_H
 
 #include "../../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -165,6 +165,6 @@ static inline boolean platform_is_same_thread(platform_thread_id a,
   return a == b;
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __THREAD_WIN32_H */
+#endif /* MEGAZEUX_THREAD_WIN32_H */

--- a/src/rasm.h
+++ b/src/rasm.h
@@ -17,8 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __RASM_H
-#define __RASM_H
+#ifndef MEGAZEUX_RASM_H
+#define MEGAZEUX_RASM_H
 
 #include "compat.h"
 #include "legacy_rasm.h"
@@ -268,7 +268,7 @@ struct token
 };
 
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 char *legacy_disassemble_program(char *program_bytecode, int bytecode_length,
  int *_disasm_length, boolean print_ignores, int base);
@@ -296,8 +296,8 @@ CORE_LIBSPEC int get_thing(char *name, int name_length);
 
 #endif // CONFIG_EDITOR
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
 #endif // CONFIG_DEBYTECODE
 
-#endif // __RASM_H
+#endif /* MEGAZEUX_RASM_H */

--- a/src/render/3ds/renderer_ctr.h
+++ b/src/render/3ds/renderer_ctr.h
@@ -19,8 +19,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __3DS_RENDER_H__
-#define __3DS_RENDER_H__
+#ifndef MEGAZEUX_RENDERER_CTR_H
+#define MEGAZEUX_RENDERER_CTR_H
 
 #include <stdlib.h>
 #include <3ds.h>
@@ -28,7 +28,7 @@
 
 #include "../../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 struct ctr_render_data;
 
@@ -41,6 +41,6 @@ void ctr_draw_2d_texture(struct ctr_render_data *render_data, C3D_Tex *texture,
 void ctr_request_set_wide(bool wide);
 int ctr_get_subscreen_height(void);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __3DS_RENDER_H__ */
+#endif /* MEGAZEUX_RENDERER_CTR_H */

--- a/src/render/nds/renderer_nds.h
+++ b/src/render/nds/renderer_nds.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __RENDER_NDS_H
-#define __RENDER_NDS_H
+#ifndef MEGAZEUX_RENDERER_NDS_H
+#define MEGAZEUX_RENDERER_NDS_H
 
 #include "../../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 // The subscreen can display different information.
 enum Subscreen_Mode
@@ -47,6 +47,6 @@ void nds_video_do_transition(void);
 boolean nds_subscreen_preview(void);
 boolean nds_subscreen_keyboard(void);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __RENDER_NDS_H
+#endif /* MEGAZEUX_RENDERER_NDS_H */

--- a/src/render/opengl/render_egl.h
+++ b/src/render/opengl/render_egl.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __RENDER_EGL_H
-#define __RENDER_EGL_H
+#ifndef MEGAZEUX_RENDER_EGL_H
+#define MEGAZEUX_RENDER_EGL_H
 
 #include "../../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "render_gl.h"
 
@@ -67,6 +67,6 @@ struct egl_render_data
   EGLSurface surface;
 };
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __RENDER_EGL_H
+#endif /* MEGAZEUX_RENDER_EGL_H */

--- a/src/render/opengl/render_gl.h
+++ b/src/render/opengl/render_gl.h
@@ -20,12 +20,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __RENDER_GL_H
-#define __RENDER_GL_H
+#ifndef MEGAZEUX_RENDER_GL_H
+#define MEGAZEUX_RENDER_GL_H
 
 #include "../../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../../configure.h"
 #include "../../graphics.h"
@@ -126,6 +126,6 @@ static inline uint32_t gl_pack_u32(uint32_t x)
 #define gl_pack_u32(x) (x)
 #endif
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __RENDER_GL_H
+#endif /* MEGAZEUX_RENDER_GL_H */

--- a/src/render/render.h
+++ b/src/render/render.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __RENDER_H
-#define __RENDER_H
+#ifndef MEGAZEUX_RENDER_H
+#define MEGAZEUX_RENDER_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../graphics.h"
 
@@ -75,6 +75,6 @@ void set_window_viewport_scaled(struct graphics_data *graphics,
 
 #endif /* CONFIG_RENDER_GL_FIXED || CONFIG_RENDER_GL_PROGRAM || ... */
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __RENDER_H
+#endif /* MEGAZEUX_RENDER_H */

--- a/src/render/render_layer.h
+++ b/src/render/render_layer.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __RENDER_LAYER_H
-#define __RENDER_LAYER_H
+#ifndef MEGAZEUX_RENDER_LAYER_H
+#define MEGAZEUX_RENDER_LAYER_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../graphics.h"
 
@@ -30,6 +30,6 @@ void render_layer(void * RESTRICT pixels,
  size_t width_px, size_t height_px, size_t pitch, int bpp,
  const struct graphics_data *graphics, const struct video_layer *layer);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __RENDER_LAYER_H
+#endif /* MEGAZEUX_RENDER_LAYER_H */

--- a/src/render/render_layer_common.hpp
+++ b/src/render/render_layer_common.hpp
@@ -17,8 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __RENDER_LAYER_COMMON_HPP
-#define __RENDER_LAYER_COMMON_HPP
+#ifndef MEGAZEUX_RENDER_LAYER_COMMON_HPP
+#define MEGAZEUX_RENDER_LAYER_COMMON_HPP
 
 #include "../graphics.h"
 #include "../platform/platform_endian.h"
@@ -133,4 +133,4 @@ static inline unsigned both_colors(const char_element *src)
   return reinterpret_cast<const uint16_t *>(src)[1];
 }
 
-#endif /* __RENDER_LAYER_COMMON_HPP */
+#endif /* MEGAZEUX_RENDER_LAYER_COMMON_HPP */

--- a/src/render/renderers.h
+++ b/src/render/renderers.h
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __RENDERERS_H
-#define __RENDERERS_H
+#ifndef MEGAZEUX_RENDERERS_H
+#define MEGAZEUX_RENDERERS_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../graphics.h"
 
@@ -95,6 +95,6 @@ extern const struct renderer renderer_dreamcast_fb;
 
 boolean set_current_renderer(struct graphics_data *graphics, const char *name);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __RENDERERS_H
+#endif /* MEGAZEUX_RENDERERS_H */

--- a/src/render/sdl/render_sdl.h
+++ b/src/render/sdl/render_sdl.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __RENDER_SDL_H
-#define __RENDER_SDL_H
+#ifndef MEGAZEUX_RENDER_SDL_H
+#define MEGAZEUX_RENDER_SDL_H
 
 #include "../../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../render.h"
 #include "../../graphics.h"
@@ -154,6 +154,6 @@ static inline dso_fn_ptr GL_GetProcAddress(const char *proc)
 
 #endif // CONFIG_RENDER_GL_FIXED || CONFIG_RENDER_GL_PROGRAM
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __RENDER_SDL_H
+#endif /* MEGAZEUX_RENDER_SDL_H */

--- a/src/render/yuv.h
+++ b/src/render/yuv.h
@@ -21,12 +21,12 @@
 // General macros and functions for YUV manipulation. Supports YUY2, UYVY, and
 // YVYU. SDL doesn't provide functions for packing/unpacking these.
 
-#ifndef __YUV_H
-#define __YUV_H
+#ifndef MEGAZEUX_YUV_H
+#define MEGAZEUX_YUV_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "../platform/platform_endian.h"
 #include <stdint.h>
@@ -208,6 +208,6 @@ static inline uint32_t rgb_to_apple_ycbcr_422(uint8_t r, uint8_t g, uint8_t b)
   return uyvy_pack(y, cb, y, cr);
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __YUV_H */
+#endif /* MEGAZEUX_YUV_H */

--- a/src/robot.h
+++ b/src/robot.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __ROBOT_H
-#define __ROBOT_H
+#ifndef MEGAZEUX_ROBOT_H
+#define MEGAZEUX_ROBOT_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "core.h"
 #include "data.h"
@@ -214,6 +214,6 @@ CORE_LIBSPEC int get_program_command_num(struct robot *cur_robot,
 CORE_LIBSPEC extern const int def_params[128];
 #endif // CONFIG_EDITOR
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __ROBOT_H
+#endif /* MEGAZEUX_ROBOT_H */

--- a/src/robot_struct.h
+++ b/src/robot_struct.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __ROBOT_STRUCT_H
-#define __ROBOT_STRUCT_H
+#ifndef MEGAZEUX_ROBOT_STRUCT_H
+#define MEGAZEUX_ROBOT_STRUCT_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "data.h"
 #include "legacy_rasm.h"
@@ -127,6 +127,6 @@ struct robot
 #endif
 };
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __ROBOT_STRUCT_H
+#endif /* MEGAZEUX_ROBOT_STRUCT_H */

--- a/src/run_stubs.h
+++ b/src/run_stubs.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __RUN_STUBS_H
-#define __RUN_STUBS_H
+#ifndef MEGAZEUX_RUN_STUBS_H
+#define MEGAZEUX_RUN_STUBS_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #ifdef CONFIG_EDITOR
 boolean is_editor(void);
@@ -53,6 +53,6 @@ static inline boolean is_updater(void)
 { return false; }
 #endif
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __RUN_STUBS_H
+#endif /* MEGAZEUX_RUN_STUBS_H */

--- a/src/scrdisp.h
+++ b/src/scrdisp.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __SCRDISP_H
-#define __SCRDISP_H
+#ifndef MEGAZEUX_SCRDISP_H
+#define MEGAZEUX_SCRDISP_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "world_struct.h"
 
@@ -38,6 +38,6 @@ void scroll_edging_ext(struct world *mzx_world, int type, boolean mask);
 void help_display(struct world *mzx_world, char *help, int offs,
  char *file, char *label);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __SCRDISP_H
+#endif /* MEGAZEUX_SCRDISP_H */

--- a/src/settings.h
+++ b/src/settings.h
@@ -17,17 +17,17 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __GAME_SETTINGS_H
-#define __GAME_SETTINGS_H
+#ifndef MEGAZEUX_SETTINGS_H
+#define MEGAZEUX_SETTINGS_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "world_struct.h"
 
 void game_settings(struct world *mzx_world);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __GAME_SETTINGS_H
+#endif /* MEGAZEUX_SETTINGS_H */

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __SPRITE_H
-#define __SPRITE_H
+#ifndef MEGAZEUX_SPRITE_H
+#define MEGAZEUX_SPRITE_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "sprite_struct.h"
 #include "world_struct.h"
@@ -69,6 +69,6 @@ boolean sprite_at_xy(struct world *mzx_world, struct sprite *cur_sprite, int x, 
 int sprite_colliding_xy(struct world *mzx_world, struct sprite *check_sprite,
  int x, int y);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __SPRITE_H
+#endif /* MEGAZEUX_SPRITE_H */

--- a/src/sprite_struct.h
+++ b/src/sprite_struct.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __SPRITE_STRUCT_H
-#define __SPRITE_STRUCT_H
+#ifndef MEGAZEUX_SPRITE_STRUCT_H
+#define MEGAZEUX_SPRITE_STRUCT_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #define MAX_SPRITES         256
 
@@ -52,6 +52,6 @@ struct collision_list
   int collisions[MAX_SPRITES];
 };
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __SPRITE_STRUCT_H
+#endif /* MEGAZEUX_SPRITE_STRUCT_H */

--- a/src/str.h
+++ b/src/str.h
@@ -19,12 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __STR_H
-#define __STR_H
+#ifndef MEGAZEUX_STR_H
+#define MEGAZEUX_STR_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <stdio.h>
 #include <string.h>
@@ -92,6 +92,6 @@ struct string *load_new_string(struct string_list *string_list, int index,
 
 void clear_string_list(struct string_list *string_list);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __STR_H
+#endif /* MEGAZEUX_STR_H */

--- a/src/updater.h
+++ b/src/updater.h
@@ -17,16 +17,16 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __UPDATER_H
-#define __UPDATER_H
+#ifndef MEGAZEUX_UPDATER_H
+#define MEGAZEUX_UPDATER_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 boolean updater_init(void);
 boolean is_updater(void);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __UPDATER_H
+#endif /* MEGAZEUX_UPDATER_H */

--- a/src/util.h
+++ b/src/util.h
@@ -20,12 +20,12 @@
 
 // Useful, generic utility functions
 
-#ifndef __UTIL_H
-#define __UTIL_H
+#ifndef MEGAZEUX_UTIL_H
+#define MEGAZEUX_UTIL_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <stdint.h>
 #include <stdio.h>
@@ -237,6 +237,6 @@ CORE_LIBSPEC void __stack_chk_fail(void);
 
 #endif /* ANDROID */
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __UTIL_H
+#endif /* MEGAZEUX_UTIL_H */

--- a/src/utils/image_common.h
+++ b/src/utils/image_common.h
@@ -17,8 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __UTILS_IMAGE_COMMON_H
-#define __UTILS_IMAGE_COMMON_H
+#ifndef MEGAZEUX_UTILS_IMAGE_COMMON_H
+#define MEGAZEUX_UTILS_IMAGE_COMMON_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -54,4 +54,4 @@ static void imagenodbg(...) {}
 }
 #endif
 
-#endif /* __UTILS_IMAGE_COMMON_H */
+#endif /* MEGAZEUX_UTILS_IMAGE_COMMON_H */

--- a/src/utils/image_file.h
+++ b/src/utils/image_file.h
@@ -17,8 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __UTILS_IMAGE_FILE_H
-#define __UTILS_IMAGE_FILE_H
+#ifndef MEGAZEUX_UTILS_IMAGE_FILE_H
+#define MEGAZEUX_UTILS_IMAGE_FILE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -136,4 +136,4 @@ const char *image_error_string(enum image_error err);
 }
 #endif
 
-#endif /* __UTILS_IMAGE_FILE_H */
+#endif /* MEGAZEUX_UTILS_IMAGE_FILE_H */

--- a/src/utils/image_gif.h
+++ b/src/utils/image_gif.h
@@ -17,8 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __UTILS_IMAGE_GIF_H
-#define __UTILS_IMAGE_GIF_H
+#ifndef MEGAZEUX_UTILS_IMAGE_GIF_H
+#define MEGAZEUX_UTILS_IMAGE_GIF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -271,4 +271,4 @@ enum gif_error gif_composite(struct gif_rgba **pixels, const struct gif_info *gi
 }
 #endif
 
-#endif /* __UTILS_IMAGE_GIF_H */
+#endif /* MEGAZEUX_UTILS_IMAGE_GIF_H */

--- a/src/utils/smzxconv.h
+++ b/src/utils/smzxconv.h
@@ -15,8 +15,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __SMZXCONV_H
-#define __SMZXCONV_H
+#ifndef MEGAZEUX_SMZXCONV_H
+#define MEGAZEUX_SMZXCONV_H
 
 struct rgba_color;
 
@@ -41,4 +41,4 @@ int smzx_convert (smzx_converter *c, const struct rgba_color *img, mzx_tile *til
  mzx_glyph *chr, mzx_color *pal);
 void smzx_convert_free (smzx_converter *c);
 
-#endif /* __SMZXCONV_H */
+#endif /* MEGAZEUX_SMZXCONV_H */

--- a/src/utils/utils_alloc.h
+++ b/src/utils/utils_alloc.h
@@ -23,12 +23,12 @@
  * core objects from MZX.
  */
 
-#ifndef __UTILS_ALLOC_H
-#define __UTILS_ALLOC_H
+#ifndef MEGAZEUX_UTILS_ALLOC_H
+#define MEGAZEUX_UTILS_ALLOC_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 /* Workaround for linking zip.o */
 FILE *mzxout_h = NULL;
@@ -71,6 +71,6 @@ CORE_LIBSPEC void *check_realloc(void *ptr, size_t size, const char *file, int l
 
 #endif
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __UTILS_ALLOC_H */
+#endif /* MEGAZEUX_UTILS_ALLOC_H */

--- a/src/utils/y4m.h
+++ b/src/utils/y4m.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __UTILS_Y4M_H
-#define __UTILS_Y4M_H
+#ifndef MEGAZEUX_UTILS_Y4M_H
+#define MEGAZEUX_UTILS_Y4M_H
 
 #include "../compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <stdint.h>
 #include <stdio.h>
@@ -131,6 +131,6 @@ void y4m_convert_frame_rgba(const struct y4m_data *y4m,
 void y4m_free_frame(struct y4m_frame_data *yf);
 void y4m_free(struct y4m_data *y4m);
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif /* __UTILS_Y4M_H */
+#endif /* MEGAZEUX_UTILS_Y4M_H */

--- a/src/window.h
+++ b/src/window.h
@@ -20,12 +20,12 @@
 
 /* WINDOW.H- Declarations for WINDOW.CPP */
 
-#ifndef __WINDOW_H
-#define __WINDOW_H
+#ifndef MEGAZEUX_WINDOW_H
+#define MEGAZEUX_WINDOW_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "world_struct.h"
 
@@ -374,6 +374,6 @@ CORE_LIBSPEC int file_manager(struct world *mzx_world,
  struct element **dialog_ext, int num_ext, int ext_height);
 #endif // CONFIG_EDITOR
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __WINDOW_H
+#endif /* MEGAZEUX_WINDOW_H */

--- a/src/world.h
+++ b/src/world.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __WORLD_H
-#define __WORLD_H
+#ifndef MEGAZEUX_WORLD_H
+#define MEGAZEUX_WORLD_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "world_struct.h"
 #include "io/vfile.h"
@@ -216,6 +216,6 @@ CORE_LIBSPEC void optimize_null_boards(struct world *mzx_world);
 
 #endif // CONFIG_EDITOR
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __WORLD_H
+#endif /* MEGAZEUX_WORLD_H */

--- a/src/world_format.h
+++ b/src/world_format.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __WORLD_FORMAT_H
-#define __WORLD_FORMAT_H
+#ifndef MEGAZEUX_WORLD_FORMAT_H
+#define MEGAZEUX_WORLD_FORMAT_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include "io/memfile.h"
 #include "io/zip.h"
@@ -997,6 +997,6 @@ err:
   return false;
 }
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __WORLD_FORMAT_H
+#endif /* MEGAZEUX_WORLD_FORMAT_H */

--- a/src/world_struct.h
+++ b/src/world_struct.h
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __WORLD_STRUCT_H
-#define __WORLD_STRUCT_H
+#ifndef MEGAZEUX_WORLD_STRUCT_H
+#define MEGAZEUX_WORLD_STRUCT_H
 
 #include "compat.h"
 
-__M_BEGIN_DECLS
+MEGAZEUX_BEGIN_DECLS
 
 #include <stdio.h>
 #include <stdint.h>
@@ -256,6 +256,6 @@ struct world
   int32_t current_time_nano;
 };
 
-__M_END_DECLS
+MEGAZEUX_END_DECLS
 
-#endif // __WORLD_STRUCT_H
+#endif /* MEGAZEUX_WORLD_STRUCT_H */

--- a/unit/Unit.hpp
+++ b/unit/Unit.hpp
@@ -68,7 +68,7 @@
 #ifndef UNIT_HPP
 #define UNIT_HPP
 
-#ifdef __M_BEGIN_DECLS
+#ifdef MEGAZEUX_BEGIN_DECLS
 #error "Include Unit.hpp first!"
 #endif
 


### PR DESCRIPTION
All identifiers beginning with `__` are reserved for "for any use" by the compiler/standard headers and should not be defined. Replacing `__M_BEGIN_DECLS`/`__M_END_DECLS` and the include guards fixes the vast majority of non-compliant uses of `__` identifiers.