### PR TITLE
Fix misc. warnings and build issues.

### DIFF
--- a/src/audio/audio_drivers.c
+++ b/src/audio/audio_drivers.c
@@ -41,10 +41,10 @@ static const struct audio_driver * const available_drivers[] =
 #ifdef CONFIG_NDS
   &audio_driver_nds,
 #endif
-#ifdef CONFIG_3DS
+#if defined(CONFIG_3DS) && !defined(CONFIG_SDL)
   &audio_driver_3ds,
 #endif
-#ifdef CONFIG_WII
+#if defined(CONFIG_WII) && !defined(CONFIG_SDL)
   &audio_driver_wii,
 #endif
 #ifdef CONFIG_DREAMCAST

--- a/src/audio/wii/audio_wii.c
+++ b/src/audio/wii/audio_wii.c
@@ -25,13 +25,11 @@
 #include <string.h>
 #include <malloc.h>
 
-#define BOOL _BOOL
 #include <asndlib.h>
 #include <gctypes.h>
 #include <ogc/lwp.h>
 #include <ogc/cache.h>
 #include <ogc/system.h>
-#undef BOOL
 
 #define STACKSIZE 8192
 

--- a/src/editor/debug.c
+++ b/src/editor/debug.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2004 Gilead Kutnick <exophase@adelphia.net>
  * Copyright (C) 2008 Alistair John Strachan <alistair@devzero.co.uk>
- * Copyright (C) 2012-2025 Alice Rowan <petrifiedrowan@gmail.com>
+ * Copyright (C) 2012-2026 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -676,7 +676,7 @@ int get_counter_safe(struct world *mzx_world, const char *name, int id)
   return get_counter(mzx_world, name, id);
 }
 
