### PR TITLE
Fix Sound Blaster 16-bit DMA.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -11,6 +11,7 @@ GIT - MZX 2.93e
 
 USERS
 
++ DOS: fixed 16-bit DMA for the Sound Blaster 16.
 + NDS: fixed PC speaker playback of rests (e.g. game over SFX).
 + Unix/Darwin: installed utilities are now prefixed with
   "megazeux-" so they can be installed to PATH. Package

--- a/src/audio/djgpp/audio_sb.c
+++ b/src/audio/djgpp/audio_sb.c
@@ -234,9 +234,6 @@ static boolean init_audio_driver_sb(struct config_info *conf)
     unsigned irq_vector;
     boolean is_16_bit = false;
 
-    if(frames > 4096) // TODO: seems arbitrary
-      frames = 4096;
-
     rate = CLAMP(rate, 5000, 44100);
 
     if(SB_VERSION_ATLEAST(sb_cfg, SB_VERSION_SB16))
@@ -277,9 +274,11 @@ static boolean init_audio_driver_sb(struct config_info *conf)
     sb_cfg.buffer_size = sb_cfg.buffer_frames * sb_cfg.buffer_channels *
      (is_16_bit ? sizeof(int16_t) : sizeof(uint8_t));
 
-    // allocate memory, without crossing 64K boundary, and clean it
-    sb_cfg.buffer_segment = djgpp_malloc_boundary(sb_cfg.buffer_size * BUFFER_BLOCKS,
-     65536, &sb_cfg.buffer_selector);
+    sb_cfg.buffer_segment = djgpp_malloc_boundary(
+     sb_cfg.buffer_size * BUFFER_BLOCKS, DMA_BOUNDARY, &sb_cfg.buffer_selector);
+    if(sb_cfg.buffer_segment < 0)
+      goto err;
+
     if(sb_cfg.nearptr_buffer_enabled)
     {
       sb_cfg.nearptr_buffer_mapping.address = sb_cfg.buffer_segment << 4;
@@ -300,7 +299,7 @@ static boolean init_audio_driver_sb(struct config_info *conf)
     {
       sb_cfg.buffer = (uint8_t *)cmalloc(sb_cfg.buffer_size * BUFFER_BLOCKS);
       if(!sb_cfg.buffer)
-        goto err;
+        goto err2;
     }
 
     audio_sb_clear_buffer();
@@ -384,6 +383,8 @@ static boolean init_audio_driver_sb(struct config_info *conf)
   }
   return true;
 
+err2:
+  __dpmi_free_dos_memory(sb_cfg.buffer_selector);
 err:
   sb_cfg.port = 0;
   return false;

--- a/src/platform/djgpp/platform_djgpp.c
+++ b/src/platform/djgpp/platform_djgpp.c
@@ -159,13 +159,13 @@ static void djgpp_enable_dma16(uint8_t port, uint8_t mode, int offset, int bytes
   switch(port & 3)
   {
     case 1:
-      outportb(0x8B, (offset >> 17));
+      outportb(0x8B, (offset >> 16));
       break;
     case 2:
-      outportb(0x89, (offset >> 17));
+      outportb(0x89, (offset >> 16));
       break;
     case 3:
-      outportb(0x8A, (offset >> 17));
+      outportb(0x8A, (offset >> 16));
       break;
   }
   outportb(0xD4, (port & 3));

--- a/src/platform/djgpp/platform_djgpp.c
+++ b/src/platform/djgpp/platform_djgpp.c
@@ -136,13 +136,40 @@ const char *djgpp_display_adapter_name(int adapter)
   return disp_adapter_names[adapter];
 }
 
+/**
+ * Allocate a buffer in DOS memory. If boundary_bytes is larger than or equal
+ * to len_bytes, this function will guarantee the returned segment contains
+ * at least len_bytes constrained within a boundary of size boundary_bytes.
+ * This is done by allocating twice as much memory as is required and shifting
+ * the returned segment to the start of the next boundary (if needed).
+ *
+ * @param len_bytes       size of allocation. If this value is less than 0 or
+ *                        too large to fit in DOS memory, this call will fail.
+ * @param boundary_bytes  size of boundary to constrain the allocation within.
+ *                        For DMA, this should be 65536. If this value is less
+ *                        than 0 or smaller than len_bytes, this call will fail.
+ * @return                a segment pointing to an allocated region of
+ *                        len_bytes on success, otherwise -1.
+ */
 int djgpp_malloc_boundary(int len_bytes, int boundary_bytes, int *selector)
 {
-  int len_segment = (len_bytes + 15) >> 4;
-  int boundary_mask = ~((boundary_bytes - 1) >> 4);
-  int segment = __dpmi_allocate_dos_memory((len_bytes + 7) >> 3, selector);
-  if(((segment + len_segment - 1) & boundary_mask) != (segment & boundary_mask))
-    segment += len_segment;
+  int len_paragraphs;
+  int boundary_mask;
+  int segment;
+
+  if(len_bytes < 0 || boundary_bytes < len_bytes || len_bytes > (1 << 19))
+    return -1;
+
+  len_paragraphs = (len_bytes + 15) >> 4;
+  boundary_mask = ~((boundary_bytes - 1) >> 4);
+
+  segment = __dpmi_allocate_dos_memory(len_paragraphs << 1, selector);
+  if(segment < 0)
+    return -1;
+
+  if(((segment + len_paragraphs - 1) & boundary_mask) != (segment & boundary_mask))
+    segment = (segment + len_paragraphs) & boundary_mask;
+
   return segment;
 }
 

--- a/src/platform/djgpp/platform_djgpp.h
+++ b/src/platform/djgpp/platform_djgpp.h
@@ -27,6 +27,8 @@ MEGAZEUX_BEGIN_DECLS
 
 #include <stdint.h>
 
+#define DMA_BOUNDARY  0x10000 /* For djgpp_malloc_boundary */
+
 #define DMA_AUTOINIT  0x10
 #define DMA_READ      0x44
 #define DMA_WRITE     0x48


### PR DESCRIPTION
It's not clear why this worked in DOSBox and DOSBox-X in the first place, but this fixes SB16 support in DOSBox Staging.

edit: it worked because every DOSBox variant up until this point was allocating buffers in pages 0 and 1. DOSBox and forks retain the high bit of the DMA offset (which apparently hardware does not do), so page 1 worked in spite of this. My setup of DOSBox Staging 0.82.2 in Fedora (but not in Windows) allocated the DMA buffer in page 2 instead, causing the bug to finally surface in DOSBox.