### PR TITLE
Preparation for hardware PC speaker and OPL3 support.

### DIFF
--- a/src/audio/3ds/audio_3ds.c
+++ b/src/audio/3ds/audio_3ds.c
@@ -19,6 +19,7 @@
 
 #include "../audio.h"
 #include "../audio_drivers.h"
+#include "../audio_players.h"
 #include "../audio_struct.h"
 #include "../../platform/3ds/platform_3ds.h"
 
@@ -103,6 +104,11 @@ const struct audio_driver audio_driver_3ds =
 {
   "3DS Audio",
   "3ds",
+
+  NULL,
+  &audio_player_pcs,
+  NULL,
+
   init_audio_driver_3ds,
   quit_audio_driver_3ds,
 };

--- a/src/audio/audio.c
+++ b/src/audio/audio.c
@@ -20,9 +20,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-// Code to handle module playing, sample playing, and PC speaker
-// sfx emulation.
-
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
@@ -408,18 +405,35 @@ void init_audio(struct config_info *conf)
 
   audio.max_simultaneous_samples = -1;
   audio.max_simultaneous_samples_config = conf->max_simultaneous_samples;
+  audio.pc_speaker_use_hardware = conf->audio_pc_speaker_use_hardware;
+  audio.opl_use_hardware = conf->audio_opl_use_hardware;
+  audio.opl_port = conf->audio_opl_port;
 
   audio_set_music_volume(conf->music_volume);
   audio_set_sound_volume(conf->sam_volume);
   audio_set_music_on(conf->music_on);
   audio_set_pcs_on(conf->pc_speaker_on);
 
-  /* This player is not in the player list and must be handled manually. */
-  audio.pcs_stream = audio_player_pcs.construct(NULL, NULL, 0, 255, 0);
+  audio.driver = audio_init_driver(conf, conf->audio_driver);
+
+  if(audio.driver)
+  {
+    /* PC speaker providers are not kept in the regular player list and
+     * are handled on a per-driver basis. */
+    const struct audio_player *pcs_player = audio.pc_speaker_use_hardware ?
+     audio.driver->pcs_hardware_player : audio.driver->pcs_software_player;
+
+    if(!pcs_player)
+      pcs_player = audio.driver->pcs_software_player;
+
+    if(!pcs_player)
+      pcs_player = audio.driver->pcs_hardware_player;
+
+    if(pcs_player)
+      audio.pcs_stream = pcs_player->construct(NULL, NULL, 0, 255, 0);
+  }
 
   audio_set_pcs_volume(conf->pc_speaker_volume);
-
-  audio.driver = audio_init_driver(conf, NULL);
 }
 
 void quit_audio(void)
@@ -489,7 +503,7 @@ int audio_play_module(char *filename, boolean safely, int volume)
   audio_end_module();
 
   real_volume = volume_function(volume, audio.music_volume);
-  a_src = audio_construct_stream(filename, 0, real_volume, 1);
+  a_src = audio_construct_stream(filename, 0, real_volume, true, true);
 
   LOCK();
 
@@ -552,10 +566,9 @@ int audio_get_max_samples(void)
 
 static void limit_samples(int max)
 {
-  int samples_playing = 0;
-  int cancel_num = 0;
   struct audio_stream *current_astream;
-  struct audio_stream *next_astream;
+  struct audio_stream *prev_astream;
+  int samples_playing = 0;
 
   // Don't limit samples if the max samples setting is -1.
   if(max < 0)
@@ -563,37 +576,22 @@ static void limit_samples(int max)
 
   LOCK();
 
-  current_astream = audio.stream_list_base;
+  /* The most recent audio streams are at the end of the list.
+   * For efficiency, walk the list in reverse. */
+  current_astream = audio.stream_list_end;
   while(current_astream)
   {
-    next_astream = current_astream->next;
+    prev_astream = current_astream->previous;
 
-    if((current_astream != audio.primary_stream) &&
-     (current_astream != (struct audio_stream *)(audio.pcs_stream)))
+    if(current_astream != audio.primary_stream && current_astream != audio.pcs_stream)
     {
+      if(samples_playing >= max)
+        current_astream->player->destruct(current_astream);
+
       samples_playing++;
     }
 
-    current_astream = next_astream;
-  }
-
-  cancel_num = samples_playing - max;
-  if(cancel_num > 0)
-  {
-    current_astream = audio.stream_list_base;
-    while(current_astream && cancel_num > 0)
-    {
-      next_astream = current_astream->next;
-
-      if((current_astream != audio.primary_stream) &&
-       (current_astream != (struct audio_stream *)(audio.pcs_stream)))
-      {
-        current_astream->player->destruct(current_astream);
-        cancel_num--;
-      }
-
-      current_astream = next_astream;
-    }
+    current_astream = prev_astream;
   }
 
   UNLOCK();
@@ -626,7 +624,8 @@ void audio_play_sample(char *filename, boolean safely, int period)
    * are treated as stereo and must also have this buggy doubling. In other
    * words, just double the frequency in the SAM loader.
    */
-  audio_construct_stream(filename, audio_get_real_frequency(period * 2), vol, 0);
+  audio_construct_stream(filename,
+   audio_get_real_frequency(period * 2), vol, false, false);
 
   limit_samples(audio.max_simultaneous_samples);
 }