-static void get_var_name(struct debug_var *v, const char **name, int *len,
+static boolean get_var_name(struct debug_var *v, const char **name, int *len,
  char buffer[VAR_LIST_WIDTH + 1])
 {
   switch((enum debug_var_type)v->type)
@@ -684,42 +684,43 @@ static void get_var_name(struct debug_var *v, const char **name, int *len,
     case V_COUNTER:
       if(name) *name = v->data.counter->name;
       if(len)  *len = v->data.counter->name_length;
-      return;
+      return true;
 
     case V_STRING:
       if(name) *name = v->data.string->name;
       if(len)  *len = v->data.string->name_length;
-      return;
+      return true;
 
     case V_VAR:
     case V_SCROLL_TEXT:
       if(name) *name = (char *)v->data.var_name;
       if(len)  *len = strlen(*name);
-      return;
+      return true;
 
     case V_VIRTUAL_VAR:
       if(name) *name = (char *)virtual_var_names[v->data.virtual_var];
       if(len)  *len = strlen(*name);
-      return;
+      return true;
 
     case V_SPRITE_VAR:
       snprintf(buffer, 32, "spr%d_%s", v->id, v->data.var_name);
       if(name) *name = buffer;
       if(len)  *len = strlen(buffer);
-      return;
+      return true;
 
     case V_SPRITE_CLIST:
       snprintf(buffer, 32, "spr_clist%d*", v->data.clist_num);
       if(name) *name = buffer;
       if(len)  *len = strlen(buffer);
-      return;
+      return true;
 
     case V_LOCAL_VAR:
       snprintf(buffer, 32, "local%d", v->data.local_num);
       if(name) *name = buffer;
       if(len)  *len = strlen(buffer);
-      return;
+      return true;
   }
+  return false; /* should never happen */
 }
 
 #define match_var(_name) (strlen(_name) == len && !memcmp(var, _name, len))
@@ -1723,10 +1724,11 @@ static boolean search_vars(struct world *mzx_world, struct debug_node *node,
 
     if(search_flags & VAR_SEARCH_NAMES)
     {
-      get_var_name(current, &var_text, &var_text_length, var_text_buffer);
-
-      matched = search_match(var_text, var_text_length, match_text,
-       match_text_index, match_length, search_flags);
+      if(get_var_name(current, &var_text, &var_text_length, var_text_buffer))
+      {
+        matched = search_match(var_text, var_text_length, match_text,
+         match_text_index, match_length, search_flags);
+      }
     }
 
     if((search_flags & VAR_SEARCH_VALUES) && !matched)
@@ -3367,14 +3369,17 @@ void __debug_counters(context *ctx)
     const char *var_name;
     int len;
 
-    get_var_name(var_list[var_selected], &var_name, &len, buffer);
-    if(len > VAR_SEARCH_MAX)
-      len = VAR_SEARCH_MAX;
-
     memcpy(previous_node_name, focus->name, DEBUG_NODE_NAME_SIZE);
     previous_node_name[DEBUG_NODE_NAME_SIZE - 1] = '\0';
-    memcpy(previous_var, var_name, len + 1);
-    previous_var[len] = '\0';
+
+    if(get_var_name(var_list[var_selected], &var_name, &len, buffer))
+    {
+      if(len > VAR_SEARCH_MAX)
+        len = VAR_SEARCH_MAX;
+
+      memcpy(previous_var, var_name, len + 1);
+      previous_var[len] = '\0';
+    }
   }
 
   // Clear the big dumb tree first

--- a/src/editor/robo_ed.c
+++ b/src/editor/robo_ed.c
@@ -3186,7 +3186,7 @@ static int validate_lines(struct robot_editor_context *rstate, int show_none)
   struct world *mzx_world = ((context *)rstate)->world;
   struct element *elements[VALIDATE_ELEMENTS];
   struct dialog di;
-  char information[64] = { 0 };
+  char information[72] = { 0 };
   int start_line = 0;
   int num_errors = 0;
   char error_messages[MAX_ERRORS][64];

--- a/src/event/wii/event_wii.c
+++ b/src/event/wii/event_wii.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#define BOOL _BOOL
 #include <gcutil.h>
 #include <ogc/lwp.h>
 #include <ogc/message.h>
@@ -35,7 +34,6 @@
 #include <ogc/usbmouse.h>
 #include <wiikeyboard/keyboard.h>
 #include <wiiuse/wpad.h>
-#undef BOOL
 
 // Shut an annoying warning up
 #if WPAD_CLASSIC_BUTTON_RIGHT == (0x8000 << 16)

--- a/src/network/Manifest.cpp
+++ b/src/network/Manifest.cpp
@@ -607,7 +607,7 @@ boolean Manifest::download_and_replace_entry(HTTPHost &http,
 
   request.clear();
   request.allowed_types = HTTPRequestInfo::binary_types;
-  snprintf(request.url, LINE_BUF_LEN, "%s/%08x%08x%08x%08x%08x%08x%08x%08x", basedir,
+  snprintf(request.url, LINE_BUF_LEN, "%s/" SHA256_PRINT_FMT, basedir,
     e->sha256[0], e->sha256[1], e->sha256[2], e->sha256[3],
     e->sha256[4], e->sha256[5], e->sha256[6], e->sha256[7]);
 
@@ -639,7 +639,7 @@ boolean Manifest::write_to_file(const char *filename) const
 
     for(ManifestEntry *e = this->head; e; e = e->next)
     {
-      vf_printf(vf, "%08x%08x%08x%08x%08x%08x%08x%08x %zu %s\n",
+      vf_printf(vf, SHA256_PRINT_FMT " %zu %s\n",
        e->sha256[0], e->sha256[1], e->sha256[2], e->sha256[3],
        e->sha256[4], e->sha256[5], e->sha256[6], e->sha256[7],
        e->size, e->name);

--- a/src/network/Manifest.hpp
+++ b/src/network/Manifest.hpp
@@ -19,7 +19,7 @@
  */
 
 #ifndef MEGAZEUX_MANIFEST_HPP
-#define MEGAZEXU_MANIFEST_HPP
+#define MEGAZEUX_MANIFEST_HPP
 
 #include "../compat.h"
 #include "../io/vfile.h"

--- a/src/network/Socket.hpp
+++ b/src/network/Socket.hpp
@@ -1,7 +1,7 @@
 /* MegaZeux
  *
  * Copyright (C) 2008 Alistair John Strachan <alistair@devzero.co.uk>
- * Copyright (C) 2018-2021 Alice Rowan <petrifiedrowan@gmail.com>
+ * Copyright (C) 2018-2026 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -53,19 +53,25 @@
 
 #elif defined(CONFIG_WII)
 
-// See arch/wii/network.cpp.
+// See Socket_wii.cpp.
 #include <network.h>
 #include <fcntl.h>
 #define UNIX_INLINE(x)
 
-// libogc uses a structure different from the regular structure and does not
-// declare pollfd. Declare this to be identical to the libogc version...
-struct pollfd
+/* libogc moved the poll defines to poll.h with no replacement net_poll
+ * defines. poll.h declares a pollfd incompatible with network.h pollsd.
+ * Interrim compile-time workaround: */
+#ifdef CONFIG_POLL
+#include <poll.h>
+#define pollfd net_pollfd
+
+struct net_pollfd
 {
   s32 fd;
   u32 events;
   u32 revents;
 };
+#endif
 
 #else // !_WIN32 && !CONFIG_WII
 

--- a/src/network/sha256.h
+++ b/src/network/sha256.h
@@ -24,7 +24,13 @@
 
 MEGAZEUX_BEGIN_DECLS
 
-#include <stdint.h>
+#include <inttypes.h>
+
+/* printf format string fragment for SHA256_ctx::H */
+#define SHA256_PRINT_FMT_1 "%08" PRIx32
+#define SHA256_PRINT_FMT_2 SHA256_PRINT_FMT_1 SHA256_PRINT_FMT_1
+#define SHA256_PRINT_FMT_4 SHA256_PRINT_FMT_2 SHA256_PRINT_FMT_2
+#define SHA256_PRINT_FMT   SHA256_PRINT_FMT_4 SHA256_PRINT_FMT_4
 
 struct SHA256_ctx
 {

--- a/src/platform/wii/platform_wii.c
+++ b/src/platform/wii/platform_wii.c
@@ -28,13 +28,10 @@
 #include <unistd.h>
 #include <sys/iosupport.h>
 
-#define BOOL _BOOL
 #include <ogc/system.h>
 #include <ogc/lwp.h>
 #include <ogc/lwp_watchdog.h>
-#include <ogc/message.h> // Suppress unused BOOL warning.
 #include <fat.h>
-#undef BOOL
 
 #define STACKSIZE 8192
 


### PR DESCRIPTION
* Fix Wii/3DS + SDL audio driver compilation errors.
* Fix Wii poll compilation errors.
* Fix GCC 16 src/editor/debug.c `get_var_name` -Wmaybe-unused warnings (Wii + SDL 1.2 only for some reason?).
* Fix GCC 16 src/editor/robo_ed.c string format warnings.
* Fix Wii BOOL warnings.
* Fix recently added(?) 3DS format warnings in the Manifest SHA256 `printf` formats.
* Fix malformed Manifest.hpp include guard.