@@ -666,10 +665,6 @@ void audio_spot_sample(int period, int which)
 
 void audio_end_sample(void)
 {
-  // Destroy all samples - something is a sample if it's not a
-  // primary or PC speaker stream. This is a bit of a dirty way
-  // to do it though (might want to keep multiple lists instead)
-
   struct audio_stream *current_astream;
   struct audio_stream *next_astream;
 
@@ -680,11 +675,8 @@ void audio_end_sample(void)
   {
     next_astream = current_astream->next;
 
-    if((current_astream != audio.primary_stream) &&
-     (current_astream != (struct audio_stream *)(audio.pcs_stream)))
-    {
+    if(current_astream != audio.primary_stream && current_astream != audio.pcs_stream)
       current_astream->player->destruct(current_astream);
-    }
 
     current_astream = next_astream;
   }
@@ -693,11 +685,25 @@ void audio_end_sample(void)
   UNLOCK();
 }
 
+/**
+ * Functions to modify the current primary stream.
+ * Keep these functions in the same order as in struct audio_stream.
+ */
+
+void audio_set_module_volume(int volume)
+{
+  int real_volume = volume_function(volume, audio.music_volume);
+
+  LOCK();
+
+  if(audio.primary_stream)
+    audio.primary_stream->player->set_volume(audio.primary_stream, real_volume);
+
+  UNLOCK();
+}
+
 void audio_set_module_order(int order)
 {
-  // This is intended for modules only, and should not be supported for any
-  // other formats.
-
   LOCK();
 
   if(audio.primary_stream && audio.primary_stream->player->set_order)
@@ -720,65 +726,8 @@ int audio_get_module_order(void)
   return order;
 }
 
-void audio_set_module_volume(int volume)
-{
-  int real_volume = volume_function(volume, audio.music_volume);
-
-  LOCK();
-
-  if(audio.primary_stream)
-    audio.primary_stream->player->set_volume(audio.primary_stream, real_volume);
-
-  UNLOCK();
-}
-
-void audio_set_module_frequency(int freq)
-{
-  // Primary had better be a sampled stream (in reality I can't imagine
-  // ever letting it be anything but, but if it comes up a type
-  // enumeration could weed this out)
-
-  // Note that shifting the frequency dynamically messes up the phase
-  // counters somewhat producing an audible pop. I've tried to reduce
-  // this without too much success... This might be less noticeable
-  // when interpolation isn't used (but the tradeoff is hardly worth it)
-
-  if(freq >= 16)
-  {
-    LOCK();
-
-    if(audio.primary_stream)
-    {
-      struct sampled_stream *s = (struct sampled_stream *)audio.primary_stream;
-      audio.primary_stream->player->set_frequency(s, freq);
-    }
-
-    UNLOCK();
-  }
-}
-
-int audio_get_module_frequency(void)
-{
-  int freq = 0;
-
-  LOCK();
-
-  if(audio.primary_stream)
-  {
-    struct sampled_stream *s = (struct sampled_stream *)audio.primary_stream;
-    freq = audio.primary_stream->player->get_frequency(s);
-  }
-
-  UNLOCK();
-
-  return freq;
-}
-
 void audio_set_module_position(int pos)
 {
-  // Position isn't a universal thing and instead depends on the
-  // medium and what it supports.
-
   LOCK();
 
   if(audio.primary_stream && audio.primary_stream->player->set_position)
@@ -863,7 +812,46 @@ int audio_get_module_loop_end(void)
   return loop_end;
 }
 
+void audio_set_module_frequency(int freq)
+{
+  if(freq < 16 || freq > (2 << 20))
+    return;
+
+  LOCK();
+
+  if(audio.primary_stream && audio.primary_stream->player->set_frequency)
+  {
+    struct sampled_stream *s = (struct sampled_stream *)audio.primary_stream;
+    audio.primary_stream->player->set_frequency(s, freq);
+  }
+
+  UNLOCK();
+}
+
+int audio_get_module_frequency(void)
+{
+  int freq = 0;
+
+  LOCK();
+
+  if(audio.primary_stream && audio.primary_stream->player->get_frequency)
+  {
+    struct sampled_stream *s = (struct sampled_stream *)audio.primary_stream;
+    freq = audio.primary_stream->player->get_frequency(s);
+  }
+
+  UNLOCK();
+
+  return freq;
+}
+
 #endif
+
+/**
+ * Functions to modify the global audio settings.
+ *
+ * The volumes are only used by the main thread and don't need read locks.
+ */
 
 void audio_set_music_on(int val)
 {
@@ -879,16 +867,15 @@ void audio_set_pcs_on(int val)
   UNLOCK();
 }
 
-// These don't have to be locked because only one thread can
-// modify them.
-
 int audio_get_music_on(void)
 {
+  /* TODO: locking would be ideal here */
   return audio.music_on;
 }
 
 int audio_get_pcs_on(void)
 {
+  /* TODO: locking would be ideal here */
   return audio.pcs_on;
 }
 
@@ -927,11 +914,8 @@ void audio_set_sound_volume(int volume)
   current_astream = audio.stream_list_base;
   while(current_astream)
   {
-    if((current_astream != audio.primary_stream) &&
-     (current_astream != audio.pcs_stream))
-    {
+    if(current_astream != audio.primary_stream && current_astream != audio.pcs_stream)
       current_astream->player->set_volume(current_astream, real_volume);
-    }
 
     current_astream = current_astream->next;
   }

--- a/src/audio/audio_drivers.c
+++ b/src/audio/audio_drivers.c
@@ -65,29 +65,36 @@ const struct audio_driver *audio_init_driver(struct config_info *conf,
     return NULL;
   }
 
+  /* If specified, search for the named driver first. */
+  if(name && name[0])
+  {
+    for(i = 0; i < ARRAY_SIZE(available_drivers); i++)
+    {
+      const struct audio_driver *driver = available_drivers[i];
+      if(!driver)
+        break;
+      if(strcasecmp(driver->name, name))
+        continue;
+
+      name_match = driver;
+      break;
+    }
+    if(name_match && name_match->init_audio_driver(conf))
+      return name_match;
+  }
+
+  /* Attempt every other driver in the list. */
   for(i = 0; i < ARRAY_SIZE(available_drivers); i++)
   {
     const struct audio_driver *driver = available_drivers[i];
     if(!driver)
       break;
-
-    if(name)
-    {
-      if(!strcasecmp(driver->name, name))
-        name_match = driver;
-      else
-        continue;
-    }
+    if(driver == name_match)
+      continue;
 
     if(driver->init_audio_driver(conf))
       return driver;
   }
 
-  // If a name was specified and it's not the default driver, try the default.
-  if(name_match && name_match != available_drivers[0])
-  {
-    if(available_drivers[0]->init_audio_driver(conf))
-      return available_drivers[0];
-  }
   return NULL;
 }

--- a/src/audio/audio_mikmod.c
+++ b/src/audio/audio_mikmod.c
@@ -189,7 +189,7 @@ static void mm_init_order_table(struct mikmod_stream *mm_stream, MODULE *mm_data
   uint32_t num_orders;
 
   num_orders = mm_data->numpos;
-  tbl = cmalloc((num_orders + 1) * sizeof(uint32_t));
+  tbl = (uint32_t *)cmalloc((num_orders + 1) * sizeof(uint32_t));
 
   for(i = 0; i < num_orders; i++)
   {
@@ -329,14 +329,6 @@ static struct audio_stream *mm_construct(vfile *vf, const char *filename,
   struct mikmod_stream *mm_stream;
   MODULE *open_file;
 
-  /**
-   * FIXME since MikMod uses a global player state, attempting to play
-   * multiple modules at the same time predictably causes crashes. Use
-   * this hack to ignore any modules played as samples for now. :(
-   */
-  if(!repeat)
-    return NULL;
-
   if(!init_mikmod())
     return NULL;
 
@@ -370,10 +362,19 @@ static struct audio_stream *mm_construct(vfile *vf, const char *filename,
   return (struct audio_stream *)mm_stream;
 }
 
+static boolean mm_test(vfile *vf, const char *filename, boolean is_primary)
+{
+  /* MikMod uses global state even for the software output driver,
+   * so it needs to be reserved for the primary stream only.
+   * Accept all primary stream inputs and let MikMod figure the format out.
+   */
+  return is_primary;
+}
+
 const struct audio_player audio_player_mikmod =
 {
   "MikMod",
-  NULL,
+  mm_test,
 
   mm_construct,
   mm_destruct,

--- a/src/audio/audio_openmpt.c
+++ b/src/audio/audio_openmpt.c
@@ -281,7 +281,7 @@ static struct audio_stream *omp_construct(vfile *vf, const char *filename,
   return (struct audio_stream *)omp_stream;
 }
 
-static boolean omp_test(vfile *vf, const char *filename)
+static boolean omp_test(vfile *vf, const char *filename, boolean is_primary)
 {
   /* TODO: OpenMPT doesn't have a way to whitelist individual formats yet,
    * and having to add Symphonie/etc. support to libxmp because a package

--- a/src/audio/audio_pcs.c
+++ b/src/audio/audio_pcs.c
@@ -169,7 +169,7 @@ static struct audio_stream *pcs_construct(vfile *vf, const char *path,
 {
   struct pc_speaker_stream *pcs_stream;
 
-  pcs_stream = ccalloc(1, sizeof(struct pc_speaker_stream));
+  pcs_stream = (struct pc_speaker_stream *)ccalloc(1, sizeof(struct pc_speaker_stream));
 
   pcs_stream->a.player = &audio_player_pcs;
 

--- a/src/audio/audio_players.c
+++ b/src/audio/audio_players.c
@@ -56,10 +56,32 @@ static const struct audio_player * const available_players[] =
   NULL
 };
 
-struct audio_stream *audio_construct_stream(const char *filename,
- uint32_t frequency, unsigned int volume, boolean repeat)
+static struct audio_stream *try_construct(const struct audio_player *player,
+ vfile *vf, const char *filename, uint32_t frequency, unsigned int volume,
+ boolean is_primary, boolean repeat)
 {
-  struct audio_stream *a_return = NULL;
+  struct audio_stream *stream;
+
+  if(player->test)
+  {
+    boolean result = player->test(vf, filename, is_primary);
+    vrewind(vf);
+    if(!result)
+      return NULL;
+  }
+
+  stream = player->construct(vf, filename, frequency, volume, repeat);
+  if(!stream)
+    vrewind(vf);
+
+  return stream;
+}
+
+struct audio_stream *audio_construct_stream(const char *filename,
+ uint32_t frequency, unsigned int volume, boolean is_primary, boolean repeat)
+{
+  const struct audio_player * const *driver_players;
+  struct audio_stream *stream = NULL;
   vfile *vf;
   unsigned i;
 
@@ -71,34 +93,34 @@ struct audio_stream *audio_construct_stream(const char *filename,
   if(!vf)
     return NULL;
 
-  if(!available_players[0])
+  driver_players = audio.driver ? audio.driver->driver_players : NULL;
+
+  if((!driver_players || !driver_players[0]) && !available_players[0])
     warn("no available audio players.\n");
 
-  for(i = 0; i < ARRAY_SIZE(available_players); i++)
+  if(driver_players)
   {
-    const struct audio_player *player = available_players[i];
-    if(!player)
-      break;
-
-    if(player->test)
+    for(i = 0; driver_players[i]; i++)
     {
-      boolean result = player->test(vf, filename);
-      vrewind(vf);
-      if(!result)
-        continue;
+      stream = try_construct(driver_players[i], vf, filename,
+       frequency, volume, is_primary, repeat);
+
+      if(stream)
+        return stream;
     }
+  }
 
-    a_return = player->construct(vf, filename, frequency, volume, repeat);
-    if(a_return)
-      break;
+  for(i = 0; i < ARRAY_SIZE(available_players) && available_players[i]; i++)
+  {
+    stream = try_construct(available_players[i], vf, filename,
+     frequency, volume, is_primary, repeat);
 
-    vrewind(vf);
+    if(stream)
+      return stream;
   }
 
   // The constructor function is responsible for closing or
   // retaining the file handle on successful loads.
-  if(!a_return)
-    vfclose(vf);
-
-  return a_return;
+  vfclose(vf);
+  return NULL;
 }

--- a/src/audio/audio_players.h
+++ b/src/audio/audio_players.h
@@ -38,7 +38,7 @@ extern const struct audio_player audio_player_mikmod;
 extern const struct audio_player audio_player_openmpt;
 
 struct audio_stream *audio_construct_stream(const char *filename,
- uint32_t frequency, unsigned int volume, boolean repeat);
+ uint32_t frequency, unsigned int volume, boolean is_primary, boolean repeat);
 
 MEGAZEUX_END_DECLS
 

--- a/src/audio/audio_reality.cpp
+++ b/src/audio/audio_reality.cpp
@@ -258,7 +258,7 @@ static struct audio_stream *rad_construct(vfile *vf, const char *filename,
   return (struct audio_stream *)rad_stream;
 }
 
-static boolean rad_test(vfile *vf, const char *filename)
+static boolean rad_test(vfile *vf, const char *filename, boolean is_primary)
 {
   char tmp[16];
   if(!vfread(tmp, 16, 1, vf))

--- a/src/audio/audio_struct.h
+++ b/src/audio/audio_struct.h
@@ -46,6 +46,7 @@ MEGAZEUX_BEGIN_DECLS
 #define SAMPLE_S16 SAMPLE_S16LE
 #endif
 
+struct audio_player;
 struct audio_stream;
 struct sampled_stream;
 
@@ -75,6 +76,11 @@ struct audio_driver
   const char *name;
   const char *ident;
 
+  /* Driver-specific audio players. Put general players in audio_players.c. */
+  const struct audio_player * const * const driver_players;
+  const struct audio_player * const pcs_software_player;
+  const struct audio_player * const pcs_hardware_player;
+
   boolean (*init_audio_driver)(struct config_info *conf);
   void    (*quit_audio_driver)(void);
 };
@@ -83,33 +89,67 @@ struct audio_player
 {
   const char *name;
 
-  boolean   (*test)(vfile *vf, const char *filename);
+  boolean   (*test)(vfile *vf, const char *filename, boolean is_primary);
   struct audio_stream *(*construct)(vfile *vf, const char *filename,
                                     uint32_t frequency, unsigned int volume,
                                     boolean repeat);
   void      (*destruct)(struct audio_stream *a_src);
 
+  /* Render data to PCM. Non-PCM players do not need to implement this.
+   * A return value of true signals to the software mixer that this stream
+   * has finished playing and may be destroyed.
+   */
   boolean   (* mix_data)(struct audio_stream *a_src, int32_t * RESTRICT buffer,
                          size_t dest_frames, unsigned int dest_channels);
 
+  /* Volume--this should be implemented for everything possible. An example
+   * of a rare exception where it is not possible: hardware PIT PC speaker.
+   */
   void      (* set_volume)(struct audio_stream *a_src, unsigned int volume);
+
+  /* Repeat--if set to 0, the stream should terminate when it has reached
+   * the end. Should be implemented for everything except PC speaker.
+   */
   void      (* set_repeat)(struct audio_stream *a_src, boolean repeat);
 
+  /* Module position in sequence ("order")--this is intended for modules only.
+   * It currently has no meaning for other formats and should not be supported
+   * by them (TODO: maybe cue points in Ogg/WAV?).
+   */
   void      (* set_order)(struct audio_stream *a_src, uint32_t order);
   uint32_t  (* get_order)(struct audio_stream *a_src);
 
+  /* Position and length--for module formats, this is measured in rows from
+   * the start of the module (originally derived from libmodplug). For PCM,
+   * this is measured in sample frames from the start of the stream. Every
+   * player needs to implement this where possible, but some module rendering
+   * libraries make it more difficult than others.
+   */
   void      (* set_position)(struct audio_stream *a_src, uint32_t pos);
   uint32_t  (* get_position)(struct audio_stream *a_src);
   uint32_t  (* get_length)(struct audio_stream *a_src);
 
+  /* Loop start and loop end--the position (in sample frames, measured from
+   * the start of the stream) of the current start and end of the loop. This
+   * is only relevant for PCM, and module players should not implement it.
+   * The loop end position must be EXCLUSIVE for all players.
+   */
   void      (* set_loop_start)(struct audio_stream *a_src, uint32_t pos);
   uint32_t  (* get_loop_start)(struct audio_stream *a_src);
   void      (* set_loop_end)(struct audio_stream *a_src, uint32_t pos);
   uint32_t  (* get_loop_end)(struct audio_stream *a_src);
 
+  /* Resampling frequency--this is a feature of MegaZeux's resampler,
+   * and it should not be implemented by anything except sampled streams.
+   * Do not attempt to approximate this by e.g. adjusting module timing.
+   */
   void      (* set_frequency)(struct sampled_stream *s_src, uint32_t frequency);
   uint32_t  (* get_frequency)(struct sampled_stream *s_src);
 
+  /* Get a copy of a sample from this audio stream as a raw PCM spec for use
+   * by audio_spot_sample. Currently, only the libxmp player implements this.
+   * audio_spot_sample assumes this function allocates a copy of the sample.
+   */
   boolean   (* get_sample)(struct audio_stream *a_src, unsigned int which,
              struct wav_info *dest);
 };
@@ -162,6 +202,9 @@ struct audio
   unsigned int global_resample_mode;
   int max_simultaneous_samples;
   int max_simultaneous_samples_config;
+  boolean pc_speaker_use_hardware;
+  boolean opl_use_hardware;
+  int opl_port;
 
   struct audio_stream *primary_stream;
   struct audio_stream *pcs_stream;

--- a/src/audio/audio_vorbis.c
+++ b/src/audio/audio_vorbis.c
@@ -467,7 +467,7 @@ static struct audio_stream *vorbis_construct(vfile *vf, const char *filename,
   return (struct audio_stream *)v_stream;
 }
 
-static boolean vorbis_test(vfile *vf, const char *filename)
+static boolean vorbis_test(vfile *vf, const char *filename, boolean is_primary)
 {
   char buf[4];
   if(!vfread(buf, 4, 1, vf))

--- a/src/audio/audio_wav.c
+++ b/src/audio/audio_wav.c
@@ -334,7 +334,7 @@ static struct audio_stream *sam_construct(vfile *vf, const char *filename,
   return a_src;
 }
 
-static boolean wav_test(vfile *vf, const char *filename)
+static boolean wav_test(vfile *vf, const char *filename, boolean is_primary)
 {
   char buf[12];
   if(!vfread(buf, 12, 1, vf))
@@ -346,7 +346,7 @@ static boolean wav_test(vfile *vf, const char *filename)
   return true;
 }
 
-static boolean sam_test(vfile *vf, const char *filename)
+static boolean sam_test(vfile *vf, const char *filename, boolean is_primary)
 {
   // .SAM files are raw 8363Hz signed 8-bit samples and can only be identified
   // by their .SAM extension.

--- a/src/audio/djgpp/audio_sb.c
+++ b/src/audio/djgpp/audio_sb.c
@@ -32,6 +32,7 @@
 #include "audio_sb.h"
 #include "../audio.h"
 #include "../audio_drivers.h"
+#include "../audio_players.h"
 #include "../audio_struct.h"
 #include "../../util.h"
 #include "../../platform/djgpp/platform_djgpp.h"
@@ -435,6 +436,11 @@ const struct audio_driver audio_driver_sb =
 {
   "Sound Blaster 16, Pro 2, Pro, 2, or DSP 2.0",
   "sb",
+
+  NULL,
+  &audio_player_pcs,
+  NULL, /* &audio_player_pcs_pit */
+
   init_audio_driver_sb,
   quit_audio_driver_sb,
 };

--- a/src/audio/dreamcast/audio_dreamcast.c
+++ b/src/audio/dreamcast/audio_dreamcast.c
@@ -18,6 +18,8 @@
  */
 
 #include "../audio.h"
+#include "../audio_drivers.h"
+#include "../audio_players.h"
 #include "../audio_struct.h"
 #include "../../util.h"
 
@@ -97,6 +99,11 @@ const struct audio_driver audio_driver_dreamcast =
 {
   "Dreamcast Audio",
   "dreamcast",
+
+  NULL,
+  &audio_player_pcs,
+  NULL,
+
   init_audio_driver_dreamcast,
   quit_audio_driver_dreamcast,
 };

--- a/src/audio/nds/audio_nds.c
+++ b/src/audio/nds/audio_nds.c
@@ -19,6 +19,7 @@
 
 #include "../audio.h"
 #include "../audio_drivers.h"
+#include "../audio_players.h"
 #include "../audio_sfx.h"
 #include "../audio_struct.h"
 
@@ -544,6 +545,11 @@ const struct audio_driver audio_driver_nds =
 {
   "NDS Audio",
   "nds",
+
+  NULL, /* &audio_player_nds_maxmod, &audio_player_nds_maxmod_sam, &audio_player_nds_maxmod_wav */
+  NULL,
+  NULL, /* &audio_player_nds_pcs */
+
   init_audio_driver_nds,
   quit_audio_driver_nds,
 };

--- a/src/audio/sdl/audio_sdl.c
+++ b/src/audio/sdl/audio_sdl.c
@@ -19,6 +19,7 @@
 
 #include "../audio.h"
 #include "../audio_drivers.h"
+#include "../audio_players.h"
 #include "../audio_struct.h"
 
 #include "../../util.h"
@@ -131,6 +132,11 @@ const struct audio_driver audio_driver_sdl =
 {
   "SDL Audio",
   "sdl",
+
+  NULL,
+  &audio_player_pcs,
+  NULL,
+
   init_audio_driver_sdl,
   quit_audio_driver_sdl,
 };

--- a/src/audio/sdl/audio_sdl3.c
+++ b/src/audio/sdl/audio_sdl3.c
@@ -22,6 +22,7 @@
 
 #include "../audio.h"
 #include "../audio_drivers.h"
+#include "../audio_players.h"
 #include "../audio_struct.h"
 
 #include "../../util.h"
@@ -159,6 +160,11 @@ const struct audio_driver audio_driver_sdl3 =
 {
   "SDL3 Audio",
   "sdl",
+
+  NULL,
+  &audio_player_pcs,
+  NULL,
+
   init_audio_driver_sdl3,
   quit_audio_driver_sdl3,
 };

--- a/src/audio/wii/audio_wii.c
+++ b/src/audio/wii/audio_wii.c
@@ -19,6 +19,7 @@
 
 #include "../audio.h"
 #include "../audio_drivers.h"
+#include "../audio_players.h"
 #include "../audio_struct.h"
 
 #include <stdlib.h>
@@ -116,6 +117,11 @@ const struct audio_driver audio_driver_wii =
 {
   "Wii Audio",
   "wii",
+
+  NULL,
+  &audio_player_pcs,
+  NULL,
+
   init_audio_driver_wii,
   quit_audio_driver_wii,
 };

--- a/src/configure.c
+++ b/src/configure.c
@@ -314,6 +314,7 @@ static const struct config_info user_conf_default =
   true,                         // allow screenshots
 
   // Audio options
+  "",                           // audio_driver
   AUDIO_SAMPLE_RATE,            // audio_sample_rate
   AUDIO_BUFFER_SAMPLES,         // audio_buffer_samples
   AUDIO_OUTPUT_CHANNELS,        // audio_output_channels
@@ -326,6 +327,9 @@ static const struct config_info user_conf_default =
   8,                            // pc_speaker_volume
   true,                         // music_on
   true,                         // pc_speaker_on
+  false,                        // audio_pc_speaker_use_hardware
+  false,                        // audio_opl_use_hardware
+  0x388,                        // audio_opl_port
 
   // Event options
   true,                         // allow_gamepad
@@ -609,7 +613,7 @@ static void config_set_network_address_family(struct config_info *conf,
 {
   int result;
   if(config_enum(&result, value, network_address_family_values))
-    conf->network_address_family = result;
+    conf->network_address_family = (enum host_family)result;
 }
 
 static void config_set_socks_host(struct config_info *conf,
@@ -719,7 +723,7 @@ static void config_set_dialog_cursor_hints(struct config_info *conf,
 {
   int result;
   if(config_enum(&result, value, cursor_hint_type_values))
-    conf->cursor_hint_mode = result;
+    conf->cursor_hint_mode = (enum cursor_mode_types)result;
 }
 
 static void config_set_fullscreen(struct config_info *conf,
@@ -732,6 +736,12 @@ static void config_set_fullscreen_windowed(struct config_info *conf,
  const char *name, const char *value, const char *extended_data)
 {
   config_boolean(&conf->fullscreen_windowed, value);
+}
+
+static void config_set_audio_driver(struct config_info *conf,
+ const char *name, const char *value, const char *extended_data)
+{
+  config_string(conf->audio_driver, value);
 }
 
 static void config_set_music(struct config_info *conf,
@@ -768,6 +778,26 @@ static void config_set_sam_volume(struct config_info *conf,
   int result;
   if(config_int(&result, value, 0, 10))
     conf->sam_volume = result;
+}
+
+static void config_set_audio_pc_speaker_use_hardware(struct config_info *conf,
+ const char *name, const char *value, const char *extended_data)
+{
+  config_boolean(&conf->audio_pc_speaker_use_hardware, value);
+}
+
+static void config_set_audio_opl_use_hardware(struct config_info *conf,
+ const char *name, const char *value, const char *extended_data)
+{
+  config_boolean(&conf->audio_opl_use_hardware, value);
+}
+
+static void config_set_audio_opl_port(struct config_info *conf,
+ const char *name, const char *value, const char *extended_data)
+{
+  int result;
+  if(config_int(&result, value, 0, 65535))
+    conf->audio_opl_port = result;
 }
 
 static void config_save_file(struct config_info *conf,
@@ -823,7 +853,7 @@ static void config_system_mouse(struct config_info *conf,
 {
   int result;
   if(config_enum(&result, value, system_mouse_values))
-    conf->system_mouse = result;
+    conf->system_mouse = (enum system_mouse_type)result;
 }
 
 static void config_grab_mouse(struct config_info *conf,
@@ -837,7 +867,7 @@ static void config_disable_screensaver(struct config_info *conf,
 {
   int result;
   if(config_enum(&result, value, screensaver_disable_values))
-    conf->disable_screensaver = result;
+    conf->disable_screensaver = (enum screensaver_disable_mode)result;
 }
 
 static void config_save_slots(struct config_info *conf,
@@ -871,7 +901,7 @@ static void config_resample_mode(struct config_info *conf,
 {
   int result;
   if(config_enum(&result, value, resample_mode_values))
-    conf->resample_mode = result;
+    conf->resample_mode = (enum resample_mode)result;
 }
 
 static void config_mod_resample_mode(struct config_info *conf,
@@ -879,7 +909,7 @@ static void config_mod_resample_mode(struct config_info *conf,
 {
   int result;
   if(config_enum(&result, value, module_resample_mode_values))
-    conf->module_resample_mode = result;
+    conf->module_resample_mode = (enum resample_mode)result;
 }
 
 #define JOY_ENUM "%15[0-9A-Za-z_]"
@@ -1295,7 +1325,11 @@ static const struct config_entry config_options[] =
   { "allow_screenshots", config_set_allow_screenshots, false },
   { "audio_buffer", config_set_audio_buffer, false },
   { "audio_buffer_samples", config_set_audio_buffer, false },
+  { "audio_driver", config_set_audio_driver, false },
+  { "audio_opl_port", config_set_audio_opl_port, false },
+  { "audio_opl_use_hardware", config_set_audio_opl_use_hardware, false },
   { "audio_output_channels", config_set_audio_channels, false },
+  { "audio_pc_speaker_use_hardware", config_set_audio_pc_speaker_use_hardware, false },
   { "audio_sample_rate", config_set_audio_freq, false },
   { "auto_decrypt_worlds", config_set_auto_decrypt_worlds, false },
   { "dialog_cursor_hints", config_set_dialog_cursor_hints, false },

--- a/src/configure.h
+++ b/src/configure.h
@@ -136,6 +136,7 @@ struct config_info
   boolean allow_screenshots;
 
   // Audio options
+  char audio_driver[16];
   int audio_sample_rate;
   int audio_buffer_samples;
   int audio_output_channels;
@@ -148,6 +149,9 @@ struct config_info
   int pc_speaker_volume;
   boolean music_on;
   boolean pc_speaker_on;
+  boolean audio_pc_speaker_use_hardware;
+  boolean audio_opl_use_hardware;
+  int audio_opl_port;
 
   // Event options
   boolean allow_gamepad;

--- a/unit/configure.cpp
+++ b/unit/configure.cpp
@@ -551,6 +551,11 @@ UNITTEST(Settings)
 
   // Audio options.
 
+  SECTION(audio_driver)
+  {
+    TEST_STRING("audio_driver", conf->audio_driver, string_data);
+  }
+
   SECTION(audio_sample_rate)
   {
     TEST_INT("audio_sample_rate", conf->audio_sample_rate, 1, INT_MAX);
@@ -631,6 +636,21 @@ UNITTEST(Settings)
   SECTION(pc_speaker_on)
   {
     TEST_ENUM("pc_speaker_on", conf->pc_speaker_on, boolean_data);
+  }
+
+  SECTION(audio_pc_speaker_use_hardware)
+  {
+    TEST_ENUM("audio_pc_speaker_use_hardware", conf->audio_pc_speaker_use_hardware, boolean_data);
+  }
+
+  SECTION(audio_opl_use_hardware)
+  {
+    TEST_ENUM("audio_opl_use_hardware", conf->audio_opl_use_hardware, boolean_data);
+  }
+
+  SECTION(audio_opl_port)
+  {
+    TEST_INT("audio_opl_port", conf->audio_opl_port, 0, 65535);
   }
 
   // Event options.


### PR DESCRIPTION
* Reimplement MikMod's primary-only behavior as a player test function argument, since this will be necessary MaxMod and hardware OPL3.
* Support per-driver player list.
* Support per-driver software and hardware PC speaker players.
* Rewrite limit_samples to only walk the streams list once.
* Add audio_driver option to select an audio driver.
* Add audio_pc_speaker_use_hardware option to specify whether hardware or software PC speaker support should be preferred. (This option is implemented but currently meaningless, and eventually, it will only be relevant for Sound Blaster, Gravis UltraSound, and LPT DAC.)
* Add audio_opl_use_hardware option to specify whether hardware or software OPL3 support should be preferred for the primary stream. (This option is not implemented yet and will only affect DOS drivers.)
* Add audio_opl_port option to specify the port base for hardware OPL3 (default 0x388).
* Clean up junk comments in audio.c and rewrite several as comments on struct audio_player's fields.